### PR TITLE
Migrate use of SuspendableTimer to EventLoop

### DIFF
--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -28,7 +28,6 @@
 #include "AlternativeTextClient.h"
 #include "DocumentMarker.h"
 #include "Position.h"
-#include "SuspendableTimer.h"
 #include <variant>
 #include <wtf/Noncopyable.h>
 
@@ -47,6 +46,8 @@ struct DictationAlternative;
 struct SimpleRange;
 struct TextCheckingResult;
 
+using EventLoopTimerPtr = uintptr_t;
+
 #if USE(AUTOCORRECTION_PANEL)
 // These backslashes are for making style checker happy.
 #define UNLESS_ENABLED(functionBody) \
@@ -56,7 +57,7 @@ struct TextCheckingResult;
 #define UNLESS_ENABLED(functionBody) functionBody
 #endif
 
-class AlternativeTextController {
+class AlternativeTextController : public CanMakeWeakPtr<AlternativeTextController> {
     WTF_MAKE_NONCOPYABLE(AlternativeTextController);
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -119,7 +120,7 @@ private:
     FloatRect rootViewRectForRange(const SimpleRange&) const;
     void markPrecedingWhitespaceForDeletedAutocorrectionAfterCommand(EditCommand*);
 
-    SuspendableTimer m_timer;
+    EventLoopTimerPtr m_timer { 0 };
     std::optional<SimpleRange> m_rangeWithAlternative;
     bool m_isActive { };
     bool m_isDismissedByEditing { };

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -35,6 +35,7 @@
 
 #include "CachedResourceRequestInitiatorTypes.h"
 #include "ContentSecurityPolicy.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "MessageEvent.h"
 #include "ResourceError.h"
@@ -60,9 +61,7 @@ inline EventSource::EventSource(ScriptExecutionContext& context, const URL& url,
     , m_url(url)
     , m_withCredentials(eventSourceInit.withCredentials)
     , m_decoder(TextResourceDecoder::create("text/plain"_s, "UTF-8"))
-    , m_connectTimer(&context, *this, &EventSource::connect)
 {
-    m_connectTimer.suspendIfNeeded();
 }
 
 ExceptionOr<Ref<EventSource>> EventSource::create(ScriptExecutionContext& context, const String& url, const Init& eventSourceInit)
@@ -135,14 +134,26 @@ void EventSource::scheduleInitialConnect()
     ASSERT(m_state == CONNECTING);
     ASSERT(!m_requestInFlight);
 
-    m_connectTimer.startOneShot(0_s);
+    auto* context = scriptExecutionContext();
+    if (m_connectTimer)
+        context->eventLoop().cancelScheduledTask(m_connectTimer);
+    m_connectTimer = context->eventLoop().scheduleTask(0_s, *context, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+        if (RefPtr strongThis = weakThis.get())
+            strongThis->connect();
+    });
 }
 
 void EventSource::scheduleReconnect()
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_isSuspendedForBackForwardCache);
     m_state = CONNECTING;
-    m_connectTimer.startOneShot(1_ms * m_reconnectDelay);
+    auto* context = scriptExecutionContext();
+    if (m_connectTimer)
+        context->eventLoop().cancelScheduledTask(m_connectTimer);
+    m_connectTimer = context->eventLoop().scheduleTask(1_ms * m_reconnectDelay, *context, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+        if (RefPtr strongThis = weakThis.get())
+            strongThis->connect();
+    });
     dispatchErrorEvent();
 }
 
@@ -154,8 +165,10 @@ void EventSource::close()
     }
 
     // Stop trying to connect/reconnect if EventSource was explicitly closed or if ActiveDOMObject::stop() was called.
-    if (m_connectTimer.isActive())
-        m_connectTimer.cancel();
+    if (auto* context = scriptExecutionContext(); context && m_connectTimer) {
+        context->eventLoop().cancelScheduledTask(m_connectTimer);
+        m_connectTimer = 0;
+    }
 
     if (m_requestInFlight)
         doExplicitLoadCancellation();

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -34,7 +34,6 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
-#include "SuspendableTimer.h"
 #include "ThreadableLoaderClient.h"
 #include "Timer.h"
 #include <wtf/URL.h>
@@ -45,6 +44,8 @@ namespace WebCore {
 class MessageEvent;
 class TextResourceDecoder;
 class ThreadableLoader;
+
+using EventLoopTimerPtr = uintptr_t;
 
 class EventSource final : public RefCounted<EventSource>, public EventTarget, private ThreadableLoaderClient, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(EventSource);
@@ -114,7 +115,7 @@ private:
 
     Ref<TextResourceDecoder> m_decoder;
     RefPtr<ThreadableLoader> m_loader;
-    SuspendableTimer m_connectTimer;
+    EventLoopTimerPtr m_connectTimer { 0 };
     Vector<UChar> m_receiveBuffer;
     bool m_discardTrailingNewline { false };
     bool m_requestInFlight { false };


### PR DESCRIPTION
#### 4bd78ab3969b623c27406ed7811aee9fa7def839
<pre>
Migrate use of SuspendableTimer to EventLoop
<a href="https://bugs.webkit.org/show_bug.cgi?id=259881">https://bugs.webkit.org/show_bug.cgi?id=259881</a>

Reviewed by Wenson Hsieh.

This PR introduces two new member functions scheduleTask and cancelScheduledTask to
EventLoop and EventLoopTaskGroup to replace the use of SuspendableTimer.

scheduleTask internally creates a new SuspendableTimer and returns the pointer value of
the timer as uintptr_t. This value can then be used to call cancelScheduledTask.

This PR replaces most uses of SuspendableTimer with scheduleTask and cancelScheduledTask.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::cancelScheduledTask):
(WebCore::EventLoopTaskGroup::scheduleTask):
(WebCore::EventLoopTaskGroup::cancelScheduledTask):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::AlternativeTextController):
(WebCore::AlternativeTextController::startAlternativeTextUITimer):
(WebCore::AlternativeTextController::stopAlternativeTextUITimer):
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::forceRestoreContext):
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::EventSource):
(WebCore::EventSource::scheduleInitialConnect):
(WebCore::EventSource::scheduleReconnect):
(WebCore::EventSource::close):
* Source/WebCore/page/EventSource.h:

Canonical link: <a href="https://commits.webkit.org/266664@main">https://commits.webkit.org/266664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be2aa043c965b4639d18650b6cc1cdfff5df8d6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16135 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16855 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12398 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12978 "1 flakes 5 failures") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13697 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17322 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1718 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->