### PR TITLE
Add hysteresis to RenderLayerCompositor's compositing policy.

### DIFF
--- a/LayoutTests/compositing/layer-creation/compositing-policy-hysteresis-expected.txt
+++ b/LayoutTests/compositing/layer-creation/compositing-policy-hysteresis-expected.txt
@@ -1,0 +1,91 @@
+transform: translate3d(10px, 1px, 1px)
+Has backing under low memory.
+transform: translateZ(0)
+translateZ(0): No backing under low memory.
+transform: translate3d(10px, 1px, 0)
+No backing under low memory.
+will-change: transform
+No backing under low memory.
+ initial
+================================
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+        (GraphicsLayer
+          (position 18.00 128.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 18.00 246.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 0.00 1.00])
+        )
+        (GraphicsLayer
+          (position 18.00 364.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+after memory warning
+================================
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+      )
+    )
+  )
+)
+memory warning cleared (PASS if same number of layers as "after memory warning")
+================================
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/compositing-policy-hysteresis.html
+++ b/LayoutTests/compositing/layer-creation/compositing-policy-hysteresis.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        body {
+            overflow:hidden; /* prevent scrollbars and document height from affecting test output */
+            height: 1000px;
+        }
+        body.changed .test {
+            overflow:hidden;
+            width:50%;
+            height:1002px;
+        }
+        .box {
+            margin: 10px;
+            height: 100px;
+            width: 300px;
+            padding: 4px;
+            background-color: silver;
+        }
+    </style>
+    <script>
+        var log = "";
+        if (window.testRunner)
+            window.testRunner.dumpAsText();
+
+        function logLayers(comment)
+        {
+            if (!window.testRunner)
+                return;
+            log += `${comment}\n================================\n${window.internals.layerTreeAsText(document)}`;
+        }
+
+        function dumpLayers()
+        {
+            let canvas = document.getElementsByTagName('canvas')[0];
+            var ctx = canvas.getContext('2d');
+            ctx.fillStyle = 'white';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            document.getElementById("layers").innerText = log;
+        }
+
+        function tryForceLayout()
+        {
+            document.body.classList.toggle("changed");
+        }
+
+        function start()
+        {
+            if (!window.internals)
+                return;
+
+            // WKTR will reset to a consistent state after running a test. Part of that is
+            // forcing a CompositingPolicy override ("normal"). This means that if you run
+            // this test with `run-webkit-tests --iterations 2` (or anything greater than 1)
+            // we will be forced into CompositingPolicy::Normal and this test will fail.
+            // This clears any override that may be present on the page.
+            window.internals.compositingPolicyOverride = null;
+
+            logLayers('initial');
+
+            window.internals.beginSimulatedMemoryWarning();
+            tryForceLayout();
+            logLayers('after memory warning');
+
+            window.internals.endSimulatedMemoryWarning();
+            tryForceLayout();
+            logLayers('memory warning cleared (PASS if same number of layers as "after memory warning")');
+
+            dumpLayers();
+        }
+
+        window.addEventListener('load', start, false);
+    </script>
+</head>
+<body>
+
+<div class="box" style="transform: translate3d(10px, 1px, 1px)">
+    <pre>transform: translate3d(10px, 1px, 1px)</pre>
+    Has backing under low memory.
+</div>
+
+<div class="box" style="transform: translateZ(0)">
+    <pre>transform: translateZ(0)</pre>
+    translateZ(0): No backing under low memory.
+</div>
+
+<div class="box" style="transform: translate3d(10px, 1px, 0)">
+    <pre>transform: translate3d(10px, 1px, 0)</pre>
+    No backing under low memory.
+</div>
+
+<div class="box" style="will-change: transform">
+    <pre>will-change: transform</pre>
+    No backing under low memory.
+</div>
+
+<canvas class="box" style="box-shadow: 0 0 10px black">
+</canvas>
+
+<pre id="layers"></pre>
+
+</body>
+</html>

--- a/LayoutTests/platform/mac/compositing/layer-creation/compositing-policy-hysteresis-expected.txt
+++ b/LayoutTests/platform/mac/compositing/layer-creation/compositing-policy-hysteresis-expected.txt
@@ -1,0 +1,103 @@
+transform: translate3d(10px, 1px, 1px)
+Has backing under low memory.
+transform: translateZ(0)
+translateZ(0): No backing under low memory.
+transform: translate3d(10px, 1px, 0)
+No backing under low memory.
+will-change: transform
+No backing under low memory.
+ initial
+================================
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+        (GraphicsLayer
+          (position 18.00 128.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 18.00 246.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 0.00 1.00])
+        )
+        (GraphicsLayer
+          (position 18.00 364.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+after memory warning
+================================
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+        (GraphicsLayer
+          (position 18.00 364.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+memory warning cleared (PASS if same number of layers as "after memory warning")
+================================
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 1018.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 1018.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [10.00 1.00 1.00 1.00])
+        )
+        (GraphicsLayer
+          (position 18.00 364.00)
+          (bounds 308.00 108.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -462,10 +462,13 @@ static inline bool layersLogEnabled()
 }
 #endif
 
+static constexpr Seconds conservativeCompositingPolicyHysteresisDuration { 2_s };
+
 RenderLayerCompositor::RenderLayerCompositor(RenderView& renderView)
     : m_renderView(renderView)
     , m_updateCompositingLayersTimer(*this, &RenderLayerCompositor::updateCompositingLayersTimerFired)
     , m_updateRenderingTimer(*this, &RenderLayerCompositor::scheduleRenderingUpdate)
+    , m_compositingPolicyHysteresis([](PAL::HysteresisState) { }, conservativeCompositingPolicyHysteresisDuration)
 {
 #if PLATFORM(IOS_FAMILY)
     if (m_renderView.frameView().platformWidget())
@@ -594,6 +597,9 @@ bool RenderLayerCompositor::updateCompositingPolicy()
         return m_compositingPolicy != currentPolicy;
     }
 
+    if (!canUpdateCompositingPolicy())
+        return false;
+
     const auto isCurrentlyUnderMemoryPressureOrWarning = [] {
         return MemoryPressureHandler::singleton().isUnderMemoryPressure() || MemoryPressureHandler::singleton().isUnderMemoryWarning();
     };
@@ -608,7 +614,17 @@ bool RenderLayerCompositor::updateCompositingPolicy()
     }
 
     m_compositingPolicy = cachedMemoryPolicy == WTF::MemoryUsagePolicy::Unrestricted ? CompositingPolicy::Normal : CompositingPolicy::Conservative;
-    return m_compositingPolicy != currentPolicy;
+
+    bool didChangePolicy = currentPolicy != m_compositingPolicy;
+    if (didChangePolicy && m_compositingPolicy == CompositingPolicy::Conservative)
+        m_compositingPolicyHysteresis.impulse();
+
+    return didChangePolicy;
+}
+
+bool RenderLayerCompositor::canUpdateCompositingPolicy() const
+{
+    return m_compositingPolicyHysteresis.state() == PAL::HysteresisState::Stopped;
 }
 
 bool RenderLayerCompositor::canRender3DTransforms() const

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -29,6 +29,7 @@
 #include "GraphicsLayerClient.h"
 #include "LayerAncestorClippingStack.h"
 #include "RenderLayer.h"
+#include <pal/HysteresisActivity.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 
@@ -388,6 +389,7 @@ private:
 
     // Returns true if the policy changed.
     bool updateCompositingPolicy();
+    bool canUpdateCompositingPolicy() const;
     
     // GraphicsLayerClient implementation
     void paintContents(const GraphicsLayer*, GraphicsContext&, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>) override;
@@ -571,6 +573,7 @@ private:
     bool m_hasAcceleratedCompositing { true };
     
     CompositingPolicy m_compositingPolicy { CompositingPolicy::Normal };
+    PAL::HysteresisActivity m_compositingPolicyHysteresis;
 
     bool m_showDebugBorders { false };
     bool m_showRepaintCounter { false };


### PR DESCRIPTION
#### bf6398b824c5bc0f5a274231301914d5d8524c99
<pre>
Add hysteresis to RenderLayerCompositor&apos;s compositing policy.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259865">https://bugs.webkit.org/show_bug.cgi?id=259865</a>
rdar://113342477

Reviewed by Simon Fraser.

RenderLayerCompositor::updateCompositingPolicy will change compositing policy when memory
pressure status has changed (266497@main). It is possible that we could bounce between
Conservative and Normal policies multiple times per second. Consider
this example:

1) We enter a memory warning and so move to Conservative, deallocating
   layer backing memory.
2) This deallocation brings us just below the threshold for memory
   warning.
3) We see this status change and return to Normal, creating new layers
   and reallocating layer backing memory.
4) This reallocation brings us back into memory warning (goto 1).

To avoid this situation this patch adds a HysteresisActivity to the
RenderLayerCompositor. Whenever we change to Conservative compositing
mode we impulse the activity and will not change compositing policy
until after the activity has stopped. Currently that means we wait 2s
after switching to a Conservative policy before allowing ourselves to switch back
to a Normal policy. We don&apos;t block ourselves from switching from Normal
to Conservative though since that can cause us to respond to system
memory pressure too slowly.

* LayoutTests/compositing/layer-creation/compositing-policy-hysteresis-expected.txt: Added.
* LayoutTests/compositing/layer-creation/compositing-policy-hysteresis.html: Added.
* LayoutTests/platform/mac/compositing/layer-creation/compositing-policy-hysteresis-expected.txt: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::RenderLayerCompositor):
(WebCore::RenderLayerCompositor::updateCompositingPolicy):
(WebCore::RenderLayerCompositor::canUpdateCompositingPolicy const):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/266738@main">https://commits.webkit.org/266738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e026875e4564a281a05dc28990305908dfd51f3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14999 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17088 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13173 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16580 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3525 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->