### PR TITLE
Convert ResourceRequest's firstPartyOrigin into a SecurityOriginData

### DIFF
--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -105,7 +105,7 @@ std::optional<ResourceRequest> ThreadableWebSocketChannel::webSocketConnectReque
     request.setHTTPUserAgent(document.userAgent(validatedURL->url));
     request.setDomainForCachePartition(document.domainForCachePartition());
     request.setAllowCookies(validatedURL->areCookiesAllowed);
-    request.setFirstPartyForCookies(document.firstPartyForCookies());
+    request.setFirstPartyOrigin(document.firstPartyForCookies());
     request.setHTTPHeaderField(HTTPHeaderName::Origin, document.securityOrigin().toString());
 
     if (auto* documentLoader = document.loader())

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -91,7 +91,7 @@ ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& reque
     preflightRequest.setHTTPMethod("OPTIONS"_s);
     preflightRequest.setHTTPHeaderField(HTTPHeaderName::AccessControlRequestMethod, request.httpMethod());
     preflightRequest.setPriority(request.priority());
-    preflightRequest.setFirstPartyForCookies(request.firstPartyForCookies());
+    preflightRequest.setFirstPartyOrigin(request.firstPartyOrigin());
     preflightRequest.setIsAppInitiated(request.isAppInitiated());
     if (!referrer.isNull())
         preflightRequest.setHTTPReferrer(referrer);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -704,7 +704,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
     // Update cookie policy base URL as URL changes, except for subframes, which use the
     // URL of the main frame which doesn't change when we redirect.
     if (m_frame->isMainFrame())
-        newRequest.setFirstPartyForCookies(newRequest.url());
+        newRequest.setFirstPartyOrigin(newRequest.url());
 
     FrameLoader::addSameSiteInfoToRequestIfNeeded(newRequest, m_frame->document());
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3069,7 +3069,7 @@ void FrameLoader::updateRequestAndAddExtraFields(ResourceRequest& request, IsMai
     // But make sure to set it on all requests regardless of protocol, as it has significance beyond the cookie policy (<rdar://problem/6616664>).
     bool isMainResource = mainResource == IsMainResource::Yes;
     bool isMainFrameMainResource = isMainResource && (m_frame.isMainFrame() || willOpenInNewWindow == WillOpenInNewWindow::Yes);
-    if (request.firstPartyOrigin().isEmpty()) {
+    if (request.firstPartyOrigin().isNull()) {
         if (isMainFrameMainResource)
             request.setFirstPartyOrigin(request.url());
         else if (Document* document = m_frame.document())

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -354,7 +354,7 @@ private:
 
     void loadProvisionalItemFromCachedPage();
 
-    void updateFirstPartyForCookies();
+    void updateFirstPartyOrigin();
     void setFirstPartyForCookies(const URL&);
 
     ResourceRequestCachePolicy defaultRequestCachingPolicy(const ResourceRequest&, FrameLoadType, bool isMainResource);

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -167,9 +167,9 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
     // up the 1st party for cookies URL and Same-Site info. Until plug-in implementations can be reigned in
     // to pipe through that method, we need to make sure there is always both a 1st party for cookies set and
     // Same-Site info. See <https://bugs.webkit.org/show_bug.cgi?id=26391>.
-    if (clientRequest.firstPartyForCookies().isNull()) {
+    if (clientRequest.firstPartyOrigin().isNull()) {
         if (Document* document = m_frame->document())
-            clientRequest.setFirstPartyForCookies(document->firstPartyForCookies());
+            clientRequest.setFirstPartyOrigin(document->firstPartyForCookies());
     }
     FrameLoader::addSameSiteInfoToRequestIfNeeded(clientRequest, m_frame->document());
 

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -220,7 +220,7 @@ void Coder<WebCore::ResourceRequest>::encode(Encoder& encoder, const WebCore::Re
     ASSERT(!instance.platformRequestUpdated());
     encoder << instance.url();
     encoder << instance.timeoutInterval();
-    encoder << instance.firstPartyForCookies().string();
+    encoder << instance.firstPartyOrigin().string();
     encoder << instance.httpMethod();
     encoder << instance.httpHeaderFields();
     encoder << instance.responseContentDispositionEncodingFallbackArray();
@@ -245,9 +245,9 @@ std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decode(
     if (!timeoutInterval)
         return std::nullopt;
 
-    std::optional<String> firstPartyForCookies;
-    decoder >> firstPartyForCookies;
-    if (!firstPartyForCookies)
+    std::optional<String> firstPartyOrigin;
+    decoder >> firstPartyOrigin;
+    if (!firstPartyOrigin)
         return std::nullopt;
 
     std::optional<String> httpMethod;
@@ -303,7 +303,7 @@ std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decode(
     WebCore::ResourceRequest request;
     request.setURL(WTFMove(*url));
     request.setTimeoutInterval(WTFMove(*timeoutInterval));
-    request.setFirstPartyForCookies(URL({ }, *firstPartyForCookies));
+    request.setFirstPartyOrigin(URL({ }, *firstPartyOrigin));
     request.setHTTPMethod(WTFMove(*httpMethod));
     request.setHTTPHeaderFields(WTFMove(*fields));
     request.setResponseContentDispositionEncodingFallbackArray(WTFMove(*array));

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -220,7 +220,7 @@ void Coder<WebCore::ResourceRequest>::encode(Encoder& encoder, const WebCore::Re
     ASSERT(!instance.platformRequestUpdated());
     encoder << instance.url();
     encoder << instance.timeoutInterval();
-    encoder << instance.firstPartyOrigin().string();
+    encoder << instance.firstPartyOrigin();
     encoder << instance.httpMethod();
     encoder << instance.httpHeaderFields();
     encoder << instance.responseContentDispositionEncodingFallbackArray();
@@ -245,7 +245,7 @@ std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decode(
     if (!timeoutInterval)
         return std::nullopt;
 
-    std::optional<String> firstPartyOrigin;
+    std::optional<WebCore::SecurityOriginData> firstPartyOrigin;
     decoder >> firstPartyOrigin;
     if (!firstPartyOrigin)
         return std::nullopt;
@@ -303,7 +303,7 @@ std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decode(
     WebCore::ResourceRequest request;
     request.setURL(WTFMove(*url));
     request.setTimeoutInterval(WTFMove(*timeoutInterval));
-    request.setFirstPartyOrigin(URL({ }, *firstPartyOrigin));
+    request.setFirstPartyOrigin(*firstPartyOrigin);
     request.setHTTPMethod(WTFMove(*httpMethod));
     request.setHTTPHeaderFields(WTFMove(*fields));
     request.setResponseContentDispositionEncodingFallbackArray(WTFMove(*array));

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -167,7 +167,7 @@ void MediaPlayerPrivateWebM::load(const String& url)
 
     ResourceRequest request(url);
     request.setAllowCookies(true);
-    request.setFirstPartyForCookies(URL(url));
+    request.setFirstPartyOrigin(URL(url));
 
     auto loader = player->createResourceLoader();
     m_resourceClient = WebMResourceClient::create(*this, *loader, WTFMove(request));

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -348,7 +348,7 @@ CacheControlDirectives parseCacheControlDirectives(const HTTPHeaderMap& headers)
 
 static String cookieRequestHeaderFieldValue(const NetworkStorageSession& session, const ResourceRequest& request)
 {
-    return session.cookieRequestHeaderFieldValue(request.firstPartyForCookies(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No, ApplyTrackingPrevention::Yes, ShouldRelaxThirdPartyCookieBlocking::No).first;
+    return session.cookieRequestHeaderFieldValue(request.firstPartyOrigin(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No, ApplyTrackingPrevention::Yes, ShouldRelaxThirdPartyCookieBlocking::No).first;
 }
 
 static String cookieRequestHeaderFieldValue(const CookieJar* cookieJar, const ResourceRequest& request)
@@ -356,7 +356,7 @@ static String cookieRequestHeaderFieldValue(const CookieJar* cookieJar, const Re
     if (!cookieJar)
         return { };
 
-    return cookieJar->cookieRequestHeaderFieldValue(request.firstPartyForCookies(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No).first;
+    return cookieJar->cookieRequestHeaderFieldValue(request.firstPartyOrigin(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No).first;
 }
 
 static String headerValueForVary(const ResourceRequest& request, StringView headerName, Function<String()>&& cookieRequestHeaderFieldValueFunction)

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -348,7 +348,7 @@ CacheControlDirectives parseCacheControlDirectives(const HTTPHeaderMap& headers)
 
 static String cookieRequestHeaderFieldValue(const NetworkStorageSession& session, const ResourceRequest& request)
 {
-    return session.cookieRequestHeaderFieldValue(request.firstPartyOrigin(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No, ApplyTrackingPrevention::Yes, ShouldRelaxThirdPartyCookieBlocking::No).first;
+    return session.cookieRequestHeaderFieldValue(request.firstPartyOrigin().toURL(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No, ApplyTrackingPrevention::Yes, ShouldRelaxThirdPartyCookieBlocking::No).first;
 }
 
 static String cookieRequestHeaderFieldValue(const CookieJar* cookieJar, const ResourceRequest& request)
@@ -356,7 +356,7 @@ static String cookieRequestHeaderFieldValue(const CookieJar* cookieJar, const Re
     if (!cookieJar)
         return { };
 
-    return cookieJar->cookieRequestHeaderFieldValue(request.firstPartyOrigin(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No).first;
+    return cookieJar->cookieRequestHeaderFieldValue(request.firstPartyOrigin().toURL(), SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No).first;
 }
 
 static String headerValueForVary(const ResourceRequest& request, StringView headerName, Function<String()>&& cookieRequestHeaderFieldValueFunction)

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -131,10 +131,10 @@ bool NetworkStorageSession::hasHadUserInteractionAsFirstParty(const RegistrableD
 
 bool NetworkStorageSession::shouldBlockCookies(const ResourceRequest& request, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
 {
-    return shouldBlockCookies(request.firstPartyForCookies(), request.url(), frameID, pageID, shouldRelaxThirdPartyCookieBlocking);
+    return shouldBlockCookies(request.firstPartyOrigin(), request.url(), frameID, pageID, shouldRelaxThirdPartyCookieBlocking);
 }
     
-bool NetworkStorageSession::shouldBlockCookies(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
+bool NetworkStorageSession::shouldBlockCookies(const URL& firstPartyOrigin, const URL& resource, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
 {
     if (shouldRelaxThirdPartyCookieBlocking == ShouldRelaxThirdPartyCookieBlocking::Yes)
         return false;
@@ -142,7 +142,7 @@ bool NetworkStorageSession::shouldBlockCookies(const URL& firstPartyForCookies, 
     if (!m_isTrackingPreventionEnabled)
         return false;
 
-    RegistrableDomain firstPartyDomain { firstPartyForCookies };
+    RegistrableDomain firstPartyDomain { firstPartyOrigin };
     if (firstPartyDomain.isEmpty())
         return false;
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -136,6 +136,11 @@ bool NetworkStorageSession::shouldBlockCookies(const ResourceRequest& request, s
     
 bool NetworkStorageSession::shouldBlockCookies(const URL& firstPartyOrigin, const URL& resource, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
 {
+    return shouldBlockCookies(SecurityOriginData::fromURL(firstPartyOrigin), resource, frameID, pageID, shouldRelaxThirdPartyCookieBlocking);
+}
+
+bool NetworkStorageSession::shouldBlockCookies(const SecurityOriginData& firstPartyOrigin, const URL& resource, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
+{
     if (shouldRelaxThirdPartyCookieBlocking == ShouldRelaxThirdPartyCookieBlocking::Yes)
         return false;
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -194,6 +194,7 @@ public:
     WEBCORE_EXPORT bool trackingPreventionDebugLoggingEnabled() const;
     WEBCORE_EXPORT bool shouldBlockCookies(const ResourceRequest&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;
     WEBCORE_EXPORT bool shouldBlockCookies(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;
+    WEBCORE_EXPORT bool shouldBlockCookies(const SecurityOriginData& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;
     WEBCORE_EXPORT bool shouldBlockThirdPartyCookies(const RegistrableDomain&) const;
     WEBCORE_EXPORT bool shouldBlockThirdPartyCookiesButKeepFirstPartyCookiesFor(const RegistrableDomain&) const;
     WEBCORE_EXPORT void setAllCookiesToSameSiteStrict(const RegistrableDomain&, CompletionHandler<void()>&&);

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -232,7 +232,7 @@ void ResourceRequestBase::setTimeoutInterval(double timeoutInterval)
     m_platformRequestUpdated = false;
 }
 
-const URL& ResourceRequestBase::firstPartyOrigin() const
+const SecurityOriginData& ResourceRequestBase::firstPartyOrigin() const
 {
     updateResourceRequest(); 
     
@@ -240,6 +240,11 @@ const URL& ResourceRequestBase::firstPartyOrigin() const
 }
 
 void ResourceRequestBase::setFirstPartyOrigin(const URL& firstPartyOrigin)
+{
+    setFirstPartyOrigin(SecurityOriginData::fromURL(firstPartyOrigin));
+}
+
+void ResourceRequestBase::setFirstPartyOrigin(const SecurityOriginData& firstPartyOrigin)
 { 
     updateResourceRequest(); 
 
@@ -829,7 +834,7 @@ String ResourceRequestBase::partitionName(const String& domain)
 
 bool ResourceRequestBase::isThirdParty() const
 {
-    return !areRegistrableDomainsEqual(url(), firstPartyOrigin());
+    return !areRegistrableDomainsEqual(url(), firstPartyOrigin().toURL());
 }
 
 }

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -63,7 +63,7 @@ void ResourceRequestBase::setAsIsolatedCopy(const ResourceRequest& other)
     setURL(other.url().isolatedCopy());
     setCachePolicy(other.cachePolicy());
     setTimeoutInterval(other.timeoutInterval());
-    setFirstPartyForCookies(other.firstPartyForCookies().isolatedCopy());
+    setFirstPartyOrigin(other.firstPartyOrigin().isolatedCopy());
     setHTTPMethod(other.httpMethod().isolatedCopy());
     setPriority(other.priority());
     setRequester(other.requester());
@@ -232,21 +232,21 @@ void ResourceRequestBase::setTimeoutInterval(double timeoutInterval)
     m_platformRequestUpdated = false;
 }
 
-const URL& ResourceRequestBase::firstPartyForCookies() const
+const URL& ResourceRequestBase::firstPartyOrigin() const
 {
     updateResourceRequest(); 
     
-    return m_requestData.m_firstPartyForCookies;
+    return m_requestData.m_firstPartyOrigin;
 }
 
-void ResourceRequestBase::setFirstPartyForCookies(const URL& firstPartyForCookies)
+void ResourceRequestBase::setFirstPartyOrigin(const URL& firstPartyOrigin)
 { 
     updateResourceRequest(); 
 
-    if (m_requestData.m_firstPartyForCookies == firstPartyForCookies)
+    if (m_requestData.m_firstPartyOrigin == firstPartyOrigin)
         return;
 
-    m_requestData.m_firstPartyForCookies = firstPartyForCookies;
+    m_requestData.m_firstPartyOrigin = firstPartyOrigin;
     
     m_platformRequestUpdated = false;
 }
@@ -674,7 +674,7 @@ bool equalIgnoringHeaderFields(const ResourceRequestBase& a, const ResourceReque
     if (a.timeoutInterval() != b.timeoutInterval())
         return false;
     
-    if (a.firstPartyForCookies() != b.firstPartyForCookies())
+    if (a.firstPartyOrigin() != b.firstPartyOrigin())
         return false;
 
     if (a.isSameSite() != b.isSameSite())
@@ -829,7 +829,7 @@ String ResourceRequestBase::partitionName(const String& domain)
 
 bool ResourceRequestBase::isThirdParty() const
 {
-    return !areRegistrableDomainsEqual(url(), firstPartyForCookies());
+    return !areRegistrableDomainsEqual(url(), firstPartyOrigin());
 }
 
 }

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -66,9 +66,9 @@ public:
     struct RequestData {
         RequestData() { }
         
-        RequestData(const URL& url, const URL& firstPartyForCookies, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false)
+        RequestData(const URL& url, const URL& firstPartyOrigin, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false)
             : m_url(url)
-            , m_firstPartyForCookies(firstPartyForCookies)
+            , m_firstPartyOrigin(firstPartyOrigin)
             , m_timeoutInterval(timeoutInterval)
             , m_httpMethod(httpMethod)
             , m_httpHeaderFields(httpHeaderFields)
@@ -92,7 +92,8 @@ public:
         }
         
         URL m_url;
-        URL m_firstPartyForCookies;
+        // FIXME: This should be a SecurityOriginData.
+        URL m_firstPartyOrigin;
         double m_timeoutInterval { s_defaultTimeoutInterval }; // 0 is a magic value for platform default on platforms that have one.
         String m_httpMethod { "GET"_s };
         HTTPHeaderMap m_httpHeaderFields;
@@ -140,8 +141,8 @@ public:
     WEBCORE_EXPORT double timeoutInterval() const; // May return 0 when using platform default.
     WEBCORE_EXPORT void setTimeoutInterval(double);
     
-    WEBCORE_EXPORT const URL& firstPartyForCookies() const;
-    WEBCORE_EXPORT void setFirstPartyForCookies(const URL&);
+    WEBCORE_EXPORT const URL& firstPartyOrigin() const;
+    WEBCORE_EXPORT void setFirstPartyOrigin(const URL&);
 
     WEBCORE_EXPORT bool isThirdParty() const;
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -32,6 +32,7 @@
 #include "HTTPHeaderMap.h"
 #include "IntRect.h"
 #include "ResourceLoadPriority.h"
+#include "SecurityOriginData.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
 
@@ -66,7 +67,7 @@ public:
     struct RequestData {
         RequestData() { }
         
-        RequestData(const URL& url, const URL& firstPartyOrigin, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false)
+        RequestData(const URL& url, const SecurityOriginData& firstPartyOrigin, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false)
             : m_url(url)
             , m_firstPartyOrigin(firstPartyOrigin)
             , m_timeoutInterval(timeoutInterval)
@@ -92,8 +93,7 @@ public:
         }
         
         URL m_url;
-        // FIXME: This should be a SecurityOriginData.
-        URL m_firstPartyOrigin;
+        SecurityOriginData m_firstPartyOrigin;
         double m_timeoutInterval { s_defaultTimeoutInterval }; // 0 is a magic value for platform default on platforms that have one.
         String m_httpMethod { "GET"_s };
         HTTPHeaderMap m_httpHeaderFields;
@@ -141,8 +141,9 @@ public:
     WEBCORE_EXPORT double timeoutInterval() const; // May return 0 when using platform default.
     WEBCORE_EXPORT void setTimeoutInterval(double);
     
-    WEBCORE_EXPORT const URL& firstPartyOrigin() const;
+    WEBCORE_EXPORT const SecurityOriginData& firstPartyOrigin() const;
     WEBCORE_EXPORT void setFirstPartyOrigin(const URL&);
+    WEBCORE_EXPORT void setFirstPartyOrigin(const SecurityOriginData&);
 
     WEBCORE_EXPORT bool isThirdParty() const;
 

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -168,7 +168,7 @@ void ResourceRequest::doUpdateResourceRequest()
     if (m_requestData.m_cachePolicy == ResourceRequestCachePolicy::UseProtocolCachePolicy)
         m_requestData.m_cachePolicy = fromPlatformRequestCachePolicy([m_nsRequest cachePolicy]);
     m_requestData.m_timeoutInterval = [m_nsRequest timeoutInterval];
-    m_requestData.m_firstPartyOrigin = [m_nsRequest mainDocumentURL];
+    m_requestData.m_firstPartyOrigin = SecurityOriginData::fromURL([m_nsRequest mainDocumentURL]);
 
     URL siteForCookies { [m_nsRequest _propertyForKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"] };
     m_requestData.m_sameSiteDisposition = siteForCookies.isNull() ? SameSiteDisposition::Unspecified : (areRegistrableDomainsEqual(siteForCookies, m_requestData.m_url) ? SameSiteDisposition::SameSite : SameSiteDisposition::CrossSite);
@@ -291,7 +291,7 @@ void ResourceRequest::doUpdatePlatformRequest()
         [nsRequest setTimeoutInterval:timeoutInterval];
     // Otherwise, respect NSURLRequest default timeout.
 
-    [nsRequest setMainDocumentURL:firstPartyOrigin()];
+    [nsRequest setMainDocumentURL:firstPartyOrigin().toURL()];
     if (!httpMethod().isEmpty())
         [nsRequest setHTTPMethod:httpMethod()];
     [nsRequest setHTTPShouldHandleCookies:allowCookies()];

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -168,7 +168,7 @@ void ResourceRequest::doUpdateResourceRequest()
     if (m_requestData.m_cachePolicy == ResourceRequestCachePolicy::UseProtocolCachePolicy)
         m_requestData.m_cachePolicy = fromPlatformRequestCachePolicy([m_nsRequest cachePolicy]);
     m_requestData.m_timeoutInterval = [m_nsRequest timeoutInterval];
-    m_requestData.m_firstPartyForCookies = [m_nsRequest mainDocumentURL];
+    m_requestData.m_firstPartyOrigin = [m_nsRequest mainDocumentURL];
 
     URL siteForCookies { [m_nsRequest _propertyForKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"] };
     m_requestData.m_sameSiteDisposition = siteForCookies.isNull() ? SameSiteDisposition::Unspecified : (areRegistrableDomainsEqual(siteForCookies, m_requestData.m_url) ? SameSiteDisposition::SameSite : SameSiteDisposition::CrossSite);
@@ -291,7 +291,7 @@ void ResourceRequest::doUpdatePlatformRequest()
         [nsRequest setTimeoutInterval:timeoutInterval];
     // Otherwise, respect NSURLRequest default timeout.
 
-    [nsRequest setMainDocumentURL:firstPartyForCookies()];
+    [nsRequest setMainDocumentURL:firstPartyOrigin()];
     if (!httpMethod().isEmpty())
         [nsRequest setHTTPMethod:httpMethod()];
     [nsRequest setHTTPShouldHandleCookies:allowCookies()];

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -67,8 +67,9 @@ GRefPtr<SoupMessage> ResourceRequest::createSoupMessage(BlobRegistryImpl& blobRe
 
     updateSoupMessageHeaders(soup_message_get_request_headers(soupMessage.get()));
 
-    if (firstPartyOrigin().protocolIsInHTTPFamily()) {
-        if (auto firstParty = urlToSoupURI(firstPartyOrigin()))
+    auto firstPartyOrigin = firstPartyOrigin().toURL();
+    if (firstPartyOrigin.protocolIsInHTTPFamily()) {
+        if (auto firstParty = urlToSoupURI(firstPartyOrigin))
             soup_message_set_first_party(soupMessage.get(), firstParty.get());
     }
 

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -67,8 +67,8 @@ GRefPtr<SoupMessage> ResourceRequest::createSoupMessage(BlobRegistryImpl& blobRe
 
     updateSoupMessageHeaders(soup_message_get_request_headers(soupMessage.get()));
 
-    if (firstPartyForCookies().protocolIsInHTTPFamily()) {
-        if (auto firstParty = urlToSoupURI(firstPartyForCookies()))
+    if (firstPartyOrigin().protocolIsInHTTPFamily()) {
+        if (auto firstParty = urlToSoupURI(firstPartyOrigin()))
             soup_message_set_first_party(soupMessage.get(), firstParty.get());
     }
 

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -554,7 +554,7 @@ ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorke
 
     request.setDomainForCachePartition(jobData.domainForCachePartition);
     request.setAllowCookies(true);
-    request.setFirstPartyForCookies(originURL(topOrigin));
+    request.setFirstPartyOrigin(originURL(topOrigin));
 
     request.setHTTPHeaderField(HTTPHeaderName::Origin, origin->toString());
     request.setHTTPReferrer(originURL(origin).string());

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -99,10 +99,10 @@ ResourceRequest EarlyHintsResourceLoader::constructPreconnectRequest(const Resou
 {
     ResourceRequest request { url };
 
-    // firstPartyForCookies and user agent are part of the HTTP socket pool keys in CFNetwork: rdar://59434166
-    auto firstPartyForCookies = originalRequest.firstPartyForCookies();
-    if (firstPartyForCookies.isValid())
-        request.setFirstPartyForCookies(firstPartyForCookies);
+    // firstPartyOrigin and user agent are part of the HTTP socket pool keys in CFNetwork: rdar://59434166
+    auto firstPartyOrigin = originalRequest.firstPartyOrigin();
+    if (firstPartyOrigin.isValid())
+        request.setFirstPartyOrigin(firstPartyOrigin);
 
     auto userAgent = originalRequest.httpUserAgent();
     if (!userAgent.isEmpty())

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -101,7 +101,7 @@ ResourceRequest EarlyHintsResourceLoader::constructPreconnectRequest(const Resou
 
     // firstPartyOrigin and user agent are part of the HTTP socket pool keys in CFNetwork: rdar://59434166
     auto firstPartyOrigin = originalRequest.firstPartyOrigin();
-    if (firstPartyOrigin.isValid())
+    if (!firstPartyOrigin.isNull())
         request.setFirstPartyOrigin(firstPartyOrigin);
 
     auto userAgent = originalRequest.httpUserAgent();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -499,7 +499,7 @@ void NetworkConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, I
 
 void NetworkConnectionToWebProcess::createSocketChannel(const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
-    NETWORK_PROCESS_MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()));
+    NETWORK_PROCESS_MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyOrigin()));
 
     ASSERT(!m_networkSocketChannels.contains(identifier));
     if (auto channel = NetworkSocketChannel::create(*this, m_sessionID, request, protocol, identifier, webPageProxyID, frameID, pageID, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, advancedPrivacyProtections, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy))
@@ -559,7 +559,7 @@ std::unique_ptr<ServiceWorkerFetchTask> NetworkConnectionToWebProcess::createFet
 
 void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadParameters&& loadParameters, std::optional<NetworkResourceLoadIdentifier> existingLoaderToResume)
 {
-    NETWORK_PROCESS_MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()));
+    NETWORK_PROCESS_MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyOrigin()));
 
     CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.object().toUInt64(), loadParameters.identifier.toUInt64(), valueOrDefault(existingLoaderToResume).toUInt64());
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -434,6 +434,11 @@ bool NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier proce
     });
 }
 
+bool NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, const SecurityOriginData& firstPartyOrigin)
+{
+    return allowsFirstPartyForCookies(processIdentifier, RegistrableDomain { firstPartyOrigin });
+}
+
 bool NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, const RegistrableDomain& firstPartyDomain)
 {
     if (!decltype(m_allowedFirstPartiesForCookies)::isValidKey(processIdentifier)) {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -418,6 +418,7 @@ public:
 
     bool allowsFirstPartyForCookies(WebCore::ProcessIdentifier, const URL&);
     bool allowsFirstPartyForCookies(WebCore::ProcessIdentifier, const RegistrableDomain&);
+    bool allowsFirstPartyForCookies(WebCore::ProcessIdentifier, const WebCore::SecurityOriginData&);
     void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, WebCore::RegistrableDomain&&, LoadedWebArchive, CompletionHandler<void()>&&);
     void webProcessWillLoadWebArchive(WebCore::ProcessIdentifier);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1777,7 +1777,7 @@ void NetworkResourceLoader::logCookieInformation() const
     auto* networkStorageSession = m_connection->networkProcess().storageSession(sessionID());
     ASSERT(networkStorageSession);
 
-    logCookieInformation(m_connection, "NetworkResourceLoader"_s, reinterpret_cast<const void*>(this), *networkStorageSession, originalRequest().firstPartyOrigin(), SameSiteInfo::create(originalRequest()), originalRequest().url(), originalRequest().httpReferrer(), frameID(), pageID(), coreIdentifier());
+    logCookieInformation(m_connection, "NetworkResourceLoader"_s, reinterpret_cast<const void*>(this), *networkStorageSession, originalRequest().firstPartyOrigin().toURL(), SameSiteInfo::create(originalRequest()), originalRequest().url(), originalRequest().httpReferrer(), frameID(), pageID(), coreIdentifier());
 }
 
 static void logBlockedCookieInformation(NetworkConnectionToWebProcess& connection, ASCIILiteral label, const void* loggedObject, const WebCore::NetworkStorageSession& networkStorageSession, const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, const String& referrer, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, std::optional<WebCore::ResourceLoaderIdentifier> identifier)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1177,7 +1177,7 @@ void NetworkResourceLoader::willSendRedirectedRequestInternal(ResourceRequest&& 
     if (auto result = WebCore::PrivateClickMeasurement::parseAttributionRequest(redirectRequest.url())) {
         privateClickMeasurementAttributionTriggerData = result.value();
         if (privateClickMeasurementAttributionTriggerData)
-            privateClickMeasurementAttributionTriggerData->destinationSite = WebCore::RegistrableDomain { request.firstPartyForCookies() };
+            privateClickMeasurementAttributionTriggerData->destinationSite = WebCore::RegistrableDomain { request.firstPartyOrigin() };
     } else if (!result.error().isEmpty())
         addConsoleMessage(MessageSource::PrivateClickMeasurement, MessageLevel::Error, result.error());
 
@@ -1777,7 +1777,7 @@ void NetworkResourceLoader::logCookieInformation() const
     auto* networkStorageSession = m_connection->networkProcess().storageSession(sessionID());
     ASSERT(networkStorageSession);
 
-    logCookieInformation(m_connection, "NetworkResourceLoader"_s, reinterpret_cast<const void*>(this), *networkStorageSession, originalRequest().firstPartyForCookies(), SameSiteInfo::create(originalRequest()), originalRequest().url(), originalRequest().httpReferrer(), frameID(), pageID(), coreIdentifier());
+    logCookieInformation(m_connection, "NetworkResourceLoader"_s, reinterpret_cast<const void*>(this), *networkStorageSession, originalRequest().firstPartyOrigin(), SameSiteInfo::create(originalRequest()), originalRequest().url(), originalRequest().httpReferrer(), frameID(), pageID(), coreIdentifier());
 }
 
 static void logBlockedCookieInformation(NetworkConnectionToWebProcess& connection, ASCIILiteral label, const void* loggedObject, const WebCore::NetworkStorageSession& networkStorageSession, const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, const String& referrer, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, std::optional<WebCore::ResourceLoaderIdentifier> identifier)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -91,7 +91,7 @@ static inline ResourceRequest constructRevalidationRequest(const Key& key, const
 {
     ResourceRequest revalidationRequest(key.identifier());
     revalidationRequest.setHTTPHeaderFields(subResourceInfo.requestHeaders());
-    revalidationRequest.setFirstPartyForCookies(subResourceInfo.firstPartyForCookies());
+    revalidationRequest.setFirstPartyOrigin(subResourceInfo.firstPartyForCookies());
     revalidationRequest.setIsSameSite(subResourceInfo.isSameSite());
     revalidationRequest.setIsTopSite(subResourceInfo.isTopSite());
     revalidationRequest.setIsAppInitiated(subResourceInfo.isAppInitiated());

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -85,7 +85,7 @@ SubresourceInfo::SubresourceInfo(const Key& key, const WebCore::ResourceRequest&
     , m_isTransient(!previousInfo)
     , m_isSameSite(request.isSameSite())
     , m_isAppInitiated(request.isAppInitiated())
-    , m_firstPartyForCookies(request.firstPartyOrigin())
+    , m_firstPartyForCookies(request.firstPartyOrigin().toURL())
     , m_requestHeaders(request.httpHeaderFields())
     , m_priority(request.priority())
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -85,7 +85,7 @@ SubresourceInfo::SubresourceInfo(const Key& key, const WebCore::ResourceRequest&
     , m_isTransient(!previousInfo)
     , m_isSameSite(request.isSameSite())
     , m_isAppInitiated(request.isAppInitiated())
-    , m_firstPartyForCookies(request.firstPartyForCookies())
+    , m_firstPartyForCookies(request.firstPartyOrigin())
     , m_requestHeaders(request.httpHeaderFields())
     , m_priority(request.priority())
 {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -229,7 +229,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 
     if (parameters.isMainFrameNavigation
         || parameters.hadMainFrameMainResourcePrivateRelayed
-        || request.url().host() == request.firstPartyForCookies().host()) {
+        || request.url().host() == request.firstPartyOrigin().host()) {
         if ([mutableRequest respondsToSelector:@selector(_setPrivacyProxyFailClosedForUnreachableNonMainHosts:)])
             [mutableRequest _setPrivacyProxyFailClosedForUnreachableNonMainHosts:YES];
     }
@@ -457,7 +457,7 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
     }
 
     if (isTopLevelNavigation())
-        request.setFirstPartyForCookies(request.url());
+        request.setFirstPartyOrigin(request.url());
 
     NetworkTaskCocoa::willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = ThreadSafeWeakPtr { *this }, redirectResponse] (auto&& request) mutable {
         auto strongThis = weakThis.get();

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1592,7 +1592,7 @@ SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(WebPageProxyIdentifie
 
 #if ENABLE(TRACKING_PREVENTION)
     if (auto* storageSession = networkStorageSession()) {
-        auto firstParty = WebCore::RegistrableDomain(request.firstPartyForCookies());
+        auto firstParty = WebCore::RegistrableDomain(request.firstPartyOrigin());
         if (storageSession->shouldBlockThirdPartyCookiesButKeepFirstPartyCookiesFor(firstParty))
             return sessionSetForPage(webPageProxyID).isolatedSession(storedCredentialsPolicy, firstParty, shouldBeConsideredAppBound, *this);
     } else

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -129,7 +129,7 @@ void NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking(const WebCore::Res
     // Cap expiry of incoming cookies in response if it is a same-site
     // subresource but it resolves to a different CNAME than the top
     // site request, a.k.a. third-party CNAME cloaking.
-    auto firstPartyURL = request.firstPartyForCookies();
+    auto firstPartyURL = request.firstPartyOrigin();
     auto firstPartyHostName = firstPartyURL.host().toString();
     auto firstPartyHostCNAME = m_networkSession->firstPartyHostCNAMEDomain(firstPartyHostName);
     auto firstPartyAddress = m_networkSession->firstPartyHostIPAddress(firstPartyHostName);
@@ -233,7 +233,7 @@ void NetworkTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& re
         if (storedCredentialsPolicy() == WebCore::StoredCredentialsPolicy::EphemeralStateless
             || (m_networkSession->networkStorageSession() && m_networkSession->networkStorageSession()->shouldBlockCookies(request, frameID(), pageID(), m_shouldRelaxThirdPartyCookieBlocking)))
             blockCookies();
-    } else if (storedCredentialsPolicy() != WebCore::StoredCredentialsPolicy::EphemeralStateless && needsFirstPartyCookieBlockingLatchModeQuirk(request.firstPartyForCookies(), request.url(), redirectResponse.url()))
+    } else if (storedCredentialsPolicy() != WebCore::StoredCredentialsPolicy::EphemeralStateless && needsFirstPartyCookieBlockingLatchModeQuirk(request.firstPartyOrigin(), request.url(), redirectResponse.url()))
         unblockCookies();
 #if !RELEASE_LOG_DISABLED
     if (m_networkSession->shouldLogCookieInformation())

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -529,7 +529,7 @@ void NetworkDataTaskCurl::restartWithCredential(const ProtectionSpace& protectio
 void NetworkDataTaskCurl::appendCookieHeader(WebCore::ResourceRequest& request)
 {
     auto includeSecureCookies = request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
-    auto cookieHeaderField = m_session->networkStorageSession()->cookieRequestHeaderFieldValue(request.firstPartyForCookies(), WebCore::SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, includeSecureCookies, ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
+    auto cookieHeaderField = m_session->networkStorageSession()->cookieRequestHeaderFieldValue(request.firstPartyOrigin(), WebCore::SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, includeSecureCookies, ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
     if (!cookieHeaderField.isEmpty())
         request.addHTTPHeaderField(HTTPHeaderName::Cookie, cookieHeaderField);
 }
@@ -541,7 +541,7 @@ void NetworkDataTaskCurl::handleCookieHeaders(const WebCore::ResourceRequest& re
     for (auto header : response.headers) {
         if (header.startsWithIgnoringASCIICase(setCookieHeader)) {
             String setCookieString = header.right(header.length() - setCookieHeader.length());
-            m_session->networkStorageSession()->setCookiesFromHTTPResponse(request.firstPartyForCookies(), response.url, setCookieString);
+            m_session->networkStorageSession()->setCookiesFromHTTPResponse(request.firstPartyOrigin(), response.url, setCookieString);
         }
     }
 }
@@ -576,7 +576,7 @@ bool NetworkDataTaskCurl::shouldBlockCookies(const WebCore::ResourceRequest& req
 
 bool NetworkDataTaskCurl::isThirdPartyRequest(const WebCore::ResourceRequest& request)
 {
-    return !WebCore::areRegistrableDomainsEqual(request.url(), request.firstPartyForCookies());
+    return !WebCore::areRegistrableDomainsEqual(request.url(), request.firstPartyOrigin());
 }
 
 void NetworkDataTaskCurl::updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics& networkLoadMetrics)

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -529,7 +529,7 @@ void NetworkDataTaskCurl::restartWithCredential(const ProtectionSpace& protectio
 void NetworkDataTaskCurl::appendCookieHeader(WebCore::ResourceRequest& request)
 {
     auto includeSecureCookies = request.url().protocolIs("https"_s) ? IncludeSecureCookies::Yes : IncludeSecureCookies::No;
-    auto cookieHeaderField = m_session->networkStorageSession()->cookieRequestHeaderFieldValue(request.firstPartyOrigin(), WebCore::SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, includeSecureCookies, ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
+    auto cookieHeaderField = m_session->networkStorageSession()->cookieRequestHeaderFieldValue(request.firstPartyOrigin().toURL(), WebCore::SameSiteInfo::create(request), request.url(), std::nullopt, std::nullopt, includeSecureCookies, ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
     if (!cookieHeaderField.isEmpty())
         request.addHTTPHeaderField(HTTPHeaderName::Cookie, cookieHeaderField);
 }
@@ -541,7 +541,7 @@ void NetworkDataTaskCurl::handleCookieHeaders(const WebCore::ResourceRequest& re
     for (auto header : response.headers) {
         if (header.startsWithIgnoringASCIICase(setCookieHeader)) {
             String setCookieString = header.right(header.length() - setCookieHeader.length());
-            m_session->networkStorageSession()->setCookiesFromHTTPResponse(request.firstPartyOrigin(), response.url, setCookieString);
+            m_session->networkStorageSession()->setCookiesFromHTTPResponse(request.firstPartyOrigin().toURL(), response.url, setCookieString);
         }
     }
 }
@@ -576,7 +576,7 @@ bool NetworkDataTaskCurl::shouldBlockCookies(const WebCore::ResourceRequest& req
 
 bool NetworkDataTaskCurl::isThirdPartyRequest(const WebCore::ResourceRequest& request)
 {
-    return !WebCore::areRegistrableDomainsEqual(request.url(), request.firstPartyOrigin());
+    return !WebCore::areRegistrableDomainsEqual(request.url(), request.firstPartyOrigin().toURL());
 }
 
 void NetworkDataTaskCurl::updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics& networkLoadMetrics)

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -108,7 +108,7 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
 
     if (m_request.allowCookies()) {
         auto includeSecureCookies = m_request.url().protocolIs("wss"_s) ? WebCore::IncludeSecureCookies::Yes : WebCore::IncludeSecureCookies::No;
-        auto cookieHeaderField = m_channel.session()->networkStorageSession()->cookieRequestHeaderFieldValue(m_request.firstPartyForCookies(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
+        auto cookieHeaderField = m_channel.session()->networkStorageSession()->cookieRequestHeaderFieldValue(m_request.firstPartyOrigin(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
         if (!cookieHeaderField.isEmpty())
             cookieHeader = makeString("Cookie: "_s, cookieHeaderField, "\r\n"_s).utf8();
     }
@@ -263,7 +263,7 @@ Expected<bool, String> WebSocketTask::validateOpeningHandshake()
 
     auto serverSetCookie = m_handshake->serverSetCookie();
     if (!serverSetCookie.isEmpty())
-        m_channel.session()->networkStorageSession()->setCookiesFromHTTPResponse(m_request.firstPartyForCookies(), m_request.url(), serverSetCookie);
+        m_channel.session()->networkStorageSession()->setCookiesFromHTTPResponse(m_request.firstPartyOrigin(), m_request.url(), serverSetCookie);
 
     m_state = State::Opened;
     m_didCompleteOpeningHandshake = true;

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -958,7 +958,7 @@ void NetworkDataTaskSoup::continueHTTPRedirection()
     request.removeCredentials();
 
     if (isTopLevelNavigation())
-        request.setFirstPartyForCookies(request.url());
+        request.setFirstPartyOrigin(request.url());
 
     if (isCrossOrigin) {
         // The network layer might carry over some headers from the original request that
@@ -1579,11 +1579,11 @@ bool NetworkDataTaskSoup::shouldAllowHSTSPolicySetting() const
     //  "Limit HSTS State to the Hostname, or the Top Level Domain + 1"
 #if ENABLE(PUBLIC_SUFFIX_LIST)
     return isTopLevelNavigation()
-        || m_currentRequest.url().host() == m_currentRequest.firstPartyForCookies().host()
+        || m_currentRequest.url().host() == m_currentRequest.firstPartyOrigin().host()
         || isPublicSuffix(m_currentRequest.url().host());
 #else
     return isTopLevelNavigation()
-        || m_currentRequest.url().host() == m_currentRequest.firstPartyForCookies().host();
+        || m_currentRequest.url().host() == m_currentRequest.firstPartyOrigin().host();
 #endif
 }
 

--- a/Source/WebKit/Shared/API/c/WKURLRequest.cpp
+++ b/Source/WebKit/Shared/API/c/WKURLRequest.cpp
@@ -48,7 +48,7 @@ WKURLRef WKURLRequestCopyURL(WKURLRequestRef requestRef)
 
 WKURLRef WKURLRequestCopyFirstPartyForCookies(WKURLRequestRef requestRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(requestRef)->resourceRequest().firstPartyOrigin());
+    return WebKit::toCopiedURLAPI(WebKit::toImpl(requestRef)->resourceRequest().firstPartyOrigin().toURL());
 }
 
 WKStringRef WKURLRequestCopyHTTPMethod(WKURLRequestRef requestRef)

--- a/Source/WebKit/Shared/API/c/WKURLRequest.cpp
+++ b/Source/WebKit/Shared/API/c/WKURLRequest.cpp
@@ -48,7 +48,7 @@ WKURLRef WKURLRequestCopyURL(WKURLRequestRef requestRef)
 
 WKURLRef WKURLRequestCopyFirstPartyForCookies(WKURLRequestRef requestRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(requestRef)->resourceRequest().firstPartyForCookies());
+    return WebKit::toCopiedURLAPI(WebKit::toImpl(requestRef)->resourceRequest().firstPartyOrigin());
 }
 
 WKStringRef WKURLRequestCopyHTTPMethod(WKURLRequestRef requestRef)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1775,7 +1775,7 @@ header: <WebCore/FrameLoaderTypes.h>
 header: <WebCore/ResourceRequest.h>
 [CustomHeader, Nested] class WebCore::ResourceRequest::RequestData {
     URL m_url;
-    URL m_firstPartyOrigin;
+    WebCore::SecurityOriginData m_firstPartyOrigin;
     double m_timeoutInterval;
     String m_httpMethod;
     WebCore::HTTPHeaderMap m_httpHeaderFields;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1775,7 +1775,7 @@ header: <WebCore/FrameLoaderTypes.h>
 header: <WebCore/ResourceRequest.h>
 [CustomHeader, Nested] class WebCore::ResourceRequest::RequestData {
     URL m_url;
-    URL m_firstPartyForCookies;
+    URL m_firstPartyOrigin;
     double m_timeoutInterval;
     String m_httpMethod;
     WebCore::HTTPHeaderMap m_httpHeaderFields;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -56,10 +56,10 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
 {
     NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([this, &task, protectedThis = Ref { *this }, protectedTask = Ref { task }]() {
         // If a frame is loading, the frame request URL will be an empty string, since the request is actually the frame URL being loaded.
-        // In this case, consider the firstPartyForCookies() to be the document including the frame. This fails for nested frames, since
+        // In this case, consider the firstPartyOrigin() to be the document including the frame. This fails for nested frames, since
         // it is always the main frame URL, not the immediate parent frame.
         // FIXME: <rdar://problem/59193765> Remove this workaround when there is a way to know the proper parent frame.
-        URL frameDocumentURL = task.frameInfo().request().url().isEmpty() ? task.request().firstPartyForCookies() : task.frameInfo().request().url();
+        URL frameDocumentURL = task.frameInfo().request().url().isEmpty() ? task.request().firstPartyOrigin() : task.frameInfo().request().url();
         URL requestURL = task.request().url();
 
         if (!m_webExtensionController) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -59,7 +59,7 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         // In this case, consider the firstPartyOrigin() to be the document including the frame. This fails for nested frames, since
         // it is always the main frame URL, not the immediate parent frame.
         // FIXME: <rdar://problem/59193765> Remove this workaround when there is a way to know the proper parent frame.
-        URL frameDocumentURL = task.frameInfo().request().url().isEmpty() ? task.request().firstPartyOrigin() : task.frameInfo().request().url();
+        URL frameDocumentURL = task.frameInfo().request().url().isEmpty() ? task.request().firstPartyOrigin().toURL() : task.frameInfo().request().url();
         URL requestURL = task.request().url();
 
         if (!m_webExtensionController) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5359,7 +5359,7 @@ void WebPageProxy::preconnectTo(ResourceRequest&& request)
             request.setHTTPUserAgent(WTFMove(userAgent));
         }
     }
-    request.setFirstPartyForCookies(request.url());
+    request.setFirstPartyOrigin(request.url());
     request.setPriority(ResourceLoadPriority::VeryHigh);
     websiteDataStore().networkProcess().preconnectTo(sessionID(), identifier(), webPageID(), WTFMove(request), storedCredentialsPolicy, isNavigatingToAppBoundDomain());
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2392,7 +2392,7 @@ void WebsiteDataStore::download(const DownloadProxy& downloadProxy, const String
 {
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     WebCore::ResourceRequest updatedRequest(downloadProxy.request());
-    // Request's firstPartyForCookies will be used as Original URL of the download request.
+    // Request's firstPartyOrigin will be used as Original URL of the download request.
     // We set the value to top level document's URL.
     if (auto* initiatingPage = downloadProxy.originatingPage()) {
 #if ENABLE(APP_BOUND_DOMAINS)
@@ -2400,12 +2400,12 @@ void WebsiteDataStore::download(const DownloadProxy& downloadProxy, const String
 #endif
 
         URL initiatingPageURL = URL { initiatingPage->pageLoadState().url() };
-        updatedRequest.setFirstPartyForCookies(initiatingPageURL);
+        updatedRequest.setFirstPartyOrigin(initiatingPageURL);
         updatedRequest.setIsSameSite(WebCore::areRegistrableDomainsEqual(initiatingPageURL, downloadProxy.request().url()));
         if (!updatedRequest.hasHTTPHeaderField(WebCore::HTTPHeaderName::UserAgent))
             updatedRequest.setHTTPUserAgent(initiatingPage->userAgentForURL(downloadProxy.request().url()));
     } else {
-        updatedRequest.setFirstPartyForCookies(URL());
+        updatedRequest.setFirstPartyOrigin(URL());
         updatedRequest.setIsSameSite(false);
         if (!updatedRequest.hasHTTPHeaderField(WebCore::HTTPHeaderName::UserAgent))
             updatedRequest.setHTTPUserAgent(WebPageProxy::standardUserAgent());

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -530,7 +530,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         existingNetworkResourceLoadIdentifierToResume = std::exchange(m_existingNetworkResourceLoadIdentifierToResume, std::nullopt);
     WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64 ")", static_cast<int>(resourceLoader.request().priority()), valueOrDefault(existingNetworkResourceLoadIdentifierToResume).toUInt64());
 
-    if (frame && !frame->settings().siteIsolationEnabled() && !WebProcess::singleton().allowsFirstPartyForCookies(loadParameters.request.firstPartyForCookies()))
+    if (frame && !frame->settings().siteIsolationEnabled() && !WebProcess::singleton().allowsFirstPartyForCookies(loadParameters.request.firstPartyOrigin()))
         RELEASE_LOG_FAULT(IPC, "scheduleLoad: Process will terminate due to failed allowsFirstPartyForCookies check");
 
     if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(loadParameters, existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {
@@ -901,9 +901,9 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
     auto* mainFrame = dynamicDowncast<WebCore::LocalFrame>(webPage.mainFrame());
     if (auto* document = mainFrame ? mainFrame->document() : nullptr) {
         if (shouldPreconnectAsFirstParty == ShouldPreconnectAsFirstParty::Yes)
-            request.setFirstPartyForCookies(request.url());
+            request.setFirstPartyOrigin(request.url());
         else
-            request.setFirstPartyForCookies(document->firstPartyForCookies());
+            request.setFirstPartyOrigin(document->firstPartyForCookies());
         if (auto* loader = document->loader())
             request.setIsAppInitiated(loader->lastNavigationWasAppInitiated());
     }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -530,7 +530,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         existingNetworkResourceLoadIdentifierToResume = std::exchange(m_existingNetworkResourceLoadIdentifierToResume, std::nullopt);
     WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64 ")", static_cast<int>(resourceLoader.request().priority()), valueOrDefault(existingNetworkResourceLoadIdentifierToResume).toUInt64());
 
-    if (frame && !frame->settings().siteIsolationEnabled() && !WebProcess::singleton().allowsFirstPartyForCookies(loadParameters.request.firstPartyOrigin()))
+    if (frame && !frame->settings().siteIsolationEnabled() && !WebProcess::singleton().allowsFirstPartyForCookies(loadParameters.request.firstPartyOrigin().toURL()))
         RELEASE_LOG_FAULT(IPC, "scheduleLoad: Process will terminate due to failed allowsFirstPartyForCookies check");
 
     if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(loadParameters, existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {


### PR DESCRIPTION
#### 44eb6de71d7b12259035b4c1e167cdf610b4603e
<pre>
Convert ResourceRequest&apos;s firstPartyOrigin into a SecurityOriginData
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::encode):
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::decode):
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::cookieRequestHeaderFieldValue):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::shouldBlockCookies const):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::firstPartyOrigin const):
(WebCore::ResourceRequestBase::setFirstPartyOrigin):
(WebCore::ResourceRequestBase::isThirdParty const):
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
* Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp:
(WebCore::ResourceRequest::createSoupMessage const):
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
(WebKit::EarlyHintsResourceLoader::constructPreconnectRequest):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::logCookieInformation const):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::handlePrivateClickMeasurementConversion):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp:
(WebKit::NetworkCache::SubresourceInfo::SubresourceInfo):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking):
(NetworkTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::appendCookieHeader):
(WebKit::NetworkDataTaskCurl::handleCookieHeaders):
(WebKit::NetworkDataTaskCurl::isThirdPartyRequest):
* Source/WebKit/Shared/API/c/WKURLRequest.cpp:
(WKURLRequestCopyFirstPartyForCookies):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
</pre>
----------------------------------------------------------------------
#### 0b3f9de5ccd29312e7e36c021e9866cc8641f451
<pre>
Rename ResourceRequest&apos;s firstPartyForCookies to firstPartyOrigin
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Other classes have similar members, but this is only changing ResourceRequest.

* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::webSocketConnectRequest):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createAccessControlPreflightRequest):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::updateFirstPartyOrigin):
(WebCore::FrameLoader::open):
(WebCore::FrameLoader::setOriginalURLForDownloadRequest):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::updateFirstPartyForCookies): Deleted.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::init):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::encode):
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::decode):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::load):
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::cookieRequestHeaderFieldValue):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::shouldBlockCookies const):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::setAsIsolatedCopy):
(WebCore::ResourceRequestBase::firstPartyOrigin const):
(WebCore::ResourceRequestBase::setFirstPartyOrigin):
(WebCore::equalIgnoringHeaderFields):
(WebCore::ResourceRequestBase::isThirdParty const):
(WebCore::ResourceRequestBase::firstPartyForCookies const): Deleted.
(WebCore::ResourceRequestBase::setFirstPartyForCookies): Deleted.
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
* Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp:
(WebCore::ResourceRequest::createSoupMessage const):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::createScriptRequest):
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
(WebKit::EarlyHintsResourceLoader::constructPreconnectRequest):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::createSocketChannel):
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allowsFirstPartyForCookies):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
(WebKit::NetworkResourceLoader::logCookieInformation const):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::handlePrivateClickMeasurementConversion):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::constructRevalidationRequest):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp:
(WebKit::NetworkCache::SubresourceInfo::SubresourceInfo):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::sessionWrapperForTask):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking):
(NetworkTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::appendCookieHeader):
(WebKit::NetworkDataTaskCurl::handleCookieHeaders):
(WebKit::NetworkDataTaskCurl::isThirdPartyRequest):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::didOpen):
(WebKit::WebSocketTask::validateOpeningHandshake):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::continueHTTPRedirection):
(WebKit::NetworkDataTaskSoup::shouldAllowHSTSPolicySetting const):
* Source/WebKit/Shared/API/c/WKURLRequest.cpp:
(WKURLRequestCopyFirstPartyForCookies):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::preconnectTo):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::download):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::preconnectTo):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44eb6de71d7b12259035b4c1e167cdf610b4603e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14938 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16023 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13523 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14675 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/16023 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14464 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15016 "2 new passes 54 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12117 "2 api tests failed or timed out") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16743 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12301 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12878 "6 flakes 5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16743 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13378 "2 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13042 "16 flakes 1 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16743 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13591 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11440 "Exiting early after 60 failures. 58426 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->