### PR TITLE
ANGLE - error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -795,3 +795,16 @@ index 0000000000000000000000000000000000000000..23e8295bcc16412d3aef3fc8e85748fa
 +
 +if __name__ == '__main__':
 +    sys.exit(main())
+diff --git a/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp b/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
+index 622defe818b3..6c2f8b654d4c 100644
+--- a/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
++++ b/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
+@@ -1208,7 +1208,7 @@ bool TCompiler::checkAndSimplifyAST(TIntermBlock *root,
+ 
+ bool TCompiler::resizeClipAndCullDistanceBuiltins(TIntermBlock *root)
+ {
+-    auto resizeVariable = [=](const ImmutableString &name, uint32_t size, uint32_t maxSize) {
++    auto resizeVariable = [this, root](const ImmutableString &name, uint32_t size, uint32_t maxSize) {
+         // Skip if the variable is not used or implicitly has the maximum size
+         if (size == 0 || size == maxSize)
+             return true;

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
@@ -1208,7 +1208,7 @@ bool TCompiler::checkAndSimplifyAST(TIntermBlock *root,
 
 bool TCompiler::resizeClipAndCullDistanceBuiltins(TIntermBlock *root)
 {
-    auto resizeVariable = [=](const ImmutableString &name, uint32_t size, uint32_t maxSize) {
+    auto resizeVariable = [this, root](const ImmutableString &name, uint32_t size, uint32_t maxSize) {
         // Skip if the variable is not used or implicitly has the maximum size
         if (size == 0 || size == maxSize)
             return true;


### PR DESCRIPTION
#### f6e9a70fa4e34e717c5960b38beda3bc0db6b5b5
<pre>
ANGLE - error: implicit capture of &apos;this&apos; with a capture default of &apos;=&apos; is deprecated [-Werror,-Wdeprecated-this-capture]
<a href="https://bugs.webkit.org/show_bug.cgi?id=259941">https://bugs.webkit.org/show_bug.cgi?id=259941</a>
rdar://111828854

Reviewed by David Kilzer.

Newer versions of clang detect the now-deprecated implicit capture
of &apos;this&apos; in lambdas. Replace that capture with explicit forms.

* Source/ThirdParty/ANGLE/changes.diff:
* Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp:
(sh::TCompiler::resizeClipAndCullDistanceBuiltins):

Canonical link: <a href="https://commits.webkit.org/266712@main">https://commits.webkit.org/266712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79ab44f70b4656391067c2f792b9172e13f0721e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13708 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16971 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20086 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13083 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17419 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1735 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->