### PR TITLE
System fonts are not displayed in the correct style for their idiom in compatibility mode on visionOS.

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -51,6 +51,10 @@
 		41E9EE2628BCA19E006A2298 /* SBSStatusBarSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E9EE2528BCA19E006A2298 /* SBSStatusBarSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4450FC9F21F5F602004DFA56 /* QuickLookSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4450FC9D21F5F602004DFA56 /* QuickLookSoftLink.mm */; };
 		4469328B28483EF700614F16 /* FoundationSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4469328A2848321C00614F16 /* FoundationSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		44B1A8642A7C334F00DC80A6 /* Device.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44B1A8632A7C334F00DC80A6 /* Device.cpp */; };
+		44B1A8672A7C339400DC80A6 /* UserInterfaceIdiom.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44B1A8652A7C339200DC80A6 /* UserInterfaceIdiom.mm */; };
+		44B1A8682A7C5BAD00DC80A6 /* Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B1A8622A7C334D00DC80A6 /* Device.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		44B1A8692A7C606000DC80A6 /* UserInterfaceIdiom.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B1A8662A7C339300DC80A6 /* UserInterfaceIdiom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44E1A8B021FA54EB00C3048E /* LookupSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */; };
 		46FF911929196C73006005B5 /* SleepDisablerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46FF911829196C73006005B5 /* SleepDisablerIOS.mm */; };
 		57F1C90A25DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57F1C90825DCF0CF00E8F6EA /* CryptoKitPrivateSoftLink.mm */; };
@@ -551,6 +555,10 @@
 		4450FC9D21F5F602004DFA56 /* QuickLookSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuickLookSoftLink.mm; sourceTree = "<group>"; };
 		4450FC9E21F5F602004DFA56 /* QuickLookSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuickLookSoftLink.h; sourceTree = "<group>"; };
 		4469328A2848321C00614F16 /* FoundationSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FoundationSPI.h; sourceTree = "<group>"; };
+		44B1A8622A7C334D00DC80A6 /* Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Device.h; sourceTree = "<group>"; };
+		44B1A8632A7C334F00DC80A6 /* Device.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Device.cpp; sourceTree = "<group>"; };
+		44B1A8652A7C339200DC80A6 /* UserInterfaceIdiom.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserInterfaceIdiom.mm; sourceTree = "<group>"; };
+		44B1A8662A7C339300DC80A6 /* UserInterfaceIdiom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserInterfaceIdiom.h; sourceTree = "<group>"; };
 		44E1A8AD21FA54DA00C3048E /* LookupSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LookupSoftLink.h; sourceTree = "<group>"; };
 		44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LookupSoftLink.mm; sourceTree = "<group>"; };
 		44EEA0FE2747438900594A83 /* NSServicesRolloverButtonCellSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSServicesRolloverButtonCellSPI.h; sourceTree = "<group>"; };
@@ -1096,7 +1104,11 @@
 		46FF911529196C02006005B5 /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				44B1A8632A7C334F00DC80A6 /* Device.cpp */,
+				44B1A8622A7C334D00DC80A6 /* Device.h */,
 				46FF911829196C73006005B5 /* SleepDisablerIOS.mm */,
+				44B1A8662A7C339300DC80A6 /* UserInterfaceIdiom.h */,
+				44B1A8652A7C339200DC80A6 /* UserInterfaceIdiom.mm */,
 			);
 			path = ios;
 			sourceTree = "<group>";
@@ -1272,6 +1284,7 @@
 				DD20DE1127BC90D80093D175 /* DataDetectorsUISPI.h in Headers */,
 				DD20DE4D27BC90D80093D175 /* DecodeEscapeSequences.h in Headers */,
 				DD20DE4427BC90D80093D175 /* DefaultSearchProvider.h in Headers */,
+				44B1A8682A7C5BAD00DC80A6 /* Device.h in Headers */,
 				DD20DE4E27BC90D80093D175 /* EncodingTables.h in Headers */,
 				DD20DE5E27BC90D80093D175 /* ExportMacros.h in Headers */,
 				DD20DDE527BC90D70093D175 /* FeatureFlagsSPI.h in Headers */,
@@ -1416,6 +1429,7 @@
 				DD20DE5D27BC90D80093D175 /* UnencodableHandling.h in Headers */,
 				DD20DE0C27BC90D80093D175 /* URLFormattingSPI.h in Headers */,
 				DD20DD2527BC90D60093D175 /* UsageTrackingSoftLink.h in Headers */,
+				44B1A8692A7C606000DC80A6 /* UserInterfaceIdiom.h in Headers */,
 				DD20DD1927BC90D60093D175 /* VideoToolboxSoftLink.h in Headers */,
 				1CDE179A2A3BC3F9004E646F /* VideoToolboxSPI.h in Headers */,
 				DD20DD2627BC90D60093D175 /* VisionKitCoreSoftLink.h in Headers */,
@@ -1529,6 +1543,7 @@
 				F4E0875C266ACA53000F814A /* DataDetectorsSoftLink.mm in Sources */,
 				7AA1E2D029EF5947002D4455 /* DataDetectorsUISoftLink.mm in Sources */,
 				A1175B581F6B470500C4B9F0 /* DefaultSearchProvider.cpp in Sources */,
+				44B1A8642A7C334F00DC80A6 /* Device.cpp in Sources */,
 				1C5C57D427571626003B540D /* EncodingTables.cpp in Sources */,
 				F44291641FA52670002CC93E /* FileSizeFormatter.cpp in Sources */,
 				F44291681FA52705002CC93E /* FileSizeFormatterCocoa.mm in Sources */,
@@ -1582,6 +1597,7 @@
 				F44C007C29A06B1C00211F33 /* TranslationUIServicesSoftLink.mm in Sources */,
 				2E1342CD215AA10A007199D2 /* UIKitSoftLink.mm in Sources */,
 				07611DB7243FA5BF00D80704 /* UsageTrackingSoftLink.mm in Sources */,
+				44B1A8672A7C339400DC80A6 /* UserInterfaceIdiom.mm in Sources */,
 				41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */,
 				F46B8C4D26740918007A6554 /* VisionKitCoreSoftLink.mm in Sources */,
 				E57B44B729AB462E006069DE /* VisionSoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -93,6 +93,9 @@ typedef enum {
 - (void)_setIdleTimerDisabled:(BOOL)disabled forReason:(NSString *)reason;
 @end
 
+static const UIUserInterfaceIdiom UIUserInterfaceIdiomWatch = (UIUserInterfaceIdiom)4;
+
+
 @interface UIColor ()
 
 + (UIColor *)systemBlueColor;

--- a/Source/WebCore/PAL/pal/system/ios/Device.h
+++ b/Source/WebCore/PAL/pal/system/ios/Device.h
@@ -23,57 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "Device.h"
+#pragma once
 
 #if PLATFORM(IOS_FAMILY)
 
-#include <mutex>
-#include <pal/spi/ios/MobileGestaltSPI.h>
-#include <wtf/NeverDestroyed.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/Forward.h>
 
-namespace WebCore {
+namespace PAL {
 
-bool deviceClassIsSmallScreen()
-{
-    static auto deviceClass = MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);
-    return deviceClass == MGDeviceClassiPhone || deviceClass == MGDeviceClassiPod || deviceClass == MGDeviceClassWatch;
+String deviceName(); // Thread-safe.
+
+// Returns true only for iPhone, iPod, Apple Watch.
+// Few callers should be making any decisions based on device class.
+// If a check like this is needed, often currentUserInterfaceIdiomIsSmallScreen is preferred.
+PAL_EXPORT bool deviceClassIsSmallScreen();
+
+PAL_EXPORT bool deviceClassIsVision();
+
+// FIXME: How does this differ from !deviceClassIsSmallScreen()?
+PAL_EXPORT bool deviceHasIPadCapability();
+
 }
-
-bool deviceClassIsVision()
-{
-#if PLATFORM(VISION)
-    static auto deviceClass = MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);
-    return deviceClass == MGDeviceClassRealityDevice;
-#else
-    return false;
-#endif
-}
-
-String deviceName()
-{
-#if ENABLE(MOBILE_GESTALT_DEVICE_NAME)
-    static NeverDestroyed<RetainPtr<CFStringRef>> deviceName;
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [] {
-        deviceName.get() = adoptCF(static_cast<CFStringRef>(MGCopyAnswer(kMGQDeviceName, nullptr)));
-    });
-    return deviceName.get().get();
-#else
-    if (!deviceClassIsSmallScreen())
-        return "iPad"_s;
-    return "iPhone"_s;
-#endif
-}
-
-bool deviceHasIPadCapability()
-{
-    static bool deviceHasIPadCapability = MGGetBoolAnswer(kMGQiPadCapability);
-    return deviceHasIPadCapability;
-}
-
-} // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.h
+++ b/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.h
@@ -27,7 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-namespace WebKit {
+namespace PAL {
 
 enum class UserInterfaceIdiom : uint8_t {
     Default,
@@ -35,13 +35,13 @@ enum class UserInterfaceIdiom : uint8_t {
     Vision
 };
 
-bool currentUserInterfaceIdiomIsSmallScreen();
-bool currentUserInterfaceIdiomIsVision();
+PAL_EXPORT bool currentUserInterfaceIdiomIsSmallScreen();
+PAL_EXPORT bool currentUserInterfaceIdiomIsVision();
 
-UserInterfaceIdiom currentUserInterfaceIdiom();
-void setCurrentUserInterfaceIdiom(UserInterfaceIdiom);
+PAL_EXPORT UserInterfaceIdiom currentUserInterfaceIdiom();
+PAL_EXPORT void setCurrentUserInterfaceIdiom(UserInterfaceIdiom);
 
-bool updateCurrentUserInterfaceIdiom();
+PAL_EXPORT bool updateCurrentUserInterfaceIdiom();
 
 }
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -505,7 +505,6 @@ platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
 platform/image-decoders/ScalableImageDecoder.cpp
 platform/image-decoders/ScalableImageDecoderFrame.cpp
 platform/ios/ColorIOS.mm
-platform/ios/Device.cpp
 platform/ios/DeviceMotionClientIOS.mm
 platform/ios/DeviceOrientationClientIOS.mm
 platform/ios/DragImageIOS.mm

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -93,7 +93,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-#include "Device.h"
+#import <pal/system/ios/Device.h>
 #endif
 
 #undef CACHEDRESOURCELOADER_RELEASE_LOG

--- a/Source/WebCore/page/NavigatorBase.cpp
+++ b/Source/WebCore/page/NavigatorBase.cpp
@@ -46,7 +46,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-#include "Device.h"
+#import <pal/system/ios/Device.h>
 #endif
 
 #ifndef WEBCORE_NAVIGATOR_PRODUCT
@@ -97,7 +97,7 @@ String NavigatorBase::platform() const
     });
     return platformName->isolatedCopy();
 #elif PLATFORM(IOS_FAMILY)
-    return deviceName();
+    return PAL::deviceName();
 #elif OS(MACOS)
     return "MacIntel"_s;
 #elif OS(WINDOWS)

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -28,7 +28,7 @@
 #include <wtf/EnumTraits.h>
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-#include "Device.h"
+#import <pal/system/ios/Device.h>
 #endif
 
 namespace WebCore {
@@ -53,7 +53,7 @@ constexpr bool isLandscape(ScreenOrientationType type)
 inline ScreenOrientationType naturalScreenOrientationType()
 {
 #if PLATFORM(IOS) || PLATFORM(VISION)
-    if (deviceHasIPadCapability())
+    if (PAL::deviceHasIPadCapability())
         return ScreenOrientationType::LandscapePrimary;
     return ScreenOrientationType::PortraitPrimary;
 #elif PLATFORM(WATCHOS)

--- a/Source/WebCore/page/cocoa/SettingsBaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/SettingsBaseCocoa.mm
@@ -29,8 +29,8 @@
 #import <wtf/NeverDestroyed.h>
 
 #if PLATFORM(IOS_FAMILY)
-#import "Device.h"
 #import <pal/spi/ios/UIKitSPI.h>
+#import <pal/system/ios/Device.h>
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -31,6 +31,7 @@
 #include "FontCascadeDescription.h"
 #include "FontMetricsNormalization.h"
 
+#include <pal/system/ios/UserInterfaceIdiom.h>
 #include <wtf/cf/TypeCastsCF.h>
 
 namespace WebCore {
@@ -380,6 +381,15 @@ static inline FontSelectionValue cssWeightOfSystemFontDescriptor(CTFontDescripto
     return FontSelectionValue(normalizeCTWeight(result));
 }
 
+static CTFontTextStylePlatform fontPlatform()
+{
+#if PLATFORM(VISION)
+    if (!PAL::currentUserInterfaceIdiomIsReality())
+        return kCTFontTextStylePlatformPhone;
+#endif
+    return kCTFontTextStylePlatformDefault;
+}
+
 auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand fontShorthand) -> SystemFontShorthandInfo
 {
     auto interrogateFontDescriptorShorthandItem = [] (CTFontDescriptorRef fontDescriptor, const String& family) {
@@ -392,7 +402,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand fontShort
 
     auto interrogateTextStyleShorthandItem = [] (CFStringRef textStyle) {
         CGFloat weight = 0;
-        float size = CTFontDescriptorGetTextStyleSize(textStyle, contentSizeCategory(), kCTFontTextStylePlatformDefault, &weight, nullptr);
+        float size = CTFontDescriptorGetTextStyleSize(textStyle, contentSizeCategory(), fontPlatform(), &weight, nullptr);
         auto cssWeight = normalizeCTWeight(weight);
         return SystemFontShorthandInfo { textStyle, size, FontSelectionValue(cssWeight) };
     };

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -29,7 +29,6 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "DeprecatedGlobalSettings.h"
-#import "Device.h"
 #import "FloatRect.h"
 #import "FloatSize.h"
 #import "GraphicsContextCG.h"
@@ -39,10 +38,12 @@
 #import "ScreenProperties.h"
 #import "WAKWindow.h"
 #import "Widget.h"
-#import <pal/cocoa/MediaToolboxSoftLink.h>
-#import <pal/ios/UIKitSoftLink.h>
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #import <pal/spi/ios/UIKitSPI.h>
+#import <pal/system/ios/Device.h>
+
+#import <pal/cocoa/MediaToolboxSoftLink.h>
+#import <pal/ios/UIKitSoftLink.h>
 
 namespace WebCore {
 
@@ -151,7 +152,7 @@ float screenPPIFactor()
 
 FloatSize screenSize()
 {
-    if (deviceHasIPadCapability() && [[PAL::getUIApplicationClass() sharedApplication] _isClassic])
+    if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClass() sharedApplication] _isClassic])
         return { 320, 480 };
 
     if (auto data = screenData(primaryScreenDisplayID()))
@@ -162,7 +163,7 @@ FloatSize screenSize()
 
 FloatSize availableScreenSize()
 {
-    if (deviceHasIPadCapability() && [[PAL::getUIApplicationClass() sharedApplication] _isClassic])
+    if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClass() sharedApplication] _isClassic])
         return { 320, 480 };
 
     if (auto data = screenData(primaryScreenDisplayID()))

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -28,11 +28,11 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import "Device.h"
 #import "SystemVersion.h"
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #import <pal/spi/ios/UIKitSPI.h>
+#import <pal/system/ios/Device.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -58,7 +58,7 @@ static inline bool isClassicPhone()
 
 ASCIILiteral osNameForUserAgent()
 {
-    if (deviceHasIPadCapability() && !isClassicPhone())
+    if (PAL::deviceHasIPadCapability() && !isClassicPhone())
         return "OS"_s;
     return "iPhone OS"_s;
 }
@@ -73,7 +73,7 @@ static StringView deviceNameForUserAgent()
     }
 
     static NeverDestroyed<String> name = [] {
-        auto name = deviceName();
+        auto name = PAL::deviceName();
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
         size_t location = name.find(" Simulator"_s);
         if (location != notFound)

--- a/Source/WebCore/platform/network/BlobRegistry.h
+++ b/Source/WebCore/platform/network/BlobRegistry.h
@@ -40,6 +40,7 @@ class BlobDataFileReference;
 class BlobPart;
 class BlobRegistry;
 class BlobRegistryImpl;
+class SecurityOriginData;
 
 struct PolicyContainer;
 

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -275,8 +275,6 @@ typedef NS_ENUM(NSInteger, _UIDatePickerOverlayAnchor) {
 @property (nonatomic, readonly, retain) NSString *buildVersion;
 @end
 
-static const UIUserInterfaceIdiom UIUserInterfaceIdiomWatch = (UIUserInterfaceIdiom)4;
-
 typedef enum {
     kUIKeyboardInputRepeat                 = 1 << 0,
     kUIKeyboardInputPopupVariant           = 1 << 1,

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -666,6 +666,7 @@ def headers_for_type(type):
         'MediaTime': ['<wtf/MediaTime.h>'],
         'MonotonicTime': ['<wtf/MonotonicTime.h>'],
         'PAL::SessionID': ['<pal/SessionID.h>'],
+        'PAL::UserInterfaceIdiom': ['<pal/system/ios/UserInterfaceIdiom.h>'],
         'PlatformXR::Device::FrameData': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::ReferenceSpaceType': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::SessionFeature': ['<WebCore/PlatformXR.h>'],

--- a/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
@@ -22,7 +22,8 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-enum class WebKit::UserInterfaceIdiom : uint8_t {
+header: <pal/system/ios/UserInterfaceIdiom.h>
+enum class PAL::UserInterfaceIdiom : uint8_t {
     Default,
     SmallScreen,
     Vision

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -33,7 +33,7 @@
 #include <wtf/NumberOfCores.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #if PLATFORM(IOS_FAMILY)
-#include "UserInterfaceIdiom.h"
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #endif
 #endif
 
@@ -70,12 +70,12 @@ bool defaultShouldPrintBackgrounds()
 
 bool defaultAlternateFormControlDesignEnabled()
 {
-    return currentUserInterfaceIdiomIsVision();
+    return PAL::currentUserInterfaceIdiomIsVision();
 }
 
 bool defaultVideoFullscreenRequiresElementFullscreen()
 {
-    return currentUserInterfaceIdiomIsVision();
+    return PAL::currentUserInterfaceIdiomIsVision();
 }
 
 #endif

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -32,7 +32,7 @@
 #include "SandboxExtension.h"
 #include "TextCheckerState.h"
 #include "UserData.h"
-#include "UserInterfaceIdiom.h"
+
 #include "WebProcessDataStoreParameters.h"
 #include <WebCore/CrossOriginMode.h>
 #include <wtf/HashMap.h>
@@ -50,6 +50,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/RenderThemeIOS.h>
+#include <pal/system/ios/UserInterfaceIdiom.h>
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
@@ -212,7 +213,7 @@ struct WebProcessCreationParameters {
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    UserInterfaceIdiom currentUserInterfaceIdiom { UserInterfaceIdiom::Default };
+    PAL::UserInterfaceIdiom currentUserInterfaceIdiom { PAL::UserInterfaceIdiom::Default };
     bool supportsPictureInPicture { false };
     WebCore::RenderThemeIOS::CSSValueToSystemColorMap cssValueToSystemColorMap;
     WebCore::Color focusRingColor;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -164,7 +164,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    WebKit::UserInterfaceIdiom currentUserInterfaceIdiom;
+    PAL::UserInterfaceIdiom currentUserInterfaceIdiom;
     bool supportsPictureInPicture;
     WebCore::RenderThemeIOS::CSSValueToSystemColorMap cssValueToSystemColorMap;
     WebCore::Color focusRingColor;

--- a/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
+++ b/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
@@ -28,10 +28,11 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import "UserInterfaceIdiom.h"
-#import <WebCore/Device.h>
-#import <pal/ios/ManagedConfigurationSoftLink.h>
 #import <pal/spi/ios/ManagedConfigurationSPI.h>
+#import <pal/system/ios/Device.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
+
+#import <pal/ios/ManagedConfigurationSoftLink.h>
 
 namespace WebKit {
 
@@ -39,7 +40,7 @@ namespace WebKit {
 
 bool defaultTextAutosizingUsesIdempotentMode()
 {
-    return !currentUserInterfaceIdiomIsSmallScreen();
+    return !PAL::currentUserInterfaceIdiomIsSmallScreen();
 }
 
 #endif
@@ -68,7 +69,7 @@ void setAllowsDeprecatedSynchronousXMLHttpRequestDuringUnload(bool allowsRequest
 
 bool defaultMediaSourceEnabled()
 {
-    return !WebCore::deviceClassIsSmallScreen();
+    return !PAL::deviceClassIsSmallScreen();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -28,7 +28,6 @@
 
 #import "APIPageConfiguration.h"
 #import "CSPExtensionUtilities.h"
-#import "UserInterfaceIdiom.h"
 #import <WebKit/WKPreferences.h>
 #import <WebKit/WKProcessPool.h>
 #import <WebKit/WKRetainPtr.h>
@@ -44,6 +43,7 @@
 #import "_WKVisitedLinkStore.h"
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/Settings.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RobinHoodHashSet.h>
 #import <wtf/URLParser.h>
@@ -204,7 +204,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     _allowsPictureInPictureMediaPlayback = YES;
 #endif
 
-    _allowsInlineMediaPlayback = !WebKit::currentUserInterfaceIdiomIsSmallScreen();
+    _allowsInlineMediaPlayback = !PAL::currentUserInterfaceIdiomIsSmallScreen();
     _inlineMediaPlaybackRequiresPlaysInlineAttribute = !_allowsInlineMediaPlayback;
     _allowsInlineMediaPlaybackAfterFullscreen = !_allowsInlineMediaPlayback;
     _mediaDataLoadsAutomatically = _allowsInlineMediaPlayback;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -43,7 +43,6 @@
 #import "SandboxExtension.h"
 #import "SandboxUtilities.h"
 #import "TextChecker.h"
-#import "UserInterfaceIdiom.h"
 #import "WKBrowsingContextControllerInternal.h"
 #import "WebBackForwardCache.h"
 #import "WebMemoryPressureHandler.h"
@@ -71,8 +70,8 @@
 #import <pal/Logging.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/spi/cf/CFNotificationCenterSPI.h>
-#import <pal/spi/cocoa/AccessibilitySupportSoftLink.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <sys/param.h>
 #import <wtf/FileSystem.h>
 #import <wtf/ProcessPrivilege.h>
@@ -85,6 +84,8 @@
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/spi/darwin/dyldSPI.h>
 #import <wtf/text/TextStream.h>
+
+#import <pal/spi/cocoa/AccessibilitySupportSoftLink.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #import <JavaScriptCore/RemoteInspector.h>
@@ -486,7 +487,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     parameters.strictSecureDecodingForAllObjCEnabled = IPC::strictSecureDecodingForAllObjCEnabled();
 
 #if PLATFORM(IOS_FAMILY)
-    parameters.currentUserInterfaceIdiom = currentUserInterfaceIdiom();
+    parameters.currentUserInterfaceIdiom = PAL::currentUserInterfaceIdiom();
     parameters.supportsPictureInPicture = supportsPictureInPicture();
     parameters.cssValueToSystemColorMap = RenderThemeIOS::cssValueToSystemColorMap();
     parameters.focusRingColor = RenderThemeIOS::systemFocusRingColor();
@@ -808,8 +809,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
     if (![UIApplication sharedApplication]) {
         m_applicationLaunchObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-            if (WebKit::updateCurrentUserInterfaceIdiom())
-                sendToAllProcesses(Messages::WebProcess::UserInterfaceIdiomDidChange(WebKit::currentUserInterfaceIdiom()));
+            if (PAL::updateCurrentUserInterfaceIdiom())
+                sendToAllProcesses(Messages::WebProcess::UserInterfaceIdiomDidChange(PAL::currentUserInterfaceIdiom()));
         }];
     }
 #endif

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -30,7 +30,6 @@
 
 #import "MessageSenderInlines.h"
 #import "SmartMagnificationControllerMessages.h"
-#import "UserInterfaceIdiom.h"
 #import "ViewGestureGeometryCollectorMessages.h"
 #import "WKContentView.h"
 #import "WKScrollView.h"
@@ -38,6 +37,7 @@
 #import "WebPageMessages.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
+#import <pal/system/ios/UserInterfaceIdiom.h>
 
 static const float smartMagnificationPanScrollThresholdZoomedOut = 60;
 static const float smartMagnificationPanScrollThresholdIPhone = 100;
@@ -120,7 +120,7 @@ void SmartMagnificationController::didCollectGeometryForSmartMagnificationGestur
     float minimumScrollDistance;
     if ([m_contentView bounds].size.width <= m_webPageProxy.unobscuredContentRect().width())
         minimumScrollDistance = smartMagnificationPanScrollThresholdZoomedOut;
-    else if (currentUserInterfaceIdiomIsSmallScreen())
+    else if (PAL::currentUserInterfaceIdiomIsSmallScreen())
         minimumScrollDistance = smartMagnificationPanScrollThresholdIPhone;
     else
         minimumScrollDistance = smartMagnificationPanScrollThresholdIPad;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -48,7 +48,6 @@
 #import "TextRecognitionUpdateResult.h"
 #import "UIKitSPI.h"
 #import "UIKitUtilities.h"
-#import "UserInterfaceIdiom.h"
 #import "WKActionSheetAssistant.h"
 #import "WKContextMenuElementInfoInternal.h"
 #import "WKContextMenuElementInfoPrivate.h"
@@ -146,6 +145,7 @@
 #import <pal/spi/ios/BarcodeSupportSPI.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <pal/spi/ios/ManagedConfigurationSPI.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CallbackAggregator.h>
@@ -532,7 +532,7 @@ constexpr double fasterTapSignificantZoomThreshold = 0.8;
         [[_contentView formAccessoryView] showAutoFillButtonWithTitle:title];
     else
         [[_contentView formAccessoryView] hideAutoFillButton];
-    if (!WebKit::currentUserInterfaceIdiomIsSmallScreen())
+    if (!PAL::currentUserInterfaceIdiomIsSmallScreen())
         [_contentView reloadInputViews];
 }
 
@@ -1626,7 +1626,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
                 if (_focusRequiresStrongPasswordAssistance)
                     return true;
 
-                if (WebKit::currentUserInterfaceIdiomIsSmallScreen())
+                if (PAL::currentUserInterfaceIdiomIsSmallScreen())
                     return true;
             }
 
@@ -2348,7 +2348,7 @@ static NSValue *nsSizeForTapHighlightBorderRadius(WebCore::IntSize borderRadius,
         if (self._shouldUseContextMenusForFormControls)
             return NO;
 #endif
-        return WebKit::currentUserInterfaceIdiomIsSmallScreen();
+        return PAL::currentUserInterfaceIdiomIsSmallScreen();
     }
     default:
         return YES;
@@ -2440,7 +2440,7 @@ static NSValue *nsSizeForTapHighlightBorderRadius(WebCore::IntSize borderRadius,
         fontSize:_focusedElementInformation.nodeFontSize
         minimumScale:_focusedElementInformation.minimumScaleFactor
         maximumScale:_focusedElementInformation.maximumScaleFactorIgnoringAlwaysScalable
-        allowScaling:_focusedElementInformation.allowsUserScalingIgnoringAlwaysScalable && WebKit::currentUserInterfaceIdiomIsSmallScreen()
+        allowScaling:_focusedElementInformation.allowsUserScalingIgnoringAlwaysScalable && PAL::currentUserInterfaceIdiomIsSmallScreen()
         forceScroll:[self requiresAccessoryView]];
 }
 
@@ -3542,7 +3542,7 @@ static void cancelPotentialTapIfNecessary(WKContentView* contentView)
         if (self._shouldUseContextMenusForFormControls)
             return NO;
 #endif
-        return WebKit::currentUserInterfaceIdiomIsSmallScreen();
+        return PAL::currentUserInterfaceIdiomIsSmallScreen();
     }
     case WebKit::InputType::Text:
     case WebKit::InputType::Password:
@@ -3555,7 +3555,7 @@ static void cancelPotentialTapIfNecessary(WKContentView* contentView)
     case WebKit::InputType::ContentEditable:
     case WebKit::InputType::TextArea:
     case WebKit::InputType::Week:
-        return WebKit::currentUserInterfaceIdiomIsSmallScreen();
+        return PAL::currentUserInterfaceIdiomIsSmallScreen();
     }
 }
 
@@ -5470,7 +5470,7 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
     [accessoryView setNextEnabled:_focusedElementInformation.hasNextNode];
     [accessoryView setPreviousEnabled:_focusedElementInformation.hasPreviousNode];
 
-    if (!WebKit::currentUserInterfaceIdiomIsSmallScreen()) {
+    if (!PAL::currentUserInterfaceIdiomIsSmallScreen()) {
         [accessoryView setClearVisible:NO];
         return;
     }
@@ -8607,7 +8607,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (BOOL)_shouldUseLegacySelectPopoverDismissalBehavior
 {
-    if (WebKit::currentUserInterfaceIdiomIsSmallScreen())
+    if (PAL::currentUserInterfaceIdiomIsSmallScreen())
         return NO;
 
     if (_focusedElementInformation.elementType != WebKit::InputType::Select)

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -29,13 +29,13 @@
 #if ENABLE(DATALIST_ELEMENT) && PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
-#import "UserInterfaceIdiom.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKFormPeripheral.h"
 #import "WKFormPopover.h"
 #import "WKWebViewPrivateForTesting.h"
 #import "WebPageProxy.h"
+#import <pal/system/ios/UserInterfaceIdiom.h>
 
 static const CGFloat maxVisibleSuggestions = 5;
 static const CGFloat suggestionsPopoverCellHeight = 44;
@@ -116,7 +116,7 @@ void WebDataListSuggestionsDropdownIOS::show(WebCore::DataListSuggestionInformat
     }
 #endif
 
-    if (currentUserInterfaceIdiomIsSmallScreen())
+    if (PAL::currentUserInterfaceIdiomIsSmallScreen())
         m_suggestionsControl = adoptNS([[WKDataListSuggestionsPicker alloc] initWithInformation:WTFMove(information) inView:m_contentView]);
     else
         m_suggestionsControl = adoptNS([[WKDataListSuggestionsPopover alloc] initWithInformation:WTFMove(information) inView:m_contentView]);

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -56,7 +56,6 @@
 #import "TapHandlingResult.h"
 #import "UIKitSPI.h"
 #import "UserData.h"
-#import "UserInterfaceIdiom.h"
 #import "VideoFullscreenManagerProxy.h"
 #import "ViewUpdateDispatcherMessages.h"
 #import "WKBrowsingContextControllerInternal.h"
@@ -79,6 +78,7 @@
 #import <WebCore/UserAgent.h>
 #import <WebCore/ValidationBubble.h>
 #import <pal/spi/ios/MobileGestaltSPI.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/text/TextStream.h>
 
@@ -1324,7 +1324,7 @@ static bool desktopClassBrowsingSupported()
     static bool supportsDesktopClassBrowsing = false;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        supportsDesktopClassBrowsing = !currentUserInterfaceIdiomIsSmallScreen();
+        supportsDesktopClassBrowsing = !PAL::currentUserInterfaceIdiomIsSmallScreen();
     });
     return supportsDesktopClassBrowsing;
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -29,13 +29,13 @@
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)
 
 #import "UIKitSPI.h"
-#import "UserInterfaceIdiom.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKWebViewPrivateForTesting.h"
 #import "WebPageProxy.h"
 #import <UIKit/UIDatePicker.h>
 #import <WebCore/LocalizedStrings.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SetForScope.h>
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -34,7 +34,6 @@
 #import "APIString.h"
 #import "PhotosUISPI.h"
 #import "UIKitSPI.h"
-#import "UserInterfaceIdiom.h"
 #import "WKContentViewInteraction.h"
 #import "WKData.h"
 #import "WKStringCF.h"
@@ -47,6 +46,7 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/MIMETypeRegistry.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/MainThread.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -30,10 +30,10 @@
 
 #import "FocusedElementInformation.h"
 #import "UIKitSPI.h"
-#import "UserInterfaceIdiom.h"
 #import "WKContentViewInteraction.h"
 #import "WebPageProxy.h"
 #import <WebCore/ColorCocoa.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #pragma mark - WKColorPicker

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -28,7 +28,6 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import "UserInterfaceIdiom.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKFormPopover.h"
@@ -36,6 +35,7 @@
 #import "WKFormSelectPopover.h"
 #import "WebPageProxy.h"
 #import <UIKit/UIPickerView.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RetainPtr.h>
 
 using namespace WebKit;
@@ -87,7 +87,7 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
     }
 #endif
 
-    if (!currentUserInterfaceIdiomIsSmallScreen())
+    if (!PAL::currentUserInterfaceIdiomIsSmallScreen())
         control = adoptNS([[WKSelectPopover alloc] initWithView:view hasGroups:hasGroups]);
     else if (view.focusedElementInformation.isMultiSelect || hasGroups)
         control = adoptNS([[WKMultipleSelectPicker alloc] initWithView:view]);

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -29,7 +29,6 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
-#import "UserInterfaceIdiom.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKFormPopover.h"
@@ -37,6 +36,7 @@
 #import "WKWebViewPrivateForTesting.h"
 #import "WebPageProxy.h"
 #import <WebCore/LocalizedStrings.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 
 using namespace WebKit;
 
@@ -1191,7 +1191,7 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
 
 - (void)configurePresentation
 {
-    if (WebKit::currentUserInterfaceIdiomIsSmallScreen()) {
+    if (PAL::currentUserInterfaceIdiomIsSmallScreen()) {
         [[_navigationController navigationBar] setBarTintColor:UIColor.systemGroupedBackgroundColor];
 
         UIPresentationController *presentationController = [_navigationController presentationController];

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2123,7 +2123,6 @@
 		E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3866B042399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp */; };
 		E3866B0A2399A2D900F88FE9 /* WebDeviceOrientationUpdateProviderMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = E3866B072399979D00F88FE9 /* WebDeviceOrientationUpdateProviderMessages.h */; };
 		E3866B0B2399A2DD00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3866B062399979C00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp */; };
-		E38A1FC023A551BF00D2374F /* UserInterfaceIdiom.mm in Sources */ = {isa = PBXBuildFile; fileRef = E38A1FBF23A551BF00D2374F /* UserInterfaceIdiom.mm */; };
 		E39628DD23960CC600658ECD /* WebDeviceOrientationUpdateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E39628DB23960CC500658ECD /* WebDeviceOrientationUpdateProvider.h */; };
 		E39628DE23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39628DC23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp */; };
 		E3C6727329D4A3AD00AD4452 /* TextTrackRepresentationCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */; };
@@ -7080,8 +7079,6 @@
 		E3866B052399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebDeviceOrientationUpdateProviderProxyMessages.h; sourceTree = "<group>"; };
 		E3866B062399979C00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebDeviceOrientationUpdateProviderMessageReceiver.cpp; sourceTree = "<group>"; };
 		E3866B072399979D00F88FE9 /* WebDeviceOrientationUpdateProviderMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebDeviceOrientationUpdateProviderMessages.h; sourceTree = "<group>"; };
-		E38A1FBE23A5511400D2374F /* UserInterfaceIdiom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserInterfaceIdiom.h; sourceTree = "<group>"; };
-		E38A1FBF23A551BF00D2374F /* UserInterfaceIdiom.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserInterfaceIdiom.mm; sourceTree = "<group>"; };
 		E39628DB23960CC500658ECD /* WebDeviceOrientationUpdateProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebDeviceOrientationUpdateProvider.h; sourceTree = "<group>"; };
 		E39628DC23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebDeviceOrientationUpdateProvider.cpp; sourceTree = "<group>"; };
 		E39628E423971F3400658ECD /* WebDeviceOrientationUpdateProvider.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebDeviceOrientationUpdateProvider.messages.in; sourceTree = "<group>"; };
@@ -9570,8 +9567,6 @@
 				2DA944981884E4F000ED86DB /* NativeWebTouchEventIOS.mm */,
 				4459984122833E6000E61373 /* SyntheticEditingCommandType.h */,
 				F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */,
-				E38A1FBE23A5511400D2374F /* UserInterfaceIdiom.h */,
-				E38A1FBF23A551BF00D2374F /* UserInterfaceIdiom.mm */,
 				F40D1B68220BDC0F00B49A01 /* WebAutocorrectionContext.h */,
 				86BAAFD529A3CD160013F9A9 /* WebAutocorrectionContext.serialization.in */,
 				F42D633F22A0EFD300D2FB3A /* WebAutocorrectionData.h */,
@@ -17318,7 +17313,6 @@
 				5C411DAA27CED4220068241A /* UnifiedSource128.cpp in Sources */,
 				5C411DAD27CED4220068241A /* UnifiedSource129.cpp in Sources */,
 				5C411DA727CED4220068241A /* UnifiedSource130.cpp in Sources */,
-				E38A1FC023A551BF00D2374F /* UserInterfaceIdiom.mm in Sources */,
 				CD491B0D1E732E4D00009066 /* UserMediaCaptureManagerMessageReceiver.cpp in Sources */,
 				CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */,
 				3F418EF91887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -52,7 +52,6 @@
 #import "TextCheckingControllerProxy.h"
 #import "UIKitSPI.h"
 #import "UserData.h"
-#import "UserInterfaceIdiom.h"
 #import "ViewGestureGeometryCollector.h"
 #import "VisibleContentRectUpdateInfo.h"
 #import "WKAccessibilityWebPageObjectIOS.h"
@@ -156,6 +155,7 @@
 #import <WebCore/UserGestureIndicator.h>
 #import <WebCore/VisibleUnits.h>
 #import <WebCore/WebEvent.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/MathExtras.h>
 #import <wtf/MemoryPressureHandler.h>
 #import <wtf/Scope.h>
@@ -5196,7 +5196,7 @@ void WebPage::animationDidFinishForElement(const WebCore::Element& animatedEleme
 
 FloatSize WebPage::screenSizeForFingerprintingProtections(const LocalFrame&, FloatSize defaultSize) const
 {
-    if (!currentUserInterfaceIdiomIsSmallScreen())
+    if (!PAL::currentUserInterfaceIdiomIsSmallScreen())
         return m_viewportConfiguration.minimumLayoutSize();
 
     static constexpr std::array fixedSizes {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -88,6 +88,7 @@ class Object;
 
 namespace PAL {
 class SessionID;
+enum class UserInterfaceIdiom : uint8_t;
 }
 
 namespace WebCore {
@@ -157,7 +158,6 @@ struct WebsiteData;
 struct WebsiteDataStoreParameters;
 
 enum class RemoteWorkerType : uint8_t;
-enum class UserInterfaceIdiom : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
 #if PLATFORM(IOS_FAMILY)
@@ -606,7 +606,7 @@ private:
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    void userInterfaceIdiomDidChange(UserInterfaceIdiom);
+    void userInterfaceIdiomDidChange(PAL::UserInterfaceIdiom);
 
     bool shouldFreezeOnSuspension() const;
     void updateFreezerStatus();

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -117,7 +117,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    UserInterfaceIdiomDidChange(enum:uint8_t WebKit::UserInterfaceIdiom idiom)
+    UserInterfaceIdiomDidChange(enum:uint8_t PAL::UserInterfaceIdiom idiom)
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -137,11 +137,11 @@
 
 #if PLATFORM(IOS_FAMILY)
 #import "RunningBoardServicesSPI.h"
-#import "UserInterfaceIdiom.h"
 #import "WKAccessibilityWebPageObjectIOS.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <UIKit/UIAccessibility.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
+#import <pal/system/ios/UserInterfaceIdiom.h>
 #endif
 
 #if PLATFORM(IOS_FAMILY) && USE(APPLE_INTERNAL_SDK)
@@ -1135,9 +1135,9 @@ void WebProcess::releaseSystemMallocMemory()
 
 #if PLATFORM(IOS_FAMILY)
 
-void WebProcess::userInterfaceIdiomDidChange(UserInterfaceIdiom idiom)
+void WebProcess::userInterfaceIdiomDidChange(PAL::UserInterfaceIdiom idiom)
 {
-    WebKit::setCurrentUserInterfaceIdiom(idiom);
+    PAL::setCurrentUserInterfaceIdiom(idiom);
 }
 
 bool WebProcess::shouldFreezeOnSuspension() const

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -35,7 +35,7 @@
 #import <wtf/text/WTFString.h>
 
 #if PLATFORM(IOS_FAMILY)
-#import <WebCore/Device.h>
+#import <pal/system/ios/Device.h>
 #endif
 
 namespace WebKit {
@@ -44,12 +44,12 @@ namespace WebKit {
 
 bool defaultAllowsInlineMediaPlayback()
 {
-    return !WebCore::deviceClassIsSmallScreen();
+    return !PAL::deviceClassIsSmallScreen();
 }
 
 bool defaultAllowsInlineMediaPlaybackAfterFullscreen()
 {
-    return WebCore::deviceClassIsSmallScreen();
+    return PAL::deviceClassIsSmallScreen();
 }
 
 bool defaultAllowsPictureInPictureMediaPlayback()
@@ -66,7 +66,7 @@ bool defaultJavaScriptCanOpenWindowsAutomatically()
 
 bool defaultInlineMediaPlaybackRequiresPlaysInlineAttribute()
 {
-    return WebCore::deviceClassIsSmallScreen();
+    return PAL::deviceClassIsSmallScreen();
 }
 
 bool defaultPassiveTouchListenersAsDefaultOnDocument()
@@ -239,7 +239,7 @@ bool defaultWheelEventGesturesBecomeNonBlocking()
 
 bool defaultMediaSourceEnabled()
 {
-    return !WebCore::deviceClassIsSmallScreen();
+    return !PAL::deviceClassIsSmallScreen();
 }
 
 #endif


### PR DESCRIPTION
#### 7ef05e80175b3e2596090dedec3c93e5ea306796
<pre>
System fonts are not displayed in the correct style for their idiom in compatibility mode on visionOS.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259844">https://bugs.webkit.org/show_bug.cgi?id=259844</a>
rdar://107389870

Reviewed by Tim Horton.

When requesting information about system fonts, we were always going with the current idiom, which for
the web-process will always match the device. If the UIProcess is in compatibility mode, we need
to make sure that we are using the idiom that it is in, or we will get system fonts on the wrong size.

We move the required classes into PAL so they can be used from WebCore while maintaining platform agnosticism
in WebCore itself, and then read the appropriate flag in the font code. Since the font database is
multithreaded, we also need to ensure that the flag is thread-safe.

* Source/WebCore/PAL/pal/system/ios/Device.cpp: Renamed from Source/WebCore/platform/ios/Device.cpp.
(PAL::deviceClassIsSmallScreen):
(PAL::deviceClassIsReality):
(PAL::deviceName):
(PAL::deviceHasIPadCapability):
* Source/WebCore/PAL/pal/system/ios/Device.h: Renamed from Source/WebCore/platform/ios/Device.h.
* Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.h: Renamed from Source/WebKit/Shared/UserInterfaceIdiom.h.
* Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm: Renamed from Source/WebKit/Shared/UserInterfaceIdiom.mm.
(PAL::currentUserInterfaceIdiomIsSmallScreen):
(PAL::currentUserInterfaceIdiomIsReality):
(PAL::currentUserInterfaceIdiom):
(PAL::setCurrentUserInterfaceIdiom):
(PAL::updateCurrentUserInterfaceIdiom):

Canonical link: <a href="https://commits.webkit.org/266710@main">https://commits.webkit.org/266710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe32bd8727739a3cb2bce5ce59c02f4e58b2be49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16284 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14925 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17013 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14641 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13111 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16508 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13825 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13828 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14582 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12968 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3771 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3515 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17457 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14971 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13672 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3587 "Passed tests") | 
<!--EWS-Status-Bubble-End-->