### PR TITLE
Integrate requestIdleCallback with HTML5 event loop and OpportunisticTaskScheduler

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1233,6 +1233,10 @@ http/wpt/html/browsers/browsing-the-web/navigating-across-documents/href.html
 # Content encoding sniffing is only supported by CFNetwork.
 http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Skip ]
 
+# Only supported on CF (Apple) WebKit2 ports for now.
+requestidlecallback [ Skip ]
+imported/w3c/web-platform-tests/requestidlecallback [ Skip ]
+
 # Only supported in WebKit2.
 http/wpt/cross-origin-resource-policy/ [ Skip ]
 
@@ -6203,9 +6207,6 @@ imported/w3c/web-platform-tests/payment-request/payment-is-showing.https.html [ 
 imported/w3c/web-platform-tests/permissions/permissions-query-feature-policy-attribute.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerlock/pointerevent_pointermove_in_pointerlock.html [ Skip ]
 imported/w3c/web-platform-tests/pointerlock/mouse_buttons_back_forward.html [ Skip ]
-imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods.html [ Skip ]
-imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls.html [ Skip ]
-imported/w3c/web-platform-tests/requestidlecallback/callback-xhr-sync.html [ Skip ]
 imported/w3c/web-platform-tests/resize-observer/observe.html [ Skip ]
 imported/w3c/web-platform-tests/resize-observer/svg.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/entry-attributes.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods-expected.txt
@@ -3,7 +3,5 @@ Test of requestIdleCallback idle period behavior
 This test validates that window.requestIdleCallback deals with callbacks during idle periods correctly.
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Check that if an idle callback calls requestIdleCallback the new callback doesn't run in the current idle period. Test timed out
+PASS Check that if an idle callback calls requestIdleCallback the new callback doesn't run in the current idle period.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS requestIdleCallback callbacks should be invoked in order (called iteratively)
-TIMEOUT requestIdleCallback callbacks should be invoked in order (called recursively) Test timed out
+PASS requestIdleCallback callbacks should be invoked in order (called recursively)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-xhr-sync-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-xhr-sync-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT re-schedule idle callbacks after sync xhr Test timed out
+PASS re-schedule idle callbacks after sync xhr
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -162,6 +162,9 @@ imported/w3c/web-platform-tests/file-system-access/ [ Pass ]
 imported/w3c/web-platform-tests/fs/ [ Pass ]
 storage/filesystemaccess/ [ Pass ]
 
+requestidlecallback [ Pass ]
+imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.
 #//////////////////////////////////////////////////////////////////////////////////////////
@@ -2119,8 +2122,6 @@ webkit.org/b/231631 [ Debug ] fast/selectors/case-insensitive-attribute-bascis.h
 webkit.org/b/231638 [ Debug ] webgl/pending/conformance/glsl/misc/shader-with-reserved-words-2.html [ Pass Timeout ]
 
 webkit.org/b/228127 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html [ Pass Crash Failure ]
-
-webkit.org/b/231684 [ Debug ] requestidlecallback/requestidlecallback-document-gc.html [ Pass Crash ]
 
 webkit.org/b/230509 fast/events/ios/dom-update-on-keydown-quirk.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -148,6 +148,9 @@ imported/w3c/web-platform-tests/file-system-access/ [ Pass ]
 imported/w3c/web-platform-tests/fs/ [ Pass ]
 storage/filesystemaccess/ [ Pass ]
 
+requestidlecallback [ Pass ]
+imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-expected.txt
@@ -4,9 +4,12 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS event.persisted is true
-PASS logs.length is 0
-PASS logs.length is 7
-PASS logs.join(", ") is "A1, B1, A2, B2, A3, B3, A4"
+PASS logsA.length is 0
+PASS logsB.length is 0
+PASS logsA.length is 4
+PASS logsA.join(", ") is "A1, A2, A3, A4"
+PASS logsB.length is 3
+PASS logsB.join(", ") is "B1, B2, B3"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html
@@ -11,7 +11,8 @@ const iframe = document.createElement('iframe');
 document.body.appendChild(iframe);
 
 let isInitialLoad = true;
-const logs = [];
+const logsA = [];
+const logsB = [];
 if (window.testRunner)
   setTimeout(() => testRunner.notifyDone(), 3000);
 
@@ -25,22 +26,25 @@ window.addEventListener("pageshow", function(event) {
       setTimeout(() => testRunner.notifyDone(), 3000);
 
     shouldBeTrue('event.persisted');
-    shouldBe('logs.length', '0');
-    iframe.contentWindow.requestIdleCallback(() => logs.push('B3'));
-    requestIdleCallback(() => logs.push('A4'));
+    shouldBe('logsA.length', '0');
+    shouldBe('logsB.length', '0');
+    iframe.contentWindow.requestIdleCallback(() => logsB.push('B3'));
+    requestIdleCallback(() => logsA.push('A4'));
     requestIdleCallback(() => {
-        shouldBe('logs.length', '7');
-        shouldBeEqualToString('logs.join(", ")', 'A1, B1, A2, B2, A3, B3, A4');
+        shouldBe('logsA.length', '4');
+        shouldBeEqualToString('logsA.join(", ")', 'A1, A2, A3, A4');
+        shouldBe('logsB.length', '3');
+        shouldBeEqualToString('logsB.join(", ")', 'B1, B2, B3');
         finishJSTest();
     });
 });
 
 window.addEventListener("pagehide", function(event) {
-    requestIdleCallback(() => logs.push('A1'));
-    iframe.contentWindow.requestIdleCallback(() => logs.push('B1'));
-    requestIdleCallback(() => logs.push('A2'));
-    iframe.contentWindow.requestIdleCallback(() => logs.push('B2'));
-    requestIdleCallback(() => logs.push('A3'));
+    requestIdleCallback(() => logsA.push('A1'));
+    iframe.contentWindow.requestIdleCallback(() => logsB.push('B1'));
+    requestIdleCallback(() => logsA.push('A2'));
+    iframe.contentWindow.requestIdleCallback(() => logsB.push('B2'));
+    requestIdleCallback(() => logsA.push('A3'));
 });
 
 onload = () => {

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-called-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-called-expected.txt
@@ -4,8 +4,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS requestIdleCallbackIsCalled is true
-PASS logs.length is 4
-PASS logs.join(", ") is "1.A1, 2.B1, 4.A2, 3.B2"
+PASS logsA.length is 2
+PASS logsA.join(", ") is "1.A1, 4.A2"
+PASS logsB.length is 2
+PASS logsB.join(", ") is "2.B1, 3.B2"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-called.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-called.html
@@ -10,35 +10,38 @@ jsTestIsAsync = true;
 
 requestIdleCallbackIsCalled = false;
 const iframe = document.createElement('iframe');
-const logs = [];
+const logsA = [];
+const logsB = [];
 
 iframe.onload = () => {
     requestIdleCallback(() => {
         requestIdleCallbackIsCalled = true;
-        logs.push('1.A1');
+        logsA.push('1.A1');
     });
 
     iframe.contentWindow.requestIdleCallback(() => {
         requestIdleCallbackIsCalled = true;
-        logs.push('2.B1');
+        logsB.push('2.B1');
     });
 
     iframe.contentWindow.requestIdleCallback(() => {
         requestIdleCallbackIsCalled = true;
-        logs.push('3.B2');
+        logsB.push('3.B2');
     });
 
     requestIdleCallback(() => {
         requestIdleCallbackIsCalled = true;
-        logs.push('4.A2');
+        logsA.push('4.A2');
     });
 }
 document.body.appendChild(iframe);
 
 setTimeout(() => {
     shouldBeTrue('requestIdleCallbackIsCalled');
-    shouldBe('logs.length', '4');
-    shouldBeEqualToString('logs.join(", ")', '1.A1, 2.B1, 4.A2, 3.B2');
+    shouldBe('logsA.length', '2');
+    shouldBeEqualToString('logsA.join(", ")', '1.A1, 4.A2');
+    shouldBe('logsB.length', '2');
+    shouldBeEqualToString('logsB.join(", ")', '2.B1, 3.B2');
     finishJSTest();
 }, 200);
 

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-not-called-when-canceled-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-not-called-when-canceled-expected.txt
@@ -4,8 +4,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS a3 is a2 + 1
-PASS logs.length is 3
-PASS logs.join(", ") is "1.A1, 3.A2, 4.A3"
+PASS logsA.length is 2
+PASS logsB.length is 1
+PASS logsA.join(", ") is "A1, A3"
+PASS logsB.join(", ") is "B1"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-not-called-when-canceled.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-not-called-when-canceled.html
@@ -9,26 +9,35 @@ description('This tests that when requestIdleCallback is enabled, requestIdleCal
 jsTestIsAsync = true;
 
 const iframe = document.createElement('iframe');
-const logs = [];
+const logsA = [];
+const logsB = [];
 
 iframe.onload = () => {
     requestIdleCallback(() => {
-        logs.push('1.A1');
-        iframe.contentWindow.cancelIdleCallback(b1);
+        logsA.push('A1');
+        cancelIdleCallback(b1);
     });
 
-    const b1 = iframe.contentWindow.requestIdleCallback(() => logs.push('2.B1'));
+    const b1 = iframe.contentWindow.requestIdleCallback(() => {
+        logsB.push('B1');
+        iframe.contentWindow.cancelIdleCallback(a3);
+        iframe.contentWindow.cancelIdleCallback(b2);
+    });
+    const b2 = iframe.contentWindow.requestIdleCallback(() => logsB.push('B2'));
 
-    window.a2 = requestIdleCallback(() => logs.push('3.A2'));
+    window.a2 = requestIdleCallback(() => logsA.push('A2'));
     cancelIdleCallback(a2 + 1);
-    window.a3 = requestIdleCallback(() => logs.push('4.A3'));
+    window.a3 = requestIdleCallback(() => logsA.push('A3'));
     shouldBe('a3', 'a2 + 1');
+    cancelIdleCallback(a2);
 }
 document.body.appendChild(iframe);
 
 setTimeout(() => {
-    shouldBe('logs.length', '3');
-    shouldBeEqualToString('logs.join(", ")', '1.A1, 3.A2, 4.A3');
+    shouldBe('logsA.length', '2');
+    shouldBe('logsB.length', '1');
+    shouldBeEqualToString('logsA.join(", ")', 'A1, A3');
+    shouldBeEqualToString('logsB.join(", ")', 'B1');
     finishJSTest();
 }, 200);
 

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -91,6 +91,9 @@ protected:
     void run();
     void clearAllTasks();
 
+    // FIXME: Account for fully-activeness of each document.
+    bool hasTasksForFullyActiveDocument() const { return !m_tasks.isEmpty(); }
+
 private:
     void scheduleToRunIfNeeded();
     virtual void scheduleToRun() = 0;

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "FrameDestructionObserverInlines.h"
 #include "IdleDeadline.h"
+#include "Timer.h"
 #include "WindowEventLoop.h"
 
 namespace WebCore {
@@ -40,17 +41,10 @@ IdleCallbackController::IdleCallbackController(Document& document)
 }
 int IdleCallbackController::queueIdleCallback(Ref<IdleRequestCallback>&& callback, Seconds)
 {
-    bool startIdlePeriod = m_idleRequestCallbacks.isEmpty() && m_runnableIdleCallbacks.isEmpty();
-
     ++m_idleCallbackIdentifier;
     auto handle = m_idleCallbackIdentifier;
 
     m_idleRequestCallbacks.append({ handle, WTFMove(callback) });
-
-    if (startIdlePeriod)
-        queueTaskToStartIdlePeriod();
-
-    // FIXME: Queue a task if timeout is positive.
 
     return handle;
 }
@@ -93,7 +87,9 @@ void IdleCallbackController::startIdlePeriod()
         m_runnableIdleCallbacks.append({ request.identifier, WTFMove(request.callback) });
     m_idleRequestCallbacks.clear();
 
-    ASSERT(!m_runnableIdleCallbacks.isEmpty());
+    if (m_runnableIdleCallbacks.isEmpty())
+        return;
+
     queueTaskToInvokeIdleCallbacks(deadline);
 
     m_lastDeadline = deadline;

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -45,9 +45,10 @@ public:
     int queueIdleCallback(Ref<IdleRequestCallback>&&, Seconds timeout);
     void removeIdleCallback(int);
 
+    void startIdlePeriod();
+
 private:
     void queueTaskToStartIdlePeriod();
-    void startIdlePeriod();
     void queueTaskToInvokeIdleCallbacks(MonotonicTime deadline);
     void invokeIdleCallbacks(MonotonicTime deadline);
 

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -45,6 +45,8 @@ public:
 
     WEBCORE_EXPORT void addCheckpointTask(std::unique_ptr<EventLoopTask>&&);
 
+    bool isEmpty() const { return m_microtaskQueue.isEmpty(); }
+
 private:
     JSC::VM& vm() const { return m_vm.get(); }
 

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -30,6 +30,7 @@
 #include "CustomElementReactionQueue.h"
 #include "Document.h"
 #include "HTMLSlotElement.h"
+#include "IdleCallbackController.h"
 #include "Microtasks.h"
 #include "MutationObserver.h"
 #include "SecurityOrigin.h"
@@ -113,6 +114,33 @@ MicrotaskQueue& WindowEventLoop::microtaskQueue()
     if (!m_microtaskQueue)
         m_microtaskQueue = makeUnique<MicrotaskQueue>(commonVM(), *this);
     return *m_microtaskQueue;
+}
+
+void WindowEventLoop::opportunisticallyRunIdleCallbacks()
+{
+    if (shouldEndIdlePeriod())
+        return;
+
+    forEachAssociatedContext([](ScriptExecutionContext& context) {
+        RefPtr document = dynamicDowncast<Document>(context);
+        if (!document)
+            return;
+        auto* idleCallbackController = document->idleCallbackController();
+        if (!idleCallbackController)
+            return;
+        idleCallbackController->startIdlePeriod();
+    });
+}
+
+bool WindowEventLoop::shouldEndIdlePeriod()
+{
+    if (hasTasksForFullyActiveDocument())
+        return true;
+    if (!microtaskQueue().isEmpty())
+        return true;
+    if (m_hasARenderingOpportunity)
+        return true;
+    return false;
 }
 
 void WindowEventLoop::didReachTimeToRun()

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -53,6 +53,11 @@ public:
 
     CustomElementQueue& backupElementQueue();
 
+    void didScheduleRenderingUpdate() { m_hasARenderingOpportunity = true; }
+    void didFinishRenderingUpdate() { m_hasARenderingOpportunity = false; }
+    void opportunisticallyRunIdleCallbacks();
+    bool shouldEndIdlePeriod();
+
     WEBCORE_EXPORT static void breakToAllowRenderingUpdate();
 
 private:
@@ -82,6 +87,8 @@ private:
 
     std::unique_ptr<CustomElementQueue> m_customElementQueue;
     bool m_processingBackupElementQueue { false };
+
+    bool m_hasARenderingOpportunity { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -173,6 +173,7 @@
 #include "WheelEventDeltaFilter.h"
 #include "WheelEventTestMonitor.h"
 #include "Widget.h"
+#include "WindowEventLoop.h"
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/VM.h>
 #include <wtf/FileSystem.h>
@@ -1685,9 +1686,12 @@ void Page::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps
 
 void Page::scheduleRenderingUpdateInternal()
 {
-    if (chrome().client().scheduleRenderingUpdate())
-        return;
-    renderingUpdateScheduler().scheduleRenderingUpdate();
+    if (!chrome().client().scheduleRenderingUpdate())
+        renderingUpdateScheduler().scheduleRenderingUpdate();
+
+    forEachWindowEventLoop([](WindowEventLoop& windowEventLoop) {
+        windowEventLoop.didScheduleRenderingUpdate();
+    });
 }
 
 void Page::didScheduleRenderingUpdate()
@@ -2034,8 +2038,13 @@ void Page::renderingUpdateCompleted()
         m_unfulfilledRequestedSteps = { };
     }
 
-    if (!isUtilityPage())
-        m_opportunisticTaskScheduler->reschedule(m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval());
+    if (!isUtilityPage()) {
+        auto nextRenderingUpdate = m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval();
+        forEachWindowEventLoop([&](WindowEventLoop& eventLoop) {
+            eventLoop.didFinishRenderingUpdate();
+        });
+        m_opportunisticTaskScheduler->reschedule(nextRenderingUpdate);
+    }
 }
 
 void Page::willStartRenderingUpdateDisplay()
@@ -3841,6 +3850,27 @@ void Page::forEachFrame(const Function<void(LocalFrame&)>& functor)
         functor(frame);
 }
 
+void Page::forEachWindowEventLoop(const Function<void(WindowEventLoop&)>& functor)
+{
+    HashSet<Ref<WindowEventLoop>> windowEventLoops;
+    WindowEventLoop* lastEventLoop = nullptr;
+    for (const Frame* frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        auto* document = localFrame->document();
+        if (!document)
+            continue;
+        Ref currentEventLoop = document->windowEventLoop();
+        if (lastEventLoop == currentEventLoop.ptr())
+            continue; // Common and faster than a hash table lookup
+        lastEventLoop = currentEventLoop.ptr();
+        windowEventLoops.add(WTFMove(currentEventLoop));
+    }
+    for (auto& eventLoop : windowEventLoops)
+        functor(eventLoop);
+}
+
 bool Page::allowsLoadFromURL(const URL& url, MainFrameMainResource mainFrameMainResource) const
 {
     if (mainFrameMainResource == MainFrameMainResource::No && !m_loadsSubresources)
@@ -4481,6 +4511,9 @@ void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::opt
 
 void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
 {
+    forEachWindowEventLoop([&](WindowEventLoop& eventLoop) {
+        eventLoop.opportunisticallyRunIdleCallbacks();
+    });
     commonVM().performOpportunisticallyScheduledTasks(deadline);
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -181,6 +181,7 @@ class VisitedLinkStore;
 class WebGLStateTracker;
 class WheelEventDeltaFilter;
 class WheelEventTestMonitor;
+class WindowEventLoop;
 
 struct AXTreeData;
 struct ApplePayAMSUIRequest;
@@ -989,6 +990,7 @@ public:
     void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);
     static void forEachDocumentFromMainFrame(const LocalFrame&, const Function<void(Document&)>&);
     void forEachFrame(const Function<void(LocalFrame&)>&);
+    void forEachWindowEventLoop(const Function<void(WindowEventLoop&)>&);
 
     bool shouldDisableCorsForRequestTo(const URL&) const;
     const HashSet<String>& maskedURLSchemes() const { return m_maskedURLSchemes; }


### PR DESCRIPTION
#### 03c76b1a950a2302989856fd66a4baa6fa6914cd
<pre>
Integrate requestIdleCallback with HTML5 event loop and OpportunisticTaskScheduler
<a href="https://bugs.webkit.org/show_bug.cgi?id=259850">https://bugs.webkit.org/show_bug.cgi?id=259850</a>

Reviewed by Yusuke Suzuki.

This PR integrates WebKit&apos;s implementation of requestIdleCallback with HTML5 event loop and Page&apos;s
OpportunisticTaskScheduler. It also skips the tests on non-CF (non-Apple) ports as RunLoopObserver,
which is used by OpportunisticTaskScheduler isn&apos;t implemented on non-CF ports.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-multiple-calls-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/callback-xhr-sync-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-expected.txt: Updated the test to not
test the order of execution of tasks scheduled across distinct frames as we no longer have any guarantee
across them (as spec&apos;ed).
* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html: Ditto.
* LayoutTests/requestidlecallback/requestidlecallback-is-not-called-when-canceled-expected.txt: Ditto.
* LayoutTests/requestidlecallback/requestidlecallback-is-not-called-when-canceled.html: Ditto.

* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoop::hasTasksForFullyActiveDocument const): Added.

* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback):
(WebCore::IdleCallbackController::startIdlePeriod):

* Source/WebCore/dom/IdleCallbackController.h:

* Source/WebCore/dom/IdleDeadline.cpp:
(WebCore::IdleDeadline::didTimeout const): Deleted.

* Source/WebCore/dom/IdleDeadline.h:
(WebCore::IdleDeadline::create): Now takes DidTimeout enum as an argument.
(WebCore::IdleDeadline::didTimeout const): Moved from cpp file. Now simply checks DidTimeout given to
the constructor.

* Source/WebCore/dom/Microtasks.h:
(WebCore::MicrotaskQueue::isEmpty): Added.

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::opportunisticallyRunIdleCallbacks): Added.
(WebCore::WindowEventLoop::shouldEndIdlePeriod): Added.

* Source/WebCore/dom/WindowEventLoop.h:
(WebCore::WindowEventLoop::didScheduleRenderingUpdate): Added.
(WebCore::WindowEventLoop::didFinishRenderingUpdate): Added.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::scheduleRenderingUpdateInternal): Added hooks for WindowEventLoop. This function is
used instead of didScheduleRenderingUpdate since the latter isn&apos;t called when the chrome client
scheduled the rendering update.
(WebCore::Page::doAfterUpdateRendering): Ditto.
(WebCore::Page::renderingUpdateCompleted):
(WebCore::Page::forEachWindowEventLoop): Added.
(WebCore::Page::performOpportunisticallyScheduledTasks): Call WindowEventLoop&apos;s
opportunisticallyRunIdleCallbacks to invoke idle callbacks.

* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/266622@main">https://commits.webkit.org/266622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd706c8860591a10efa36380ef8aa7635b98f597

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16214 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16766 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19910 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16272 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11462 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12758 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17237 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1706 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->