### PR TITLE
Implement `text-wrap: balance` via Knuth-Plass

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1692,6 +1692,7 @@ layout/formattingContexts/flex/FlexFormattingState.cpp
 layout/floats/FloatAvoider.cpp
 layout/floats/FloatingContext.cpp
 layout/floats/FloatingState.cpp
+layout/formattingContexts/inline/InlineContentBalancer.cpp
 layout/formattingContexts/inline/InlineContentBreaker.cpp
 layout/formattingContexts/inline/InlineFormattingContext.cpp
 layout/formattingContexts/inline/InlineFormattingGeometry.cpp
@@ -1705,6 +1706,7 @@ layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
 layout/formattingContexts/inline/InlineLineBuilder.cpp
 layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
 layout/formattingContexts/inline/InlineTextItem.cpp
+layout/formattingContexts/inline/InlineWidthOverride.cpp
 layout/formattingContexts/inline/display/InlineDisplayContent.cpp
 layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
 layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
@@ -1,0 +1,495 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InlineContentBalancer.h"
+
+#include "InlineLineBuilder.h"
+#include <limits>
+
+namespace WebCore {
+namespace Layout {
+
+InlineContentBalancer::InlineContentBalancer(const InlineFormattingContext& inlineFormattingContext, const InlineItems& inlineItems, const HorizontalConstraints& horizontalConstraints)
+    : m_inlineFormattingContext(inlineFormattingContext)
+    , m_inlineItems(inlineItems)
+    , m_horizontalConstraints(horizontalConstraints)
+{
+    initialize();
+}
+
+InlineContentBalancer::~InlineContentBalancer()
+{
+    delete m_lineBuilder;
+}
+
+void InlineContentBalancer::initialize()
+{
+    m_numItems = m_inlineItems.size();
+    m_maxLineWidth = m_horizontalConstraints.logicalWidth;
+
+    // Always consider all inline items, as modification of one line can impact line layout
+    // across earlier/later lines due to rebalancing.
+    InlineItemRange layoutRange = InlineItemRange { 0, m_inlineItems.size() };
+
+    // Perform a line layout with `text-wrap: wrap` to compute the number of lines needed for balancing
+    auto floatingState = FloatingState { m_inlineFormattingContext.root() };
+    auto parentBlockLayoutState = BlockLayoutState { floatingState, { } };
+    auto inlineLayoutState = InlineLayoutState { parentBlockLayoutState, { } };
+    m_lineBuilder = new LineBuilder { m_inlineFormattingContext, inlineLayoutState, floatingState, m_horizontalConstraints, m_inlineItems };
+    auto previousLineEnd = std::optional<InlineItemPosition> { };
+    auto previousLine = std::optional<PreviousLine> { };
+    auto lineIndex = 0lu;
+    while (!layoutRange.isEmpty()) {
+        auto lineInitialRect = InlineRect { 0.f, m_horizontalConstraints.logicalLeft, m_horizontalConstraints.logicalWidth, 0.f };
+        auto lineLayoutResult = m_lineBuilder->layoutInlineContent({ layoutRange, lineInitialRect }, previousLine);
+        m_lineRanges.append(lineLayoutResult.inlineItemRange);
+        m_lineEndsWithForcedBreak.append(!lineLayoutResult.inlineContent.isEmpty() && lineLayoutResult.inlineContent.last().isLineBreak());
+
+        // Abort if float is encountered
+        if (!floatingState.isEmpty()) {
+            m_cannotBalanceContent = true;
+            return;
+        }
+
+        layoutRange.start = InlineFormattingGeometry::leadingInlineItemPositionForNextLine(lineLayoutResult.inlineItemRange.end, previousLineEnd, layoutRange.end);
+        previousLineEnd = layoutRange.start;
+        previousLine = PreviousLine { lineIndex, lineLayoutResult.contentGeometry.trailingOverflowingContentWidth, !lineLayoutResult.inlineContent.isEmpty() && lineLayoutResult.inlineContent.last().isLineBreak(), lineLayoutResult.directionality.inlineBaseDirection, WTFMove(lineLayoutResult.floatContent.suspendedFloats) };
+
+        lineIndex++;
+    }
+
+    // Record the total number of lines used when laying out inline content as if `text-wrap: wrap` is applied.
+    m_numLines = lineIndex;
+}
+
+std::optional<Vector<LayoutUnit>> InlineContentBalancer::computeBalanceConstraints()
+{
+    if (m_cannotBalanceContent)
+        return std::nullopt;
+
+    // If forced line breaks exist, then we can balance each forced-break-delimited
+    // chunk of text separately. This helps simplify the Knuth-Plass implementation
+    // and any indentation logic.
+    Vector<size_t> chunkSizes;
+    size_t currChunkSize = 0;
+    for (size_t i = 0; i < m_lineRanges.size(); i++) {
+        currChunkSize++;
+        if (m_lineEndsWithForcedBreak[i]) {
+            chunkSizes.append(currChunkSize);
+            currChunkSize = 0;
+        }
+    }
+    if (currChunkSize > 0)
+        chunkSizes.append(currChunkSize);
+
+    // Balance each chunk
+    size_t startLine = 0;
+    Vector<LayoutUnit> lineWidths;
+    for (auto chunkSize : chunkSizes) {
+        std::optional<bool> previousChunkEndsWithLineBreak { std::nullopt };
+
+        if (startLine > 0)
+            previousChunkEndsWithLineBreak = m_lineEndsWithForcedBreak[startLine - 1];
+
+        auto rangeToBalance = InlineItemRange { m_lineRanges[startLine].startIndex(), m_lineRanges[startLine + chunkSize - 1].endIndex() };
+        std::optional<Vector<LayoutUnit>> lineRanges { std::nullopt };
+        if (m_numLines > maxLinesToBalanceWithLineLimit)
+            lineRanges = balanceRangeWithKnuthPlassNoLimit(rangeToBalance, previousChunkEndsWithLineBreak);
+        else
+            lineRanges = balanceRangeWithKnuthPlass(rangeToBalance, chunkSize, previousChunkEndsWithLineBreak);
+
+        if (!lineRanges) {
+            for (size_t i = 0; i < chunkSize; i++)
+                lineWidths.append(m_maxLineWidth);
+        } else {
+            for (size_t i = 0; i < lineRanges->size(); i++)
+                lineWidths.append(lineRanges.value()[i]);
+        }
+
+        startLine += chunkSize;
+    }
+
+    return lineWidths;
+}
+
+std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithKnuthPlass(InlineItemRange range, unsigned long numLines, std::optional<bool> previousChunkEndsWithLineBreak)
+{
+    initializeWidthPrefixSums(range.startIndex(), range.endIndex());
+
+    // breakOpportunities holds the indices i such that a line break can occur before m_inlineItems[i].
+    auto breakOpportunities = m_lineBuilder->listBreakOpportunities(range);
+
+    // We need a dummy break opportunity at the beginning for algorithmic base case purposes
+    breakOpportunities.insert(0, range.startIndex());
+    auto numBreakOpportunities = breakOpportunities.size();
+
+    // Compute ideal line width via averaging the total content width across the number of lines
+    // FIXME: Be smarter about first-line styling and spaces
+    InlineLayoutUnit idealLineWidth = computeWidthBetween(range.startIndex(), range.endIndex(), false) / numLines;
+
+    // Indentation
+    auto firstLineTextIndent = m_inlineFormattingContext.formattingGeometry().computedTextIndent(InlineFormattingGeometry::IsIntrinsicWidthMode::No, previousChunkEndsWithLineBreak, m_maxLineWidth);
+    auto textIndent = m_inlineFormattingContext.formattingGeometry().computedTextIndent(InlineFormattingGeometry::IsIntrinsicWidthMode::No, false, m_maxLineWidth);
+
+    struct Entry {
+        float accumulatedCost;
+        size_t previousBreakIdx;
+    };
+
+    // state[i][j] holds an optimal solution considering all items up to the ith break opportunity (exclusive) with j lines
+    Vector<Vector<Entry>> state(numBreakOpportunities, Vector<Entry>(numLines + 1, { std::numeric_limits<float>::infinity(), 0 }));
+    state[0][0].accumulatedCost = 0.f;
+
+
+    // Special case the first line because of ::first-line styling, indentation, etc.
+    bool applyFirstLineStyling = !range.startIndex();
+    for (size_t endIdx = 1; endIdx < numBreakOpportunities; endIdx++) {
+        size_t start = breakOpportunities[0];
+        size_t end = breakOpportunities[endIdx];
+
+        auto candidateLineWidth = computeWidthBetween(start, end, applyFirstLineStyling) + firstLineTextIndent;
+        if (candidateLineWidth > m_maxLineWidth)
+            break;
+
+        auto candidateLineCost = computeCost(candidateLineWidth, idealLineWidth);
+        state[endIdx][1] = { candidateLineCost, 0 };
+    }
+
+    // breakOpportunities[firstStartIdx] is the first possible starting position for a candidate line that is NOT the first line
+    size_t firstStartIdx = 1;
+    for (size_t breakIdx = 1; breakIdx < numBreakOpportunities; breakIdx++) {
+        size_t end = breakOpportunities[breakIdx];
+
+        while (computeWidthBetween(breakOpportunities[firstStartIdx], end, false) + textIndent > m_maxLineWidth)
+            firstStartIdx++;
+
+        for (size_t startIdx = firstStartIdx; startIdx < breakIdx; startIdx++) {
+            size_t start = breakOpportunities[startIdx];
+            auto candidateLineWidth = computeWidthBetween(start, end, false) + textIndent;
+            auto candidateLineCost = computeCost(candidateLineWidth, idealLineWidth);
+
+            for (size_t lines = 2; lines <= numLines; lines++) {
+                auto accumulatedCost = candidateLineCost + state[startIdx][lines - 1].accumulatedCost;
+                if (accumulatedCost < state[breakIdx][lines].accumulatedCost) {
+                    state[breakIdx][lines].accumulatedCost = accumulatedCost;
+                    state[breakIdx][lines].previousBreakIdx = startIdx;
+                }
+            }
+        }
+    }
+
+    // Check if we found no solution
+    if (std::isinf(state[numBreakOpportunities - 1][numLines].accumulatedCost))
+        return std::nullopt;
+
+    // breaks[i] equals the index into m_inlineItems before which the ith line will break
+    Vector<size_t> breaks(numLines);
+    size_t breakIdx = numBreakOpportunities - 1;
+    for (size_t line = numLines; line > 0; line--) {
+        breaks[line - 1] = breakOpportunities[breakIdx];
+        breakIdx = state[breakIdx][line].previousBreakIdx;
+    }
+
+    // Compute final line widths (adding indentation width)
+    Vector<LayoutUnit> lineWidths(numLines);
+    for (size_t i = 0; i < numLines; i++) {
+        auto start = i > 0 ? breaks[i - 1] : range.startIndex();
+        auto end = breaks[i];
+        auto indentWidth = i > 0 ? textIndent : firstLineTextIndent;
+        auto lineWidth = computeWidthBetween(start, end, !i && applyFirstLineStyling) + indentWidth;
+        lineWidths[i] = LayoutUnit::fromFloatCeil(lineWidth + LayoutUnit::epsilon());
+    }
+
+    return lineWidths;
+}
+
+std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithKnuthPlassNoLimit(InlineItemRange range, std::optional<bool> previousChunkEndsWithLineBreak)
+{
+    initializeWidthPrefixSums(range.startIndex(), range.endIndex());
+
+    // breakOpportunities holds the indices i such that a line break can occur before m_inlineItems[i].
+    auto breakOpportunities = m_lineBuilder->listBreakOpportunities(range);
+
+    // We need a dummy break opportunity at the beginning for algorithmic base case purposes
+    breakOpportunities.insert(0, range.startIndex());
+    auto numBreakOpportunities = breakOpportunities.size();
+
+    // Indentation
+    auto firstLineTextIndent = m_inlineFormattingContext.formattingGeometry().computedTextIndent(InlineFormattingGeometry::IsIntrinsicWidthMode::No, previousChunkEndsWithLineBreak, m_maxLineWidth);
+    auto textIndent = m_inlineFormattingContext.formattingGeometry().computedTextIndent(InlineFormattingGeometry::IsIntrinsicWidthMode::No, false, m_maxLineWidth);
+
+    struct Entry {
+        float accumulatedCost;
+        size_t previousBreakIdx;
+    };
+
+    // We should only accomodate ::first-line styling when the InlineItemRange starts at 0.
+    // It's possible that we are not balancing the first chunk of text, in which case we
+    // ignore ::first-line styling.
+    bool applyFirstLineStyling = !range.startIndex();
+
+    // After breakIdx is greater than lastFirstLineBreakIdx, it is no longer possible
+    // for a line that ends at breakOpportunities[breakIdx] to be the first line.
+    size_t lastFirstLineBreakIdx = 1;
+    while (lastFirstLineBreakIdx < numBreakOpportunities) {
+        auto firstLineWidth = computeWidthBetween(range.startIndex(), breakOpportunities[lastFirstLineBreakIdx], applyFirstLineStyling) + firstLineTextIndent;
+        if (firstLineWidth > m_maxLineWidth)
+            break;
+        lastFirstLineBreakIdx++;
+    }
+    lastFirstLineBreakIdx--;
+
+    // state[i] holds the optimal set of line breaks where the last line break is right before m_inlineItems[breakOpportunities[i]]
+    Vector<Entry> state(numBreakOpportunities, { std::numeric_limits<float>::infinity(), 0 });
+    state[0].accumulatedCost = 0.f;
+
+    // Iterate through all possible line break positions.
+    // At each break position, record a prior break position such that of the SUM of
+    //     (1) the cost of the line delimited by the current and the prior break position
+    //     (2) the cost of the optimal solution that breaks at the prior break position
+    // is minimized. This results in an optimal solution for the current break position.
+
+    // breakOpportunities[firstStartIdx] is the first possible starting position for a candidate line that is NOT the first line
+    size_t firstStartIdx = 1;
+    for (size_t breakIdx = 1; breakIdx < numBreakOpportunities; breakIdx++) {
+        size_t end = breakOpportunities[breakIdx];
+
+        // Our candidate line can be the first line, handle this special case
+        if (breakIdx <= lastFirstLineBreakIdx) {
+            auto firstLineCandidateWidth = computeWidthBetween(range.startIndex(), end, applyFirstLineStyling) + firstLineTextIndent;
+            auto cost = computeCost(firstLineCandidateWidth, m_maxLineWidth);
+            state[breakIdx].accumulatedCost = cost;
+            state[breakIdx].previousBreakIdx = 0;
+        }
+
+        // We prune our search space by limiting the possible starting positions for our candidate line.
+        while (computeWidthBetween(breakOpportunities[firstStartIdx], end, false) + textIndent > m_maxLineWidth)
+            firstStartIdx++;
+
+        for (size_t startIdx = firstStartIdx; startIdx < breakIdx; startIdx++) {
+            size_t start = breakOpportunities[startIdx];
+            ASSERT(start != range.startIndex());
+
+            auto candidateWidth = computeWidthBetween(start, end, false) + textIndent;
+            ASSERT(candidateWidth <= m_maxLineWidth);
+
+            auto accumulatedCost = computeCost(candidateWidth, m_maxLineWidth) + state[startIdx].accumulatedCost;
+            if (accumulatedCost < state[breakIdx].accumulatedCost) {
+                state[breakIdx].accumulatedCost = accumulatedCost;
+                state[breakIdx].previousBreakIdx = startIdx;
+            }
+        }
+    }
+
+    // Check if we found no solution
+    if (std::isinf(state[numBreakOpportunities - 1].accumulatedCost))
+        return std::nullopt;
+
+    // breaks[i] equals the index into m_inlineItems before which the ith line will break
+    Vector<size_t> breaks;
+    size_t breakIdx = numBreakOpportunities - 1;
+    do {
+        breaks.append(breakOpportunities[breakIdx]);
+        breakIdx = state[breakIdx].previousBreakIdx;
+    } while (breakIdx);
+    breaks.reverse();
+
+    // Compute final line widths (adding indentation width)
+    Vector<LayoutUnit> lineWidths(breaks.size());
+    for (size_t i = 0; i < breaks.size(); i++) {
+        auto start = i > 0 ? breaks[i - 1] : range.startIndex();
+        auto end = breaks[i];
+        auto indentWidth = i > 0 ? textIndent : firstLineTextIndent;
+        auto lineWidth = computeWidthBetween(start, end, !i && applyFirstLineStyling) + indentWidth;
+        lineWidths[i] = LayoutUnit::fromFloatCeil(lineWidth + LayoutUnit::epsilon());
+    }
+
+    return lineWidths;
+}
+
+InlineLayoutUnit InlineContentBalancer::inlineItemWidth(const InlineItem& inlineItem, bool applyFirstLineStyling)
+{
+    ASSERT(inlineItem.layoutBox().isInlineLevelBox());
+    if (is<InlineTextItem>(inlineItem)) {
+        auto& inlineTextItem = downcast<InlineTextItem>(inlineItem);
+        if (auto contentWidth = inlineTextItem.width())
+            return *contentWidth;
+        auto& fontCascade = applyFirstLineStyling ? inlineTextItem.firstLineStyle().fontCascade() : inlineTextItem.style().fontCascade();
+        if (!inlineTextItem.isWhitespace() || InlineTextItem::shouldPreserveSpacesAndTabs(inlineTextItem))
+            return TextUtil::width(inlineTextItem, fontCascade, 0);
+        return TextUtil::width(inlineTextItem, fontCascade, inlineTextItem.start(), inlineTextItem.start() + 1, 0);
+    }
+
+    if (inlineItem.isLineBreak() || inlineItem.isWordBreakOpportunity())
+        return { };
+
+    auto& layoutBox = inlineItem.layoutBox();
+    auto& boxGeometry = m_inlineFormattingContext.geometryForBox(layoutBox);
+
+    if (layoutBox.isReplacedBox())
+        return boxGeometry.marginBoxWidth();
+
+    if (inlineItem.isInlineBoxStart()) {
+        auto logicalWidth = boxGeometry.marginStart() + boxGeometry.borderStart() + boxGeometry.paddingStart().value_or(0);
+#if ENABLE(CSS_BOX_DECORATION_BREAK)
+        auto& style = applyFirstLineStyling ? inlineItem.firstLineStyle() : inlineItem.style();
+        if (style.boxDecorationBreak() == BoxDecorationBreak::Clone)
+            logicalWidth += boxGeometry.borderEnd() + boxGeometry.paddingEnd().value_or(0_lu);
+#endif
+        return logicalWidth;
+    }
+
+    if (inlineItem.isInlineBoxEnd())
+        return boxGeometry.marginEnd() + boxGeometry.borderEnd() + boxGeometry.paddingEnd().value_or(0);
+
+    // FIXME: The overhang should be computed to not overlap the neighboring runs or overflow the line.
+    if (auto* rubyAdjustments = layoutBox.rubyAdjustments()) {
+        auto& overhang = applyFirstLineStyling ? rubyAdjustments->firstLineOverhang : rubyAdjustments->overhang;
+        return boxGeometry.marginBoxWidth() - (overhang.start + overhang.end);
+    }
+
+    // Non-replaced inline box (e.g. inline-block)
+    return boxGeometry.marginBoxWidth();
+}
+
+bool InlineContentBalancer::shouldTrimLeading(const InlineItem& inlineItem, bool applyFirstLineStyling)
+{
+    auto& style = applyFirstLineStyling ? inlineItem.firstLineStyle() : inlineItem.style();
+
+    // Handle line break first so we can focus on other types of white space
+    if (inlineItem.isLineBreak())
+        return true;
+
+    if (inlineItem.isText()) {
+        auto& textItem = downcast<InlineTextItem>(inlineItem);
+        if (textItem.isWhitespace()) {
+            if (style.whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve || style.whiteSpaceCollapse() == WhiteSpaceCollapse::BreakSpaces)
+                return false;
+            return true;
+        }
+        return false;
+    }
+
+    if (inlineItemWidth(inlineItem, applyFirstLineStyling) <= 0)
+        return true;
+
+    return false;
+}
+
+bool InlineContentBalancer::shouldTrimTrailing(const InlineItem& inlineItem, bool applyFirstLineStyling)
+{
+    auto& style = applyFirstLineStyling ? inlineItem.firstLineStyle() : inlineItem.style();
+
+    // Handle line break first so we can focus on other types of white space
+    if (inlineItem.isLineBreak())
+        return true;
+
+    if (inlineItem.isText()) {
+        auto& textItem = downcast<InlineTextItem>(inlineItem);
+        if (textItem.isWhitespace()) {
+            if (style.whiteSpaceCollapse() == WhiteSpaceCollapse::BreakSpaces)
+                return false;
+            return true;
+        }
+        return false;
+    }
+
+    if (inlineItemWidth(inlineItem, applyFirstLineStyling) <= 0)
+        return true;
+
+    return false;
+}
+
+// Initialize prefix sums for inline items from start (inclusive) to end (exclusive)
+void InlineContentBalancer::initializeWidthPrefixSums(size_t start, size_t end)
+{
+    m_prefixSumOffset = start;
+    size_t numItems = end - start;
+
+    m_widthPrefixSum.clear();
+    m_firstLineWidthPrefixSum.clear();
+    m_widthPrefixSum.reserveCapacity(numItems + 1);
+    m_firstLineWidthPrefixSum.reserveCapacity(numItems + 1);
+
+    // Compute width prefix sums to efficiently query the width of an arbitrary
+    // sequence of inline items.
+    double accumulatedWidth = 0;
+    m_widthPrefixSum.append(accumulatedWidth);
+    for (size_t i = start ; i < end; i++) {
+        accumulatedWidth += inlineItemWidth(m_inlineItems[i], false);
+        accumulatedWidth = fmod(accumulatedWidth, prefixSumMod);
+        m_widthPrefixSum.append(accumulatedWidth);
+    }
+
+    accumulatedWidth = 0;
+    m_firstLineWidthPrefixSum.append(accumulatedWidth);
+    for (size_t i = start ; i < end; i++) {
+        accumulatedWidth += inlineItemWidth(m_inlineItems[i], true);
+        accumulatedWidth = fmod(accumulatedWidth, prefixSumMod);
+        m_firstLineWidthPrefixSum.append(accumulatedWidth);
+    }
+}
+
+// Helper function to compute line width of inlineItems from start (inclusive)
+// to end (exclusive). Trims any starting/ending whitespace.
+InlineLayoutUnit InlineContentBalancer::computeWidthBetween(size_t start, size_t end, bool applyFirstLineStyling)
+{
+    ASSERT(start <= end);
+    if (start == end)
+        return 0.f;
+
+    while (start < end) {
+        if (shouldTrimLeading(m_inlineItems[start], applyFirstLineStyling))
+            start++;
+        else
+            break;
+    }
+
+    while (start < end) {
+        if (shouldTrimTrailing(m_inlineItems[end - 1], applyFirstLineStyling))
+            end--;
+        else
+            break;
+    }
+
+    // Note that width prefix sums only represent a subrange of the entire inline items.
+    // We need to adjust the start/end indices.
+    start -= m_prefixSumOffset;
+    end -= m_prefixSumOffset;
+
+    auto sum = applyFirstLineStyling ? m_firstLineWidthPrefixSum[end] - m_firstLineWidthPrefixSum[start] : m_widthPrefixSum[end] - m_widthPrefixSum[start];
+    return fmod(sum + prefixSumMod, prefixSumMod);
+};
+
+// Cost function for a single line. The sum of this cost function will be minimized across all lines.
+float InlineContentBalancer::computeCost(InlineLayoutUnit candidateLineWidth, InlineLayoutUnit idealLineWidth)
+{
+    auto cost = idealLineWidth - candidateLineWidth;
+    return cost * cost;
+};
+
+}
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FormattingConstraints.h"
+#include "InlineFormattingContext.h"
+#include "InlineFormattingGeometry.h"
+#include "InlineItem.h"
+#include "InlineLineBuilder.h"
+#include "InlineTextItem.h"
+
+namespace WebCore {
+namespace Layout {
+
+class InlineContentBalancer {
+public:
+    InlineContentBalancer(const InlineFormattingContext&, const InlineItems&, const HorizontalConstraints&);
+    ~InlineContentBalancer();
+    std::optional<Vector<LayoutUnit>> computeBalanceConstraints();
+
+private:
+    void initialize();
+
+    // FIXME: Consider tabs? contentLogicalLeft parameter
+    InlineLayoutUnit inlineItemWidth(const InlineItem&, bool applyFirstLineStyling);
+    bool shouldTrimLeading(const InlineItem&, bool applyFirstLineStyling);
+    bool shouldTrimTrailing(const InlineItem&, bool applyFirstLineStyling);
+    void initializeWidthPrefixSums(size_t start, size_t end);
+    InlineLayoutUnit computeWidthBetween(size_t start, size_t end, bool applyFirstLineStyling);
+    float computeCost(InlineLayoutUnit candidateLineWidth, InlineLayoutUnit idealLineWidth);
+
+    std::optional<Vector<LayoutUnit>> balanceRangeWithKnuthPlass(InlineItemRange, unsigned long numLines, std::optional<bool> previousChunkEndsWithLineBreak);
+    std::optional<Vector<LayoutUnit>> balanceRangeWithKnuthPlassNoLimit(InlineItemRange, std::optional<bool> previousChunkEndsWithLineBreak);
+
+    const InlineFormattingContext& m_inlineFormattingContext;
+    const InlineItems& m_inlineItems;
+    const HorizontalConstraints& m_horizontalConstraints;
+
+    // Used to lay out lines to compute the initial line count. Also used to list wrapping opportunities
+    // in a specific range.
+    LineBuilder* m_lineBuilder;
+
+    // Holds the inline item ranges that correspond to each line built by the initial line layout.
+    // (The initial line layout is performed as if the default text-wrap: wrap behavior is in effect).
+    Vector<InlineItemRange> m_lineRanges;
+    Vector<bool> m_lineEndsWithForcedBreak;
+
+    double m_maxLineWidth;
+    size_t m_numLines;
+    size_t m_numItems;
+
+    // m_widthPrefixSum[i] holds the total accumulated width excluding the ith inlineItem
+    // Note, this is the ith inlineItem starting from the inline item denoted by m_prefixSumOffset
+    Vector<double> m_widthPrefixSum;
+
+    // m_firstLineWidthPrefixSum[i] holds the total accumulated width excluding the ith inlineItem.
+    // Each inlineItem uses the ::first-line styling instead of the regular styling.
+    // Note, this is the ith inlineItem starting from the inline item denoted by m_prefixSumOffset
+    Vector<double> m_firstLineWidthPrefixSum;
+
+    // The first inline item included in the width prefix sums
+    size_t m_prefixSumOffset;
+
+    // This flag is set if this balancer finds conditions that make it unable to balance the m_inlineItems
+    // e.g. there exist floats
+    bool m_cannotBalanceContent = false;
+
+    // The balancing algorithm (which can have potentially quadratic time complexity) will only operate on chunks
+    // of text no longer than `maxLinesPerChunk` lines long (when laid out as if text-wrap: wrap).
+    static const size_t maxLinesPerChunk = 10;
+
+    // Ideally, the act of balancing inline content will use the same number of lines as if the inline content
+    // was laid out via `text-wrap: wrap`. However, adhering to this ideal is expensive (quadratic in the number
+    // of break opportunities), and not caring about this ideal will allow us to use a more efficient algorithm.
+    // Since inline content with more lines is less likely to depend on the number of lines used, we ignore this
+    // ideal number of lines requirement beyond this threshold.
+    static const size_t maxLinesToBalanceWithLineLimit = 12;
+
+    // Used as the modulus for prefix sum calculations. Need to preserve floating point precision while
+    // accumulating inline item widths, so prefix sum must never go above this number.
+    // FIXME: We assume that content width will never exceed 100000px? Could change this
+    // to m_maxLineWidth.
+    static constexpr float prefixSumMod = 100000.f;
+};
+
+}
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.cpp
@@ -459,6 +459,24 @@ InlineLayoutUnit InlineFormattingGeometry::horizontalAlignmentOffset(InlineLayou
     return { };
 }
 
+InlineItemPosition InlineFormattingGeometry::leadingInlineItemPositionForNextLine(InlineItemPosition lineContentEnd, std::optional<InlineItemPosition> previousLineTrailingInlineItemPosition, InlineItemPosition layoutRangeEnd)
+{
+    if (!previousLineTrailingInlineItemPosition)
+        return lineContentEnd;
+    if (previousLineTrailingInlineItemPosition->index < lineContentEnd.index || (previousLineTrailingInlineItemPosition->index == lineContentEnd.index && previousLineTrailingInlineItemPosition->offset < lineContentEnd.offset)) {
+        // Either full or partial advancing.
+        return lineContentEnd;
+    }
+    if (previousLineTrailingInlineItemPosition->index == lineContentEnd.index && !previousLineTrailingInlineItemPosition->offset && !lineContentEnd.offset) {
+        // Can't mangage to put any content on line (most likely due to floats). Note that this only applies to full content.
+        return lineContentEnd;
+    }
+    // This looks like a partial content and we are stuck. Let's force-move over to the next inline item.
+    // We certainly lose some content, but we would be busy looping otherwise.
+    ASSERT_NOT_REACHED();
+    return { std::min(lineContentEnd.index + 1, layoutRangeEnd.index), { } };
+}
+
 }
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.h
@@ -64,6 +64,8 @@ public:
     enum class IsLastLineOrAfterLineBreak : bool { No, Yes };
     InlineLayoutUnit horizontalAlignmentOffset(InlineLayoutUnit horizontalAvailableSpace, IsLastLineOrAfterLineBreak, std::optional<TextDirection> inlineBaseDirectionOverride = std::nullopt) const;
 
+    static InlineItemPosition leadingInlineItemPositionForNextLine(InlineItemPosition lineContentEnd, std::optional<InlineItemPosition> previousLineTrailingInlineItemPosition, InlineItemPosition layoutRangeEnd);
+
 private:
     InlineLayoutUnit contentLeftAfterLastLine(const ConstraintsForInFlowContent&, std::optional<InlineLayoutUnit> lastLineLogicalBottom, const FloatingContext&) const;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
@@ -27,6 +27,7 @@
 
 #include "BlockLayoutState.h"
 #include "FloatingState.h"
+#include "InlineWidthOverride.h"
 
 namespace WebCore {
 namespace Layout {
@@ -46,12 +47,16 @@ public:
 
     LayoutUnit nestedListMarkerOffset(const ElementBox& listMarkerBox) const { return m_nestedListMarkerOffsets.get(&listMarkerBox); }
 
+    void setInlineWidthOverride(InlineWidthOverride inlineWidthOverride) { m_inlineWidthOverride = inlineWidthOverride; }
+    const InlineWidthOverride& inlineWidthOverride() const { return m_inlineWidthOverride; }
+
 private:
     BlockLayoutState& m_parentBlockLayoutState;
     InlineLayoutUnit m_clearGapBeforeFirstLine { 0.f };
     InlineLayoutUnit m_clearGapAfterLastLine { 0.f };
     // FIXME: This is required by the integaration codepath.
     HashMap<const ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
+    InlineWidthOverride m_inlineWidthOverride;
 };
 
 inline InlineLayoutState::InlineLayoutState(BlockLayoutState& parentBlockLayoutState, HashMap<const ElementBox*, LayoutUnit>&& nestedListMarkerOffsets)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
@@ -103,6 +103,7 @@ public:
         std::optional<InlineLayoutUnit> hintForNextLineTopToAvoidIntrusiveFloat { }; // This is only used for cases when intrusive floats prevent any content placement at current vertical position.
     };
     LayoutResult layoutInlineContent(const LineInput&, const std::optional<PreviousLine>&);
+    Vector<size_t> listBreakOpportunities(const InlineItemRange& layoutRange);
 
 private:
     void candidateContentForLine(LineCandidate&, size_t inlineItemIndex, const InlineItemRange& needsLayoutRange, InlineLayoutUnit currentLogicalRight);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineWidthOverride.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineWidthOverride.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InlineWidthOverride.h"
+
+namespace WebCore {
+namespace Layout {
+
+InlineWidthOverride::InlineWidthOverride()
+{
+    m_globalWidthOverride = std::nullopt;
+    m_individualWidthOverrides = std::nullopt;
+}
+
+InlineWidthOverride::InlineWidthOverride(LayoutUnit globalWidthOverride)
+{
+    m_globalWidthOverride = globalWidthOverride;
+}
+
+InlineWidthOverride::InlineWidthOverride(Vector<LayoutUnit> individualWidthOverrides)
+{
+    m_individualWidthOverrides = individualWidthOverrides;
+}
+
+std::optional<LayoutUnit> InlineWidthOverride::getWidthOverride(size_t lineIndex) const
+{
+    if (m_globalWidthOverride)
+        return m_globalWidthOverride;
+
+    if (m_individualWidthOverrides)
+        return lineIndex < m_individualWidthOverrides->size() ? std::optional<LayoutUnit> { m_individualWidthOverrides.value()[lineIndex] } : std::nullopt;
+
+    return std::nullopt;
+}
+
+}
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineWidthOverride.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineWidthOverride.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebCore/LayoutUnit.h"
+#include <optional>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+namespace Layout {
+
+class InlineWidthOverride {
+public:
+    InlineWidthOverride();
+    InlineWidthOverride(LayoutUnit globalWidthOverride);
+    InlineWidthOverride(Vector<LayoutUnit> individualWidthOverrides);
+    std::optional<LayoutUnit> getWidthOverride(size_t lineIndex) const;
+
+private:
+    // Logical width constraint applied to all line boxes
+    // Takes precedence over individual width overrides
+    std::optional<LayoutUnit> m_globalWidthOverride;
+
+    // Logical width constraints applied separately for each line box
+    std::optional<Vector<LayoutUnit>> m_individualWidthOverrides;
+};
+
+}
+}

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -499,6 +499,8 @@ bool shouldInvalidateLineLayoutPathAfterChangeFor(const RenderBlockFlow& rootBlo
         // Single mutation only atm.
         return true;
     }
+    if (renderer.style().textWrap() == TextWrap::Balance)
+        return true;
 
     auto rootHasNonSupportedRenderer = [&] {
         for (auto* sibling = rootBlockContainer.firstChild(); sibling; sibling = sibling->nextSibling()) {


### PR DESCRIPTION
#### c119ce16727946a3a701dee51a42c929963f9435
<pre>
Implement `text-wrap: balance` via Knuth-Plass
<a href="https://bugs.webkit.org/show_bug.cgi?id=249840">https://bugs.webkit.org/show_bug.cgi?id=249840</a>
rdar://problem/103663513

Reviewed by NOBODY (OOPS!).

This patch implements `text-wrap: balance` in IFC. It uses a Knuth-Plass
style dynamic programming algorithm to minimize the variance of all the
line lengths. This approach does accomodate floats (or other types of intrusive
content such as initial-letter). Currently, `text-wrap: balance` is not
implemented in legacy line layout.

Ideally, the act of balancing inline content will use the same number of
lines as if the inline content was laid out via `text-wrap: wrap`. However,
adhering to this ideal is expensive, and not caring about this ideal will
allow us to use a more efficient algorithm. Since inline content with more
lines is less likely to depend on the number of lines used, we ignore this
ideal number of lines requirement beyond a certain line count (tentatively
set to 12 lines for now).

There are two implementations of the Knuth-Plass style algorithm:
  (1) one which attempts to preserve the number of lines used, and
  (2) one that ignores that requirement.
If we let N denote the number of break opportunities, let L denote the
number of lines used, and let K denote the maximum number of inline items
that can fit in a single line, then algorithm (1) has a time complexity of
O(N * L * K), while algorithm (2) has a time complexity of O(N * K).

We use algorithm (1) when we want to preserve the number of lines used,
and we use algorithm (2) when we want to prioritize performance. It is
worth noting that algorithm (2) will often also preserve the number of
lines used.

This is an initial implementation, and not all features are supported.
Currently supported features include:
- first-line styling
- indentation
- white-space-collapse
Unsupported features include (and are not limited to):
- tabs
- hyphens
- floats (including initial-letter)

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp: Added.
(WebCore::Layout::InlineContentBalancer::InlineContentBalancer):
(WebCore::Layout::InlineContentBalancer::~InlineContentBalancer):
(WebCore::Layout::InlineContentBalancer::initialize):
(WebCore::Layout::InlineContentBalancer::computeBalanceConstraints):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithKnuthPlass):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithKnuthPlassNoLimit):
(WebCore::Layout::InlineContentBalancer::inlineItemWidth):
(WebCore::Layout::InlineContentBalancer::shouldTrimLeading):
(WebCore::Layout::InlineContentBalancer::shouldTrimTrailing):
(WebCore::Layout::InlineContentBalancer::initializeWidthPrefixSums):
(WebCore::Layout::InlineContentBalancer::computeWidthBetween):
(WebCore::Layout::InlineContentBalancer::computeCost):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::layoutInFlowAndFloatContent):
(WebCore::Layout::InlineFormattingContext::lineLayout):
(WebCore::Layout::InlineFormattingContext::computedIntrinsicWidthForConstraint const):
(WebCore::Layout::leadingInlineItemPositionForNextLine): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.cpp:
(WebCore::Layout::InlineFormattingGeometry::leadingInlineItemPositionForNextLine):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h:
(WebCore::Layout::InlineLayoutState::setInlineWidthOverride):
(WebCore::Layout::InlineLayoutState::inlineWidthOverride const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::handleInlineContent):
(WebCore::Layout::LineBuilder::listBreakOpportunities):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineWidthOverride.cpp: Added.
(WebCore::Layout::InlineWidthOverride::InlineWidthOverride):
(WebCore::Layout::InlineWidthOverride::getWidthOverride const):
* Source/WebCore/layout/formattingContexts/inline/InlineWidthOverride.h: Added.
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::shouldInvalidateLineLayoutPathAfterChangeFor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c119ce16727946a3a701dee51a42c929963f9435

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15053 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16140 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13627 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14787 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/16140 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12224 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16861 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12406 "2 flakes 8 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12985 "1 flakes 5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16861 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13483 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13148 "13 flakes 1 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16861 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13546 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->