### PR TITLE
[JSC] Support Intl.NumberFormat's FormatApproximately operation

### DIFF
--- a/JSTests/stress/intl-numberformat-approximately-sign.js
+++ b/JSTests/stress/intl-numberformat-approximately-sign.js
@@ -1,0 +1,24 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + " " + expected);
+}
+
+var fmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+if (fmt.formatRange && fmt.formatRangeToParts) {
+    if ($vm.icuVersion() < 71) {
+        shouldBe(fmt.formatRange(42, 42), `~$42`);
+        shouldBe(fmt.formatRange(41.999, 42.195), `~$42`);
+        shouldBe(JSON.stringify(fmt.formatRangeToParts(42, 42)), `[{"type":"currency","value":"$","source":"shared"},{"type":"integer","value":"42","source":"shared"}]`);
+        shouldBe(JSON.stringify(fmt.formatRangeToParts(41.999, 42.195)), `[{"type":"currency","value":"$","source":"shared"},{"type":"integer","value":"42","source":"shared"}]`);
+    } else {
+        shouldBe(fmt.formatRange(42, 42), `~$42`);
+        shouldBe(fmt.formatRange(41.999, 42.195), `~$42`);
+        shouldBe(JSON.stringify(fmt.formatRangeToParts(42, 42)), `[{"type":"approximatelySign","value":"~","source":"shared"},{"type":"currency","value":"$","source":"shared"},{"type":"integer","value":"42","source":"shared"}]`);
+        shouldBe(JSON.stringify(fmt.formatRangeToParts(41.999, 42.195)), `[{"type":"approximatelySign","value":"~","source":"shared"},{"type":"currency","value":"$","source":"shared"},{"type":"integer","value":"42","source":"shared"}]`);
+    }
+}


### PR DESCRIPTION
#### 7e05da12ab1da52fe09ec20a4157240cab4457d9
<pre>
[JSC] Support Intl.NumberFormat&apos;s FormatApproximately operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=259869">https://bugs.webkit.org/show_bug.cgi?id=259869</a>
rdar://113461245

Reviewed by Mark Lam.

This patch supports Intl.NumberFormats&apos;s FormatApproximately operation[1].
This happens when start and end are *practically-equal* (spec-term) like `formatRangeToParts(1, 1)`.

The problem is that this approximatelySign formatRangeToParts parsing is only supported after ICU 71.
In this patch, we switch the implementation at runtime, and we support FormatApproximately only when
it is ICU 71~. Otherwise, we go to the old path.

[1]: <a href="https://tc39.es/ecma402/#sec-formatapproximately">https://tc39.es/ecma402/#sec-formatapproximately</a>

* JSTests/stress/intl-numberformat-approximately-sign.js: Added.
(shouldBe):
(vm.icuVersion):
(else.shouldBe.JSON.stringify.fmt.formatRangeToParts):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::partTypeString):
(JSC::IntlNumberFormat::formatRangeToParts const):

Canonical link: <a href="https://commits.webkit.org/266645@main">https://commits.webkit.org/266645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01150d79e98a8f396702d52b4a231399ac501dab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16106 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14754 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15086 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16824 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12371 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/12955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12293 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13448 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13656 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11511 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14410 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12955 "Failed to checkout and rebase branch from PR 16429") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3733 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14798 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1714 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/3550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->