### PR TITLE
Enable the ability to override available width for line boxes

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/AvailableLineWidthOverride.h
+++ b/Source/WebCore/layout/formattingContexts/inline/AvailableLineWidthOverride.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayoutUnit.h"
+#include <optional>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+namespace Layout {
+
+// This class overrides the total line width available for candidate content on a line.
+// Note that this only impacts how much content can fit in a line, and it does not change
+// the line box dimensions themselves (i.e. this won't change where text is aligned, etc).
+class AvailableLineWidthOverride {
+public:
+    AvailableLineWidthOverride() { }
+    AvailableLineWidthOverride(LayoutUnit globalLineWidthOverride) { m_globalLineWidthOverride = globalLineWidthOverride; }
+    AvailableLineWidthOverride(Vector<LayoutUnit> individualLineWidthOverrides) { m_individualLineWidthOverrides = individualLineWidthOverrides; }
+    std::optional<LayoutUnit> availableLineWidthOverrideForLine(size_t lineIndex) const
+    {
+        if (m_globalLineWidthOverride)
+            return m_globalLineWidthOverride;
+        if (m_individualLineWidthOverrides && lineIndex < m_individualLineWidthOverrides->size())
+            return m_individualLineWidthOverrides.value()[lineIndex];
+        return { };
+    }
+
+private:
+    // Logical width constraint applied to all lines
+    // Takes precedence over individual width overrides
+    std::optional<LayoutUnit> m_globalLineWidthOverride;
+
+    // Logical width constraints applied separately for each line
+    std::optional<Vector<LayoutUnit>> m_individualLineWidthOverrides;
+};
+
+}
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AvailableLineWidthOverride.h"
 #include "BlockLayoutState.h"
 #include "FloatingState.h"
 
@@ -46,12 +47,16 @@ public:
 
     LayoutUnit nestedListMarkerOffset(const ElementBox& listMarkerBox) const { return m_nestedListMarkerOffsets.get(&listMarkerBox); }
 
+    void setAvailableLineWidthOverride(AvailableLineWidthOverride availableLineWidthOverride) { m_availableLineWidthOverride = availableLineWidthOverride; }
+    const AvailableLineWidthOverride& availableLineWidthOverride() const { return m_availableLineWidthOverride; }
+
 private:
     BlockLayoutState& m_parentBlockLayoutState;
     InlineLayoutUnit m_clearGapBeforeFirstLine { 0.f };
     InlineLayoutUnit m_clearGapAfterLastLine { 0.f };
     // FIXME: This is required by the integaration codepath.
     HashMap<const ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
+    AvailableLineWidthOverride m_availableLineWidthOverride;
 };
 
 inline InlineLayoutState::InlineLayoutState(BlockLayoutState& parentBlockLayoutState, HashMap<const ElementBox*, LayoutUnit>&& nestedListMarkerOffsets)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1181,7 +1181,14 @@ LineBuilder::Result LineBuilder::handleInlineContent(const InlineItemRange& layo
     auto [lineRectAdjutedWithCandidateContent, candidateContentIsConstrainedByFloat] = adjustedLineRectWithCandidateInlineContent(lineCandidate);
     // Note that adjusted line height never shrinks.
     m_candidateInlineContentEnclosingHeight = lineRectAdjutedWithCandidateContent.height();
-    auto availableWidthForCandidateContent = availableWidth(inlineContent, m_line, lineRectAdjutedWithCandidateContent.width());
+
+    // If width constraint overrides exist, modify the available width accordingly.
+    auto lineIndex = m_previousLine ? (m_previousLine->lineIndex + 1) : 0lu;
+    const auto& availableLineWidthOverride = m_inlineLayoutState.availableLineWidthOverride();
+    auto widthOverride = availableLineWidthOverride.availableLineWidthOverrideForLine(lineIndex);
+    auto availableTotalWidthForContent = widthOverride ? InlineLayoutUnit { widthOverride.value() } - m_lineMarginStart : lineRectAdjutedWithCandidateContent.width();
+
+    auto availableWidthForCandidateContent = availableWidth(inlineContent, m_line, availableTotalWidthForContent);
     auto lineIsConsideredContentful = m_line.hasContentOrListMarker() || m_lineIsConstrainedByFloat || candidateContentIsConstrainedByFloat;
     auto lineStatus = InlineContentBreaker::LineStatus {
         m_line.contentLogicalRight(),


### PR DESCRIPTION
#### b603ea06b45a819fb8f33abae2f011b83d84e1ac
<pre>
Enable the ability to override available width for line boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=259937">https://bugs.webkit.org/show_bug.cgi?id=259937</a>
rdar://113575336

Reviewed by Alan Baradlay.

The available width for a line box is originally determined by the
HorizontalConstraints struct. However, it is sometimes desirable to
override that width constraint. One potential reason to override that
width constraint is to force line breaks at particular inline items.
(Currently, there is no way to specify to the LineBuilder to break at
certain InlineItems, and the only way to do so is to modify the available
space on the line.) This is useful for CSS properties such as text-wrap,
which need to make line-breaking decisions that do not follow the current
greedy approach of filling up the entire available width.

This patch introduces a new class (AvailableLineWidthOverride) that overrides
either a global width constraint (applies to all line boxes) or individual
width constraints (applied to each line box individually). If a global
override is specified, then that will always take precedence over any
individual overrides.

AvailableLineWidthOverride objects are placed in InlineLayoutState, and are used
in the LineBuilder to override the available logical width for inline content.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/inline/AvailableLineWidthOverride.h: Added.
(WebCore::Layout::AvailableLineWidthOverride::AvailableLineWidthOverride):
(WebCore::Layout::AvailableLineWidthOverride::availableLineWidthOverrideForLine const):
* Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h:
(WebCore::Layout::InlineLayoutState::setAvailableLineWidthOverride):
(WebCore::Layout::InlineLayoutState::availableLineWidthOverride const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::handleInlineContent):

Canonical link: <a href="https://commits.webkit.org/266921@main">https://commits.webkit.org/266921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c40390d5b39cb6d6f7d0d3fa9507852ed4294c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14095 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16721 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17464 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20475 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12827 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16916 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14244 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14241 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12043 "Exiting early after 10 failures. 350 tests run. 1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15178 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13367 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3641 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17857 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15410 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14082 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3682 "Passed tests") | 
<!--EWS-Status-Bubble-End-->