### PR TITLE
[macOS] Present SCKit picker with `-[SCContentSharingPicker presentPickerUsingContentStyle:]`

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -40,6 +40,14 @@
 
 #import <pal/mac/ScreenCaptureKitSoftLink.h>
 
+// FIXME: Remove this once it is in a public header.
+
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+@interface SCContentSharingPicker (SCContentSharingPicker_Pending_Public_API)
+- (void)presentPickerUsingContentStyle:(SCShareableContentStyle)contentStyle;
+@end
+#endif
+
 using namespace WebCore;
 
 @interface WebDisplayMediaPromptHelper : NSObject <SCContentSharingSessionProtocol
@@ -432,15 +440,19 @@ bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker(Dis
     ASSERT(useSCContentSharingPicker());
 
     auto configuration = adoptNS([PAL::allocSCContentSharingPickerConfigurationInstance() init]);
+    SCShareableContentStyle shareableContentStyle = SCShareableContentStyleWindow;
     switch (promptType) {
     case DisplayCapturePromptType::Window:
         [configuration setAllowedPickerModes:SCContentSharingPickerModeSingleWindow];
+        shareableContentStyle = SCShareableContentStyleWindow;
         break;
     case DisplayCapturePromptType::Screen:
         [configuration setAllowedPickerModes:SCContentSharingPickerModeSingleDisplay];
+        shareableContentStyle = SCShareableContentStyleDisplay;
         break;
     case DisplayCapturePromptType::UserChoose:
         [configuration setAllowedPickerModes:SCContentSharingPickerModeSingleWindow | SCContentSharingPickerModeSingleDisplay];
+        shareableContentStyle = SCShareableContentStyleNone;
         break;
     }
 
@@ -449,7 +461,11 @@ bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker(Dis
     picker.maximumStreamCount = @(1);
     picker.defaultConfiguration = configuration.get();
     [m_promptHelper startObservingPicker:picker];
-    [picker present];
+
+    if (shareableContentStyle != SCShareableContentStyleNone && [picker respondsToSelector:@selector(presentPickerUsingContentStyle:)])
+        [picker presentPickerUsingContentStyle:shareableContentStyle];
+    else
+        [picker present];
 
     return true;
 #else


### PR DESCRIPTION
#### 3eac88b8c6c7480b19d42446a58284fa8b4439b2
<pre>
[macOS] Present SCKit picker with `-[SCContentSharingPicker presentPickerUsingContentStyle:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=259851">https://bugs.webkit.org/show_bug.cgi?id=259851</a>
rdar://113424298

Reviewed by Andy Estes.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker): Call
`-[SCContentSharingPicker presentPickerUsingContentStyle:]` when it is available and we
are supposed to limit picking to either window or screen.

Canonical link: <a href="https://commits.webkit.org/266640@main">https://commits.webkit.org/266640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/667cebc56d183023c91e037459f1b249fe5a7183

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16737 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19885 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16245 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11436 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12872 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->