### PR TITLE
Non-unified build fixes, early August 2023 edition

### DIFF
--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -31,7 +31,7 @@
 #include "IntersectionObserverEntry.h"
 #include "NodeRenderStyle.h"
 #include "RenderElement.h"
-#include "RenderStyle.h"
+#include "RenderStyleInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -44,6 +44,7 @@
 #include "PseudoClassChangeInvalidation.h"
 #include "QualifiedName.h"
 #include "Quirks.h"
+#include "RenderBlock.h"
 #include "Settings.h"
 #include <wtf/LoggerHelper.h>
 

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -76,11 +76,13 @@ static inline bool isBlobURLContainingNullOrigin(const URL& url)
     return StringView(url.string()).substring(startIndex, endIndex - startIndex - 1) == "null"_s;
 }
 
+#if ASSERT_ENABLED
 static inline bool isInternalBlobURL(const URL& url)
 {
     constexpr auto prefix = "blob:blobinternal://"_s;
     return url.string().startsWith(prefix);
 }
+#endif
 
 // If the blob URL contains null origin, as in the context with unique security origin or file URL, save the mapping between url and origin so that the origin can be retrived when doing security origin check.
 static void addToOriginMapIfNecessary(const URL& url, RefPtr<SecurityOrigin>&& origin)

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.h
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <optional>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/track/InbandGenericTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.cpp
@@ -31,6 +31,7 @@
 #include "Document.h"
 #include "InbandTextTrackPrivate.h"
 #include "Logging.h"
+#include "TextTrackCueList.h"
 #include "TextTrackList.h"
 #include "VTTRegionList.h"
 #include <math.h>

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -70,9 +70,6 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(VTTCue);
 WTF_MAKE_ISO_ALLOCATED_IMPL(VTTCueBox);
 
-// This constant should correspond with the percentage returned by CaptionUserPreferences::captionFontSizeScaleAndImportance.
-constexpr double DEFAULTCAPTIONFONTSIZEPERCENTAGE = 5;
-
 static const CSSValueID displayWritingModeMap[] = {
     CSSValueHorizontalTb, CSSValueVerticalRl, CSSValueVerticalLr
 };

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -172,52 +172,6 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
     return logicalFlexItemList;
 }
 
-static inline BoxGeometry::HorizontalMargin horizontalMargin(const FlexRect& rect, FlexDirection flexDirection)
-{
-    auto marginValue = BoxGeometry::HorizontalMargin { };
-    switch (flexDirection) {
-    case FlexDirection::Row:
-        marginValue = { rect.marginLeft(), rect.marginRight() };
-        break;
-    case FlexDirection::RowReverse:
-        marginValue = { rect.marginRight(), rect.marginLeft() };
-        break;
-    case FlexDirection::Column:
-        marginValue = { rect.marginTop(), rect.marginBottom() };
-        break;
-    case FlexDirection::ColumnReverse:
-        marginValue = { rect.marginBottom(), rect.marginTop() };
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-    return marginValue;
-}
-
-static inline BoxGeometry::VerticalMargin verticalMargin(const FlexRect& rect, FlexDirection flexDirection)
-{
-    auto marginValue = BoxGeometry::VerticalMargin { };
-    switch (flexDirection) {
-    case FlexDirection::Row:
-        marginValue = { rect.marginTop(), rect.marginBottom() };
-        break;
-    case FlexDirection::RowReverse:
-        marginValue = { rect.marginBottom(), rect.marginTop() };
-        break;
-    case FlexDirection::Column:
-        marginValue = { rect.marginLeft(), rect.marginRight() };
-        break;
-    case FlexDirection::ColumnReverse:
-        marginValue = { rect.marginRight(), rect.marginLeft() };
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-    return marginValue;
-}
-
 void FlexFormattingContext::setFlexItemsGeometry(const FlexLayout::LogicalFlexItems& logicalFlexItemList, const FlexLayout::LogicalFlexItemRects& logicalRects, const ConstraintsForFlexContent& constraints)
 {
     auto& formattingState = this->formattingState();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -64,26 +64,6 @@ InlineFormattingContext::InlineFormattingContext(const ElementBox& formattingCon
 {
 }
 
-static inline const Box* nextInlineLevelBoxToLayout(const Box& layoutBox, const ElementBox& stayWithin)
-{
-    // Atomic inline-level boxes and floats are opaque boxes meaning that they are
-    // responsible for their own content (do not need to descend into their subtrees).
-    // Only inline boxes may have relevant descendant content.
-    if (layoutBox.isInlineBox()) {
-        if (is<ElementBox>(layoutBox) && downcast<ElementBox>(layoutBox).hasInFlowOrFloatingChild()) {
-            // Anonymous inline text boxes/line breaks can't have descendant content by definition.
-            ASSERT(!layoutBox.isInlineTextBox() && !layoutBox.isLineBreakBox());
-            return downcast<ElementBox>(layoutBox).firstInFlowOrFloatingChild();
-        }
-    }
-
-    for (auto* nextInPreOrder = &layoutBox; nextInPreOrder && nextInPreOrder != &stayWithin; nextInPreOrder = &nextInPreOrder->parent()) {
-        if (auto* nextSibling = nextInPreOrder->nextInFlowOrFloatingSibling())
-            return nextSibling;
-    }
-    return nullptr;
-}
-
 InlineLayoutResult InlineFormattingContext::layoutInFlowAndFloatContent(const ConstraintsForInlineContent& constraints, InlineLayoutState& inlineLayoutState)
 {
     if (!root().hasInFlowChild()) {

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -32,7 +32,10 @@
 
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
+#include "FrameLoader.h"
 #include "LocalFrame.h"
+#include "LocalFrameLoaderClient.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -41,6 +41,7 @@
 #include "Logging.h"
 #include "Performance.h"
 #include "RenderBlock.h"
+#include "RenderBoxInlines.h"
 #include "RenderInline.h"
 #include "RenderLineBreak.h"
 #include "RenderView.h"

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -29,6 +29,7 @@
 #include "LayoutSize.h"
 #include "ResizeObserverBoxOptions.h"
 
+#include <wtf/IsoMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/page/SecurityOriginData.cpp
+++ b/Source/WebCore/page/SecurityOriginData.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SecurityOriginData.h"
 
+#include "BlobURL.h"
 #include "Document.h"
 #include "LegacySchemeRegistry.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
+++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
@@ -125,7 +125,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     cookieDatabase().setCookie(firstParty, url, value, CookieJarDB::Source::Script, cappedLifetime);
 }
 
-bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, Cookie&& cookie) const
+bool NetworkStorageSession::setCookieFromDOM(const URL&, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, Cookie&&) const
 {
     // FIXME: Implement for the Cookie Store API.
     return false;
@@ -163,7 +163,7 @@ std::pair<String, bool> NetworkStorageSession::cookiesForDOM(const URL& firstPar
     return cookiesForSession(*this, firstParty, url, false, includeSecureCookies);
 }
 
-std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForDOMAsVector(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, IncludeSecureCookies includeSecureCookies, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&& options) const
+std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForDOMAsVector(const URL&, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&&) const
 {
     // FIXME: Implement for the Cookie Store API.
     return std::nullopt;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "RenderFlexibleBox.h"
 
+#include "BaselineAlignment.h"
 #include "FlexibleBoxAlgorithm.h"
 #include "FontBaseline.h"
 #include "HitTestResult.h"

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -35,11 +35,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceContainer);
 
-static inline SVGDocumentExtensions& svgExtensionsFromElement(SVGElement& element)
-{
-    return element.document().accessSVGExtensions();
-}
-
 RenderSVGResourceContainer::RenderSVGResourceContainer(SVGElement& element, RenderStyle&& style)
     : LegacyRenderSVGHiddenContainer(element, WTFMove(style))
     , m_id(element.getIdAttribute())

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -32,6 +32,10 @@
 #include <wtf/Scope.h>
 #include <wtf/persistence/PersistentCoders.h>
 
+#if ASSERT_ENABLED
+#include <wtf/RunLoop.h>
+#endif
+
 namespace WebCore {
 namespace StorageUtilities {
 
@@ -82,8 +86,5 @@ bool writeOriginToFile(const String& filePath, const ClientOrigin& origin)
     return true;
 }
 
-} // namespace WebKit
 } // namespace StorageUtilities
-
-
-
+} // namespace WebCore

--- a/Source/WebCore/storage/StorageUtilities.h
+++ b/Source/WebCore/storage/StorageUtilities.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <optional>
+#include <wtf/Forward.h>
+
 namespace WebCore {
 struct ClientOrigin;
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -41,6 +41,7 @@
 #include "Element.h"
 #include "KeyframeEffect.h"
 #include "KeyframeEffectStack.h"
+#include "Quirks.h"
 #include "RenderElement.h"
 #include "RenderListItem.h"
 #include "RenderListMarker.h"

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -31,12 +31,9 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/FetchOptions.h>
 #include <WebCore/NetworkLoadInformation.h>
+#include <pal/SessionID.h>
 #include <variant>
 #include <wtf/WeakPtr.h>
-
-namespace PAL {
-class SessionID;
-}
 
 namespace WebCore {
 class ContentSecurityPolicy;

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/SQLiteStatement.h>
 #include <WebCore/SQLiteTransaction.h>
 #include <WebCore/StorageMap.h>
+#include <wtf/FileSystem.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "Connection.h"
 
+#include "Encoder.h"
 #include "Logging.h"
 #include "MessageFlags.h"
 #include "MessageReceiveQueues.h"

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -133,7 +133,9 @@ void WebFullScreenManager::setPIPStandbyElement(WebCore::HTMLVideoElement* pipSt
     if (pipStandbyElement == m_pipStandbyElement)
         return;
 
+#if !RELEASE_LOG_DISABLED
     auto logIdentifierForElement = [] (auto* element) { return element ? element->logIdentifier() : nullptr; };
+#endif
     ALWAYS_LOG(LOGIDENTIFIER, "old element ", logIdentifierForElement(m_pipStandbyElement.get()), ", new element ", logIdentifierForElement(pipStandbyElement));
 
     if (m_pipStandbyElement)

--- a/Source/WebKit/WebProcess/WebPage/playstation/WebPagePlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/playstation/WebPagePlayStation.cpp
@@ -27,6 +27,7 @@
 #include "WebPage.h"
 
 #include <WebCore/NotImplemented.h>
+#include <WebCore/Page.h>
 #include <WebCore/PointerCharacteristics.h>
 #include <WebCore/Settings.h>
 #include <WebCore/UserAgent.h>


### PR DESCRIPTION
#### 56e725ce615193cd3472f3fe4d4e8df79f1c26ef
<pre>
Non-unified build fixes, early August 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=259913">https://bugs.webkit.org/show_bug.cgi?id=259913</a>

Unreviewed non-unified build fix.

Fix non-unified build and any warnings found. A non-unified build
reports more warnings around unused statically scoped values.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
* Source/WebCore/dom/FullscreenManager.cpp:
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
* Source/WebCore/fileapi/ThreadableBlobRegistry.h:
* Source/WebCore/html/track/InbandGenericTextTrack.cpp:
* Source/WebCore/html/track/VTTCue.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
(WebCore::Layout::horizontalMargin): Deleted.
(WebCore::Layout::verticalMargin): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::nextInlineLevelBoxToLayout): Deleted.
* Source/WebCore/loader/MixedContentChecker.cpp:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/SecurityOriginData.cpp:
* Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp:
(WebCore::NetworkStorageSession::setCookieFromDOM const):
(WebCore::NetworkStorageSession::cookiesForDOMAsVector const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::svgExtensionsFromElement): Deleted.
* Source/WebCore/storage/StorageUtilities.cpp:
* Source/WebCore/storage/StorageUtilities.h:
* Source/WebCore/style/Styleable.cpp:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
* Source/WebKit/Platform/IPC/Connection.cpp:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::setPIPStandbyElement):
* Source/WebKit/WebProcess/WebPage/playstation/WebPagePlayStation.cpp:

Canonical link: <a href="https://commits.webkit.org/266674@main">https://commits.webkit.org/266674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f486046f1a3343ac60f3a14a0c7b5e0c2e80bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16172 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15147 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16896 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13013 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11569 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13019 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3494 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->