### PR TITLE
Missing value default for `animateTransform` 'type' is 'translate'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/animatetransform-type-missing-value-default-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/animatetransform-type-missing-value-default-expected.txt
@@ -1,0 +1,6 @@
+
+PASS <animateTransform> 'type' attribute missing/invalid value default, "type" attribute is "translate"
+PASS <animateTransform> 'type' attribute missing/invalid value default, missing "type" attribute
+PASS <animateTransform> 'type' attribute missing/invalid value default, invalid "type" attribute
+FAIL <animateTransform> 'type' attribute missing/invalid value default, removed "type" attribute assert_equals: expected 70 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/animatetransform-type-missing-value-default.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/animatetransform-type-missing-value-default.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<title>&lt;animateTransform> 'type' attribute missing/invalid value default</title>
+<link rel="help" href="https://svgwg.org/specs/animations/#AnimateTransformElementTypeAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg height="10">
+  <rect width="10" height="10" fill="blue">
+    <animateTransform attributeName="transform" type="translate"
+                      fill="freeze" dur="1s" from="10 0" to="10 0"/>
+  </rect>
+  <rect width="10" height="10" fill="blue">
+    <animateTransform attributeName="transform"
+                      fill="freeze" dur="1s" from="30 0" to="30 0"/>
+  </rect>
+  <rect width="10" height="10" fill="blue">
+    <animateTransform attributeName="transform" type="foo"
+                      fill="freeze" dur="1s" from="50 0" to="50 0"/>
+  </rect>
+  <rect width="10" height="10" fill="blue">
+    <animateTransform attributeName="transform" type="foo"
+                      fill="freeze" dur="1s" from="70 0" to="70 0"/>
+  </rect>
+</svg>
+<script>
+  const animations = document.querySelectorAll('animateTransform');
+
+  async_test(t => {
+    animations[0].addEventListener('beginEvent', t.step_func_done(function() {
+      let ctm = animations[0].targetElement.getCTM();
+      assert_equals(ctm.e, 10);
+      assert_equals(ctm.f, 0);
+    }));
+  }, document.title + ', "type" attribute is "translate"');
+
+  async_test(t => {
+    animations[1].addEventListener('beginEvent', t.step_func_done(function() {
+      let ctm = animations[1].targetElement.getCTM();
+      assert_equals(ctm.e, 30);
+      assert_equals(ctm.f, 0);
+    }));
+  }, document.title + ', missing "type" attribute');
+
+  async_test(t => {
+    animations[2].addEventListener('beginEvent', t.step_func_done(function() {
+      let ctm = animations[2].targetElement.getCTM();
+      assert_equals(ctm.e, 0);
+      assert_equals(ctm.f, 0);
+    }));
+  }, document.title + ', invalid "type" attribute');
+
+  async_test(t => {
+    animations[3].addEventListener('beginEvent', t.step_func(function() {
+      animations[3].removeAttribute('type');
+
+      window.requestAnimationFrame(t.step_func_done(function() {
+        let ctm = animations[3].targetElement.getCTM();
+        assert_equals(ctm.e, 70);
+        assert_equals(ctm.f, 0);
+      }));
+    }));
+  }, document.title + ', removed "type" attribute');
+</script>

--- a/Source/WebCore/svg/SVGAnimateTransformElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.cpp
@@ -33,7 +33,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SVGAnimateTransformElement);
 
 inline SVGAnimateTransformElement::SVGAnimateTransformElement(const QualifiedName& tagName, Document& document)
     : SVGAnimateElementBase(tagName, document)
-    , m_type(SVGTransformValue::SVG_TRANSFORM_UNKNOWN)
+    , m_type(SVGTransformValue::SVG_TRANSFORM_TRANSLATE)
 {
     ASSERT(hasTagName(SVGNames::animateTransformTag));
 }


### PR DESCRIPTION
#### a36c08c207956760be4d478f9dc86e3938394cb4
<pre>
Missing value default for `animateTransform` &apos;type&apos; is &apos;translate&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=259885">https://bugs.webkit.org/show_bug.cgi?id=259885</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web-Spec [1].

[1] <a href="https://www.w3.org/TR/SVG11/animate.html#AnimateTransformElementTypeAttribute">https://www.w3.org/TR/SVG11/animate.html#AnimateTransformElementTypeAttribute</a>

&quot;If the attribute is not specified, then the effect is as if a value of &apos;translate&apos;
were specified&quot;.

This PR changes default value from &apos;SVG_TRANSFORM_UNKNOWN&apos; to
&apos;SVG_TRANSFORM_TRANSLATE&apos;.

* Source/WebCore/svg/SVGAnimateTransformElement.cpp: As above
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/animatetransform-type-missing-value-default.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scr…/animatetransform-type-missing-value-default-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/266758@main">https://commits.webkit.org/266758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e780026dbbf458ab61f2e9610fd5168c72ffdb5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16811 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19946 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16312 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12799 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3537 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->