### PR TITLE
Use EventLoop in XMLHttpRequestProgressEventThrottle instead of SuspendableTimer

### DIFF
--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -74,6 +74,9 @@ public:
     EventLoopTimerPtr scheduleTask(Seconds timeout, ScriptExecutionContext&, std::unique_ptr<EventLoopTask>&&);
     void cancelScheduledTask(EventLoopTimerPtr);
 
+    EventLoopTimerPtr scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, ScriptExecutionContext&, std::unique_ptr<EventLoopTask>&&);
+    void cancelRepeatingTask(EventLoopTimerPtr);
+
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
     void queueMicrotask(std::unique_ptr<EventLoopTask>&&);
 
@@ -105,6 +108,7 @@ private:
     // Use a global queue instead of multiple task queues since HTML5 spec allows UA to pick arbitrary queue.
     Vector<std::unique_ptr<EventLoopTask>> m_tasks;
     HashSet<std::unique_ptr<EventLoopTimer>> m_scheduledTasks;
+    HashSet<std::unique_ptr<EventLoopTimer>> m_repeatingTasks;
     WeakHashSet<EventLoopTaskGroup> m_associatedGroups;
     WeakHashSet<EventLoopTaskGroup> m_groupsWithSuspendedTasks;
     WeakHashSet<ScriptExecutionContext> m_associatedContexts;
@@ -205,6 +209,9 @@ public:
 
     EventLoopTimerPtr scheduleTask(Seconds timeout, ScriptExecutionContext&, TaskSource, EventLoop::TaskFunction&&);
     void cancelScheduledTask(EventLoopTimerPtr);
+
+    EventLoopTimerPtr scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, ScriptExecutionContext&, TaskSource, EventLoop::TaskFunction&&);
+    void cancelRepeatingTask(EventLoopTimerPtr);
 
 private:
     enum class State : uint8_t { Running, Suspended, ReadyToStop, Stopped };

--- a/Source/WebCore/page/SuspendableTimer.cpp
+++ b/Source/WebCore/page/SuspendableTimer.cpp
@@ -148,9 +148,4 @@ void SuspendableTimerBase::augmentRepeatInterval(Seconds delta)
     }
 }
 
-const char* SuspendableTimer::activeDOMObjectName() const
-{
-    return "SuspendableTimer";
-}
-
 } // namespace WebCore

--- a/Source/WebCore/page/SuspendableTimer.h
+++ b/Source/WebCore/page/SuspendableTimer.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+// Do not use this class for new code. Use EventLoop's scheduleTask and scheduleRepeatingTask instead.
 class SuspendableTimerBase : private TimerBase, public ActiveDOMObject {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -76,33 +77,6 @@ private:
 
     bool m_suspended { false };
     bool m_savedIsActive { false };
-};
-
-class SuspendableTimer final : public SuspendableTimerBase {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    template <typename TimerFiredClass, typename TimerFiredBaseClass>
-    SuspendableTimer(ScriptExecutionContext* context, TimerFiredClass& object, void (TimerFiredBaseClass::*function)())
-        : SuspendableTimerBase(context)
-        , m_function(std::bind(function, &object))
-    {
-    }
-
-    SuspendableTimer(ScriptExecutionContext* context, Function<void()>&& function)
-        : SuspendableTimerBase(context)
-        , m_function(WTFMove(function))
-    {
-    }
-
-private:
-    void fired() final
-    {
-        m_function();
-    }
-
-    const char* activeDOMObjectName() const final;
-
-    Function<void()> m_function;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "XMLHttpRequestProgressEventThrottle.h"
 
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "EventTarget.h"
 #include "XMLHttpRequest.h"
@@ -38,9 +39,7 @@ const Seconds XMLHttpRequestProgressEventThrottle::minimumProgressEventDispatchi
 
 XMLHttpRequestProgressEventThrottle::XMLHttpRequestProgressEventThrottle(XMLHttpRequest& target)
     : m_target(target)
-    , m_dispatchThrottledProgressEventTimer(target.scriptExecutionContext(), *this, &XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFired)
 {
-    m_dispatchThrottledProgressEventTimer.suspendIfNeeded();
 }
 
 XMLHttpRequestProgressEventThrottle::~XMLHttpRequestProgressEventThrottle() = default;
@@ -54,14 +53,18 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
     if (!isAsync || !m_target.hasEventListeners(eventNames().progressEvent))
         return;
 
-    if (!m_shouldDeferEventsDueToSuspension && !m_dispatchThrottledProgressEventTimer.isActive()) {
+    if (!m_shouldDeferEventsDueToSuspension && !m_dispatchThrottledProgressEventTimer) {
         // The timer is not active so the least frequent event for now is every byte. Just dispatch the event.
 
         // We should not have any throttled progress event.
         ASSERT(!m_hasPendingThrottledProgressEvent);
 
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, lengthComputable, loaded, total));
-        m_dispatchThrottledProgressEventTimer.startRepeating(minimumProgressEventDispatchingInterval);
+        m_dispatchThrottledProgressEventTimer = m_target.scriptExecutionContext()->eventLoop().scheduleRepeatingTask(
+            minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, *m_target.scriptExecutionContext(), TaskSource::Networking, [weakThis = WeakPtr { *this }] {
+                if (weakThis)
+                    weakThis->dispatchThrottledProgressEventTimerFired();
+            });
         m_hasPendingThrottledProgressEvent = false;
         return;
     }
@@ -115,17 +118,21 @@ void XMLHttpRequestProgressEventThrottle::flushProgressEvent()
 
     m_hasPendingThrottledProgressEvent = false;
     // We stop the timer as this is called when no more events are supposed to occur.
-    m_dispatchThrottledProgressEventTimer.cancel();
+    if (m_dispatchThrottledProgressEventTimer) {
+        m_target.scriptExecutionContext()->eventLoop().cancelRepeatingTask(m_dispatchThrottledProgressEventTimer);
+        m_dispatchThrottledProgressEventTimer = 0;
+    }
 
     dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, m_lengthComputable, m_loaded, m_total));
 }
 
 void XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFired()
 {
-    ASSERT(m_dispatchThrottledProgressEventTimer.isActive());
+    ASSERT(m_dispatchThrottledProgressEventTimer);
     if (!m_hasPendingThrottledProgressEvent) {
         // No progress event was queued since the previous dispatch, we can safely stop the timer.
-        m_dispatchThrottledProgressEventTimer.cancel();
+        m_target.scriptExecutionContext()->eventLoop().cancelRepeatingTask(m_dispatchThrottledProgressEventTimer);
+        m_dispatchThrottledProgressEventTimer = 0;
         return;
     }
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -26,14 +26,16 @@
 
 #pragma once
 
-#include "SuspendableTimer.h"
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class Event;
 class XMLHttpRequest;
+
+using EventLoopTimerPtr = uintptr_t;
 
 enum ProgressEventAction {
     DoNotFlushProgressEvent,
@@ -42,7 +44,7 @@ enum ProgressEventAction {
 
 // This implements the XHR2 progress event dispatching: "dispatch a progress event called progress
 // about every 50ms or for every byte received, whichever is least frequent".
-class XMLHttpRequestProgressEventThrottle {
+class XMLHttpRequestProgressEventThrottle : public CanMakeWeakPtr<XMLHttpRequestProgressEventThrottle> {
 public:
     explicit XMLHttpRequestProgressEventThrottle(XMLHttpRequest&);
     virtual ~XMLHttpRequestProgressEventThrottle();
@@ -68,7 +70,7 @@ private:
     unsigned long long m_loaded { 0 };
     unsigned long long m_total { 0 };
 
-    SuspendableTimer m_dispatchThrottledProgressEventTimer;
+    EventLoopTimerPtr m_dispatchThrottledProgressEventTimer { 0 };
 
     bool m_hasPendingThrottledProgressEvent { false };
     bool m_lengthComputable { false };


### PR DESCRIPTION
#### ed16852c54277646774ded6258044e4b2e054986
<pre>
Use EventLoop in XMLHttpRequestProgressEventThrottle instead of SuspendableTimer
<a href="https://bugs.webkit.org/show_bug.cgi?id=259901">https://bugs.webkit.org/show_bug.cgi?id=259901</a>

Reviewed by Wenson Hsieh.

Replaced the use of SuspendableTimer in XMLHttpRequestProgressEventThrottle by
EventLoop/EventLoopTaskGroup&apos;s scheduleRepeatingTask and cancelRepeatingTask.

This PR also removes SuspendableTimer itself, only leaving SuspendableTimerBase,
which is used by DOMTimer and EventLoop itself.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoop::cancelRepeatingTask):
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::cancelRepeatingTask):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/page/SuspendableTimer.cpp:
(WebCore::SuspendableTimer::SuspendableTimer): Deleted.
(WebCore::SuspendableTimer::activeDOMObjectName const): Deleted.
* Source/WebCore/page/SuspendableTimer.h:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::XMLHttpRequestProgressEventThrottle):
(WebCore::XMLHttpRequestProgressEventThrottle::updateProgress):
(WebCore::XMLHttpRequestProgressEventThrottle::flushProgressEvent):
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFired):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h:

Canonical link: <a href="https://commits.webkit.org/266676@main">https://commits.webkit.org/266676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21b82f7d13929e6b9ca7df1c0326826776a9aea2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14821 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16898 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13016 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13021 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17358 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1721 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->