### PR TITLE
REGRESSION (iOS 16): Web content cannot capture Cmd+F keyboard events

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10821,6 +10821,26 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 #if HAVE(UIFINDINTERACTION)
 
+- (void)find:(id)sender
+{
+    [self.webView find:sender];
+}
+
+- (void)findAndReplace:(id)sender
+{
+    [self.webView findAndReplace:sender];
+}
+
+- (void)findNext:(id)sender
+{
+    [self.webView findNext:sender];
+}
+
+- (void)findPrevious:(id)sender
+{
+    [self.webView findPrevious:sender];
+}
+
 - (void)useSelectionForFindForWebView:(id)sender
 {
     if (!_page->hasSelectedRange())


### PR DESCRIPTION
#### 0ea6efe2a2ee878fb018be791860d0987595fdcc
<pre>
REGRESSION (iOS 16): Web content cannot capture Cmd+F keyboard events
<a href="https://bugs.webkit.org/show_bug.cgi?id=259892">https://bugs.webkit.org/show_bug.cgi?id=259892</a>
rdar://113516225

Reviewed by Richard Robinson.

Following the addition of new keyboard shortcuts for find and replace in iOS
16, UIKit stopped giving WebKit a chance to handle Cmd+F (and related shortcuts)
prior to performing the system action.

In order to fix the issue, a UIKit change is required. However, once the issue
is fixed in UIKit, the find/replace actions will be dispatched to
`WKContentView` (the input delegate), rather than to `WKWebView`. Currently,
WebKit handles find/replace actions in `WKWebView`, in order to ensure support
for `WKPDFView`.

To prevent an issue following a UIKit fix, implement the find/replace actions on
`WKContentView`, forwarding calls back to `WKWebView` to perform the actual logic.

No new tests at this time, as there is no behavior change from this patch alone,
and a UIKit change is required to get the keyboard event working end-to-end.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView find:]):
(-[WKContentView findAndReplace:]):
(-[WKContentView findNext:]):
(-[WKContentView findPrevious:]):

Canonical link: <a href="https://commits.webkit.org/266663@main">https://commits.webkit.org/266663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944ebe2031c63d267898c87482b865f3dfcc5e85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13616 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14771 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16842 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19974 "3 flakes 110 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12971 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3483 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->