### PR TITLE
Crash under ProcessThrottlerActivity::isValid()

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -459,7 +459,11 @@ auto ProcessThrottlerTimedActivity::operator=(ProcessThrottler::ActivityVariant&
 void ProcessThrottlerTimedActivity::activityTimedOut()
 {
     RELEASE_LOG_ERROR(ProcessSuspension, "%p - ProcessThrottlerTimedActivity::activityTimedOut:", this);
-    m_activity = nullptr;
+    // Use variant::swap() to make sure that m_activity is in a good state when the underlying
+    // ProcessThrottlerActivity gets destroyed. This is important as destroying the activity runs code
+    // that may use / modify m_activity.
+    ActivityVariant nullActivity { nullptr };
+    m_activity.swap(nullActivity);
 }
 
 void ProcessThrottlerTimedActivity::updateTimer()


### PR DESCRIPTION
#### fe792fdab477f9b81bb3d07089dd39e548041e1f
<pre>
Crash under ProcessThrottlerActivity::isValid()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259886">https://bugs.webkit.org/show_bug.cgi?id=259886</a>
rdar://113459152

Reviewed by Brent Fulgham.

ProcessThrottlerTimedActivity::activityTimedOut() was getting called, it
would set `m_activity` to nullptr, which would destroy the
ProcessThrottlerActivity. Because this was the last activity, it would
cause the prepareToSuspend logic to get called, which could cause
`m_activity` to get queried while in the middle of the assignment, causing
a crash.

To address the issue, I now use std::variant::swap() in activityTimedOut()
so that m_activity is in a good state (nullptr) when the
ProcessThrottlerActivity gets destroyed.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottlerTimedActivity::activityTimedOut):

Canonical link: <a href="https://commits.webkit.org/266642@main">https://commits.webkit.org/266642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/671b513d2dba8c3ba4175f38865aeb25121f230c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12356 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16310 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11498 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12939 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3471 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->