### PR TITLE
REGRESSION(261288@main): [Win] TestWebCore.WebCoreBundleTest.BundlePathFromNameTypeDirectory is failing

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -211,9 +211,3 @@ list(APPEND WebCoreTestSupport_LIBRARIES
     Cairo::Cairo
     shlwapi
 )
-
-file(COPY
-    "${WEBCORE_DIR}/en.lproj/Localizable.strings"
-    DESTINATION
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WebKit.resources/en.lproj
-)

--- a/Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp
@@ -65,16 +65,6 @@ TEST_F(WebCoreBundleTest, BundlePathFromNameTypeDirectory)
     auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
     EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
 
-    actual = WebCore::webKitBundlePath("Localizable"_s, "strings"_s, ""_s);
-    expected = FileSystem::pathByAppendingComponents(m_root, { "en.lproj"_s, "Localizable.strings"_s });
-    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
-
-#if !ENABLE(MODERN_MEDIA_CONTROLS)
-    actual = WebCore::webKitBundlePath("mediaControlsLocalizedStrings"_s, "js"_s, ""_s);
-    expected = FileSystem::pathByAppendingComponents(m_root, { "en.lproj"_s, "mediaControlsLocalizedStrings.js"_s });
-    EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
-#endif
-
     actual = WebCore::webKitBundlePath("file-does-not"_s, "exist"_s, "file"_s);
     expected = emptyString();
     EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());


### PR DESCRIPTION
#### 2e4cd29233b71e17121a3210a7cfe500117464d8
<pre>
REGRESSION(261288@main): [Win] TestWebCore.WebCoreBundleTest.BundlePathFromNameTypeDirectory is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259942">https://bugs.webkit.org/show_bug.cgi?id=259942</a>

Reviewed by Don Olmstead.

Windows port no longer uses Localizable.strings and
mediaControlsLocalizedStrings.js. Removed the test.

* Source/WebCore/PlatformWin.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp:
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/266793@main">https://commits.webkit.org/266793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d54f8bb8025773f16025f00c852a9b8d38fe200

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16367 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16972 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20087 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11625 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13084 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3568 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->