### PR TITLE
Unreviewed, adjust JSONValues memoryCost function for debug build (because of RefCounted's additional fields)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -672,28 +672,28 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::null();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 16U);
+        EXPECT_LE(memoryCost, 24U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(true);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 16U);
+        EXPECT_LE(memoryCost, 24U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(1.0);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 16U);
+        EXPECT_LE(memoryCost, 24U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(1);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 16U);
+        EXPECT_LE(memoryCost, 24U);
     }
 
     {
@@ -701,9 +701,9 @@ TEST(JSONValue, MemoryCost)
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
 #if HAVE(36BIT_ADDRESS)
-        EXPECT_LE(memoryCost, 52U);
+        EXPECT_LE(memoryCost, 60U);
 #else
-        EXPECT_LE(memoryCost, 44U);
+        EXPECT_LE(memoryCost, 52U);
 #endif
     }
 
@@ -712,9 +712,9 @@ TEST(JSONValue, MemoryCost)
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
 #if HAVE(36BIT_ADDRESS)
-        EXPECT_LE(memoryCost, 48U);
+        EXPECT_LE(memoryCost, 56U);
 #else
-        EXPECT_LE(memoryCost, 40U);
+        EXPECT_LE(memoryCost, 48U);
 #endif
     }
 
@@ -722,7 +722,7 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::create(String());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 16U);
+        EXPECT_LE(memoryCost, 24U);
     }
 
     {
@@ -746,14 +746,14 @@ TEST(JSONValue, MemoryCost)
         value->setValue("test"_s, JSON::Value::null());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 60U);
+        EXPECT_LE(memoryCost, 92U);
     }
 
     {
         Ref<JSON::Object> value = JSON::Object::create();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 40U);
+        EXPECT_LE(memoryCost, 64U);
     }
 
     {
@@ -781,14 +781,14 @@ TEST(JSONValue, MemoryCost)
         value->pushValue(JSON::Value::null());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 48U);
+        EXPECT_LE(memoryCost, 64U);
     }
 
     {
         Ref<JSON::Array> value = JSON::Array::create();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 32U);
+        EXPECT_LE(memoryCost, 40U);
     }
 
     {


### PR DESCRIPTION
#### 70e3b433158b093498adfeba5af16df3f943e530
<pre>
Unreviewed, adjust JSONValues memoryCost function for debug build (because of RefCounted&apos;s additional fields)
<a href="https://bugs.webkit.org/show_bug.cgi?id=259919">https://bugs.webkit.org/show_bug.cgi?id=259919</a>
rdar://113545689

* Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/266679@main">https://commits.webkit.org/266679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21f8957ac9975f7e46b7a341344fe8d1032dde60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16184 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14624 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16908 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13743 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13031 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17368 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1723 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->