### PR TITLE
Fix :user-invalid/:user-valid interactions with form reset & submission

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
@@ -1,5 +1,11 @@
 
+Test form interactions (reset / submit):
+
+
+
+
 
 PASS :user-invalid selector should respond to user action
+PASS :user-invalid selector properly interacts with submit & reset buttons
 PASS :user-error selector should not be supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html
@@ -8,20 +8,28 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <style>
-input {
+:is(input:not([type=submit], [type=reset]), textarea) {
   border: 2px solid black;
 }
 
-input:user-valid {
+:is(input:not([type=submit], [type=reset]), textarea):user-valid {
   border-color: green;
 }
 
-input:user-invalid {
+:is(input:not([type=submit], [type=reset]), textarea):user-invalid {
   border-color: red;
 }
 </style>
 
 <input id="initially-invalid" type="email" value="foo">
+
+<p>Test form interactions (reset / submit):</p>
+<form id="form">
+  <input placeholder="Required field" required id="required-input"><br>
+  <textarea placeholder="Required field" required id="required-textarea"></textarea><br>
+  <input type="submit" id="submit-button">
+  <input type="reset" id="reset-button">
+</form>
 
 <script>
 promise_test(async () => {
@@ -54,6 +62,39 @@ promise_test(async () => {
   assert_true(input.matches(":user-valid"), "Put a valid email, :user-valid now matches");
   assert_false(input.matches(":user-invalid"), "Put an valid email, :user-invalid no longer matches");
 }, ':user-invalid selector should respond to user action');
+
+promise_test(async () => {
+  const form = document.querySelector("#form");
+  const requiredInput = document.querySelector("#required-input");
+  const requiredTextarea = document.querySelector("#required-textarea");
+  const submitButton = document.querySelector("#submit-button");
+  const resetButton = document.querySelector("#reset-button");
+
+  assert_false(requiredInput.validity.valid);
+  assert_false(requiredTextarea.validity.valid);
+  // The selector can't match because no interaction has happened.
+  assert_false(requiredInput.matches(":user-valid"), "Initially does not match :user-valid");
+  assert_false(requiredInput.matches(":user-invalid"), "Initially does not match :user-invalid");
+
+  assert_false(requiredTextarea.matches(":user-valid"), "Initially does not match :user-valid");
+  assert_false(requiredTextarea.matches(":user-invalid"), "Initially does not match :user-invalid");
+
+  await test_driver.click(submitButton);
+
+  assert_true(requiredInput.matches(":user-invalid"), "Submitted the form, input is validated");
+  assert_false(requiredInput.matches(":user-valid"), "Submitted the form, input is validated");
+
+  assert_true(requiredTextarea.matches(":user-invalid"), "Submitted the form, textarea is validated");
+  assert_false(requiredTextarea.matches(":user-valid"), "Submitted the form, textarea is validated");
+
+  await test_driver.click(resetButton);
+
+  assert_false(requiredInput.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
+  assert_false(requiredInput.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
+
+  assert_false(requiredTextarea.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
+  assert_false(requiredTextarea.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
+}, ":user-invalid selector properly interacts with submit & reset buttons");
 
 // historical: https://github.com/w3c/csswg-drafts/issues/1329
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
@@ -1,4 +1,10 @@
 
+Test form interactions (reset / submit):
+
+
+
+
 
 PASS :user-valid selector should respond to user action
+PASS :user-valid selector properly interacts with submit & reset buttons
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html
@@ -8,28 +8,35 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <style>
-input {
+:is(input:not([type=submit], [type=reset]), textarea) {
   border: 2px solid black;
 }
 
-input:user-valid {
+:is(input:not([type=submit], [type=reset]), textarea):user-valid {
   border-color: green;
 }
 
-input:user-invalid {
+:is(input:not([type=submit], [type=reset]), textarea):user-invalid {
   border-color: red;
 }
 </style>
 
 <input id="initially-valid" type="email">
 
+<p>Test form interactions (reset / submit):</p>
+<form id="form">
+  <input placeholder="Optional field" id="optional-input"><br>
+  <textarea placeholder="Optional field" id="optional-textarea"></textarea><br>
+  <input required placeholder="Required field"> <!-- Prevent the form from navigating with this invalid input -->
+  <input type="submit" id="submit-button">
+  <input type="reset" id="reset-button">
+</form>
+
 <script>
 promise_test(async () => {
   const input = document.querySelector("#initially-valid");
   assert_true(input.validity.valid);
   // The selector can't match because no interaction has happened.
-  assert_false(input.matches(':user-valid'));
-
   assert_false(input.matches(":user-valid"), "Initially does not match :user-valid");
   assert_false(input.matches(":user-invalid"), "Initially does not match :user-invalid");
 
@@ -52,4 +59,37 @@ promise_test(async () => {
   assert_false(input.matches(":user-valid"), "Cleared required input, :user-valid no longer matches");
   assert_true(input.matches(":user-invalid"), "Cleared required input, :user-invalid now matches");
 }, ":user-valid selector should respond to user action");
+
+promise_test(async () => {
+  const form = document.querySelector("#form");
+  const optionalInput = document.querySelector("#optional-input");
+  const optionalTextarea = document.querySelector("#optional-textarea");
+  const submitButton = document.querySelector("#submit-button");
+  const resetButton = document.querySelector("#reset-button");
+
+  assert_true(optionalInput.validity.valid);
+  assert_true(optionalTextarea.validity.valid);
+  // The selector can't match because no interaction has happened.
+  assert_false(optionalInput.matches(":user-valid"), "Initially does not match :user-valid");
+  assert_false(optionalInput.matches(":user-invalid"), "Initially does not match :user-invalid");
+
+  assert_false(optionalTextarea.matches(":user-valid"), "Initially does not match :user-valid");
+  assert_false(optionalTextarea.matches(":user-invalid"), "Initially does not match :user-invalid");
+
+  await test_driver.click(submitButton);
+
+  assert_true(optionalInput.matches(":user-valid"), "Submitted the form, input is validated");
+  assert_false(optionalInput.matches(":user-invalid"), "Submitted the form, input is validated");
+
+  assert_true(optionalTextarea.matches(":user-valid"), "Submitted the form, textarea is validated");
+  assert_false(optionalTextarea.matches(":user-invalid"), "Submitted the form, textarea is validated");
+
+  await test_driver.click(resetButton);
+
+  assert_false(optionalInput.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
+  assert_false(optionalInput.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
+
+  assert_false(optionalTextarea.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
+  assert_false(optionalTextarea.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
+}, ":user-valid selector properly interacts with submit & reset buttons");
 </script>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
@@ -1,5 +1,11 @@
 
+Test form interactions (reset / submit):
+
+
+
+
 
 FAIL :user-invalid selector should respond to user action assert_true: Typed an invalid email, :user-invalid now matches expected true got false
+PASS :user-invalid selector properly interacts with submit & reset buttons
 PASS :user-error selector should not be supported
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
@@ -1,4 +1,10 @@
 
+Test form interactions (reset / submit):
+
+
+
+
 
 FAIL :user-valid selector should respond to user action assert_true: Typed a valid email, :user-valid now matches expected true got false
+PASS :user-valid selector properly interacts with submit & reset buttons
 

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -142,6 +142,7 @@ bool FormAssociatedCustomElement::isEnumeratable() const
 void FormAssociatedCustomElement::reset()
 {
     ASSERT(m_element->isDefinedCustomElement());
+    setInteractedWithSinceLastFormSubmitEvent(false);
     CustomElementReactionQueue::enqueueFormResetCallbackIfNeeded(*m_element);
 }
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -263,7 +263,7 @@ void HTMLFormElement::submitIfPossible(Event* event, HTMLFormControlElement* sub
     if (UserGestureIndicator::processingUserGesture()) {
         for (auto& element : m_listedElements) {
             if (auto* formControlElement = dynamicDowncast<HTMLFormControlElement>(*element))
-                formControlElement->setInteractedWithSinceLastFormSubmitEvent(false);
+                formControlElement->setInteractedWithSinceLastFormSubmitEvent(true);
         }
     }
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -981,6 +981,7 @@ void HTMLInputElement::reset()
         updateValidity();
     }
 
+    setInteractedWithSinceLastFormSubmitEvent(false);
     setAutoFilled(false);
     setAutoFilledAndViewable(false);
     setAutoFilledAndObscured(false);

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -79,6 +79,7 @@ void HTMLOutputElement::attributeChanged(const QualifiedName& name, const AtomSt
 
 void HTMLOutputElement::reset()
 {
+    setInteractedWithSinceLastFormSubmitEvent(false);
     stringReplaceAll(defaultValue());
     m_defaultValueOverride = { };
 }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1120,6 +1120,7 @@ void HTMLSelectElement::reset()
     if (!selectedOption && firstOption && !m_multiple && m_size <= 1)
         firstOption->setSelectedState(true);
 
+    setInteractedWithSinceLastFormSubmitEvent(false);
     invalidateSelectedItems();
     setOptionsChangedOnRenderer();
     invalidateStyleForSubtree();

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -220,6 +220,7 @@ bool HTMLTextAreaElement::appendFormData(DOMFormData& formData)
 
 void HTMLTextAreaElement::reset()
 {
+    setInteractedWithSinceLastFormSubmitEvent(false);
     setNonDirtyValue(defaultValue(), TextControlSetValueSelection::SetSelectionToEnd);
 }
 


### PR DESCRIPTION
#### b148a49fc1bd68975a06d799062e7c36a12026eb
<pre>
Fix :user-invalid/:user-valid interactions with form reset &amp; submission
<a href="https://bugs.webkit.org/show_bug.cgi?id=257988">https://bugs.webkit.org/show_bug.cgi?id=257988</a>
rdar://110677832

Reviewed by Aditya Keerthi.

Form submission should trigger user-validation styles, to do this, we set the user-interacted flag to true on form submission (but only initiated from user input).

Form reset should reset form control user-interacted flags.

This matches the WIP spec PR at: <a href="https://github.com/whatwg/html/pull/9047">https://github.com/whatwg/html/pull/9047</a>

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::reset):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitIfPossible):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::reset):
* Source/WebCore/html/HTMLOutputElement.cpp:
(WebCore::HTMLOutputElement::reset):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::reset):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::reset):

Canonical link: <a href="https://commits.webkit.org/266702@main">https://commits.webkit.org/266702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78a81f16d4390d822f63c58841349b2399507108

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16353 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16949 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20078 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16460 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12915 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17402 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1730 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->