### PR TITLE
Uncouple EventLoopTimer from SuspendableTimer

### DIFF
--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -114,7 +114,7 @@ void AlternativeTextController::startAlternativeTextUITimer(AlternativeTextType 
         m_rangeWithAlternative = std::nullopt;
     m_type = type;
     stopAlternativeTextUITimer();
-    m_timer = m_document.eventLoop().scheduleTask(correctionPanelTimerInterval, m_document, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
+    m_timer = m_document.eventLoop().scheduleTask(correctionPanelTimerInterval, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
         if (!weakThis)
             return;
         weakThis->timerFired();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5753,7 +5753,7 @@ void WebGLRenderingContextBase::maybeRestoreContextSoon(Seconds timeout)
         m_restoreTimer = 0;
     }
 
-    m_restoreTimer = scriptExecutionContext->eventLoop().scheduleTask(timeout, *scriptExecutionContext, TaskSource::WebGL, [weakThis = WeakPtr { *this }] {
+    m_restoreTimer = scriptExecutionContext->eventLoop().scheduleTask(timeout, TaskSource::WebGL, [weakThis = WeakPtr { *this }] {
         if (CheckedPtr checkedThis = weakThis.get()) {
             checkedThis->m_restoreTimer = 0;
             checkedThis->maybeRestoreContext();

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -137,7 +137,7 @@ void EventSource::scheduleInitialConnect()
     auto* context = scriptExecutionContext();
     if (m_connectTimer)
         context->eventLoop().cancelScheduledTask(m_connectTimer);
-    m_connectTimer = context->eventLoop().scheduleTask(0_s, *context, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+    m_connectTimer = context->eventLoop().scheduleTask(0_s, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
         if (RefPtr strongThis = weakThis.get())
             strongThis->connect();
     });
@@ -150,7 +150,7 @@ void EventSource::scheduleReconnect()
     auto* context = scriptExecutionContext();
     if (m_connectTimer)
         context->eventLoop().cancelScheduledTask(m_connectTimer);
-    m_connectTimer = context->eventLoop().scheduleTask(1_ms * m_reconnectDelay, *context, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+    m_connectTimer = context->eventLoop().scheduleTask(1_ms * m_reconnectDelay, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
         if (RefPtr strongThis = weakThis.get())
             strongThis->connect();
     });

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -61,7 +61,7 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
 
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, lengthComputable, loaded, total));
         m_dispatchThrottledProgressEventTimer = m_target.scriptExecutionContext()->eventLoop().scheduleRepeatingTask(
-            minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, *m_target.scriptExecutionContext(), TaskSource::Networking, [weakThis = WeakPtr { *this }] {
+            minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, TaskSource::Networking, [weakThis = WeakPtr { *this }] {
                 if (weakThis)
                     weakThis->dispatchThrottledProgressEventTimerFired();
             });


### PR DESCRIPTION
#### 73fb990c113ce068101337e9081d033d6bd8cd19
<pre>
Uncouple EventLoopTimer from SuspendableTimer
<a href="https://bugs.webkit.org/show_bug.cgi?id=259903">https://bugs.webkit.org/show_bug.cgi?id=259903</a>

Reviewed by Chris Dumez.

This PR makes EventLoopTimer no longer inherit from SuspendableTimer so that
scheduleTask and scheduleRepeatingTask no longer takes ScriptExecutionContext&amp;
as an argument.

EventLoopTimer now implements the logic to suspend &amp; resume timers on its own
based off of a similar implementation in SuspendableTimer.

The plan is for SuspendableTimer to be deleted in the near future once DOMTimer
migrates to EventLoopTimer.

This PR also fixes a bug that EventLoopTimer wasn&apos;t getting removed upon firing.

Finally, this PR also makes EventLoopTimer ref-counted so that it can keep itself
alive even if the timer was canceled while it&apos;s getting executed.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::cancelScheduledTask):
(WebCore::EventLoop::didExecuteScheduledTask): Added. Removes the timer from
the global hash set.
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoop::cancelRepeatingTask):
(WebCore::EventLoopTaskGroup::markAsReadyToStop):
(WebCore::EventLoopTaskGroup::suspend):
(WebCore::EventLoopTaskGroup::resume):
(WebCore::EventLoopTaskGroup::scheduleTask):
(WebCore::EventLoopTaskGroup::didExecuteScheduledTask): Added. Removes the timer
from this group&apos;s WeakHashSet.
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::didAddTimer):
(WebCore::EventLoopTaskGroup::didRemoveTimer):

* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoopTaskGroup::markAsReadyToStop): Moved to cpp file.
(WebCore::EventLoopTaskGroup::suspend): Ditto.
(WebCore::EventLoopTaskGroup::resume): Ditto.

* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::startAlternativeTextUITimer):

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):

* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::scheduleInitialConnect):
(WebCore::EventSource::scheduleReconnect):

* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::updateProgress):

Canonical link: <a href="https://commits.webkit.org/266699@main">https://commits.webkit.org/266699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fabc65e3260e0a60c3ff988fbc73ff15d39ac8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16961 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20075 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16456 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13786 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17411 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1729 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->