### PR TITLE
Follow-up to 259548.752@safari-7615-branch to cancel navigations instead of blocking them

### DIFF
--- a/LayoutTests/fast/files/null-origin-string-expected.txt
+++ b/LayoutTests/fast/files/null-origin-string-expected.txt
@@ -1,2 +1,7 @@
 CONSOLE MESSAGE: Started reading...
-PASS if no crash.
+
+Test that using FileReader from a document with unique origin doesn't cause a crash.
+
+If testing manually, please drop a file on an input above.
+
+PASS if not crash.

--- a/LayoutTests/fast/files/null-origin-string.html
+++ b/LayoutTests/fast/files/null-origin-string.html
@@ -16,7 +16,7 @@ function onInputFileChange()
     reader.readAsText(file);
     console.log('Started reading...');
 
-    top.location = 'data:text/html,<p>PASS if no crash.</p><script>testRunner.notifyDone()</scr' + 'ipt>';
+    top.postMessage('finish', '*');
 }
 </script>
 
@@ -25,10 +25,16 @@ if (window.eventSender) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 }
+addEventListener('message', (e) => {
+    if (e.data == 'finish')
+        testRunner.notifyDone();
+});
+
 document.write('<iframe src="data:text/html,<input type=file id=file onchange=\'onInputFileChange()\'><script>' + document.getElementsByTagName("script")[0].innerText + 'runTest()</scr' + 'ipt>" style="left:0px;top:0px"></iframe>');
 </script>
 
 <p>Test that using FileReader from a document with unique origin doesn't cause a crash.</p>
 <p>If testing manually, please drop a file on an input above.</p>
+<p>PASS if not crash.</p>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes-expected.txt
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes-expected.txt
@@ -1,0 +1,16 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html' from frame with URL 'http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+
+CONSOLE MESSAGE: SecurityError: The operation is insecure.
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html' from frame with URL 'http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+
+CONSOLE MESSAGE: SecurityError: The operation is insecure.
+Test blocking of suspicious top-level navigations by a third-party iframe (same-site but different scheme)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS All navigations by subframes have been blocked
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test blocking of suspicious top-level navigations by a third-party iframe (same-site but different scheme)");
+jsTestIsAsync = true;
+onload = () => {
+    setTimeout(() => {
+        document.getElementById('testFrame').src = "http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html";
+        setTimeout(() => {
+            testPassed("All navigations by subframes have been blocked");
+            finishJSTest();
+        }, 100);
+    }, 10);
+}
+</script>
+<iframe src="http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html"></iframe>
+<iframe id="testFrame"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html' from frame with URL 'http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+Test blocking of suspicious top-level navigations by a third-party iframe (same-site but redirects to a different site)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS All navigations by subframes have been blocked
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test blocking of suspicious top-level navigations by a third-party iframe (same-site but redirects to a different site)");
+jsTestIsAsync = true;
+onload = () => {
+    setTimeout(() => {
+        document.getElementById('testFrame').src = "http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html";
+        setTimeout(() => {
+            testPassed("All navigations by subframes have been blocked");
+            finishJSTest();
+        }, 100);
+    }, 10);
+}
+</script>
+<iframe id="testFrame"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html
+++ b/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+Success! The navigation was blocked
+<script>
+window.addEventListener("load", e => {
+  top.location = "https://127.0.0.1:8443/security/resources/should-not-have-loaded.html";
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html
+++ b/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+Success! The navigation was blocked
+<script>
+window.addEventListener("load", e => {
+  // The initial navigation URL is same-site but it redirects to a different site.
+  top.location = "http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/security/resources/should-not-have-loaded.html";
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3937,10 +3937,13 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame&
 
     // Only prevent cross-site navigations.
     RefPtr targetDocument = targetFrame.document();
-    if (targetDocument && (targetDocument->securityOrigin().isSameOriginDomain(SecurityOrigin::create(destinationURL)) || areRegistrableDomainsEqual(targetDocument->url(), destinationURL)))
-        return false;
+    if (!targetDocument)
+        return true;
 
-    return true;
+    if (targetDocument->securityOrigin().protocol() != destinationURL.protocol())
+        return true;
+
+    return !(targetDocument->securityOrigin().isSameOriginDomain(SecurityOrigin::create(destinationURL)) || areRegistrableDomainsEqual(targetDocument->url(), destinationURL));
 }
 
 void Document::didRemoveAllPendingStylesheet()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1779,6 +1779,7 @@ public:
 #endif
 
     virtual void didChangeViewSize() { }
+    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame& targetFrame, const URL& destinationURL);
 
     void updateRelevancyOfContentVisibilityElements();
     void scheduleContentRelevancyUpdate(ContentRelevancyStatus);
@@ -1886,7 +1887,6 @@ private:
     void didLoadResourceSynchronously(const URL&) final;
 
     bool canNavigateInternal(LocalFrame& targetFrame);
-    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame& targetFrame, const URL& destinationURL);
 
 #if USE(QUICK_LOOK)
     bool shouldEnforceQuickLookSandbox() const;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -676,7 +676,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
                         , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.");
                     m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
                 }
-                cancelMainResourceLoad(frameLoader()->blockedError(newRequest));
+                cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
                 return completionHandler(WTFMove(newRequest));
             }
         }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -664,6 +664,24 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         return completionHandler(WTFMove(newRequest));
     }
 
+    if (auto requester = m_triggeringAction.requester(); requester && requester->documentIdentifier) {
+        if (RefPtr requestingDocument = Document::allDocumentsMap().get(requester->documentIdentifier); requestingDocument && requestingDocument->frame()) {
+            if (m_frame && requestingDocument->isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*m_frame, newRequest.url())) {
+                DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - cross-site redirect of top frame triggered by third-party iframe");
+                if (m_frame->document()) {
+                    auto message = makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"
+                        , m_frame->document()->url().string()
+                        , "' from frame with URL '"
+                        , requestingDocument->url().string()
+                        , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.");
+                    m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
+                }
+                cancelMainResourceLoad(frameLoader()->blockedError(newRequest));
+                return completionHandler(WTFMove(newRequest));
+            }
+        }
+    }
+
     ASSERT(timing().startTime());
     if (didReceiveRedirectResponse) {
         if (newRequest.url().protocolIsAbout() || newRequest.url().protocolIsData()) {

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -38,7 +38,8 @@ NavigationRequester NavigationRequester::from(Document& document)
         document.topOrigin(),
         document.policyContainer(),
         document.frameID(),
-        document.pageID()
+        document.pageID(),
+        document.identifier()
     };
 }
 

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -42,6 +42,7 @@ struct NavigationRequester {
     PolicyContainer policyContainer;
     std::optional<FrameIdentifier> frameID;
     std::optional<PageIdentifier> pageID;
+    ScriptExecutionContextIdentifier documentIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4310,6 +4310,7 @@ struct WebCore::NavigationRequester {
     WebCore::PolicyContainer policyContainer;
     std::optional<WebCore::FrameIdentifier> frameID;
     std::optional<WebCore::PageIdentifier> pageID;
+    WebCore::ScriptExecutionContextIdentifier documentIdentifier;
 };
 
 struct WebCore::PolicyContainer {


### PR DESCRIPTION
#### 9f262c71b0a6dc8eb008288142231a823372f697
<pre>
Follow-up to 259548.752@safari-7615-branch to cancel navigations instead of blocking them
<a href="https://bugs.webkit.org/show_bug.cgi?id=257161">https://bugs.webkit.org/show_bug.cgi?id=257161</a>
rdar://108794051

Reviewed by Alex Christensen.

259548.752@safari-7615-branch added further restrictions to prevent top-frame navigations
by third-party iframes, in particular using redirects. I had decided to block the redirect
with a blockedError(). However, it turns out that Safari shows an error page when doing
so, which results in a bad user experience since the top frame is still being navigated
(to an error page).

To address the issue, I am now cancelling the redirect instead and returning a
cancelledError(). I have verified that Safari doesn&apos;t show an error page in this case and
that the top frame is not getting navigated.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):

Originally-landed-as: 259548.773@safari-7615-branch (3d72c3255b5f). rdar://113172008
Canonical link: <a href="https://commits.webkit.org/266667@main">https://commits.webkit.org/266667@main</a>
</pre>
----------------------------------------------------------------------
#### a438f531da737c8a975174c1585cd25336f26960
<pre>
Restrict further top-frame navigations by a third-party iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=256549">https://bugs.webkit.org/show_bug.cgi?id=256549</a>
rdar://108794051

Reviewed by Geoffrey Garen.

Restrict further top-frame navigations by a third-party iframe:
- Block navigations to a different scheme
- Block navigations that start off same-site but redirect to a different site

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::NavigationRequester::from):
* Source/WebCore/loader/NavigationRequester.h:
(WebCore::NavigationRequester::encode const):
(WebCore::NavigationRequester::decode):

Originally-landed-as: 259548.752@safari-7615-branch (a0fa94d1a572). rdar://113170544
Canonical link: <a href="https://commits.webkit.org/266666@main">https://commits.webkit.org/266666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cc660cb75c25a98ad78e75fa6100d4bb920f7e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16132 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14779 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16852 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12980 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13143 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11539 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12839 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3487 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->