### PR TITLE
makeOpportunisticTaskDeferralScopeIfPossible has a wrong early exit logic

### DIFF
--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -38,7 +38,6 @@ namespace WebCore {
 
 class DOMTimerFireState;
 class Document;
-class OpportunisticTaskDeferralScope;
 class ScheduledAction;
 
 class DOMTimer final : public RefCounted<DOMTimer>, public SuspendableTimerBase, public CanMakeWeakPtr<DOMTimer> {
@@ -70,9 +69,6 @@ private:
 
     WEBCORE_EXPORT Seconds intervalClampedToMinimum() const;
 
-    void makeOpportunisticTaskDeferralScopeIfPossible(ScriptExecutionContext&);
-    void clearOpportunisticTaskDeferralScopeIfPossible();
-
     bool isDOMTimersThrottlingEnabled(const Document&) const;
     void updateThrottlingStateIfNecessary(const DOMTimerFireState&);
 
@@ -98,7 +94,6 @@ private:
     bool m_oneShot;
     Seconds m_currentTimerInterval;
     RefPtr<UserGestureToken> m_userGestureTokenToForward;
-    std::unique_ptr<OpportunisticTaskDeferralScope> m_opportunisticTaskDeferralScope;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -141,6 +141,7 @@ class MediaPlaybackTarget;
 class MediaRecorderProvider;
 class MediaSessionCoordinatorPrivate;
 class ModelPlayerProvider;
+class OpportunisticTaskDeferralScope;
 class PageConfiguration;
 class PageConsoleClient;
 class PageDebuggable;


### PR DESCRIPTION
#### e9d28ce63fa4b7ad9bfd34c955c661d10e3bd03c
<pre>
makeOpportunisticTaskDeferralScopeIfPossible has a wrong early exit logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=259857">https://bugs.webkit.org/show_bug.cgi?id=259857</a>

Reviewed by Mark Lam, Yusuke Suzuki and Wenson Hsieh.

We want to defer opportunistic task whenever we have a timer firing in the next 1ms,
not whenever we have a timer firing in 1ms or later. But changing the condition to
that causes ~1% Speedometer 2.1 regression in macOS Sonoma so simply delete
OpportunisticTaskDeferralScope entirely out of DOMTimer. This seems perf neutral on
macOS Sonoma and around ~0.7% Speedometer 2.1 progression in macOS Ventura.

* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::install):
(WebCore::DOMTimer::removeById):
(WebCore::DOMTimer::fired):
(WebCore::DOMTimer::didStop):
(WebCore::DOMTimer::makeOpportunisticTaskDeferralScopeIfPossible): Deleted.
(WebCore::DOMTimer::clearOpportunisticTaskDeferralScopeIfPossible): Deleted.
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/266680@main">https://commits.webkit.org/266680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f76feefae9210f013f374f211d753a9a1f8ae0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16912 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13024 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16409 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11578 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17365 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1724 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->