### PR TITLE
Fix font-size-adjust toggling font sizes for 'system-ui' font.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-size-adjust-prop">
+<style>
+html {
+    margin: 0;
+    padding: 0;
+}
+body {
+    font-family: system-ui;
+    font-size: 100px;
+    font-size-adjust: 0.528;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    height: 200px;
+    width: 200px;
+}
+</style>
+</head>
+<body>
+    <div id="target">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-size-adjust-prop">
+<style>
+html {
+    margin: 0;
+    padding: 0;
+}
+body {
+    font-family: system-ui;
+    font-size: 100px;
+    font-size-adjust: 0.528;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    height: 200px;
+    width: 200px;
+}
+</style>
+</head>
+<body>
+    <div id="target">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-size-adjust-prop">
+<link rel="match" href="font-size-adjust-reload-ref.html">
+<style>
+body {
+    margin: 0;
+    padding: 0;
+}
+</style>
+</head>
+<body>
+    <iframe id="iframe" width=400 height=400 frameBorder=0 src="font-size-adjust-reload-ref.html"></iframe>
+</body>
+<script>
+    const iframe = document.getElementById('iframe');
+    // Forcing reload
+    iframe.src += '';
+    iframe.contentWindow.onload = function(){
+        document.documentElement.classList.remove("reftest-wait");
+    };
+</script>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -58,10 +58,11 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
 
         auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(font.get(), fontDescription, ShouldComputePhysicalTraits::Yes).boldObliquePair();
 
-        return makeUnique<FontPlatformData>(font.get(), size, false, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
+        auto platformData = makeUnique<FontPlatformData>(font.get(), size, false, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
+        platformData->updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+        return platformData;
     });
 
-    originalPlatformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     return FontRanges(FontCache::forCurrentThread().fontForPlatformData(originalPlatformData));
 }
 


### PR DESCRIPTION
#### 04c2e0b22b88d749e9400a8701765c6ca09a4f27
<pre>
Fix font-size-adjust toggling font sizes for &apos;system-ui&apos; font.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259895">https://bugs.webkit.org/show_bug.cgi?id=259895</a>
rdar://111709567

Reviewed by Tim Nguyen.

When using &apos;system-ui&apos; font, we will end up calling FontFamilySpecificationCoreText::fontRanges for obtaining FontRanges
with an appended font.

Before this patch, ::fontRanges() was updating the font&apos;s size for the
font-size-adjust everytime fontRange was called. The update would mutate
the font that is cached. After the page is refreshed and this function
was called again, we would retrieve the cached font, and execute the
size adjustment again, what would cause the bug.

This patch moves the call to updateSizeWithFontSizeAdjust to the lambda
function invoked when the Font is being cached, guaranteeing it will be
called just once.

 * LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload-expected.html: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload-ref.html: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-reload.html: Added.
 * Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp:
 (WebCore::FontFamilySpecificationCoreText::fontRanges const):

Canonical link: <a href="https://commits.webkit.org/266771@main">https://commits.webkit.org/266771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b1b055332d8a480bc92c695c571fcefa78edaf5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16494 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15152 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17228 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12707 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14014 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13159 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3545 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->