### PR TITLE
[visionOS] AudioSession interruptions do not stop playback

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1123,6 +1123,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::durationChanged()
 
 void MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged()
 {
+    m_playing = !paused();
     if (auto player = m_player.get())
         player->rateChanged();
 }


### PR DESCRIPTION
#### ac6294fe9e54d9a6ca7577d7576b57d1a7e26305
<pre>
[visionOS] AudioSession interruptions do not stop playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=259887">https://bugs.webkit.org/show_bug.cgi?id=259887</a>
rdar://112044261

Reviewed by Eric Carlson.

Timing differences on visionOS result in `AVSampleBufferRenderSynchronizer`&apos;s
rate being set to zero, prior to the interruption notification being dispatched
when an interruption occurs. This difference ordering in ordering results in a
sequence of events that causes WebKit to automatically resume playback following
an interruption.

Specifically:

1. `CMTimebaseEffectiveRateChangedCallback` is fired as AVSBRS has its rate changed, by the system.
2. Through the callback, the rate is observed as zero, resulting in playback being considered paused in the GPU process.
3. The GPU process state is reflected in the web process with a call to `MediaPlayerPrivateRemote::updateCachedState`.
4. `AVAudioSessionInterruptionNotification` is dispatched in the GPU process, by the system.
5. `HTMLMediaElement::updatePlayState()` is called in the web process.
6. The web process believes that playback is already paused, due to (3).
7. Consequently, the GPU process is never told to pause content; specifically, `MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal()` is elided.
8. Importantly, that method sets a flag variable, `m_playing` to false.
9. Since `m_playing` is not set to false, `MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying()` will return true.
10. `MediaPlayerPrivateMediaSourceAVFObjC::updateAllRenderersHaveAvailableSamples()` eventually restarts playback, since `shouldBePlaying()` is true.

On iOS, steps 1-3 do not occur before `AVAudioSessionInterruptionNotification`,
and `MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal()` drives the pausing
of playback.

To fix, ensure the value of `m_playing` reflects the rate change.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged):

Canonical link: <a href="https://commits.webkit.org/266665@main">https://commits.webkit.org/266665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13efd4acd5271a4557a3590ad2b1a7c875697bf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16818 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19957 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11508 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12949 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3486 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->