### PR TITLE
SVG rect with rx or ry set to zero is drawn incorrectly

### DIFF
--- a/LayoutTests/svg/custom/rect-radius-constraints-expected.svg
+++ b/LayoutTests/svg/custom/rect-radius-constraints-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="100" height="100" fill="green"/>
+    <rect x="120" y="10" width="100" height="100" fill="green"/>
+
+    <rect x="10" y="120" width="100" height="100" fill="green" rx="50" ry="50"/>
+    <rect x="120" y="120" width="100" height="100" fill="green" rx="50" ry="50"/>
+</svg>

--- a/LayoutTests/svg/custom/rect-radius-constraints.svg
+++ b/LayoutTests/svg/custom/rect-radius-constraints.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect x="10" y="10" width="100" height="100" fill="green" rx="30" ry="0"/>
+    <rect x="120" y="10" width="100" height="100" fill="green" rx="0" ry="30"/>
+
+    <rect x="10" y="120" width="100" height="100" fill="green" rx="100" ry="-10"/>
+    <rect x="120" y="120" width="100" height="100" fill="green" rx="-10" ry="100"/>
+</svg>


### PR DESCRIPTION
#### 3dc74d79ceb7bd7fe9cb76a3952a5ee42c41b705
<pre>
SVG rect with rx or ry set to zero is drawn incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=259772">https://bugs.webkit.org/show_bug.cgi?id=259772</a>
rdar://113396109

Reviewed by Nikolas Zimmermann.

According to the SVG rect element specs [1], when rx or ry is set to negative,
the other corner radius value is used. If rx or ry is set to zero, no rounded
corner is drawn for the rect.

[1] <a href="https://www.w3.org/TR/SVG2/geometry.html#RxProperty">https://www.w3.org/TR/SVG2/geometry.html#RxProperty</a>

* LayoutTests/svg/custom/rect-radius-constraints-expected.svg: Added.
* LayoutTests/svg/custom/rect-radius-constraints.svg: Added.
* Source/WebCore/rendering/svg/SVGPathData.cpp:
(WebCore::pathFromRectElement):

Canonical link: <a href="https://commits.webkit.org/266641@main">https://commits.webkit.org/266641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4a348e54307f292ccabff69b7fcb0d011f686ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16184 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16731 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19877 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16236 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11432 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12867 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3470 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->