### PR TITLE
Compositing overlap testing is broken with filters in some configurations

### DIFF
--- a/LayoutTests/compositing/layer-creation/overlap-transform-filter-contribution-expected.txt
+++ b/LayoutTests/compositing/layer-creation/overlap-transform-filter-contribution-expected.txt
@@ -1,0 +1,41 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 630.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 630.00)
+      (contentsOpaque 1)
+      (children 5
+        (GraphicsLayer
+          (position 209.00 251.00)
+          (bounds 200.00 300.00)
+          (opacity 0.50)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 -100.00 0.00 1.00])
+        )
+        (GraphicsLayer
+          (position 310.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 445.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 505.00 445.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 505.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/overlap-transform-filter-contribution.html
+++ b/LayoutTests/compositing/layer-creation/overlap-transform-filter-contribution.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        .container {
+            position: relative;
+            margin: 200px;
+            border: 1px solid black;
+            width: 200px;
+            height: 200px;
+            
+        }
+        .box {
+            position: absolute;
+            top: 50px;
+            left: 0px;
+            width: 100%;
+            height: 300px;
+            opacity: 0.5;
+            object-fit: cover;
+            background-color: blue;
+            filter: blur(4px);
+            transform: translate(100px, -100px);
+            will-change: transform;
+        }
+        
+        .dot {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 4px;
+            width: 4px;
+            background-color: silver;
+        }
+        
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        function makeCornerDots(centerLeft, centerTop)
+        {
+            const width = 2;
+            const height = 2;
+            
+            const spacing = 20;
+            
+            for (let row = 0; row < height; ++row) {
+                for (let col = 0; col < width; ++col) {
+                    const dot = document.createElement('div');
+                    dot.className = 'dot';
+                    dot.style.left = `${centerLeft + spacing * col}px`
+                    dot.style.top = `${centerTop + spacing * row}px`
+                    document.body.appendChild(dot);
+                }
+            }
+        }
+        
+        function makeDots()
+        {
+            makeCornerDots(290, 130);
+            makeCornerDots(290, 445);
+            makeCornerDots(505, 445);
+            makeCornerDots(505, 130);
+
+            if (window.testRunner)
+                document.getElementById("layers").innerText = window.internals.layerTreeAsText(document);
+        }
+        
+        window.addEventListener('load', makeDots, false);
+    </script>
+</head>
+<body>
+    <div class="container">
+        <div class="box"></div>
+    </div>
+<pre id="layers">Layer tree goes here</pre>
+</body>
+</html>

--- a/LayoutTests/compositing/layer-creation/overlap-transform-filter-expected.txt
+++ b/LayoutTests/compositing/layer-creation/overlap-transform-filter-expected.txt
@@ -1,0 +1,27 @@
+ This element should be composited
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 50.00 50.00)
+          (bounds 100.00 100.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 50.00 250.00)
+          (bounds 200.00 200.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 -100.00 0.00 1.00])
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/overlap-transform-filter.html
+++ b/LayoutTests/compositing/layer-creation/overlap-transform-filter.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+		.composited {
+			position: absolute;
+			top: 50px;
+            left: 50px;
+		    width: 100px;
+		    height: 100px;
+		    background-color: silver;
+            will-change: transform;
+        }
+        
+        .box {
+            position: absolute;
+            top: 250px;
+            left: 50px;
+            width: 200px;
+            height: 200px;
+            background-color: blue;
+            filter: blur(1px);
+            transform: translate(100px, -100px);
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        window.addEventListener('load', () => {
+            if (window.testRunner)
+                document.getElementById("layers").innerText = window.internals.layerTreeAsText(document);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="composited">&nbsp;</div>
+    <div class="box">This element should be composited</div>    
+<pre id="layers">Layer tree goes here</pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/overlap-transform-filter-contribution-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/overlap-transform-filter-contribution-expected.txt
@@ -1,0 +1,41 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 629.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 629.00)
+      (contentsOpaque 1)
+      (children 5
+        (GraphicsLayer
+          (position 209.00 251.00)
+          (bounds 200.00 300.00)
+          (opacity 0.50)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 -100.00 0.00 1.00])
+        )
+        (GraphicsLayer
+          (position 310.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 445.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 505.00 445.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 505.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4930,8 +4930,8 @@ FloatRect RenderLayer::absoluteBoundingBoxForPainting() const
 LayoutRect RenderLayer::overlapBounds() const
 {
     if (overlapBoundsIncludeChildren())
-        return calculateLayerBounds(this, { }, defaultCalculateLayerBoundsFlags() | IncludeFilterOutsets);
-    
+        return calculateLayerBounds(this, { }, { UseLocalClipRectIfPossible, IncludeFilterOutsets, UseFragmentBoxesExcludingCompositing });
+
     return localBoundingBox();
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4255,7 +4255,7 @@ TextStream& operator<<(TextStream& ts, const RenderLayerBacking& backing)
     if (backing.paintsIntoCompositedAncestor())
         ts << " paintsIntoCompositedAncestor";
 
-    ts << " primary layer ID " << backing.graphicsLayer()->primaryLayerID();
+    ts << " primary layer ID " << backing.graphicsLayer()->primaryLayerID().object();
     if (auto nodeID = backing.scrollingNodeIDForRole(ScrollCoordinationRole::ViewportConstrained))
         ts << " viewport constrained scrolling node " << nodeID;
     if (auto nodeID = backing.scrollingNodeIDForRole(ScrollCoordinationRole::Scrolling))


### PR DESCRIPTION
#### 2e1ca5ac8e801e668419d46f9c82a1dba8c5b1a3
<pre>
Compositing overlap testing is broken with filters in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=259848">https://bugs.webkit.org/show_bug.cgi?id=259848</a>
rdar://113420795

Reviewed by Alan Baradlay.

`RenderLayer::overlapBounds()` needs to return a rectangle which doesn&apos;t include the layer&apos;s own transform,
since the caller applies the transform. However, if the layer has a filter that moves pixels (causing
`overlapBoundsIncludeChildren()` to return true), then it used `defaultCalculateLayerBoundsFlags()`
which includes `IncludeSelfTransform`.

So pass a set of flags that cause the transform to be ignored.

The tests exercise a filtered layer overlapping another layer, and other layers overlapping a filtered
layer.

This is part of a set of issues that affect reddit.com (rdar://112807737).

* LayoutTests/compositing/layer-creation/overlap-transform-filter-contribution-expected.txt: Added.
* LayoutTests/compositing/layer-creation/overlap-transform-filter-contribution.html: Added.
* LayoutTests/compositing/layer-creation/overlap-transform-filter-expected.txt: Added.
* LayoutTests/compositing/layer-creation/overlap-transform-filter.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/266669@main">https://commits.webkit.org/266669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c363c995e957f196e31324e0eaaa111da84d9bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16134 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14781 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16854 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12974 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16354 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11541 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12834 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3489 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->