### PR TITLE
[WebCodecs] AudioDecoder and AudioData support

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6273,6 +6273,31 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any
 imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.html [ DumpJSConsoleLogInStdErr ]
 
+# AudioDecoder and AudioData implementation missing.
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?adts_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp4_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?opus [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_alaw [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_mulaw [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?adts_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp4_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?opus [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_alaw [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_mulaw [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any.worker.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any.html [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any.worker.html [ Failure ]
+
 webkit.org/b/258192 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h264_avc [ Pass Failure ]
 
 # These tests crash in debug since their import.

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Verify closing AudioData does not propagate accross contexts. Can't find variable: AudioData
-FAIL Verify posting closed AudioData throws. Can't find variable: AudioData
-FAIL Verify transferring audio data closes them. Can't find variable: AudioData
+PASS Verify closing AudioData does not propagate accross contexts.
+PASS Verify posting closed AudioData throws.
+PASS Verify transferring audio data closes them.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.any-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Verify AudioData constructors Can't find variable: AudioData
-FAIL Verify closing and cloning AudioData Can't find variable: AudioData
-FAIL Test we can construct AudioData with a negative timestamp. Can't find variable: AudioData
-FAIL Test conversion of uint8 data to float32 Can't find variable: AudioData
-FAIL Test conversion of int16 data to float32 Can't find variable: AudioData
-FAIL Test conversion of int32 data to float32 Can't find variable: AudioData
-FAIL Test conversion of float32 data to float32 Can't find variable: AudioData
-FAIL Test copying out planar and interleaved data Can't find variable: AudioData
+PASS Verify AudioData constructors
+PASS Verify closing and cloning AudioData
+PASS Test we can construct AudioData with a negative timestamp.
+PASS Test conversion of uint8 data to float32
+PASS Test conversion of int16 data to float32
+PASS Test conversion of int32 data to float32
+PASS Test conversion of float32 data to float32
+PASS Test copying out planar and interleaved data
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Verify AudioData constructors Can't find variable: AudioData
-FAIL Verify closing and cloning AudioData Can't find variable: AudioData
-FAIL Test we can construct AudioData with a negative timestamp. Can't find variable: AudioData
-FAIL Test conversion of uint8 data to float32 Can't find variable: AudioData
-FAIL Test conversion of int16 data to float32 Can't find variable: AudioData
-FAIL Test conversion of int32 data to float32 Can't find variable: AudioData
-FAIL Test conversion of float32 data to float32 Can't find variable: AudioData
-FAIL Test copying out planar and interleaved data Can't find variable: AudioData
+PASS Verify AudioData constructors
+PASS Verify closing and cloning AudioData
+PASS Test we can construct AudioData with a negative timestamp.
+PASS Test conversion of uint8 data to float32
+PASS Test conversion of int16 data to float32
+PASS Test conversion of int32 data to float32
+PASS Test conversion of float32 data to float32
+PASS Test copying out planar and interleaved data
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Can't find variable: AudioData
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Can't find variable: AudioData
+FAIL Test construction and copyTo() using a SharedArrayBuffer Type error
+FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Type error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer Can't find variable: AudioDecoder
-FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) Can't find variable: AudioDecoder
+FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer Can't find variable: AudioDecoder
-FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) Can't find variable: AudioDecoder
+FAIL Test isConfigSupported() and configure() using a SharedArrayBuffer promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Test isConfigSupported() and configure() using a Uint8Array(SharedArrayBuffer) promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
@@ -1,18 +1,14 @@
 
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Empty codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Unrecognized codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Video codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Ambiguous codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Codec with MIME type Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Empty codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Unrecognized codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Video codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Ambiguous codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Codec with MIME type Can't find variable: AudioDecoder
-FAIL Test AudioDecoder construction assert_throws_js: function "() => {
-    new AudioDecoder({});
-  }" threw object "ReferenceError: Can't find variable: AudioDecoder" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Verify unconfigured AudioDecoder operations Can't find variable: AudioDecoder
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Empty codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Unrecognized codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Video codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
+PASS Test that AudioDecoder.configure() rejects invalid config:Empty codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Unrecognized codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Video codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Ambiguous codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Codec with MIME type
+PASS Test AudioDecoder construction
+PASS Verify unconfigured AudioDecoder operations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
@@ -1,18 +1,14 @@
 
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Empty codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Unrecognized codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Video codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Ambiguous codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config:Codec with MIME type Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Empty codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Unrecognized codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Video codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Ambiguous codec Can't find variable: AudioDecoder
-FAIL Test that AudioDecoder.configure() rejects invalid config:Codec with MIME type Can't find variable: AudioDecoder
-FAIL Test AudioDecoder construction assert_throws_js: function "() => {
-    new AudioDecoder({});
-  }" threw object "ReferenceError: Can't find variable: AudioDecoder" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Verify unconfigured AudioDecoder operations Can't find variable: AudioDecoder
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Empty codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Unrecognized codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Video codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
+PASS Test that AudioDecoder.configure() rejects invalid config:Empty codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Unrecognized codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Video codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Ambiguous codec
+PASS Test that AudioDecoder.configure() rejects invalid config:Codec with MIME type
+PASS Test AudioDecoder construction
+PASS Verify unconfigured AudioDecoder operations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any-expected.txt
@@ -1,7 +1,25 @@
-CONSOLE MESSAGE: ReferenceError: Can't find variable: AudioData
-
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioData
 
 FAIL Simple audio encoding promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
 FAIL Encode audio with negative timestamp promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Channel number variation: 1 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Channel number variation: 2 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 3000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 13000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 23000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 33000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 43000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 53000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 63000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 73000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 83000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Sample rate variation: 93000 promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Encoding and decoding promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Emit decoder config and extra data. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL encodeQueueSize test promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Test encoding Opus with additional parameters: Empty Opus config promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Test encoding Opus with additional parameters: Opus with frameDuration promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Test encoding Opus with additional parameters: Opus with complexity promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Test encoding Opus with additional parameters: Opus with useinbandfec promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Test encoding Opus with additional parameters: Opus with usedtx promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+FAIL Test encoding Opus with additional parameters: Opus mixed parameters promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_adts_aac-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_adts_aac-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_mp3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_mp3-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_mp4_aac-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_mp4_aac-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_opus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_opus-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_pcm_alaw-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_pcm_alaw-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_pcm_mulaw-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker_pcm_mulaw-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_adts_aac-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_adts_aac-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_mp3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_mp3-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_mp4_aac-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_mp4_aac-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_opus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_opus-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_pcm_alaw-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_pcm_alaw-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_pcm_mulaw-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any_pcm_mulaw-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: AudioDecoder
-
-NOTRUN Test isConfigSupported()
-NOTRUN Test that AudioDecoder.isConfigSupported() returns a parsed configuration
-NOTRUN Test configure()
-NOTRUN Verify closed AudioDecoder operations
-NOTRUN Test decoding
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test decoding after flush
-NOTRUN Test reset during flush
-NOTRUN AudioDecoder decodeQueueSize test
+PASS Test isConfigSupported()
+PASS Test that AudioDecoder.isConfigSupported() returns a parsed configuration
+PASS Test configure()
+PASS Verify closed AudioDecoder operations
+PASS Test decoding
+PASS Test decoding a with negative timestamp
+PASS Test decoding after flush
+PASS Test reset during flush
+PASS AudioDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Verify EncodedAudioChunk is serializable. Can't find variable: EncodedAudioChunk
+PASS Verify EncodedAudioChunk is serializable.
 PASS Verify EncodedVideoChunk is serializable.
 PASS Verify EncodedVideoChunk cannot be stored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test we can construct an EncodedAudioChunk. Can't find variable: EncodedAudioChunk
-FAIL Test copyTo() exception if destination invalid Can't find variable: EncodedAudioChunk
+PASS Test we can construct an EncodedAudioChunk.
+PASS Test copyTo() exception if destination invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test we can construct an EncodedAudioChunk. Can't find variable: EncodedAudioChunk
-FAIL Test copyTo() exception if destination invalid Can't find variable: EncodedAudioChunk
+PASS Test we can construct an EncodedAudioChunk.
+PASS Test copyTo() exception if destination invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Can't find variable: EncodedAudioChunk
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Can't find variable: EncodedAudioChunk
+PASS Test construction and copyTo() using a SharedArrayBuffer
+PASS Test construction and copyTo() using a Uint8Array(SharedArrayBuffer)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test construction and copyTo() using a SharedArrayBuffer Can't find variable: EncodedAudioChunk
-FAIL Test construction and copyTo() using a Uint8Array(SharedArrayBuffer) Can't find variable: EncodedAudioChunk
+PASS Test construction and copyTo() using a SharedArrayBuffer
+PASS Test construction and copyTo() using a Uint8Array(SharedArrayBuffer)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any-expected.txt
@@ -1,20 +1,24 @@
 
 FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
 PASS idl_test validation
-FAIL AudioDecoder interface: existence and properties of interface object assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface object length assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface object name assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: existence and properties of interface prototype object assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: attribute state assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: attribute decodeQueueSize assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation configure(AudioDecoderConfig) assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation decode(EncodedAudioChunk) assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation flush() assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation reset() assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation close() assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation isConfigSupported(AudioDecoderConfig) assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
+FAIL AudioDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "AudioDecoder" is not Function.prototype expected function "function () {
+    [native code]
+}" but got function "function EventTarget() {
+    [native code]
+}"
+PASS AudioDecoder interface object length
+PASS AudioDecoder interface object name
+FAIL AudioDecoder interface: existence and properties of interface prototype object assert_equals: prototype of AudioDecoder.prototype is not Object.prototype expected object "[object Object]" but got object "[object EventTarget]"
+PASS AudioDecoder interface: existence and properties of interface prototype object's "constructor" property
+PASS AudioDecoder interface: existence and properties of interface prototype object's @@unscopables property
+PASS AudioDecoder interface: attribute state
+PASS AudioDecoder interface: attribute decodeQueueSize
+PASS AudioDecoder interface: operation configure(AudioDecoderConfig)
+PASS AudioDecoder interface: operation decode(EncodedAudioChunk)
+PASS AudioDecoder interface: operation flush()
+PASS AudioDecoder interface: operation reset()
+PASS AudioDecoder interface: operation close()
+PASS AudioDecoder interface: operation isConfigSupported(AudioDecoderConfig)
 FAIL VideoDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "VideoDecoder" is not Function.prototype expected function "function () {
     [native code]
 }" but got function "function EventTarget() {
@@ -65,17 +69,17 @@ PASS VideoEncoder interface: operation flush()
 PASS VideoEncoder interface: operation reset()
 PASS VideoEncoder interface: operation close()
 PASS VideoEncoder interface: operation isConfigSupported(VideoEncoderConfig)
-FAIL EncodedAudioChunk interface: existence and properties of interface object assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface object length assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface object name assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: existence and properties of interface prototype object assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute type assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute timestamp assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute duration assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute byteLength assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: operation copyTo(BufferSource) assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
+PASS EncodedAudioChunk interface: existence and properties of interface object
+PASS EncodedAudioChunk interface object length
+PASS EncodedAudioChunk interface object name
+PASS EncodedAudioChunk interface: existence and properties of interface prototype object
+PASS EncodedAudioChunk interface: existence and properties of interface prototype object's "constructor" property
+PASS EncodedAudioChunk interface: existence and properties of interface prototype object's @@unscopables property
+PASS EncodedAudioChunk interface: attribute type
+PASS EncodedAudioChunk interface: attribute timestamp
+PASS EncodedAudioChunk interface: attribute duration
+PASS EncodedAudioChunk interface: attribute byteLength
+PASS EncodedAudioChunk interface: operation copyTo(BufferSource)
 PASS EncodedVideoChunk interface: existence and properties of interface object
 PASS EncodedVideoChunk interface object length
 PASS EncodedVideoChunk interface object name
@@ -87,22 +91,22 @@ PASS EncodedVideoChunk interface: attribute timestamp
 PASS EncodedVideoChunk interface: attribute duration
 PASS EncodedVideoChunk interface: attribute byteLength
 PASS EncodedVideoChunk interface: operation copyTo(BufferSource)
-FAIL AudioData interface: existence and properties of interface object assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface object length assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface object name assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: existence and properties of interface prototype object assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute format assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute sampleRate assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute numberOfFrames assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute numberOfChannels assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute duration assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute timestamp assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation allocationSize(AudioDataCopyToOptions) assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation copyTo(BufferSource, AudioDataCopyToOptions) assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation clone() assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation close() assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
+PASS AudioData interface: existence and properties of interface object
+PASS AudioData interface object length
+PASS AudioData interface object name
+PASS AudioData interface: existence and properties of interface prototype object
+PASS AudioData interface: existence and properties of interface prototype object's "constructor" property
+PASS AudioData interface: existence and properties of interface prototype object's @@unscopables property
+PASS AudioData interface: attribute format
+PASS AudioData interface: attribute sampleRate
+PASS AudioData interface: attribute numberOfFrames
+PASS AudioData interface: attribute numberOfChannels
+PASS AudioData interface: attribute duration
+PASS AudioData interface: attribute timestamp
+FAIL AudioData interface: operation allocationSize(AudioDataCopyToOptions) assert_equals: property has wrong .length expected 1 but got 0
+PASS AudioData interface: operation copyTo(BufferSource, AudioDataCopyToOptions)
+PASS AudioData interface: operation clone()
+PASS AudioData interface: operation close()
 PASS VideoFrame interface: existence and properties of interface object
 PASS VideoFrame interface object length
 PASS VideoFrame interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/idlharness.https.any.worker-expected.txt
@@ -1,20 +1,24 @@
 
 FAIL idl_test setup promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ImageDecoder"
 PASS idl_test validation
-FAIL AudioDecoder interface: existence and properties of interface object assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface object length assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface object name assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: existence and properties of interface prototype object assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: attribute state assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: attribute decodeQueueSize assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation configure(AudioDecoderConfig) assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation decode(EncodedAudioChunk) assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation flush() assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation reset() assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation close() assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
-FAIL AudioDecoder interface: operation isConfigSupported(AudioDecoderConfig) assert_own_property: self does not have own property "AudioDecoder" expected property "AudioDecoder" missing
+FAIL AudioDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "AudioDecoder" is not Function.prototype expected function "function () {
+    [native code]
+}" but got function "function EventTarget() {
+    [native code]
+}"
+PASS AudioDecoder interface object length
+PASS AudioDecoder interface object name
+FAIL AudioDecoder interface: existence and properties of interface prototype object assert_equals: prototype of AudioDecoder.prototype is not Object.prototype expected object "[object Object]" but got object "[object EventTarget]"
+PASS AudioDecoder interface: existence and properties of interface prototype object's "constructor" property
+PASS AudioDecoder interface: existence and properties of interface prototype object's @@unscopables property
+PASS AudioDecoder interface: attribute state
+PASS AudioDecoder interface: attribute decodeQueueSize
+PASS AudioDecoder interface: operation configure(AudioDecoderConfig)
+PASS AudioDecoder interface: operation decode(EncodedAudioChunk)
+PASS AudioDecoder interface: operation flush()
+PASS AudioDecoder interface: operation reset()
+PASS AudioDecoder interface: operation close()
+PASS AudioDecoder interface: operation isConfigSupported(AudioDecoderConfig)
 FAIL VideoDecoder interface: existence and properties of interface object assert_equals: prototype of self's property "VideoDecoder" is not Function.prototype expected function "function () {
     [native code]
 }" but got function "function EventTarget() {
@@ -65,17 +69,17 @@ PASS VideoEncoder interface: operation flush()
 PASS VideoEncoder interface: operation reset()
 PASS VideoEncoder interface: operation close()
 PASS VideoEncoder interface: operation isConfigSupported(VideoEncoderConfig)
-FAIL EncodedAudioChunk interface: existence and properties of interface object assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface object length assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface object name assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: existence and properties of interface prototype object assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute type assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute timestamp assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute duration assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: attribute byteLength assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
-FAIL EncodedAudioChunk interface: operation copyTo(BufferSource) assert_own_property: self does not have own property "EncodedAudioChunk" expected property "EncodedAudioChunk" missing
+PASS EncodedAudioChunk interface: existence and properties of interface object
+PASS EncodedAudioChunk interface object length
+PASS EncodedAudioChunk interface object name
+PASS EncodedAudioChunk interface: existence and properties of interface prototype object
+PASS EncodedAudioChunk interface: existence and properties of interface prototype object's "constructor" property
+PASS EncodedAudioChunk interface: existence and properties of interface prototype object's @@unscopables property
+PASS EncodedAudioChunk interface: attribute type
+PASS EncodedAudioChunk interface: attribute timestamp
+PASS EncodedAudioChunk interface: attribute duration
+PASS EncodedAudioChunk interface: attribute byteLength
+PASS EncodedAudioChunk interface: operation copyTo(BufferSource)
 PASS EncodedVideoChunk interface: existence and properties of interface object
 PASS EncodedVideoChunk interface object length
 PASS EncodedVideoChunk interface object name
@@ -87,22 +91,22 @@ PASS EncodedVideoChunk interface: attribute timestamp
 PASS EncodedVideoChunk interface: attribute duration
 PASS EncodedVideoChunk interface: attribute byteLength
 PASS EncodedVideoChunk interface: operation copyTo(BufferSource)
-FAIL AudioData interface: existence and properties of interface object assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface object length assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface object name assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: existence and properties of interface prototype object assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute format assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute sampleRate assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute numberOfFrames assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute numberOfChannels assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute duration assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: attribute timestamp assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation allocationSize(AudioDataCopyToOptions) assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation copyTo(BufferSource, AudioDataCopyToOptions) assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation clone() assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
-FAIL AudioData interface: operation close() assert_own_property: self does not have own property "AudioData" expected property "AudioData" missing
+PASS AudioData interface: existence and properties of interface object
+PASS AudioData interface object length
+PASS AudioData interface object name
+PASS AudioData interface: existence and properties of interface prototype object
+PASS AudioData interface: existence and properties of interface prototype object's "constructor" property
+PASS AudioData interface: existence and properties of interface prototype object's @@unscopables property
+PASS AudioData interface: attribute format
+PASS AudioData interface: attribute sampleRate
+PASS AudioData interface: attribute numberOfFrames
+PASS AudioData interface: attribute numberOfChannels
+PASS AudioData interface: attribute duration
+PASS AudioData interface: attribute timestamp
+FAIL AudioData interface: operation allocationSize(AudioDataCopyToOptions) assert_equals: property has wrong .length expected 1 but got 0
+PASS AudioData interface: operation copyTo(BufferSource, AudioDataCopyToOptions)
+PASS AudioData interface: operation clone()
+PASS AudioData interface: operation close()
 PASS VideoFrame interface: existence and properties of interface object
 PASS VideoFrame interface object length
 PASS VideoFrame interface object name

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1153,6 +1153,34 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker.html [ Skip ]
 
+# Our MP3 decoder is not yet spec-compliant.
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]
+
+# Failing for unknown reasons, only in the SDK runtime. To be re-evaluated after updating to 23.08.
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?adts_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp4_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?adts_aac [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp4_aac [ Failure ]
+
+imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?opus [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_alaw [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_mulaw [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?opus [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_alaw [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_mulaw [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.any.worker.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/encoded-audio-chunk.crossOriginIsolated.https.any.worker.html [ Pass ]
+
 # This test is flaky crashing with the current GStreamer version of the SDK (1.22), raising a
 # critical warning in GStreamer, but the issue is not happening with GStreamer 1.23. So this test is
 # expected to pass again once we update to GStreamer 1.24.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-data.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-data.any-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Verify AudioData constructors
+PASS Verify closing and cloning AudioData
+PASS Test we can construct AudioData with a negative timestamp.
+FAIL Test conversion of uint8 data to float32 assert_array_approx_equals: interleaved channel 0 property 1, expected 1 +/- 0.003937007874015748, expected 1 but got 0.9921875
+PASS Test conversion of int16 data to float32
+PASS Test conversion of int32 data to float32
+PASS Test conversion of float32 data to float32
+PASS Test copying out planar and interleaved data
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Verify AudioData constructors
+PASS Verify closing and cloning AudioData
+PASS Test we can construct AudioData with a negative timestamp.
+FAIL Test conversion of uint8 data to float32 assert_array_approx_equals: interleaved channel 0 property 1, expected 1 +/- 0.003937007874015748, expected 1 but got 0.9921875
+PASS Test conversion of int16 data to float32
+PASS Test conversion of int32 data to float32
+PASS Test conversion of float32 data to float32
+PASS Test copying out planar and interleaved data
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7385,22 +7385,20 @@ WebCodecsAV1Enabled:
       "USE(GSTREAMER)": true
       default: false
 
-WebCodecsEnabled:
+WebCodecsAudioEnabled:
   type: bool
-  status: stable
+  status: preview
   category: media
-  humanReadableName: "WebCodecs API"
-  humanReadableDescription: "Enable WebCodecs API"
+  humanReadableName: "WebCodecs Audio API"
+  humanReadableDescription: "Enable WebCodecs Audio API"
   condition: ENABLE(WEB_CODECS)
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA)": true
       "USE(GSTREAMER)": true
       default: false
     WebCore:
-      "PLATFORM(COCOA)": true
       "USE(GSTREAMER)": true
       default: false
 
@@ -7418,6 +7416,25 @@ WebCodecsHEVCEnabled:
       "USE(GSTREAMER)": true
       default: false
     WebCore:
+      "USE(GSTREAMER)": true
+      default: false
+
+WebCodecsVideoEnabled:
+  type: bool
+  status: stable
+  category: media
+  humanReadableName: "WebCodecs Video API"
+  humanReadableDescription: "Enable WebCodecs Video API"
+  condition: ENABLE(WEB_CODECS)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "PLATFORM(COCOA)": true
+      "USE(GSTREAMER)": true
+      default: false
+    WebCore:
+      "PLATFORM(COCOA)": true
       "USE(GSTREAMER)": true
       default: false
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -733,10 +733,11 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webauthn/ResidentKeyRequirement.idl
     Modules/webauthn/UserVerificationRequirement.idl
 
+    Modules/webcodecs/AudioSampleFormat.idl
     Modules/webcodecs/AvcEncoderConfig.idl
     Modules/webcodecs/BitrateMode.idl
-    Modules/webcodecs/LatencyMode.idl
     Modules/webcodecs/HardwareAcceleration.idl
+    Modules/webcodecs/LatencyMode.idl
     Modules/webcodecs/PlaneLayout.idl
     Modules/webcodecs/VideoColorPrimaries.idl
     Modules/webcodecs/VideoColorSpace.idl
@@ -745,7 +746,14 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webcodecs/VideoPixelFormat.idl
     Modules/webcodecs/VideoTransferCharacteristics.idl
     Modules/webcodecs/WebCodecsAlphaOption.idl
+    Modules/webcodecs/WebCodecsAudioData.idl
+    Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl
+    Modules/webcodecs/WebCodecsAudioDecoder.idl
+    Modules/webcodecs/WebCodecsAudioDecoderConfig.idl
+    Modules/webcodecs/WebCodecsAudioDecoderSupport.idl
     Modules/webcodecs/WebCodecsCodecState.idl
+    Modules/webcodecs/WebCodecsEncodedAudioChunk.idl
+    Modules/webcodecs/WebCodecsEncodedAudioChunkType.idl
     Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
     Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl
     Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
@@ -759,8 +767,8 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webcodecs/WebCodecsVideoEncoderConfig.idl
     Modules/webcodecs/WebCodecsVideoEncoderEncodeOptions.idl
     Modules/webcodecs/WebCodecsVideoEncoderSupport.idl
-    Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl
     Modules/webcodecs/WebCodecsVideoFrame.idl
+    Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl
 
     Modules/webdatabase/Database.idl
     Modules/webdatabase/DatabaseCallback.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -717,6 +717,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webauthn/PublicKeyCredentialType.idl \
     $(WebCore)/Modules/webauthn/ResidentKeyRequirement.idl \
     $(WebCore)/Modules/webauthn/UserVerificationRequirement.idl \
+    $(WebCore)/Modules/webcodecs/AudioSampleFormat.idl \
     $(WebCore)/Modules/webcodecs/AvcEncoderConfig.idl \
     $(WebCore)/Modules/webcodecs/BitrateMode.idl \
     $(WebCore)/Modules/webcodecs/LatencyMode.idl \
@@ -729,6 +730,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webcodecs/VideoPixelFormat.idl \
     $(WebCore)/Modules/webcodecs/VideoTransferCharacteristics.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsAlphaOption.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsAudioData.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedAudioChunk.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsEncodedAudioChunkType.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkMetadata.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl \
@@ -736,6 +741,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webcodecs/WebCodecsErrorCallback.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsCodecState.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsSvcOutputMetadata.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsAudioData.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsAudioDecoder.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsAudioDecoderConfig.idl \
+    $(WebCore)/Modules/webcodecs/WebCodecsAudioDecoderSupport.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoder.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoderConfig.idl \
     $(WebCore)/Modules/webcodecs/WebCodecsVideoDecoderSupport.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -607,6 +607,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/webcodecs/VideoColorSpaceInit.h
     Modules/webcodecs/WebCodecsAlphaOption.h
+    Modules/webcodecs/WebCodecsAudioData.h
+    Modules/webcodecs/WebCodecsAudioInternalData.h
+    Modules/webcodecs/WebCodecsEncodedAudioChunk.h
+    Modules/webcodecs/WebCodecsEncodedAudioChunkData.h
+    Modules/webcodecs/WebCodecsEncodedAudioChunkType.h
     Modules/webcodecs/WebCodecsEncodedVideoChunk.h
     Modules/webcodecs/WebCodecsEncodedVideoChunkData.h
     Modules/webcodecs/WebCodecsEncodedVideoChunkType.h
@@ -1595,6 +1600,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/scrolling/ThreadedScrollingTree.h
 
     platform/AbortableTaskQueue.h
+    platform/AudioSampleFormat.h
     platform/CaretAnimator.h
     platform/CPUMonitor.h
     platform/ColorChooser.h
@@ -1770,6 +1776,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/PlatformAudioData.h
     platform/audio/PlatformMediaSession.h
     platform/audio/PlatformMediaSessionManager.h
+    platform/audio/PlatformRawAudioData.h
     platform/audio/PushPullFIFO.h
 
     platform/audio/gstreamer/AudioDestinationGStreamer.h

--- a/Source/WebCore/Modules/webcodecs/AudioSampleFormat.idl
+++ b/Source/WebCore/Modules/webcodecs/AudioSampleFormat.idl
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS
+] enum AudioSampleFormat {
+    // 8-bit unsigned integer samples with interleaved channel arrangement.
+    "u8",
+    // 16-bit signed integer samples with interleaved channel arrangement.
+    "s16",
+    // 32-bit signed integer samples with interleaved channel arrangement.
+    "s32",
+    // 32-bit float samples with interleaved channel arrangement.
+    "f32",
+    // 8-bit unsigned integer samples with planar channel arrangement.
+    "u8-planar",
+    // 16-bit signed integer samples with planar channel arrangement.
+    "s16-planar",
+    // 32-bit signed integer samples with planar channel arrangement.
+    "s32-planar",
+    // 32-bit float samples with planar channel arrangement.
+    "f32-planar",
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsAudioData.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "ExceptionOr.h"
+#include "JSDOMPromiseDeferred.h"
+#include "PlatformRawAudioData.h"
+#include "WebCodecsAudioDataAlgorithms.h"
+
+namespace WebCore {
+
+// https://www.w3.org/TR/webcodecs/#dom-audiodata-audiodata
+ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::create(ScriptExecutionContext& context, Init&& init)
+{
+    if (!isValidAudioDataInit(init))
+        return Exception { TypeError, "Invalid init data"_s };
+
+    auto rawData = init.data.span();
+    auto data = PlatformRawAudioData::create(WTFMove(rawData), init.format, init.sampleRate, init.timestamp, init.numberOfFrames, init.numberOfChannels);
+
+    return adoptRef(*new WebCodecsAudioData(context, WebCodecsAudioInternalData { WTFMove(data) }));
+}
+
+Ref<WebCodecsAudioData> WebCodecsAudioData::create(ScriptExecutionContext& context, Ref<PlatformRawAudioData>&& data)
+{
+    return adoptRef(*new WebCodecsAudioData(context, WebCodecsAudioInternalData { WTFMove(data) }));
+}
+
+WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context)
+    : ContextDestructionObserver(&context)
+{
+}
+
+WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context, WebCodecsAudioInternalData&& data)
+    : ContextDestructionObserver(&context)
+    , m_data(WTFMove(data))
+{
+}
+
+WebCodecsAudioData::~WebCodecsAudioData()
+{
+    if (m_isDetached)
+        return;
+    if (auto* context = scriptExecutionContext()) {
+        context->postTask([](auto& context) {
+            context.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "A AudioData was destroyed without having been closed explicitly"_s);
+        });
+    }
+}
+
+std::optional<AudioSampleFormat> WebCodecsAudioData::format() const
+{
+    return m_data.audioData ? std::make_optional(m_data.audioData->format()) : std::nullopt;
+}
+
+float WebCodecsAudioData::sampleRate() const
+{
+    return m_data.audioData ? m_data.audioData->sampleRate() : 0;
+}
+
+size_t WebCodecsAudioData::numberOfFrames() const
+{
+    return m_data.audioData ? m_data.audioData->numberOfFrames() : 0;
+}
+
+size_t WebCodecsAudioData::numberOfChannels() const
+{
+    return m_data.audioData ? m_data.audioData->numberOfChannels() : 0;
+}
+
+std::optional<uint64_t> WebCodecsAudioData::duration()
+{
+    return m_data.audioData ? m_data.audioData->duration() : std::nullopt;
+}
+
+int64_t WebCodecsAudioData::timestamp() const
+{
+    return m_data.audioData ? m_data.audioData->timestamp() : 0;
+}
+
+// https://www.w3.org/TR/webcodecs/#dom-audiodata-allocationsize
+ExceptionOr<size_t> WebCodecsAudioData::allocationSize(const CopyToOptions& options)
+{
+    if (isDetached())
+        return Exception { InvalidStateError, "AudioData is detached"_s };
+
+    auto copyElementCount = computeCopyElementCount(*this, options);
+    if (copyElementCount.hasException())
+        return copyElementCount.releaseException();
+
+    auto destFormat = options.format.value_or(*format());
+    auto bytesPerSample = computeBytesPerSample(destFormat);
+    return copyElementCount.releaseReturnValue() * bytesPerSample;
+}
+
+// https://www.w3.org/TR/webcodecs/#dom-audiodata-copyto
+ExceptionOr<void> WebCodecsAudioData::copyTo(BufferSource&& source, CopyToOptions&& options)
+{
+    if (isDetached())
+        return Exception { InvalidStateError, "AudioData is detached"_s };
+
+    auto copyElementCount = computeCopyElementCount(*this, options);
+    if (copyElementCount.hasException())
+        return copyElementCount.releaseException();
+
+    auto destFormat = options.format.value_or(*format());
+    auto bytesPerSample = computeBytesPerSample(destFormat);
+    auto maxCopyElementCount = copyElementCount.releaseReturnValue();
+    unsigned long allocationSize;
+    if (!WTF::safeMultiply(maxCopyElementCount, bytesPerSample, allocationSize))
+        return Exception { RangeError, "Calculated destination buffer size overflows"_s };
+
+    if (allocationSize > source.length())
+        return Exception { RangeError, "Buffer is too small"_s };
+
+    std::span<uint8_t> buffer { static_cast<uint8_t*>(source.mutableData()), source.length() };
+    m_data.audioData->copyTo(buffer, destFormat, options.planeIndex, options.frameOffset, options.frameCount, maxCopyElementCount);
+    return { };
+}
+
+// https://www.w3.org/TR/webcodecs/#dom-audiodata-clone
+ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::clone(ScriptExecutionContext& context)
+{
+    if (isDetached())
+        return Exception { InvalidStateError,  "AudioData is detached"_s };
+
+    return adoptRef(*new WebCodecsAudioData(context, WebCodecsAudioInternalData { m_data }));
+}
+
+// https://www.w3.org/TR/webcodecs/#dom-audiodata-close
+void WebCodecsAudioData::close()
+{
+    m_data.audioData = nullptr;
+
+    m_isDetached = true;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "AudioSampleFormat.h"
+#include "BufferSource.h"
+#include "ContextDestructionObserver.h"
+#include "WebCodecsAudioInternalData.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class PlatformRawAudioData;
+template<typename> class ExceptionOr;
+
+class WebCodecsAudioData : public RefCounted<WebCodecsAudioData>, public ContextDestructionObserver {
+public:
+    ~WebCodecsAudioData();
+
+    struct Init {
+        AudioSampleFormat format { AudioSampleFormat::U8 };
+        float sampleRate;
+        int64_t timestamp { 0 };
+
+        BufferSource data;
+        size_t numberOfFrames;
+        size_t numberOfChannels;
+    };
+
+    static ExceptionOr<Ref<WebCodecsAudioData>> create(ScriptExecutionContext&, Init&&);
+    static Ref<WebCodecsAudioData> create(ScriptExecutionContext&, Ref<PlatformRawAudioData>&&);
+    static Ref<WebCodecsAudioData> create(ScriptExecutionContext& context, WebCodecsAudioInternalData&& data) { return adoptRef(*new WebCodecsAudioData(context, WTFMove(data))); }
+
+    std::optional<AudioSampleFormat> format() const;
+    float sampleRate() const;
+    size_t numberOfFrames() const;
+    size_t numberOfChannels() const;
+    std::optional<uint64_t> duration();
+    int64_t timestamp() const;
+
+    struct CopyToOptions {
+        size_t planeIndex;
+        std::optional<size_t> frameOffset { 0 };
+        std::optional<size_t> frameCount;
+        std::optional<AudioSampleFormat> format;
+    };
+    ExceptionOr<size_t> allocationSize(const CopyToOptions&);
+
+    ExceptionOr<void> copyTo(BufferSource&&, CopyToOptions&&);
+    ExceptionOr<Ref<WebCodecsAudioData>> clone(ScriptExecutionContext&);
+    void close();
+
+    bool isDetached() const { return m_isDetached; }
+
+    const WebCodecsAudioInternalData& data() const { return m_data; }
+
+    size_t memoryCost() const { return m_data.memoryCost(); }
+
+private:
+    explicit WebCodecsAudioData(ScriptExecutionContext&);
+    WebCodecsAudioData(ScriptExecutionContext&, WebCodecsAudioInternalData&&);
+
+    WebCodecsAudioInternalData m_data;
+    bool m_isDetached { false };
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.idl
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+// FIXME: Support Serializable and Transferable.
+[
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsAudioEnabled,
+    Exposed=(Window,DedicatedWorker),
+    InterfaceName=AudioData,
+    ReportExtraMemoryCost,
+] interface WebCodecsAudioData {
+    [CallWith=CurrentScriptExecutionContext] constructor(AudioDataInit init);
+
+    readonly attribute AudioSampleFormat? format;
+    readonly attribute float sampleRate;
+    readonly attribute unsigned long numberOfFrames;
+    readonly attribute unsigned long numberOfChannels;
+    readonly attribute unsigned long long? duration;
+    readonly attribute long long timestamp;
+
+    unsigned long allocationSize(optional AudioDataCopyToOptions options = {});
+    undefined copyTo([AllowShared] (ArrayBufferView or ArrayBuffer) destination, AudioDataCopyToOptions options);
+    [CallWith=CurrentScriptExecutionContext] WebCodecsAudioData clone();
+    undefined close();
+};
+
+[Conditional=WEB_CODECS]
+dictionary AudioDataInit {
+    required AudioSampleFormat format;
+    required float sampleRate;
+    required [EnforceRange] long long timestamp;
+    required (ArrayBufferView or ArrayBuffer) data;
+    required [EnforceRange] unsigned long numberOfFrames;
+    required [EnforceRange] unsigned long numberOfChannels;
+};
+
+[Conditional=WEB_CODECS]
+dictionary AudioDataCopyToOptions {
+    [EnforceRange] unsigned long planeIndex;
+    [EnforceRange] unsigned long frameOffset;
+    [EnforceRange] unsigned long frameCount;
+    AudioSampleFormat format;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsAudioDataAlgorithms.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "ExceptionCode.h"
+#include "ExceptionOr.h"
+
+namespace WebCore {
+
+// https://www.w3.org/TR/webcodecs/#valid-audiodatainit
+bool isValidAudioDataInit(const WebCodecsAudioData::Init& init)
+{
+    if (init.sampleRate <= 0)
+        return false;
+
+    if (!init.numberOfFrames)
+        return false;
+
+    if (!init.numberOfChannels)
+        return false;
+
+    size_t totalSamples, totalSize;
+    if (!WTF::safeMultiply(init.numberOfFrames, init.numberOfChannels, totalSamples))
+        return false;
+
+    auto bytesPerSample = computeBytesPerSample(init.format);
+    if (!WTF::safeMultiply(totalSamples, bytesPerSample, totalSize))
+        return false;
+
+    auto dataSize = init.data.span().size();
+    return dataSize >= totalSize;
+}
+
+bool isAudioSampleFormatInterleaved(const AudioSampleFormat& format)
+{
+    switch (format) {
+    case AudioSampleFormat::U8:
+    case AudioSampleFormat::S16:
+    case AudioSampleFormat::S32:
+    case AudioSampleFormat::F32:
+        return true;
+    case AudioSampleFormat::U8Planar:
+    case AudioSampleFormat::S16Planar:
+    case AudioSampleFormat::S32Planar:
+    case AudioSampleFormat::F32Planar:
+        return false;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return false;
+}
+
+size_t computeBytesPerSample(const AudioSampleFormat& format)
+{
+    switch (format) {
+    case AudioSampleFormat::U8:
+    case AudioSampleFormat::U8Planar:
+        return 1;
+    case AudioSampleFormat::S16:
+    case AudioSampleFormat::S16Planar:
+        return 2;
+    case AudioSampleFormat::S32:
+    case AudioSampleFormat::F32:
+    case AudioSampleFormat::S32Planar:
+    case AudioSampleFormat::F32Planar:
+        return 4;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0;
+}
+
+// https://www.w3.org/TR/webcodecs/#compute-copy-element-count
+ExceptionOr<size_t> computeCopyElementCount(const WebCodecsAudioData& data, const WebCodecsAudioData::CopyToOptions& options)
+{
+    auto platformData = data.data().audioData;
+    if (!platformData)
+        return Exception { InvalidAccessError, "Internal AudioData storage is null"_s };
+
+    auto destFormat = options.format.value_or(platformData->format());
+
+    auto isInterleaved = isAudioSampleFormatInterleaved(destFormat);
+    if (isInterleaved && options.planeIndex > 0)
+        return Exception { RangeError, "Invalid planeIndex for interleaved format"_s };
+    if (options.planeIndex >= data.numberOfChannels())
+        return Exception { RangeError, "Invalid planeIndex for planar format"_s };
+
+    if (options.format && *options.format != destFormat && destFormat != AudioSampleFormat::F32Planar)
+        return Exception { NotSupportedError, "AudioData currently only supports copy conversion to f32-planar"_s };
+
+    auto frameCount = data.numberOfFrames() / data.numberOfChannels();
+    if (options.frameOffset && *options.frameOffset > frameCount)
+        return Exception { RangeError, "frameOffset is too large"_s };
+
+    auto copyFrameCount = frameCount;
+    if (options.frameOffset)
+        copyFrameCount -= *options.frameOffset;
+    if (options.frameCount) {
+        if (*options.frameCount > copyFrameCount)
+            return Exception { RangeError, "frameCount is too large"_s };
+
+        copyFrameCount = *options.frameCount;
+    }
+
+    if (isInterleaved) {
+        size_t aggregatedFrameCount;
+        if (!WTF::safeMultiply(copyFrameCount, data.numberOfChannels(), aggregatedFrameCount))
+            return Exception { RangeError, "Provided options are causing an overflow"_s };
+
+        return aggregatedFrameCount;
+    }
+
+    return copyFrameCount;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebCodecsAudioData.h"
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+bool isValidAudioDataInit(const WebCodecsAudioData::Init&);
+
+bool isAudioSampleFormatInterleaved(const AudioSampleFormat&);
+size_t computeBytesPerSample(const AudioSampleFormat&);
+ExceptionOr<size_t> computeCopyElementCount(const WebCodecsAudioData&, const WebCodecsAudioData::CopyToOptions&);
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class WebCodecsAudioData;
+
+class WebCodecsAudioDataOutputCallback : public RefCounted<WebCodecsAudioDataOutputCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<void> handleEvent(WebCodecsAudioData&) = 0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS,
+] callback WebCodecsAudioDataOutputCallback = undefined(WebCodecsAudioData output);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsAudioDecoder.h"
+
+#if ENABLE(WEB_CODECS)
+
+#include "DOMException.h"
+#include "Event.h"
+#include "EventNames.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSWebCodecsAudioDecoderSupport.h"
+#include "ScriptExecutionContext.h"
+#include "WebCodecsAudioData.h"
+#include "WebCodecsAudioDataOutputCallback.h"
+#include "WebCodecsEncodedAudioChunk.h"
+#include "WebCodecsErrorCallback.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(WebCodecsAudioDecoder);
+
+Ref<WebCodecsAudioDecoder> WebCodecsAudioDecoder::create(ScriptExecutionContext& context, Init&& init)
+{
+    auto decoder = adoptRef(*new WebCodecsAudioDecoder(context, WTFMove(init)));
+    decoder->suspendIfNeeded();
+    return decoder;
+}
+
+WebCodecsAudioDecoder::WebCodecsAudioDecoder(ScriptExecutionContext& context, Init&& init)
+    : ActiveDOMObject(&context)
+    , m_output(init.output.releaseNonNull())
+    , m_error(init.error.releaseNonNull())
+{
+}
+
+WebCodecsAudioDecoder::~WebCodecsAudioDecoder()
+{
+}
+
+static bool isValidDecoderConfig(const WebCodecsAudioDecoderConfig& config, const Settings::Values&)
+{
+    return AudioDecoder::isCodecSupported(config.codec);
+}
+
+static AudioDecoder::Config createAudioDecoderConfig(const WebCodecsAudioDecoderConfig& config)
+{
+    std::span<const uint8_t> description;
+    if (config.description) {
+        auto* data = std::visit([](auto& buffer) -> const uint8_t* {
+            return buffer ? static_cast<const uint8_t*>(buffer->data()) : nullptr;
+        }, *config.description);
+        auto length = std::visit([](auto& buffer) -> size_t {
+            return buffer ? buffer->byteLength() : 0;
+        }, *config.description);
+        if (length)
+            description = { data, length };
+    }
+
+    return {
+        description,
+        config.sampleRate.value_or(0),
+        config.numberOfChannels.value_or(0)
+    };
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext& context, WebCodecsAudioDecoderConfig&& config)
+{
+    if (!isValidDecoderConfig(config, context.settingsValues()))
+        return Exception { TypeError, "Config is not valid"_s };
+
+    if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
+        return Exception { InvalidStateError, "AudioDecoder is closed"_s };
+
+    m_state = WebCodecsCodecState::Configured;
+    m_isKeyChunkRequired = true;
+
+    queueControlMessageAndProcess([this, config = WTFMove(config), identifier = scriptExecutionContext()->identifier()]() mutable {
+        m_isMessageQueueBlocked = true;
+        AudioDecoder::PostTaskCallback postTaskCallback = [identifier, weakThis = WeakPtr { *this }](auto&& task) {
+            ScriptExecutionContext::postTaskTo(identifier, [weakThis, task = WTFMove(task)](auto&) mutable {
+                if (!weakThis)
+                    return;
+                weakThis->queueTaskKeepingObjectAlive(*weakThis, TaskSource::MediaElement, [task = WTFMove(task)]() mutable {
+                    task();
+                });
+            });
+        };
+
+        AudioDecoder::create(config.codec, createAudioDecoderConfig(config), [this](auto&& result) {
+            if (!result.has_value()) {
+                closeDecoder(Exception { NotSupportedError, WTFMove(result.error()) });
+                return;
+            }
+            setInternalDecoder(WTFMove(result.value()));
+            m_isMessageQueueBlocked = false;
+            processControlMessageQueue();
+        }, [this](auto&& result) {
+            if (m_state != WebCodecsCodecState::Configured)
+                return;
+
+            if (!result.has_value()) {
+                closeDecoder(Exception { EncodingError, WTFMove(result).error() });
+                return;
+            }
+
+            auto decodedResult = WTFMove(result).value();
+            auto audioData = WebCodecsAudioData::create(*scriptExecutionContext(), WTFMove(decodedResult.data));
+            m_output->handleEvent(WTFMove(audioData));
+        }, WTFMove(postTaskCallback));
+    });
+    return { };
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::decode(Ref<WebCodecsEncodedAudioChunk>&& chunk)
+{
+    if (m_state != WebCodecsCodecState::Configured)
+        return Exception { InvalidStateError, "AudioDecoder is not configured"_s };
+
+    if (m_isKeyChunkRequired) {
+        if (chunk->type() != WebCodecsEncodedAudioChunkType::Key)
+            return Exception { DataError, "Key frame is required"_s };
+        m_isKeyChunkRequired = false;
+    }
+
+    ++m_decodeQueueSize;
+    queueControlMessageAndProcess([this, chunk = WTFMove(chunk)]() mutable {
+        ++m_beingDecodedQueueSize;
+        --m_decodeQueueSize;
+        scheduleDequeueEvent();
+
+        m_internalDecoder->decode({ { chunk->data(), chunk->byteLength() }, chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }, [this](auto&& result) {
+            --m_beingDecodedQueueSize;
+            if (!result.isNull())
+                closeDecoder(Exception { EncodingError, WTFMove(result) });
+        });
+    });
+    return { };
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::flush(Ref<DeferredPromise>&& promise)
+{
+    if (m_state != WebCodecsCodecState::Configured)
+        return Exception { InvalidStateError, "AudioDecoder is not configured"_s };
+
+    m_isKeyChunkRequired = true;
+    m_pendingFlushPromises.append(promise.copyRef());
+    m_isFlushing = true;
+    queueControlMessageAndProcess([this, clearFlushPromiseCount = m_clearFlushPromiseCount] {
+        m_internalDecoder->flush([this, clearFlushPromiseCount] {
+            if (clearFlushPromiseCount != m_clearFlushPromiseCount)
+                return;
+
+            m_pendingFlushPromises.takeFirst()->resolve();
+            m_isFlushing = !m_pendingFlushPromises.isEmpty();
+        });
+    });
+    return { };
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::reset()
+{
+    return resetDecoder(Exception { AbortError, "Reset called"_s });
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::close()
+{
+    return closeDecoder(Exception { AbortError, "Close called"_s });
+}
+
+void WebCodecsAudioDecoder::isConfigSupported(ScriptExecutionContext& context, WebCodecsAudioDecoderConfig&& config, Ref<DeferredPromise>&& promise)
+{
+    if (!isValidDecoderConfig(config, context.settingsValues())) {
+        promise->reject(Exception { TypeError, "Config is not valid"_s });
+        return;
+    }
+
+    auto* promisePtr = promise.ptr();
+    context.addDeferredPromise(WTFMove(promise));
+
+    auto audioDecoderConfig = createAudioDecoderConfig(config);
+    Vector<uint8_t> description { audioDecoderConfig.description };
+    AudioDecoder::create(config.codec, createAudioDecoderConfig(config), [identifier = context.identifier(), config = config.isolatedCopyWithoutDescription(), description = WTFMove(description), promisePtr](auto&& result) mutable {
+        ScriptExecutionContext::postTaskTo(identifier, [success = result.has_value(), config = WTFMove(config).isolatedCopyWithoutDescription(), description = WTFMove(description), promisePtr](auto& context) mutable {
+            if (auto promise = context.takeDeferredPromise(promisePtr)) {
+                if (description.size())
+                    config.description = RefPtr { JSC::ArrayBuffer::create(description.data(), description.size()) };
+                promise->template resolve<IDLDictionary<WebCodecsAudioDecoderSupport>>(WebCodecsAudioDecoderSupport { success, WTFMove(config) });
+            }
+        });
+    }, [](auto&&) {
+    }, [](auto&& task) {
+        task();
+    });
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::closeDecoder(Exception&& exception)
+{
+    auto result = resetDecoder(exception);
+    if (result.hasException())
+        return result;
+    m_state = WebCodecsCodecState::Closed;
+    m_internalDecoder = nullptr;
+    if (exception.code() != AbortError) {
+        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = WTFMove(exception)]() mutable {
+            m_error->handleEvent(DOMException::create(WTFMove(exception)));
+        });
+    }
+    return { };
+}
+
+ExceptionOr<void> WebCodecsAudioDecoder::resetDecoder(const Exception& exception)
+{
+    if (m_state == WebCodecsCodecState::Closed)
+        return Exception { InvalidStateError, "AudioDecoder is closed"_s };
+
+    m_state = WebCodecsCodecState::Unconfigured;
+    if (m_internalDecoder)
+        m_internalDecoder->reset();
+    m_controlMessageQueue.clear();
+    if (m_decodeQueueSize) {
+        m_decodeQueueSize = 0;
+        scheduleDequeueEvent();
+    }
+    ++m_clearFlushPromiseCount;
+
+    while (!m_pendingFlushPromises.isEmpty())
+        m_pendingFlushPromises.takeFirst()->reject(exception);
+
+    return { };
+}
+
+void WebCodecsAudioDecoder::scheduleDequeueEvent()
+{
+    if (m_dequeueEventScheduled)
+        return;
+
+    m_dequeueEventScheduled = true;
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
+        dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        m_dequeueEventScheduled = false;
+    });
+}
+
+void WebCodecsAudioDecoder::setInternalDecoder(UniqueRef<AudioDecoder>&& internalDecoder)
+{
+    m_internalDecoder = internalDecoder.moveToUniquePtr();
+}
+
+void WebCodecsAudioDecoder::queueControlMessageAndProcess(Function<void()>&& message)
+{
+    if (m_isMessageQueueBlocked) {
+        m_controlMessageQueue.append(WTFMove(message));
+        return;
+    }
+    if (m_controlMessageQueue.isEmpty()) {
+        message();
+        return;
+    }
+
+    m_controlMessageQueue.append(WTFMove(message));
+    processControlMessageQueue();
+}
+
+void WebCodecsAudioDecoder::processControlMessageQueue()
+{
+    while (!m_isMessageQueueBlocked && !m_controlMessageQueue.isEmpty())
+        m_controlMessageQueue.takeFirst()();
+}
+
+void WebCore::WebCodecsAudioDecoder::suspend(ReasonForSuspension)
+{
+    // FIXME: Implement.
+}
+
+void WebCodecsAudioDecoder::stop()
+{
+    m_state = WebCodecsCodecState::Closed;
+    m_internalDecoder = nullptr;
+}
+
+const char* WebCodecsAudioDecoder::activeDOMObjectName() const
+{
+    return "AudioDecoder";
+}
+
+bool WebCodecsAudioDecoder::virtualHasPendingActivity() const
+{
+    return m_state == WebCodecsCodecState::Configured && (m_decodeQueueSize || m_beingDecodedQueueSize || m_isFlushing);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "ActiveDOMObject.h"
+#include "AudioDecoder.h"
+#include "EventTarget.h"
+#include "JSDOMPromiseDeferredForward.h"
+#include "WebCodecsAudioDecoderConfig.h"
+#include "WebCodecsAudioDecoderSupport.h"
+#include "WebCodecsCodecState.h"
+#include "WebCodecsEncodedAudioChunkType.h"
+#include <wtf/Deque.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class WebCodecsEncodedAudioChunk;
+class WebCodecsErrorCallback;
+class WebCodecsAudioDataOutputCallback;
+
+class WebCodecsAudioDecoder
+    : public RefCounted<WebCodecsAudioDecoder>
+    , public ActiveDOMObject
+    , public EventTarget {
+    WTF_MAKE_ISO_ALLOCATED(WebCodecsAudioDecoder);
+public:
+    ~WebCodecsAudioDecoder();
+
+    struct Init {
+        RefPtr<WebCodecsAudioDataOutputCallback> output;
+        RefPtr<WebCodecsErrorCallback> error;
+    };
+
+    static Ref<WebCodecsAudioDecoder> create(ScriptExecutionContext&, Init&&);
+
+    WebCodecsCodecState state() const { return m_state; }
+    size_t decodeQueueSize() const { return m_decodeQueueSize; }
+
+    ExceptionOr<void> configure(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&&);
+    ExceptionOr<void> decode(Ref<WebCodecsEncodedAudioChunk>&&);
+    ExceptionOr<void> flush(Ref<DeferredPromise>&&);
+    ExceptionOr<void> reset();
+    ExceptionOr<void> close();
+
+    static void isConfigSupported(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&&, Ref<DeferredPromise>&&);
+
+    using RefCounted::ref;
+    using RefCounted::deref;
+
+private:
+    WebCodecsAudioDecoder(ScriptExecutionContext&, Init&&);
+
+    // ActiveDOMObject API.
+    void stop() final;
+    const char* activeDOMObjectName() const final;
+    void suspend(ReasonForSuspension) final;
+    bool virtualHasPendingActivity() const final;
+
+    // EventTarget
+    void refEventTarget() final { ref(); }
+    void derefEventTarget() final { deref(); }
+    EventTargetInterface eventTargetInterface() const final { return WebCodecsAudioDecoderEventTargetInterfaceType; }
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+
+    ExceptionOr<void> closeDecoder(Exception&&);
+    ExceptionOr<void> resetDecoder(const Exception&);
+    void setInternalDecoder(UniqueRef<AudioDecoder>&&);
+    void scheduleDequeueEvent();
+
+    void queueControlMessageAndProcess(Function<void()>&&);
+    void processControlMessageQueue();
+
+    WebCodecsCodecState m_state { WebCodecsCodecState::Unconfigured };
+    size_t m_decodeQueueSize { 0 };
+    size_t m_beingDecodedQueueSize { 0 };
+    Ref<WebCodecsAudioDataOutputCallback> m_output;
+    Ref<WebCodecsErrorCallback> m_error;
+    std::unique_ptr<AudioDecoder> m_internalDecoder;
+    bool m_dequeueEventScheduled { false };
+    Deque<Ref<DeferredPromise>> m_pendingFlushPromises;
+    size_t m_clearFlushPromiseCount { 0 };
+    bool m_isKeyChunkRequired { false };
+    Deque<Function<void()>> m_controlMessageQueue;
+    bool m_isMessageQueueBlocked { false };
+    bool m_isFlushing { false };
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.idl
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// FIXME: Support Serializable and Transferable.
+[
+    ActiveDOMObject,
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsAudioEnabled,
+    Exposed=(Window,DedicatedWorker),
+    InterfaceName=AudioDecoder,
+] interface WebCodecsAudioDecoder : EventTarget {
+    [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsAudioDecoderInit init);
+
+    readonly attribute WebCodecsCodecState state;
+    readonly attribute unsigned long decodeQueueSize;
+    attribute EventHandler ondequeue;
+
+    [CallWith=CurrentScriptExecutionContext] undefined configure(WebCodecsAudioDecoderConfig config);
+    undefined decode(WebCodecsEncodedAudioChunk chunk);
+    Promise<undefined> flush();
+    undefined reset();
+    undefined close();
+
+    [CallWith=CurrentScriptExecutionContext] static Promise<WebCodecsAudioDecoderSupport> isConfigSupported(WebCodecsAudioDecoderConfig config);
+};
+
+[
+    Conditional=WEB_CODECS,
+] dictionary WebCodecsAudioDecoderInit {
+    required WebCodecsAudioDataOutputCallback output;
+    required WebCodecsErrorCallback error;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "BufferSource.h"
+#include <optional>
+
+namespace WebCore {
+
+struct WebCodecsAudioDecoderConfig {
+    String codec;
+    std::optional<BufferSource::VariantType> description;
+    std::optional<size_t> sampleRate;
+    std::optional<size_t> numberOfChannels;
+
+    WebCodecsAudioDecoderConfig isolatedCopyWithoutDescription() && { return { WTFMove(codec).isolatedCopy(), { }, sampleRate, numberOfChannels }; }
+    WebCodecsAudioDecoderConfig isolatedCopyWithoutDescription() const & { return { codec.isolatedCopy(), { }, sampleRate, numberOfChannels }; }
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.idl
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef [EnforceRange] unsigned long WebCodecsAudioDecoderConfigSize;
+
+[
+    Conditional=WEB_CODECS,
+    JSGenerateToJSObject,
+] dictionary WebCodecsAudioDecoderConfig {
+    required DOMString codec;
+    WebCodecsAudioDecoderConfigSize sampleRate;
+    WebCodecsAudioDecoderConfigSize numberOfChannels;
+    (ArrayBufferView or ArrayBuffer) description;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderSupport.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderSupport.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "WebCodecsAudioDecoderConfig.h"
+
+namespace WebCore {
+
+struct WebCodecsAudioDecoderSupport {
+    std::optional<bool> supported;
+    std::optional<WebCodecsAudioDecoderConfig> config;
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderSupport.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderSupport.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_CODECS,
+    JSGenerateToJSObject,
+] dictionary WebCodecsAudioDecoderSupport {
+  boolean supported;
+  WebCodecsAudioDecoderConfig config;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioInternalData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioInternalData.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "PlatformRawAudioData.h"
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+struct WebCodecsAudioInternalData {
+    size_t memoryCost() const { return audioData ? audioData->memoryCost() : 0; }
+
+    RefPtr<PlatformRawAudioData> audioData;
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCodecsEncodedAudioChunk.h"
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+WebCodecsEncodedAudioChunk::WebCodecsEncodedAudioChunk(Init&& init)
+    : m_storage { WebCodecsEncodedAudioChunkStorage::create(init.type, init.timestamp, init.duration, std::span<const uint8_t> { init.data.data(), init.data.length() }) }
+{
+}
+
+ExceptionOr<void> WebCodecsEncodedAudioChunk::copyTo(BufferSource&& source)
+{
+    if (source.length() < byteLength())
+        return Exception { TypeError, "buffer is too small"_s };
+
+    std::memcpy(source.mutableData(), data(), byteLength());
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "BufferSource.h"
+#include "ExceptionOr.h"
+#include "WebCodecsEncodedAudioChunkData.h"
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class WebCodecsEncodedAudioChunkStorage : public ThreadSafeRefCounted<WebCodecsEncodedAudioChunkStorage> {
+public:
+    static Ref<WebCodecsEncodedAudioChunkStorage> create(WebCodecsEncodedAudioChunkType type, int64_t timestamp, std::optional<uint64_t> duration, Vector<uint8_t>&& buffer) { return create(WebCodecsEncodedAudioChunkData { type, timestamp, duration, WTFMove(buffer) }); }
+    static Ref<WebCodecsEncodedAudioChunkStorage> create(WebCodecsEncodedAudioChunkData&& data) { return adoptRef(* new WebCodecsEncodedAudioChunkStorage(WTFMove(data))); }
+
+    const WebCodecsEncodedAudioChunkData& data() const { return m_data; }
+    uint64_t memoryCost() const { return m_data.buffer.size(); }
+
+private:
+    explicit WebCodecsEncodedAudioChunkStorage(WebCodecsEncodedAudioChunkData&&);
+
+    const WebCodecsEncodedAudioChunkData m_data;
+};
+
+class WebCodecsEncodedAudioChunk : public RefCounted<WebCodecsEncodedAudioChunk> {
+public:
+    ~WebCodecsEncodedAudioChunk() = default;
+
+    struct Init {
+        WebCodecsEncodedAudioChunkType type { WebCodecsEncodedAudioChunkType::Key };
+        int64_t timestamp { 0 };
+        std::optional<uint64_t> duration;
+        BufferSource data;
+    };
+
+    static Ref<WebCodecsEncodedAudioChunk> create(Init&& init) { return adoptRef(*new WebCodecsEncodedAudioChunk(WTFMove(init))); }
+    static Ref<WebCodecsEncodedAudioChunk> create(Ref<WebCodecsEncodedAudioChunkStorage>&& storage) { return adoptRef(*new WebCodecsEncodedAudioChunk(WTFMove(storage))); }
+
+    WebCodecsEncodedAudioChunkType type() const { return m_storage->data().type; };
+    int64_t timestamp() const { return m_storage->data().timestamp; }
+    std::optional<uint64_t> duration() const { return m_storage->data().duration; }
+    size_t byteLength() const { return m_storage->data().buffer.size(); }
+
+    ExceptionOr<void> copyTo(BufferSource&&);
+
+    const uint8_t* data() const { return m_storage->data().buffer.data(); }
+    WebCodecsEncodedAudioChunkStorage& storage() { return m_storage.get(); }
+
+private:
+    explicit WebCodecsEncodedAudioChunk(Init&&);
+    explicit WebCodecsEncodedAudioChunk(Ref<WebCodecsEncodedAudioChunkStorage>&&);
+
+    Ref<WebCodecsEncodedAudioChunkStorage> m_storage;
+};
+
+inline WebCodecsEncodedAudioChunkStorage::WebCodecsEncodedAudioChunkStorage(WebCodecsEncodedAudioChunkData&& data)
+    : m_data { WTFMove(data) }
+{
+}
+
+inline WebCodecsEncodedAudioChunk::WebCodecsEncodedAudioChunk(Ref<WebCodecsEncodedAudioChunkStorage>&& storage)
+    : m_storage(WTFMove(storage))
+{
+}
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.idl
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// FIXME: Support Serializable and Transferable.
+[
+    Conditional=WEB_CODECS,
+    EnabledBySetting=WebCodecsAudioEnabled,
+    Exposed=(Window,DedicatedWorker),
+    InterfaceName=EncodedAudioChunk,
+] interface WebCodecsEncodedAudioChunk {
+  constructor(WebCodecsEncodedAudioChunkInit init);
+  readonly attribute WebCodecsEncodedAudioChunkType type;
+  readonly attribute long long timestamp;
+  readonly attribute unsigned long long? duration;
+  readonly attribute unsigned long byteLength;
+
+  undefined copyTo([AllowShared] (ArrayBufferView or ArrayBuffer) destination);
+};
+
+typedef [EnforceRange] long long WebCodecsEncodedAudioChunkInitTimestamp;
+typedef [EnforceRange] unsigned long long WebCodecsEncodedAudioChunkInitDuration;
+
+[
+    Conditional=WEB_CODECS
+] dictionary WebCodecsEncodedAudioChunkInit {
+  required WebCodecsEncodedAudioChunkType type;
+  WebCodecsEncodedAudioChunkInitTimestamp timestamp;
+  WebCodecsEncodedAudioChunkInitDuration duration;
+  required [AllowShared] (ArrayBufferView or ArrayBuffer) data;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkData.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "WebCodecsEncodedAudioChunkType.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct WebCodecsEncodedAudioChunkData {
+    WebCodecsEncodedAudioChunkType type { WebCodecsEncodedAudioChunkType::Key };
+    int64_t timestamp { 0 };
+    std::optional<uint64_t> duration { 0 };
+    Vector<uint8_t> buffer;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkType.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkType.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+namespace WebCore {
+
+enum class WebCodecsEncodedAudioChunkType : bool {
+    Key,
+    Delta
+};
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkType.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkType.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+[
+    Conditional=WEB_CODECS
+] enum WebCodecsEncodedAudioChunkType {
+    "key",
+    "delta",
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.idl
@@ -26,7 +26,7 @@
 // FIXME: Support Serializable and Transferable.
 [
     Conditional=WEB_CODECS,
-    EnabledBySetting=WebCodecsEnabled,
+    EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=EncodedVideoChunk,
 ] interface WebCodecsEncodedVideoChunk {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl
@@ -27,7 +27,7 @@
 [
     ActiveDOMObject,
     Conditional=WEB_CODECS,
-    EnabledBySetting=WebCodecsEnabled,
+    EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=VideoDecoder,
 ] interface WebCodecsVideoDecoder : EventTarget {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
@@ -27,7 +27,7 @@
 [
     ActiveDOMObject,
     Conditional=WEB_CODECS,
-    EnabledBySetting=WebCodecsEnabled,
+    EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=VideoEncoder,
 ] interface WebCodecsVideoEncoder : EventTarget {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -39,7 +39,7 @@ typedef (HTMLImageElement
 // FIXME: Support Serializable and Transferable.
 [
     Conditional=WEB_CODECS,
-    EnabledBySetting=WebCodecsEnabled,
+    EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=VideoFrame,
     ReportExtraMemoryCost,

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -432,6 +432,10 @@ Modules/webauthn/fido/FidoParsingUtils.cpp
 Modules/webauthn/fido/Pin.cpp
 Modules/webauthn/fido/U2fCommandConstructor.cpp
 Modules/webauthn/fido/U2fResponseConverter.cpp
+Modules/webcodecs/WebCodecsAudioDecoder.cpp
+Modules/webcodecs/WebCodecsAudioData.cpp
+Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
+Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
 Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
 Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -2017,6 +2021,7 @@ page/scrolling/ScrollingTreeStickyNode.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+platform/AudioDecoder.cpp
 platform/CaretAnimator.cpp
 platform/CommonAtomStrings.cpp
 platform/ContentType.cpp
@@ -2142,6 +2147,7 @@ platform/audio/MultiChannelResampler.cpp
 platform/audio/Panner.cpp
 platform/audio/PlatformMediaSession.cpp
 platform/audio/PlatformMediaSessionManager.cpp
+platform/audio/PlatformRawAudioData.cpp
 platform/audio/PushPullFIFO.cpp
 platform/audio/Reverb.cpp
 platform/audio/ReverbAccumulationBuffer.cpp
@@ -3173,6 +3179,7 @@ JSBeforeUnloadEvent.cpp
 JSBiquadFilterNode.cpp
 JSBiquadFilterOptions.cpp
 JSBiquadFilterType.cpp
+JSAudioSampleFormat.cpp
 JSAvcEncoderConfig.cpp
 JSBackgroundFetchEvent.cpp
 JSBackgroundFetchEventInit.cpp
@@ -4338,6 +4345,13 @@ JSWaveShaperNode.cpp
 JSWaveShaperOptions.cpp
 JSWebAnimation.cpp
 JSWebCodecsAlphaOption.cpp
+JSWebCodecsAudioData.cpp
+JSWebCodecsAudioDataOutputCallback.cpp
+JSWebCodecsAudioDecoder.cpp
+JSWebCodecsAudioDecoderConfig.cpp
+JSWebCodecsAudioDecoderSupport.cpp
+JSWebCodecsEncodedAudioChunk.cpp
+JSWebCodecsEncodedAudioChunkType.cpp
 JSWebCodecsEncodedVideoChunk.cpp
 JSWebCodecsEncodedVideoChunkMetadata.cpp
 JSWebCodecsEncodedVideoChunkOutputCallback.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -76,6 +76,8 @@ namespace WebCore {
     macro(AudioBuffer) \
     macro(AudioBufferSourceNode) \
     macro(AudioContext) \
+    macro(AudioData) \
+    macro(AudioDecoder) \
     macro(AudioDestinationNode) \
     macro(AudioListener) \
     macro(AudioNode) \
@@ -175,6 +177,7 @@ namespace WebCore {
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
     macro(ElementInternals) \
+    macro(EncodedAudioChunk) \
     macro(EncodedVideoChunk) \
     macro(ExtendableCookieChangeEvent) \
     macro(ExtendableEvent) \

--- a/Source/WebCore/dom/EventTargetFactory.in
+++ b/Source/WebCore/dom/EventTargetFactory.in
@@ -72,6 +72,7 @@ VideoTrackList conditional=VIDEO
 VisualViewport
 WakeLockSentinel
 WebAnimation
+WebCodecsAudioDecoder conditional=WEB_CODECS
 WebCodecsVideoDecoder conditional=WEB_CODECS
 WebCodecsVideoEncoder conditional=WEB_CODECS
 WebKitMediaKeySession conditional=LEGACY_ENCRYPTED_MEDIA

--- a/Source/WebCore/platform/AudioDecoder.cpp
+++ b/Source/WebCore/platform/AudioDecoder.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AudioDecoder.h"
+
+#if ENABLE(WEB_CODECS)
+
+#if USE(GSTREAMER)
+#include "AudioDecoderGStreamer.h"
+#include "GStreamerRegistryScanner.h"
+#endif
+
+#include <wtf/MainThread.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+bool AudioDecoder::isCodecSupported(const StringView& codec)
+{
+    // FIXME: Check codec more accurately.
+    bool isCodecAllowed = codec.startsWith("mp4a."_s) || codec == "mp3"_s || codec == "opus"_s
+        || codec == "alaw"_s || codec == "ulaw"_s || codec == "flac"_s
+        || codec == "vorbis"_s || codec.startsWith("pcm-"_s);
+
+    if (!isCodecAllowed)
+        return false;
+
+    bool result = false;
+#if USE(GSTREAMER)
+    // FIXME: Workaround for the "GStreamerSinksWorkarounds" quirks expecting to run in the main thread...
+    callOnMainThreadAndWait([&] {
+        auto& scanner = GStreamerRegistryScanner::singleton();
+        result = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codec.toString());
+    });
+#endif
+
+    return result;
+}
+
+void AudioDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postCallback)
+{
+#if USE(GSTREAMER)
+    if (GStreamerAudioDecoder::create(codecName, config, WTFMove(callback), WTFMove(outputCallback), WTFMove(postCallback)))
+        return;
+#else
+    UNUSED_PARAM(codecName);
+    UNUSED_PARAM(config);
+    UNUSED_PARAM(outputCallback);
+    UNUSED_PARAM(postCallback);
+#endif
+
+    callback(makeUnexpected("Not supported"_s));
+}
+
+AudioDecoder::AudioDecoder() = default;
+AudioDecoder::~AudioDecoder() = default;
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/AudioDecoder.h
+++ b/Source/WebCore/platform/AudioDecoder.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include <span>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Expected.h>
+#include <wtf/Ref.h>
+
+namespace WebCore {
+
+class PlatformRawAudioData;
+
+class AudioDecoder {
+public:
+    WEBCORE_EXPORT AudioDecoder();
+    WEBCORE_EXPORT virtual ~AudioDecoder();
+
+    static bool isCodecSupported(const StringView&);
+
+    struct Config {
+        std::span<const uint8_t> description;
+        uint64_t sampleRate { 0 };
+        uint64_t numberOfChannels { 0 };
+    };
+
+    struct EncodedData {
+        std::span<const uint8_t> data;
+        bool isKeyFrame { false };
+        int64_t timestamp { 0 };
+        std::optional<uint64_t> duration;
+    };
+    struct DecodedData {
+        Ref<PlatformRawAudioData> data;
+    };
+
+    using PostTaskCallback = Function<void(Function<void()>&&)>;
+    using OutputCallback = Function<void(Expected<DecodedData, String>&&)>;
+    using CreateResult = Expected<UniqueRef<AudioDecoder>, String>;
+    using CreateCallback = Function<void(CreateResult&&)>;
+
+    using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+    WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);
+
+    static void create(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+
+    using DecodeCallback = Function<void(String&&)>;
+    virtual void decode(EncodedData&&, DecodeCallback&&) = 0;
+
+    virtual void flush(Function<void()>&&) = 0;
+    virtual void reset() = 0;
+    virtual void close() = 0;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebCore/platform/AudioSampleFormat.h
+++ b/Source/WebCore/platform/AudioSampleFormat.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class AudioSampleFormat {
+    U8,
+    S16,
+    S32,
+    F32,
+    U8Planar,
+    S16Planar,
+    S32Planar,
+    F32Planar,
+};
+
+}

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -38,10 +38,12 @@ Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
 
 Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
 
+platform/audio/gstreamer/AudioDecoderGStreamer.cpp
 platform/audio/gstreamer/AudioDestinationGStreamer.cpp
 platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
 platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
 platform/audio/gstreamer/FFTFrameGStreamer.cpp
+platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
 platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp @no-unify
 
 platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp

--- a/Source/WebCore/platform/audio/PlatformRawAudioData.cpp
+++ b/Source/WebCore/platform/audio/PlatformRawAudioData.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "PlatformRawAudioData.h"
+
+#include "AudioSampleFormat.h"
+#include "NotImplemented.h"
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+#if !USE(GSTREAMER)
+RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_t>&&, AudioSampleFormat, float, int64_t, size_t, size_t)
+{
+    notImplemented();
+    return nullptr;
+}
+
+void PlatformRawAudioData::copyTo(std::span<uint8_t>, AudioSampleFormat, size_t, std::optional<size_t>, std::optional<size_t>, unsigned long)
+{
+    notImplemented();
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformRawAudioData.h
+++ b/Source/WebCore/platform/audio/PlatformRawAudioData.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <span>
+#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+enum class AudioSampleFormat;
+
+class PlatformRawAudioData : public ThreadSafeRefCounted<PlatformRawAudioData> {
+public:
+    virtual ~PlatformRawAudioData() = default;
+    static RefPtr<PlatformRawAudioData> create(std::span<const uint8_t>&&, AudioSampleFormat, float sampleRate, int64_t timestamp, size_t numberOfFrames, size_t numberOfChannels);
+
+    virtual AudioSampleFormat format() const = 0;
+    virtual size_t sampleRate() const = 0;
+    virtual size_t numberOfChannels() const = 0;
+    virtual size_t numberOfFrames() const = 0;
+    virtual std::optional<uint64_t> duration() const = 0;
+    virtual int64_t timestamp() const = 0;
+
+    virtual size_t memoryCost() const = 0;
+
+    void copyTo(std::span<uint8_t>, AudioSampleFormat, size_t planeIndex, std::optional<size_t> frameOffset, std::optional<size_t> frameCount, unsigned long copyElementCount);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "AudioDecoderGStreamer.h"
+
+#if ENABLE(WEB_CODECS) && USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+#include "GStreamerElementHarness.h"
+#include "GStreamerRegistryScanner.h"
+#include "PlatformRawAudioDataGStreamer.h"
+#include <wtf/NeverDestroyed.h>
+#include <wtf/UniqueRef.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebCore {
+
+GST_DEBUG_CATEGORY(webkit_audio_decoder_debug);
+#define GST_CAT_DEFAULT webkit_audio_decoder_debug
+
+static WorkQueue& gstDecoderWorkQueue()
+{
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("GStreamer AudioDecoder Queue"));
+    return queue.get();
+}
+
+class GStreamerInternalAudioDecoder : public ThreadSafeRefCounted<GStreamerInternalAudioDecoder>
+    , public CanMakeWeakPtr<GStreamerInternalAudioDecoder, WeakPtrFactoryInitialization::Eager> {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    static Ref<GStreamerInternalAudioDecoder> create(const String& codecName, const AudioDecoder::Config& config, AudioDecoder::OutputCallback&& outputCallback, AudioDecoder::PostTaskCallback&& postTaskCallback, GRefPtr<GstElement>&& element)
+    {
+        return adoptRef(*new GStreamerInternalAudioDecoder(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element)));
+    }
+    ~GStreamerInternalAudioDecoder() = default;
+
+    void postTask(Function<void()>&& task) { m_postTaskCallback(WTFMove(task)); }
+    void decode(std::span<const uint8_t>, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration, AudioDecoder::DecodeCallback&&);
+    void flush(Function<void()>&&);
+    void close() { m_isClosed = true; }
+    bool isConfigured() const { return !!m_inputCaps; }
+
+    GstElement* harnessedElement() const { return m_harness->element(); }
+
+private:
+    GStreamerInternalAudioDecoder(const String& codecName, const AudioDecoder::Config&, AudioDecoder::OutputCallback&&, AudioDecoder::PostTaskCallback&&, GRefPtr<GstElement>&&);
+
+    AudioDecoder::OutputCallback m_outputCallback;
+    AudioDecoder::PostTaskCallback m_postTaskCallback;
+
+    RefPtr<GStreamerElementHarness> m_harness;
+    GRefPtr<GstCaps> m_inputCaps;
+    GRefPtr<GstBuffer> m_header;
+    bool m_isClosed { false };
+};
+
+bool GStreamerAudioDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback)
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_audio_decoder_debug, "webkitaudiodecoder", 0, "WebKit WebCodecs Audio Decoder");
+    });
+
+    GRefPtr<GstElement> element;
+    if (codecName.startsWith("pcm-"_s)) {
+        auto components = codecName.split('-');
+        if (components.size() != 2) {
+            GST_WARNING("Invalid LPCM codec string: %s", codecName.ascii().data());
+            return false;
+        }
+    } else {
+        auto& scanner = GStreamerRegistryScanner::singleton();
+        auto lookupResult = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codecName);
+        if (!lookupResult) {
+            GST_WARNING("No decoder found for codec %s", codecName.ascii().data());
+            return false;
+        }
+        element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
+    }
+
+    auto decoder = makeUniqueRef<GStreamerAudioDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element));
+    if (!decoder->m_internalDecoder->isConfigured()) {
+        GST_WARNING("Internal video decoder failed to configure for codec %s", codecName.ascii().data());
+        return false;
+    }
+
+    gstDecoderWorkQueue().dispatch([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
+        auto internalDecoder = decoder->m_internalDecoder;
+        internalDecoder->postTask([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
+            GST_DEBUG_OBJECT(decoder->m_internalDecoder->harnessedElement(), "Audio decoder created");
+            callback(UniqueRef<AudioDecoder> { WTFMove(decoder) });
+        });
+    });
+
+    return true;
+}
+
+GStreamerAudioDecoder::GStreamerAudioDecoder(const String& codecName, const Config& config, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback, GRefPtr<GstElement>&& element)
+    : m_internalDecoder(GStreamerInternalAudioDecoder::create(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element)))
+{
+}
+
+GStreamerAudioDecoder::~GStreamerAudioDecoder()
+{
+    GST_DEBUG_OBJECT(m_internalDecoder->harnessedElement(), "Disposing");
+    close();
+}
+
+void GStreamerAudioDecoder::decode(EncodedData&& data, DecodeCallback&& callback)
+{
+    gstDecoderWorkQueue().dispatch([value = Vector<uint8_t> { data.data }, isKeyFrame = data.isKeyFrame, timestamp = data.timestamp, duration = data.duration, decoder = m_internalDecoder, callback = WTFMove(callback)]() mutable {
+        decoder->decode({ value.data(), value.size() }, isKeyFrame, timestamp, duration, WTFMove(callback));
+    });
+}
+
+void GStreamerAudioDecoder::flush(Function<void()>&& callback)
+{
+    gstDecoderWorkQueue().dispatch([decoder = m_internalDecoder, callback = WTFMove(callback)]() mutable {
+        decoder->flush(WTFMove(callback));
+    });
+}
+
+void GStreamerAudioDecoder::reset()
+{
+    m_internalDecoder->close();
+}
+
+void GStreamerAudioDecoder::close()
+{
+    m_internalDecoder->close();
+}
+
+GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codecName, const AudioDecoder::Config& config, AudioDecoder::OutputCallback&& outputCallback, AudioDecoder::PostTaskCallback&& postTaskCallback, GRefPtr<GstElement>&& element)
+    : m_outputCallback(WTFMove(outputCallback))
+    , m_postTaskCallback(WTFMove(postTaskCallback))
+{
+    GST_DEBUG_OBJECT(element.get(), "Configuring decoder for codec %s", codecName.ascii().data());
+
+    const char* parser = nullptr;
+    if (codecName.startsWith("mp4a"_s)) {
+        m_inputCaps = adoptGRef(gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 4, "channels", G_TYPE_INT, config.numberOfChannels, nullptr));
+        auto codecData = wrapSpanData(config.description);
+        if (codecData)
+            gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), "stream-format", G_TYPE_STRING, "raw", nullptr);
+        else
+            gst_caps_set_simple(m_inputCaps.get(), "stream-format", G_TYPE_STRING, "adts", nullptr);
+    } else if (codecName == "mp3"_s) {
+        m_inputCaps = adoptGRef(gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 1, "layer", G_TYPE_INT, 3, "rate", G_TYPE_INT, config.sampleRate, "channels", G_TYPE_INT, config.numberOfChannels, "parsed", G_TYPE_BOOLEAN, TRUE, nullptr));
+    } else if (codecName == "opus"_s) {
+        int channelMappingFamily = config.numberOfChannels <= 2 ? 0 : 1;
+        m_inputCaps = adoptGRef(gst_caps_new_simple("audio/x-opus", "channel-mapping-family", G_TYPE_INT, channelMappingFamily, nullptr));
+        m_header = wrapSpanData(config.description);
+        if (m_header)
+            parser = "opusparse";
+    } else if (codecName == "alaw"_s)
+        m_inputCaps = adoptGRef(gst_caps_new_simple("audio/x-alaw", "rate", G_TYPE_INT, config.sampleRate, "channels", G_TYPE_INT, config.numberOfChannels, nullptr));
+    else if (codecName == "ulaw"_s)
+        m_inputCaps = adoptGRef(gst_caps_new_simple("audio/x-mulaw", "rate", G_TYPE_INT, config.sampleRate, "channels", G_TYPE_INT, config.numberOfChannels, nullptr));
+    else if (codecName == "flac"_s) {
+        m_header = wrapSpanData(config.description);
+        if (!m_header) {
+            GST_WARNING("Decoder config description for flac codec is mandatory");
+            return;
+        }
+        parser = "flacparse";
+        m_inputCaps = adoptGRef(gst_caps_new_empty_simple("audio/x-flac"));
+    } else if (codecName == "vorbis"_s) {
+        m_header = wrapSpanData(config.description);
+        if (!m_header) {
+            GST_WARNING("Decoder config description for vorbis codec is mandatory");
+            return;
+        }
+        parser = "oggparse";
+        m_inputCaps = adoptGRef(gst_caps_new_empty_simple("application/ogg"));
+    } else if (codecName.startsWith("pcm-"_s)) {
+        auto components = codecName.split('-');
+        auto pcmFormat = components[1].convertToASCIILowercase();
+        GstAudioFormat gstPcmFormat = GST_AUDIO_FORMAT_UNKNOWN;
+        if (pcmFormat == "u8"_s)
+            gstPcmFormat = GST_AUDIO_FORMAT_U8;
+        else if (pcmFormat == "s16"_s)
+            gstPcmFormat = GST_AUDIO_FORMAT_S16;
+        else if (pcmFormat == "s24"_s)
+            gstPcmFormat = GST_AUDIO_FORMAT_S24;
+        else if (pcmFormat == "s32"_s)
+            gstPcmFormat = GST_AUDIO_FORMAT_S32;
+        else if (pcmFormat == "f32"_s)
+            gstPcmFormat = GST_AUDIO_FORMAT_F32;
+        else {
+            GST_WARNING("Invalid LPCM codec format: %s", pcmFormat.ascii().data());
+            return;
+        }
+        m_inputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, gst_audio_format_to_string(gstPcmFormat),
+            "rate", G_TYPE_INT, config.sampleRate, "channels", G_TYPE_INT, config.numberOfChannels,
+            "layout", G_TYPE_STRING, "interleaved", nullptr));
+        parser = "rawaudioparse";
+    } else
+        return;
+
+    configureAudioDecoderForHarnessing(element);
+
+    GRefPtr<GstElement> harnessedElement;
+    bool isParserRequired = false;
+    if (element) {
+        auto* factory = gst_element_get_factory(element.get());
+        isParserRequired = !gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get());
+    }
+    if (!g_strcmp0(parser, "rawaudioparse")) {
+        harnessedElement = makeGStreamerElement(parser, nullptr);
+        if (!harnessedElement) {
+            GST_WARNING_OBJECT(element.get(), "Required parser %s not found", parser);
+            m_inputCaps.clear();
+            return;
+        }
+    } else if (parser && isParserRequired) {
+        // The decoder won't accept the input caps, so put a parser in front.
+        auto* parserElement = makeGStreamerElement(parser, nullptr);
+        if (!parserElement) {
+            GST_WARNING_OBJECT(element.get(), "Required parser %s not found, decoding will fail", parser);
+            m_inputCaps.clear();
+            return;
+        }
+        harnessedElement = gst_bin_new(nullptr);
+        gst_bin_add_many(GST_BIN_CAST(harnessedElement.get()), parserElement, element.get(), nullptr);
+        gst_element_link(parserElement, element.get());
+        auto sinkPad = adoptGRef(gst_element_get_static_pad(parserElement, "sink"));
+        gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("sink", sinkPad.get()));
+        auto srcPad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
+        gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("src", srcPad.get()));
+    } else
+        harnessedElement = WTFMove(element);
+
+    m_harness = GStreamerElementHarness::create(WTFMove(harnessedElement), [weakThis = WeakPtr { *this }, this](auto& stream, const GRefPtr<GstBuffer>& outputBuffer) {
+        if (!weakThis)
+            return;
+        if (m_isClosed)
+            return;
+
+        if (GST_BUFFER_FLAG_IS_SET(outputBuffer.get(), GST_BUFFER_FLAG_DECODE_ONLY))
+            return;
+
+        if (!gst_buffer_n_memory(outputBuffer.get()))
+            return;
+
+        GST_TRACE_OBJECT(m_harness->element(), "Got frame with PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(outputBuffer.get())));
+
+        const GstSegment* segment = nullptr;
+        if (auto segmentEvent = adoptGRef(gst_pad_get_sticky_event(stream.pad().get(), GST_EVENT_SEGMENT, 0)))
+            gst_event_parse_segment(segmentEvent.get(), &segment);
+        auto sample = adoptGRef(gst_sample_new(outputBuffer.get(), stream.outputCaps().get(), segment, nullptr));
+        auto data = PlatformRawAudioDataGStreamer::create(WTFMove(sample));
+        m_postTaskCallback([weakThis = WeakPtr { *this }, this, data = WTFMove(data)]() mutable {
+            if (!weakThis)
+                return;
+            if (!m_isClosed)
+                m_outputCallback(AudioDecoder::DecodedData { WTFMove(data) });
+        });
+    });
+}
+
+void GStreamerInternalAudioDecoder::decode(std::span<const uint8_t> frameData, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration, AudioDecoder::DecodeCallback&& callback)
+{
+    GST_DEBUG_OBJECT(m_harness->element(), "Decoding%s frame", isKeyFrame ? " key" : "");
+
+    auto encodedData = wrapSpanData(frameData);
+    if (!encodedData) {
+        m_postTaskCallback([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback)]() mutable {
+            if (!weakThis)
+                return;
+            if (m_isClosed)
+                return;
+
+            m_outputCallback(makeUnexpected("Empty frame"_s));
+            callback({ });
+        });
+        return;
+    }
+
+    GstSegment segment;
+    gst_segment_init(&segment, GST_FORMAT_TIME);
+    if (timestamp < 0)
+        segment.rate = -1.0;
+
+    if (m_header) {
+        GST_DEBUG_OBJECT(m_harness->element(), "Pushing initial header");
+        m_harness->start(GRefPtr<GstCaps>(m_inputCaps), &segment);
+        m_harness->pushBuffer(WTFMove(m_header));
+    }
+
+    GST_BUFFER_PTS(encodedData.get()) = abs(timestamp) * 1000;
+    if (duration)
+        GST_BUFFER_DURATION(encodedData.get()) = *duration;
+
+    auto result = m_harness->pushSample(adoptGRef(gst_sample_new(encodedData.get(), m_inputCaps.get(), &segment, nullptr)));
+    m_postTaskCallback([weakThis = WeakPtr { *this }, this, callback = WTFMove(callback), result]() mutable {
+        if (!weakThis)
+            return;
+        if (m_isClosed)
+            return;
+
+        if (result)
+            m_harness->processOutputBuffers();
+        else
+            m_outputCallback(makeUnexpected("Decode error"_s));
+
+        callback({ });
+    });
+}
+
+void GStreamerInternalAudioDecoder::flush(Function<void()>&& callback)
+{
+    if (m_isClosed) {
+        GST_DEBUG_OBJECT(m_harness->element(), "Decoder closed, nothing to flush");
+        m_postTaskCallback(WTFMove(callback));
+        return;
+    }
+
+    auto buffer = adoptGRef(gst_buffer_new());
+    GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_DISCONT);
+    m_harness->pushBuffer(WTFMove(buffer));
+
+    m_harness->flushBuffers();
+    m_postTaskCallback(WTFMove(callback));
+}
+
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CODECS) && USE(GSTREAMER)

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS) && USE(GSTREAMER)
+
+#include "AudioDecoder.h"
+#include "GRefPtrGStreamer.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class GStreamerInternalAudioDecoder;
+
+class GStreamerAudioDecoder : public ThreadSafeRefCounted<GStreamerAudioDecoder>, public AudioDecoder {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    static bool create(const String& codecName, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
+
+    GStreamerAudioDecoder(const String& codecName, const Config&, OutputCallback&&, PostTaskCallback&&, GRefPtr<GstElement>&&);
+    ~GStreamerAudioDecoder();
+
+private:
+    void decode(EncodedData&&, DecodeCallback&&) final;
+    void flush(Function<void()>&&) final;
+    void reset() final;
+    void close() final;
+
+    Ref<GStreamerInternalAudioDecoder> m_internalDecoder;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS) && USE(GSTREAMER)

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "PlatformRawAudioDataGStreamer.h"
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+#include "GUniquePtrGStreamer.h"
+#include "SharedBuffer.h"
+#include "WebCodecsAudioDataAlgorithms.h"
+#include <gst/audio/audio-converter.h>
+
+GST_DEBUG_CATEGORY(webkit_audio_data_debug);
+#define GST_CAT_DEFAULT webkit_audio_data_debug
+
+namespace WebCore {
+
+static void ensureAudioDataDebugCategoryInitialized()
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_audio_data_debug, "webkitaudiodata", 0, "WebKit Audio Data");
+    });
+}
+
+static std::pair<GstAudioFormat, GstAudioLayout> convertAudioSampleFormatToGStreamerFormat(const AudioSampleFormat& format)
+{
+    switch (format) {
+    case AudioSampleFormat::U8:
+        return { GST_AUDIO_FORMAT_U8, GST_AUDIO_LAYOUT_INTERLEAVED };
+    case AudioSampleFormat::S16:
+        return { GST_AUDIO_FORMAT_S16, GST_AUDIO_LAYOUT_INTERLEAVED };
+    case AudioSampleFormat::S32:
+        return { GST_AUDIO_FORMAT_S32, GST_AUDIO_LAYOUT_INTERLEAVED };
+    case AudioSampleFormat::F32:
+        return { GST_AUDIO_FORMAT_F32, GST_AUDIO_LAYOUT_INTERLEAVED };
+    case AudioSampleFormat::U8Planar:
+        return { GST_AUDIO_FORMAT_U8, GST_AUDIO_LAYOUT_NON_INTERLEAVED };
+    case AudioSampleFormat::S16Planar:
+        return { GST_AUDIO_FORMAT_S16, GST_AUDIO_LAYOUT_NON_INTERLEAVED };
+    case AudioSampleFormat::S32Planar:
+        return { GST_AUDIO_FORMAT_S32, GST_AUDIO_LAYOUT_NON_INTERLEAVED };
+    case AudioSampleFormat::F32Planar:
+        return { GST_AUDIO_FORMAT_F32, GST_AUDIO_LAYOUT_NON_INTERLEAVED };
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return { GST_AUDIO_FORMAT_UNKNOWN, GST_AUDIO_LAYOUT_INTERLEAVED };
+}
+
+RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_t>&& sourceData, AudioSampleFormat format, float sampleRate, int64_t timestamp, size_t numberOfFrames, size_t numberOfChannels)
+{
+    ensureAudioDataDebugCategoryInitialized();
+    auto [gstFormat, layout] = convertAudioSampleFormatToGStreamerFormat(format);
+
+    GstAudioInfo info;
+    gst_audio_info_set_format(&info, gstFormat, static_cast<int>(sampleRate), numberOfChannels, nullptr);
+    GST_AUDIO_INFO_LAYOUT(&info) = layout;
+
+    auto caps = adoptGRef(gst_audio_info_to_caps(&info));
+    GST_TRACE("Creating raw audio wrapper with caps %" GST_PTR_FORMAT, caps.get());
+
+    Vector<uint8_t> dataStorage { sourceData.data(), sourceData.size() };
+    auto data = SharedBuffer::create(WTFMove(dataStorage));
+    gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->data()));
+    auto bufferLength = data->size();
+    auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferLength, 0, bufferLength, reinterpret_cast<gpointer>(&data.leakRef()), [](gpointer data) {
+        static_cast<SharedBuffer*>(data)->deref();
+    }));
+    GST_BUFFER_DURATION(buffer.get()) = (numberOfFrames / sampleRate) * 1000000000;
+
+    GstSegment segment;
+    gst_segment_init(&segment, GST_FORMAT_TIME);
+    if (timestamp < 0)
+        segment.rate = -1.0;
+
+    GST_BUFFER_PTS(buffer.get()) = abs(timestamp) * 1000;
+
+    gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, nullptr);
+
+    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), &segment, nullptr));
+    return PlatformRawAudioDataGStreamer::create(WTFMove(sample));
+}
+
+PlatformRawAudioDataGStreamer::PlatformRawAudioDataGStreamer(GRefPtr<GstSample>&& sample)
+    : m_sample(WTFMove(sample))
+{
+    ensureAudioDataDebugCategoryInitialized();
+    gst_audio_info_from_caps(&m_info, gst_sample_get_caps(m_sample.get()));
+}
+
+AudioSampleFormat PlatformRawAudioDataGStreamer::format() const
+{
+    auto gstFormat = GST_AUDIO_INFO_FORMAT(&m_info);
+    auto layout = GST_AUDIO_INFO_LAYOUT(&m_info);
+    switch (gstFormat) {
+    case GST_AUDIO_FORMAT_U8:
+        if (layout == GST_AUDIO_LAYOUT_INTERLEAVED)
+            return AudioSampleFormat::U8;
+        return AudioSampleFormat::U8Planar;
+    case GST_AUDIO_FORMAT_S16:
+        if (layout == GST_AUDIO_LAYOUT_INTERLEAVED)
+            return AudioSampleFormat::S16;
+        return AudioSampleFormat::S16Planar;
+    case GST_AUDIO_FORMAT_S32:
+        if (layout == GST_AUDIO_LAYOUT_INTERLEAVED)
+            return AudioSampleFormat::S32;
+        return AudioSampleFormat::S32Planar;
+    case GST_AUDIO_FORMAT_F32:
+        if (layout == GST_AUDIO_LAYOUT_INTERLEAVED)
+            return AudioSampleFormat::F32;
+        return AudioSampleFormat::F32Planar;
+    default:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return AudioSampleFormat::U8;
+}
+
+size_t PlatformRawAudioDataGStreamer::sampleRate() const
+{
+    return GST_AUDIO_INFO_RATE(&m_info);
+}
+
+size_t PlatformRawAudioDataGStreamer::numberOfChannels() const
+{
+    return GST_AUDIO_INFO_CHANNELS(&m_info);
+}
+
+size_t PlatformRawAudioDataGStreamer::numberOfFrames() const
+{
+    auto totalFrames = gst_buffer_get_size(gst_sample_get_buffer(m_sample.get())) / GST_AUDIO_INFO_BPS(&m_info);
+    return totalFrames / numberOfChannels();
+}
+
+std::optional<uint64_t> PlatformRawAudioDataGStreamer::duration() const
+{
+    auto buffer = gst_sample_get_buffer(m_sample.get());
+    if (!GST_BUFFER_DURATION_IS_VALID(buffer))
+        return { };
+
+    return GST_TIME_AS_USECONDS(GST_BUFFER_DURATION(buffer));
+}
+
+int64_t PlatformRawAudioDataGStreamer::timestamp() const
+{
+    auto buffer = gst_sample_get_buffer(m_sample.get());
+    auto timestamp = GST_TIME_AS_USECONDS(GST_BUFFER_PTS(buffer));
+    auto segment = gst_sample_get_segment(m_sample.get());
+    if (segment->rate < 0)
+        return -timestamp;
+    return timestamp;
+}
+
+size_t PlatformRawAudioDataGStreamer::memoryCost() const
+{
+    return gst_buffer_get_size(gst_sample_get_buffer(m_sample.get()));
+}
+
+void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFormat format, size_t planeIndex, std::optional<size_t> frameOffset, std::optional<size_t>, unsigned long)
+{
+    auto& self = *reinterpret_cast<PlatformRawAudioDataGStreamer*>(this);
+
+    auto [sourceFormat, sourceLayout] = convertAudioSampleFormatToGStreamerFormat(self.format());
+    auto [destinationFormat, destinationLayout] = convertAudioSampleFormatToGStreamerFormat(format);
+
+    auto sourceOffset = frameOffset.value_or(0);
+    const char* destinationFormatDescription = gst_audio_format_to_string(destinationFormat);
+
+    GST_TRACE("Copying %s data at planeIndex %zu, destination format is %s, source offset: %zu", gst_audio_format_to_string(sourceFormat), planeIndex, destinationFormatDescription, sourceOffset);
+    GST_TRACE("Input caps: %" GST_PTR_FORMAT, gst_sample_get_caps(self.sample()));
+
+    GstMappedAudioBuffer mappedBuffer(self.sample(), GST_MAP_READ);
+    const auto inputBuffer = mappedBuffer.get();
+
+    if (self.format() == format) {
+        if (destinationLayout == GST_AUDIO_LAYOUT_NON_INTERLEAVED) {
+            auto size = computeBytesPerSample(format) * inputBuffer->n_samples;
+            memcpy(destination.data(), static_cast<uint8_t*>(inputBuffer->planes[planeIndex]) + sourceOffset, size);
+        } else {
+            GstMappedBuffer in(inputBuffer->buffer, GST_MAP_READ);
+            memcpy(destination.data(), in.data() + sourceOffset, in.size() - sourceOffset);
+        }
+        return;
+    }
+
+    GstAudioInfo destinationInfo;
+    gst_audio_info_set_format(&destinationInfo, destinationFormat, static_cast<int>(self.sampleRate()), self.numberOfChannels(), nullptr);
+    GST_AUDIO_INFO_LAYOUT(&destinationInfo) = destinationLayout;
+#ifndef GST_DISABLE_GST_DEBUG
+    auto outputCaps = adoptGRef(gst_audio_info_to_caps(&destinationInfo));
+    GST_TRACE("Output caps: %" GST_PTR_FORMAT, outputCaps.get());
+#endif
+
+    GUniquePtr<GstAudioInfo> sourceInfo(gst_audio_info_copy(self.info()));
+    GUniquePtr<GstAudioConverter> converter(gst_audio_converter_new(GST_AUDIO_CONVERTER_FLAG_NONE, sourceInfo.get(), &destinationInfo, nullptr));
+
+    auto inFrames = gst_buffer_get_size(gst_sample_get_buffer(self.sample())) / GST_AUDIO_INFO_BPF(sourceInfo.get());
+    auto outFrames = gst_audio_converter_get_out_frames(converter.get(), inFrames);
+    auto destinationBuffer = adoptGRef(gst_buffer_new_and_alloc(outFrames * GST_AUDIO_INFO_BPF(&destinationInfo)));
+    if (destinationLayout == GST_AUDIO_LAYOUT_NON_INTERLEAVED)
+        gst_buffer_add_audio_meta(destinationBuffer.get(), &destinationInfo, self.numberOfFrames(), nullptr);
+
+    GstMappedAudioBuffer mappedDestinationBuffer(destinationBuffer.get(), destinationInfo, GST_MAP_WRITE);
+    auto outputBuffer = mappedDestinationBuffer.get();
+    gst_audio_converter_samples(converter.get(), GST_AUDIO_CONVERTER_FLAG_NONE, inputBuffer->planes, inputBuffer->n_samples, outputBuffer->planes, outputBuffer->n_samples);
+
+    auto planeSize = computeBytesPerSample(format) * outputBuffer->n_samples;
+    memcpy(destination.data(), static_cast<uint8_t*>(outputBuffer->planes[planeIndex]) + sourceOffset, planeSize);
+}
+
+} // namespace WebCore
+
+#undef GST_CAT_DEFAULT
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "PlatformRawAudioData.h"
+
+#if USE(GSTREAMER)
+
+#include "GRefPtrGStreamer.h"
+#include <gst/audio/audio.h>
+
+namespace WebCore {
+
+class PlatformRawAudioDataGStreamer final : public PlatformRawAudioData {
+public:
+    static Ref<PlatformRawAudioData> create(GRefPtr<GstSample>&& sample)
+    {
+        return adoptRef(*new PlatformRawAudioDataGStreamer(WTFMove(sample)));
+    }
+
+    AudioSampleFormat format() const final;
+    size_t sampleRate() const final;
+    size_t numberOfChannels() const final;
+    size_t numberOfFrames() const final;
+    std::optional<uint64_t> duration() const final;
+    int64_t timestamp() const final;
+
+    size_t memoryCost() const final;
+
+    GstSample* sample() const { return m_sample.get(); }
+    const GstAudioInfo* info() const { return &m_info; }
+
+private:
+    PlatformRawAudioDataGStreamer(GRefPtr<GstSample>&&);
+
+    GRefPtr<GstSample> m_sample;
+    GstAudioInfo m_info;
+};
+
+}
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "DisplayListItems.h"
 #include "GraphicsContext.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1024,6 +1024,12 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
         GST_VIDEO_INFO_COLORIMETRY(info).range = GST_VIDEO_COLOR_RANGE_UNKNOWN;
 }
 
+void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>& element)
+{
+    if (gstObjectHasProperty(element.get(), "max-errors"))
+        g_object_set(element.get(), "max-errors", 0, nullptr);
+}
+
 void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>& element)
 {
     if (gstObjectHasProperty(element.get(), "max-threads"))

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -299,6 +299,63 @@ private:
     bool m_isValid { false };
 };
 
+class GstMappedAudioBuffer {
+    WTF_MAKE_NONCOPYABLE(GstMappedAudioBuffer);
+public:
+
+    GstMappedAudioBuffer(GstBuffer* buffer, GstAudioInfo info, GstMapFlags flags)
+    {
+        m_isValid = gst_audio_buffer_map(&m_buffer, &info, buffer, flags);
+    }
+
+    GstMappedAudioBuffer(GRefPtr<GstSample> sample, GstMapFlags flags)
+    {
+        GstAudioInfo info;
+
+        if (!gst_audio_info_from_caps(&info, gst_sample_get_caps(sample.get()))) {
+            m_isValid = false;
+            return;
+        }
+
+        m_isValid = gst_audio_buffer_map(&m_buffer, &info, gst_sample_get_buffer(sample.get()), flags);
+    }
+
+    GstAudioBuffer* get()
+    {
+        if (!m_isValid) {
+            GST_INFO("Invalid buffer, returning NULL");
+
+            return nullptr;
+        }
+
+        return &m_buffer;
+    }
+
+    GstAudioInfo* info()
+    {
+        if (!m_isValid) {
+            GST_INFO("Invalid frame, returning NULL");
+
+            return nullptr;
+        }
+
+        return &m_buffer.info;
+    }
+
+    ~GstMappedAudioBuffer()
+    {
+        if (m_isValid)
+            gst_audio_buffer_unmap(&m_buffer);
+        m_isValid = false;
+    }
+
+    explicit operator bool() const { return m_isValid; }
+
+private:
+    GstAudioBuffer m_buffer;
+    bool m_isValid { false };
+};
+
 
 void connectSimpleBusMessageCallback(GstElement*, Function<void(GstMessage*)>&& = [](GstMessage*) { });
 void disconnectSimpleBusMessageCallback(GstElement*);
@@ -329,6 +386,7 @@ PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps*);
 PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo&);
 void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoColorSpace&);
 
+void configureAudioDecoderForHarnessing(const GRefPtr<GstElement>&);
 void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);
 
 bool gstObjectHasProperty(GstElement*, const char* name);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -507,6 +507,8 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         { ElementFactories::Type::AudioDecoder, "audio/x-dts", { }, { } },
         { ElementFactories::Type::AudioDecoder, "audio/x-sbc", { }, { } },
         { ElementFactories::Type::AudioDecoder, "audio/x-sid", { }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-alaw", { }, { "alaw"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-mulaw", { }, { "ulaw"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-speex", { "audio/speex"_s, "audio/x-speex"_s }, { } },
         { ElementFactories::Type::AudioDecoder, "audio/x-wavpack", { "audio/x-wavpack"_s }, { } },
         { ElementFactories::Type::VideoDecoder, "video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false", { "video/mpeg"_s }, { "mpeg"_s } },

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -50,6 +50,7 @@ WTF_DEFINE_GPTR_DELETER(GstFlowCombiner, gst_flow_combiner_free)
 WTF_DEFINE_GPTR_DELETER(GstByteReader, gst_byte_reader_free)
 WTF_DEFINE_GPTR_DELETER(GstVideoConverter, gst_video_converter_free)
 WTF_DEFINE_GPTR_DELETER(GstAudioConverter, gst_audio_converter_free)
+WTF_DEFINE_GPTR_DELETER(GstAudioInfo, gst_audio_info_free)
 
 #if defined(BUILDING_WebCore) && USE(GSTREAMER_WEBRTC)
 WTF_DEFINE_GPTR_DELETER(GstWebRTCSessionDescription, gst_webrtc_session_description_free)

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "SQLiteFileSystem.h"
 
+#include "Logging.h"
 #include "SQLiteDatabase.h"
 #include "SQLiteStatement.h"
 #include <pal/crypto/CryptoDigest.h>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1317,6 +1317,17 @@ struct WebCore::WebCodecsEncodedVideoChunkData {
 };
 #endif
 
+header: <WebCore/WebCodecsEncodedAudioChunk.h>
+#if ENABLE(WEB_CODECS)
+enum class WebCore::WebCodecsEncodedAudioChunkType : bool;
+struct WebCore::WebCodecsEncodedAudioChunkData {
+    WebCore::WebCodecsEncodedAudioChunkType type;
+    int64_t timestamp;
+    std::optional<uint64_t> duration;
+    Vector<uint8_t> buffer;
+};
+#endif
+
 struct WebCore::HTMLModelElementCamera {
     double pitch;
     double yaw;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4479,7 +4479,7 @@ static void adjustSettingsForLockdownMode(Settings& settings, const WebPreferenc
         break;
     }
 #if ENABLE(WEB_CODECS)
-    settings.setWebCodecsEnabled(false);
+    settings.setWebCodecsVideoEnabled(false);
     settings.setWebCodecsAV1Enabled(false);
 #endif
 #if ENABLE(WEB_RTC)


### PR DESCRIPTION
#### 1842861b125b97a693e2f4aa6bcd70e02b0b5bce
<pre>
[WebCodecs] AudioDecoder and AudioData support
<a href="https://bugs.webkit.org/show_bug.cgi?id=259874">https://bugs.webkit.org/show_bug.cgi?id=259874</a>
&lt;rdar://problem/113823411&gt;

Reviewed by Youenn Fablet.

This patch provides an initial implementation of the AudioDecoder and AudioData objects as defined
by the WebCodecs spec. Platform implementations are provided for the GStreamer ports.

The WebCodecsEnabled setting was renamed to WebCodecsVideoEnabled and a new WebCodecsAudioEnabled
setting was added, on by default for GStreamer ports.

Canonical link: <a href="https://commits.webkit.org/267278@main">https://commits.webkit.org/267278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbcc53118e19a683bf60e3d589de9ce36c5a6461

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16178 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16606 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18708 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14641 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18037 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15416 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13057 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16380 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14625 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4080 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18991 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17546 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15222 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3872 "Passed tests") | 
<!--EWS-Status-Bubble-End-->