### PR TITLE
Block sandboxed frames from navigating to javascript URLs without allow-scripts sandbox flag.

### DIFF
--- a/LayoutTests/http/tests/security/sandboxed-iframe-javascript-self-navigation-expected.txt
+++ b/LayoutTests/http/tests/security/sandboxed-iframe-javascript-self-navigation-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Blocked script execution in 'about:srcdoc' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+Tests that an iframe without "allow-scripts" can not navigate itself to a javascript URL.
+
+

--- a/LayoutTests/http/tests/security/sandboxed-iframe-javascript-self-navigation.html
+++ b/LayoutTests/http/tests/security/sandboxed-iframe-javascript-self-navigation.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+<body>
+<p>
+Tests that an iframe without "allow-scripts" can not navigate
+itself to a javascript URL.
+</p>
+<iframe id="ifr" sandbox="allow-same-origin" srcdoc="<a href='javascript:alert(`FAIL`)'>Click Me</a>"></iframe>
+<script>
+    ifr.addEventListener("load", () => {
+        ifr.contentDocument.getElementsByTagName("a")[0].click();
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+</script>
+</body>

--- a/LayoutTests/http/tests/security/sandboxed-iframe-javascript-top-navigation-expected.txt
+++ b/LayoutTests/http/tests/security/sandboxed-iframe-javascript-top-navigation-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Blocked script execution in 'about:srcdoc' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+Tests that an iframe with "allow-top-navigation" but without "allow-scripts" can not navigate the top frame to a javascript URL.
+
+

--- a/LayoutTests/http/tests/security/sandboxed-iframe-javascript-top-navigation.html
+++ b/LayoutTests/http/tests/security/sandboxed-iframe-javascript-top-navigation.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+<body>
+<p>
+Tests that an iframe with "allow-top-navigation" but without "allow-scripts"
+can not navigate the top frame to a javascript URL.
+</p>
+<iframe id="ifr" sandbox="allow-same-origin allow-top-navigation" srcdoc="<a href='javascript:alert(`FAIL`)' target='_top'>Click Me</a>"></iframe>
+<script>
+    ifr.addEventListener("load", () => {
+        ifr.contentDocument.getElementsByTagName("a")[0].click();
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+</script>
+</body>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3641,7 +3641,14 @@ void FrameLoader::executeJavaScriptURL(const URL& url, const NavigationAction& a
         ownerDocument->incrementLoadEventDelayCount();
 
     bool didReplaceDocument = false;
-    m_frame.script().executeJavaScriptURL(url, action.requester() ? action.requester()->securityOrigin.ptr() : nullptr, action.shouldReplaceDocumentIfJavaScriptURL(), didReplaceDocument);
+    bool requesterSandboxedFromScripts = action.requester() ? (action.requester()->sandboxFlags & SandboxScripts) : false;
+    if (requesterSandboxedFromScripts) {
+        // FIXME: This message should be moved off the console once a solution to https://bugs.webkit.org/show_bug.cgi?id=103274 exists.
+        // This message is identical to the message in ScriptController::canExecuteScripts.
+        if (auto* document = m_frame.document())
+            document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked script execution in '" + action.requester()->url.stringCenterEllipsizedToLength() + "' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.");
+    } else
+        m_frame.script().executeJavaScriptURL(url, action.requester() ? action.requester()->securityOrigin.ptr() : nullptr, action.shouldReplaceDocumentIfJavaScriptURL(), didReplaceDocument);
 
     // We need to communicate that a load happened, even if the JavaScript URL execution didn't end up replacing the document.
     if (auto* document = m_frame.document(); isFirstNavigationInFrame && !didReplaceDocument)

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -39,7 +39,8 @@ NavigationRequester NavigationRequester::from(Document& document)
         document.policyContainer(),
         document.frameID(),
         document.pageID(),
-        document.identifier()
+        document.identifier(),
+        document.sandboxFlags()
     };
 }
 

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -27,6 +27,7 @@
 
 #include "GlobalFrameIdentifier.h"
 #include "PolicyContainer.h"
+#include "SecurityContext.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {
@@ -43,6 +44,7 @@ struct NavigationRequester {
     std::optional<FrameIdentifier> frameID;
     std::optional<PageIdentifier> pageID;
     ScriptExecutionContextIdentifier documentIdentifier;
+    SandboxFlags sandboxFlags;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4311,6 +4311,7 @@ struct WebCore::NavigationRequester {
     std::optional<WebCore::FrameIdentifier> frameID;
     std::optional<WebCore::PageIdentifier> pageID;
     WebCore::ScriptExecutionContextIdentifier documentIdentifier;
+    WebCore::SandboxFlags sandboxFlags;
 };
 
 struct WebCore::PolicyContainer {


### PR DESCRIPTION
#### bfe32ce05ee3b00154b18fef84cc2dff3c7bf5af
<pre>
Block sandboxed frames from navigating to javascript URLs without allow-scripts sandbox flag.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257824">https://bugs.webkit.org/show_bug.cgi?id=257824</a>
rdar://108462161

Reviewed by Alex Christensen.

Sandboxed iframes could execute script in a target frame by navigating
the frame to a javascript: URL. For example, the top frame when the
iframe has the sandbox flag &quot;allow-top-navigation&quot;. This change checks to see if
the &quot;allow-scripts&quot; flag is set before executing the URL in the target frame.

* LayoutTests/http/tests/security/sandboxed-iframe-javascript-self-navigation-expected.txt: Added.
* LayoutTests/http/tests/security/sandboxed-iframe-javascript-self-navigation.html: Added.
* LayoutTests/http/tests/security/sandboxed-iframe-javascript-top-navigation-expected.txt: Added.
* LayoutTests/http/tests/security/sandboxed-iframe-javascript-top-navigation.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::executeJavaScriptURL):
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::NavigationRequester::from):
* Source/WebCore/loader/NavigationRequester.h:
(WebCore::NavigationRequester::encode const):
(WebCore::NavigationRequester::decode):

Originally-landed-as: 259548.813@safari-7615-branch (47ed6aa2ea88). rdar://113223713
Canonical link: <a href="https://commits.webkit.org/266689@main">https://commits.webkit.org/266689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2dc25311b88053f5f07b34f1f00eb092b3affee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14849 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16927 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20049 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16428 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11599 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3500 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->