### PR TITLE
Update to Vision idiom.

### DIFF
--- a/Source/WebCore/platform/ios/Device.cpp
+++ b/Source/WebCore/platform/ios/Device.cpp
@@ -42,7 +42,7 @@ bool deviceClassIsSmallScreen()
     return deviceClass == MGDeviceClassiPhone || deviceClass == MGDeviceClassiPod || deviceClass == MGDeviceClassWatch;
 }
 
-bool deviceClassIsReality()
+bool deviceClassIsVision()
 {
 #if PLATFORM(VISION)
     static auto deviceClass = MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);

--- a/Source/WebCore/platform/ios/Device.h
+++ b/Source/WebCore/platform/ios/Device.h
@@ -38,7 +38,7 @@ String deviceName(); // Thread-safe.
 // If a check like this is needed, often currentUserInterfaceIdiomIsSmallScreen is preferred.
 WEBCORE_EXPORT bool deviceClassIsSmallScreen();
 
-WEBCORE_EXPORT bool deviceClassIsReality();
+WEBCORE_EXPORT bool deviceClassIsVision();
 
 // FIXME: How does this differ from !deviceClassIsSmallScreen()?
 WEBCORE_EXPORT bool deviceHasIPadCapability();

--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
@@ -35,9 +35,9 @@ namespace WebCore {
 static UITraitCollection *adjustedTraitCollection(UITraitCollection *traitCollection)
 {
 #if PLATFORM(VISION)
-    // Use the iPad idiom instead of the Reality idiom, since some system colors are transparent
-    // in the Reality idiom, and are not web-compatible.
-    if (traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomReality)
+    // Use the iPad idiom instead of the Vision idiom, since some system colors are transparent
+    // in the Vision idiom, and are not web-compatible.
+    if (traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomVision)
         return [PAL::getUITraitCollectionClass() traitCollectionWithTraitsFromCollections:@[ traitCollection, [PAL::getUITraitCollectionClass() traitCollectionWithUserInterfaceIdiom:UIUserInterfaceIdiomPad] ]];
 #endif
     return traitCollection;

--- a/Source/WebKit/Shared/UserInterfaceIdiom.h
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.h
@@ -32,11 +32,11 @@ namespace WebKit {
 enum class UserInterfaceIdiom : uint8_t {
     Default,
     SmallScreen,
-    Reality
+    Vision
 };
 
 bool currentUserInterfaceIdiomIsSmallScreen();
-bool currentUserInterfaceIdiomIsReality();
+bool currentUserInterfaceIdiomIsVision();
 
 UserInterfaceIdiom currentUserInterfaceIdiom();
 void setCurrentUserInterfaceIdiom(UserInterfaceIdiom);

--- a/Source/WebKit/Shared/UserInterfaceIdiom.mm
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.mm
@@ -42,11 +42,11 @@ bool currentUserInterfaceIdiomIsSmallScreen()
     return s_currentUserInterfaceIdiom == UserInterfaceIdiom::SmallScreen;
 }
 
-bool currentUserInterfaceIdiomIsReality()
+bool currentUserInterfaceIdiomIsVision()
 {
     if (!s_currentUserInterfaceIdiom)
         updateCurrentUserInterfaceIdiom();
-    return s_currentUserInterfaceIdiom == UserInterfaceIdiom::Reality;
+    return s_currentUserInterfaceIdiom == UserInterfaceIdiom::Vision;
 }
 
 UserInterfaceIdiom currentUserInterfaceIdiom()
@@ -72,15 +72,15 @@ bool updateCurrentUserInterfaceIdiom()
         if (![UIApplication sharedApplication]) {
             if (WebCore::deviceClassIsSmallScreen())
                 return UserInterfaceIdiom::SmallScreen;
-            if (WebCore::deviceClassIsReality())
-                return UserInterfaceIdiom::Reality;
+            if (WebCore::deviceClassIsVision())
+                return UserInterfaceIdiom::Vision;
         } else {
             auto idiom = [[UIDevice currentDevice] userInterfaceIdiom];
             if (idiom == UIUserInterfaceIdiomPhone || idiom == UIUserInterfaceIdiomWatch)
                 return UserInterfaceIdiom::SmallScreen;
 #if PLATFORM(VISION)
-            if (idiom == UIUserInterfaceIdiomReality)
-                return UserInterfaceIdiom::Reality;
+            if (idiom == UIUserInterfaceIdiomVision)
+                return UserInterfaceIdiom::Vision;
 #endif
         }
 

--- a/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
@@ -25,7 +25,7 @@
 enum class WebKit::UserInterfaceIdiom : uint8_t {
     Default,
     SmallScreen,
-    Reality
+    Vision
 };
 
 #endif

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -70,12 +70,12 @@ bool defaultShouldPrintBackgrounds()
 
 bool defaultAlternateFormControlDesignEnabled()
 {
-    return currentUserInterfaceIdiomIsReality();
+    return currentUserInterfaceIdiomIsVision();
 }
 
 bool defaultVideoFullscreenRequiresElementFullscreen()
 {
-    return currentUserInterfaceIdiomIsReality();
+    return currentUserInterfaceIdiomIsVision();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -329,7 +329,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
     }];
 
 #if PLATFORM(VISION)
-    if (webView.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomReality) {
+    if (webView.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomVision) {
         [_shareSheetViewController setAllowsCustomPresentationStyle:YES];
         [_shareSheetViewController setModalPresentationStyle:UIModalPresentationFormSheet];
     } else

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -101,7 +101,7 @@ static void replaceViewWithView(UIView *view, UIView *otherView)
 
 static bool useSpatialFullScreenTransition()
 {
-    return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomReality;
+    return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomVision;
 }
 
 static void resizeScene(UIWindowScene *scene, CGSize size, CompletionHandler<void()>&& completionHandler)


### PR DESCRIPTION
#### 9776a6b158e1f7c1f1ddbab70ca50b2c80fbc02b
<pre>
Update to Vision idiom.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259907">https://bugs.webkit.org/show_bug.cgi?id=259907</a>
rdar://113531570

Reviewed by Wenson Hsieh.

Updated to new idiom now that reality idiom is deprecated.

* Source/WebCore/platform/ios/Device.cpp:
(WebCore::deviceClassIsVision):
(WebCore::deviceClassIsReality): Deleted.
* Source/WebCore/platform/ios/Device.h:
* Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm:
(WebCore::adjustedTraitCollection):
* Source/WebKit/Shared/UserInterfaceIdiom.h:
* Source/WebKit/Shared/UserInterfaceIdiom.mm:
(WebKit::currentUserInterfaceIdiomIsVision):
(WebKit::updateCurrentUserInterfaceIdiom):
(WebKit::currentUserInterfaceIdiomIsReality): Deleted.
* Source/WebKit/Shared/UserInterfaceIdiom.serialization.in:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultAlternateFormControlDesignEnabled):
(WebKit::defaultVideoFullscreenRequiresElementFullscreen):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithShareDataArray:inRect:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::useSpatialFullScreenTransition):

Canonical link: <a href="https://commits.webkit.org/266673@main">https://commits.webkit.org/266673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d9092a125b600addd1ed01e235ae43eaafad497

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16153 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14800 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16875 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12419 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16376 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11557 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13002 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->