### PR TITLE
REGRESSION (261984@main): Copied tables from some web pages don't properly paste into Numbers

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -190,4 +190,88 @@ typedef NS_ENUM(NSInteger, _UIDataOwner) {
 + (UIColor *)tableCellDefaultSelectionTintColor;
 @end
 
+typedef NS_ENUM(NSUInteger, NSTextBlockValueType) {
+    NSTextBlockAbsoluteValueType    = 0, // Absolute value in points
+    NSTextBlockPercentageValueType  = 1 // Percentage value (out of 100)
+};
+
+typedef NS_ENUM(NSUInteger, NSTextBlockDimension) {
+    NSTextBlockWidth            = 0,
+    NSTextBlockMinimumWidth     = 1,
+    NSTextBlockMaximumWidth     = 2,
+    NSTextBlockHeight           = 4,
+    NSTextBlockMinimumHeight    = 5,
+    NSTextBlockMaximumHeight    = 6
+};
+
+typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
+    NSTextBlockPadding  = -1,
+    NSTextBlockBorder   =  0,
+    NSTextBlockMargin   =  1
+};
+
+typedef NS_ENUM(NSUInteger, NSTextTableLayoutAlgorithm) {
+    NSTextTableAutomaticLayoutAlgorithm = 0,
+    NSTextTableFixedLayoutAlgorithm     = 1
+};
+
+typedef NS_ENUM(NSUInteger, NSTextBlockVerticalAlignment) {
+    NSTextBlockTopAlignment         = 0,
+    NSTextBlockMiddleAlignment      = 1,
+    NSTextBlockBottomAlignment      = 2,
+    NSTextBlockBaselineAlignment    = 3
+};
+
+typedef NS_ENUM(NSUInteger, NSTextTabType) {
+    NSLeftTabStopType = 0,
+    NSRightTabStopType,
+    NSCenterTabStopType,
+    NSDecimalTabStopType
+};
+
+@interface NSColor : UIColor
++ (id)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
+@end
+
+@interface NSTextTab ()
+- (id)initWithType:(NSTextTabType)type location:(CGFloat)loc;
+@end
+
+@interface NSTextBlock : NSObject
+- (void)setValue:(CGFloat)val type:(NSTextBlockValueType)type forDimension:(NSTextBlockDimension)dimension;
+- (void)setBackgroundColor:(UIColor *)color;
+- (UIColor *)backgroundColor;
+- (void)setBorderColor:(UIColor *)color; // Convenience method sets all edges at once
+- (void)setVerticalAlignment:(NSTextBlockVerticalAlignment)alignment;
+@end
+
+@interface NSTextTable : NSTextBlock
+- (void)setNumberOfColumns:(NSUInteger)numCols;
+- (void)setCollapsesBorders:(BOOL)flag;
+- (void)setHidesEmptyCells:(BOOL)flag;
+- (void)setLayoutAlgorithm:(NSTextTableLayoutAlgorithm)algorithm;
+- (NSUInteger)numberOfColumns;
+- (void)release;
+@end
+
+@interface NSTextTableBlock : NSTextBlock
+- (id)initWithTable:(NSTextTable *)table startingRow:(NSInteger)row rowSpan:(NSInteger)rowSpan startingColumn:(NSInteger)col columnSpan:(NSInteger)colSpan; // Designated initializer
+- (NSTextTable *)table;
+- (NSInteger)startingColumn;
+- (NSInteger)startingRow;
+- (NSUInteger)numberOfColumns;
+- (NSInteger)columnSpan;
+- (NSInteger)rowSpan;
+@end
+
+@interface NSParagraphStyle ()
+- (NSInteger)headerLevel;
+- (NSArray<NSTextBlock *> *)textBlocks;
+@end
+
+@interface NSMutableParagraphStyle ()
+- (void)setHeaderLevel:(NSInteger)level;
+- (void)setTextBlocks:(NSArray<NSTextBlock *> *)array;
+@end
+
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import <wtf/ObjectIdentifier.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
@@ -43,7 +44,7 @@
 #define PlatformNSTextList              NSTextList
 #define PlatformNSTextTab               NSTextTab
 #define PlatformNSTextTable             NSTextTable
-#define PlatformNSTextTableBlock        NSTextTableBlock
+#define PlatformNSTextTableBlock        NSTextTableBlock.class
 #else
 #define PlatformColor                   UIColor
 #define PlatformColorClass              PAL::getUIColorClass()
@@ -79,6 +80,19 @@ struct WEBCORE_EXPORT AttributedString {
         size_t location { 0 };
         size_t length { 0 };
     };
+
+    struct TextTableIDType;
+    using TextTableID = ObjectIdentifier<TextTableIDType>;
+
+    struct TextListIDType;
+    using TextListID = ObjectIdentifier<TextListIDType>;
+
+    struct ParagraphStyleWithTableAndListIDs {
+        RetainPtr<NSParagraphStyle> style;
+        Vector<std::optional<TextTableID>> tableIDs; // Same length as `-textBlocks`.
+        Vector<TextListID> listIDs; // Same length as `-textLists`.
+    };
+
     struct AttributeValue {
         std::variant<
             double,
@@ -87,7 +101,7 @@ struct WEBCORE_EXPORT AttributedString {
             Ref<Font>,
             Vector<String>,
             Vector<double>,
-            RetainPtr<NSParagraphStyle>,
+            ParagraphStyleWithTableAndListIDs,
             RetainPtr<NSPresentationIntent>,
             RetainPtr<NSTextAttachment>,
             RetainPtr<NSShadow>,

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -89,43 +89,6 @@ using namespace HTMLNames;
 #if PLATFORM(IOS_FAMILY)
 
 enum {
-    NSTextBlockAbsoluteValueType    = 0,    // Absolute value in points
-    NSTextBlockPercentageValueType  = 1     // Percentage value (out of 100)
-};
-typedef NSUInteger NSTextBlockValueType;
-
-enum {
-    NSTextBlockWidth            = 0,
-    NSTextBlockMinimumWidth     = 1,
-    NSTextBlockMaximumWidth     = 2,
-    NSTextBlockHeight           = 4,
-    NSTextBlockMinimumHeight    = 5,
-    NSTextBlockMaximumHeight    = 6
-};
-typedef NSUInteger NSTextBlockDimension;
-
-enum {
-    NSTextBlockPadding  = -1,
-    NSTextBlockBorder   =  0,
-    NSTextBlockMargin   =  1
-};
-typedef NSInteger NSTextBlockLayer;
-
-enum {
-    NSTextTableAutomaticLayoutAlgorithm = 0,
-    NSTextTableFixedLayoutAlgorithm     = 1
-};
-typedef NSUInteger NSTextTableLayoutAlgorithm;
-
-enum {
-    NSTextBlockTopAlignment         = 0,
-    NSTextBlockMiddleAlignment      = 1,
-    NSTextBlockBottomAlignment      = 2,
-    NSTextBlockBaselineAlignment    = 3
-};
-typedef NSUInteger NSTextBlockVerticalAlignment;
-
-enum {
     NSEnterCharacter                = 0x0003,
     NSBackspaceCharacter            = 0x0008,
     NSTabCharacter                  = 0x0009,
@@ -138,53 +101,9 @@ enum {
     NSParagraphSeparatorCharacter   = 0x2029,
 };
 
-enum {
-    NSLeftTabStopType = 0,
-    NSRightTabStopType,
-    NSCenterTabStopType,
-    NSDecimalTabStopType
-};
-typedef NSUInteger NSTextTabType;
-
-@interface NSColor : UIColor
-+ (id)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
-@end
-
-@interface NSTextTab ()
-- (id)initWithType:(NSTextTabType)type location:(CGFloat)loc;
-@end
-
-@interface NSParagraphStyle ()
-- (void)setHeaderLevel:(NSInteger)level;
-- (void)setTextBlocks:(NSArray *)array;
-@end
-
-@interface NSTextBlock : NSObject
-- (void)setValue:(CGFloat)val type:(NSTextBlockValueType)type forDimension:(NSTextBlockDimension)dimension;
+@interface NSTextBlock ()
 - (void)setWidth:(CGFloat)val type:(NSTextBlockValueType)type forLayer:(NSTextBlockLayer)layer edge:(NSRectEdge)edge;
-- (void)setBackgroundColor:(UIColor *)color;
-- (UIColor *)backgroundColor;
 - (void)setBorderColor:(UIColor *)color forEdge:(NSRectEdge)edge;
-- (void)setBorderColor:(UIColor *)color;        // Convenience method sets all edges at once
-- (void)setVerticalAlignment:(NSTextBlockVerticalAlignment)alignment;
-@end
-
-@interface NSTextTable : NSTextBlock
-- (void)setNumberOfColumns:(NSUInteger)numCols;
-- (void)setCollapsesBorders:(BOOL)flag;
-- (void)setHidesEmptyCells:(BOOL)flag;
-- (void)setLayoutAlgorithm:(NSTextTableLayoutAlgorithm)algorithm;
-- (NSUInteger)numberOfColumns;
-- (void)release;
-@end
-
-@interface NSTextTableBlock : NSTextBlock
-- (id)initWithTable:(NSTextTable *)table startingRow:(NSInteger)row rowSpan:(NSInteger)rowSpan startingColumn:(NSInteger)col columnSpan:(NSInteger)colSpan;     // Designated initializer
-- (NSInteger)startingColumn;
-- (NSInteger)startingRow;
-- (NSUInteger)numberOfColumns;
-- (NSInteger)columnSpan;
-- (NSInteger)rowSpan;
 @end
 
 #else

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -58,9 +58,9 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<String, MemoryCompactLookupOnlyRo
             }
         };
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         auto allUTIs = adoptCF(_UTCopyDeclaredTypeIdentifiers());
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         for (NSString *uti in (__bridge NSArray<NSString *> *)allUTIs.get()) {
             auto type = adoptCF(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)uti, kUTTagClassMIMEType));
             if (!type)

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -48,8 +48,14 @@ header: <WebCore/ResourceRequest.h>
     bool m_useAdvancedPrivacyProtections;
 };
 
+[Nested] struct WebCore::AttributedString::ParagraphStyleWithTableAndListIDs {
+    RetainPtr<NSParagraphStyle> style
+    Vector<std::optional<WebCore::AttributedString::TextTableID>> tableIDs
+    Vector<WebCore::AttributedString::TextListID> listIDs
+}
+
 [Nested] struct WebCore::AttributedString::AttributeValue {
-    std::variant<double, String, URL, Ref<WebCore::Font>, Vector<String>, Vector<double>, RetainPtr<NSParagraphStyle>, RetainPtr<NSPresentationIntent>, RetainPtr<NSTextAttachment>, RetainPtr<NSShadow>, RetainPtr<NSDate>, RetainPtr<PlatformColor>, RetainPtr<CGColorRef>> value;
+    std::variant<double, String, URL, Ref<WebCore::Font>, Vector<String>, Vector<double>, WebCore::AttributedString::ParagraphStyleWithTableAndListIDs, RetainPtr<NSPresentationIntent>, RetainPtr<NSTextAttachment>, RetainPtr<NSShadow>, RetainPtr<NSDate>, RetainPtr<PlatformColor>, RetainPtr<CGColorRef>> value;
 }
 
 [Nested] struct WebCore::AttributedString::Range {


### PR DESCRIPTION
#### 664af9c1e8d722f89b18f8783a1737d799a2fafc
<pre>
REGRESSION (261984@main): Copied tables from some web pages don&apos;t properly paste into Numbers
<a href="https://bugs.webkit.org/show_bug.cgi?id=259928">https://bugs.webkit.org/show_bug.cgi?id=259928</a>
rdar://112030767

Reviewed by Megan Gardner.

When copying a table in Quip and pasting into the Numbers app, tables are programmatically written
to the pasteboard as HTML; upon paste, UIFoundation uses `nsattributedstringagent` to convert this
pasted markup into an `NSAttributedString`, by loading the markup in a `WKWebView` and asking it to
`-_getContentsAsAttributedStringWithCompletionHandler:`. This exercises the `HTMLConverter` codepath
in WebCore, which implements the correct logic for representing tables and lists in the markup as
`-textBlocks` and `-textLists`, respectively, on `NSParagraphStyle`; for tables, we list multiple
`NSTextTableBlock`s that all point to the same `NSTextTable` object. For instance, two adjacent
cells in the same table would be represented as:

```
&quot;NSParagraphStyle&quot; =&gt; {
    textBlocks =&gt; [ NSTextTableBlock 0x6000006e7100, table=&lt;NSTextTable 0x6000003f27d0&gt;, {0, 0} ],
    …
}
&quot;NSParagraphStyle&quot; =&gt; {
    textBlocks =&gt; [ NSTextTableBlock 0x6000006e6d80, table=&lt;NSTextTable 0x6000003f27d0&gt;, {0, 1} ],
    …
}
```

Similarly, lists are represented by having multiple paragraph styles with the same `NSTextList`s.
Two adjacent items in the same list, for instance, will have paragraph styles whose `-textLists`
array contains the exact same list (i.e. equal pointers):

```
&quot;NSParagraphStyle&quot; =&gt; {
    textLists =&gt; [ NSTextList 0x600002676400 format &lt;{disc}&gt; ],
    …
}
&quot;NSParagraphStyle&quot; =&gt; {
    textLists =&gt; [ NSTextList 0x600002676400 format &lt;{disc}&gt; ],
    …
}
```

Prior to the changes in 261984@main, we used a single `NSKeyedArchiver`/`NSKeyedUnarchiver` to
encode/decode an `NSAttributedString` when sending this data from the web process to the UI process
for writing to the pasteboard. This meant that Foundation&apos;s internal object caching mechanism in the
keyed archiver would ensure that multiple `NSParagraphStyle` instances that all reference the same
`NSTextList` or `NSTextTable` upon encoding would still reference the same list or table upon
decoding, thereby preserving the table/list structure when writing to the pasteboard.

However, after 261984@main, we now use a different keyed (un)archiver when encoding/decoding each
individual attribute; as a result, different `NSParagraphStyle` instances that reference the same
`NSTextList` or `NSTextTable` no longer correspond to the same object in the archiver&apos;s backing map.
This means that in the two above examples, we&apos;d end up with two 2x1 tables (each with only 1 cell
populated), and two single-item lists, respectively.

To fix this, we add some logic to plumb unique identifiers corresponding to tables or lists for each
`NSTextBlock` or `NSTextList` in `-[NSParagraphStyle textBlocks]` and `-[NSParagraph textLists]`,
which are propagated along with the rest of the attributes upon encoding. When decoding, we use
these unique identifiers to ensure that all paragraph styles that previously referenced the same
table or list will continue to do so after decoding.

Tests:  WKWebView.AttributedStringFromTable
        WKWebView.AttributedStringFromList

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:

Move various UIKit SPI and IPI declarations out of the implementation file in `HTMLConverter.mm`
and into `UIKitSPI.h` instead, so that these declarations can be used in both `AttributedString.mm`
and `HTMLConverter.mm`.

* Source/WebCore/editing/cocoa/AttributedString.h:

Instead of encoding a single `RetainPtr&lt;NSParagraphStyle&gt;`, send a struct containing an
`RetainPtr&lt;NSParagraphStyle&gt;`, a list of `TextTableID` representing each text block, and a list of
`TextListID`. Note that `tableIDs` is a list of optional identifiers, since a `textBlock` may not
necessarily correspond to a table cell, in which case we use represent it via `nullopt`. `textLists`
doesn&apos;t have this same constraint since each entry corresponds directly to an `NSTextList`.

* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::reconstructStyle):

Add a helper method to take `HashMap`s of tables and lists by ID, and (only if necessary) create a
copy of the decoded `NSParagraphStyle` whose referenced tables and lists match those that were
previously referenced when decoding earlier parts of the attributed string.

(WebCore::toNSObject):
(WebCore::toNSDictionary):

Maintain maps of tables and lists by unique ID over the whole lifetime of decoding the string.

(WebCore::AttributedString::documentAttributesAsNSDictionary const):
(WebCore::AttributedString::nsAttributedString const):
(WebCore::extractListIDs):
(WebCore::extractTableIDs):
(WebCore::extractValue):
(WebCore::extractDictionary):
(WebCore::AttributedString::fromNSAttributedStringAndDocumentAttributes):

Implement the opposite half of the above logic, by collecting identical `NSTextList`s and
`NSTextTable`s that are referenced by `NSParagraphStyle`s during encoding. This allows us to build a
list of unique IDs that correspond to each table or list, which we send over IPC and use during
decoding to preserve references to the same objects when deserializing paragraph styles.

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::extensionsForMIMETypeMap):

Drive-by fix: suppress a new deprecation warning.

* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(-[WKWebView _contentsAsAttributedString]):

Add a couple of API tests to exercise attributed string conversion for tables and lists.
Importantly, these tests verify that table/list structure is preserved in the decoded string.

Canonical link: <a href="https://commits.webkit.org/266700@main">https://commits.webkit.org/266700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aca85bc729a6fff40c051726c82f2285619bfd40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14864 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14658 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15186 "2 new passes 9 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20077 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11608 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13063 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3511 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->