### PR TITLE
AX: Improve smart pointer hygiene in AXObjectCache and AXIsolatedObject::updateBackingStore

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3237,6 +3237,8 @@ http/tests/privateClickMeasurement [ Skip ]
 # Application Manifest tests
 webkit.org/b/153152 http/tests/security/contentSecurityPolicy/manifest-src-allowed.html [ Skip ]
 webkit.org/b/153152 http/tests/security/contentSecurityPolicy/manifest-src-blocked.html [ Skip ]
+webkit.org/b/153152 http/wpt/content-security-policy/sandbox-manifest-blocked.html [ Skip ]
+webkit.org/b/153152 http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html [ Skip ]
 webkit.org/b/158205 applicationmanifest/ [ Skip ]
 
 webkit.org/b/178785 perf/object-keys.html [ Pass Failure ]

--- a/LayoutTests/http/wpt/content-security-policy/manifest.json
+++ b/LayoutTests/http/wpt/content-security-policy/manifest.json
@@ -1,0 +1,3 @@
+{
+  "name": "manifest"
+}

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt
@@ -1,0 +1,5 @@
+http://localhost:8800/WebKit/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html - didFinishLoading
+CONSOLE MESSAGE: Origin null is not allowed by Access-Control-Allow-Origin. Status code: 200
+http://127.0.0.1:8800/WebKit/content-security-policy/manifest.json - didFailLoadingWithError: <NSError domain , code 0, failing URL "http://127.0.0.1:8800/WebKit/content-security-policy/manifest.json">
+CONSOLE MESSAGE: Fetched manifest: http://127.0.0.1:8800/WebKit/content-security-policy/manifest.json
+

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html
@@ -1,0 +1,16 @@
+<head>
+    <link
+        rel="manifest"
+        href="http://{{hosts[alt][]}}:{{ports[http][0]}}/WebKit/content-security-policy/manifest.json"
+    />
+</head>
+<script>
+    testRunner?.dumpAsText();
+    testRunner?.dumpResourceLoadCallbacks();
+    testRunner?.waitUntilDone();
+    testRunner?.getApplicationManifestThen(() => {
+        const elem = document.querySelector("link");
+        console.log(`Fetched manifest: ${elem.href}`);
+        testRunner.notifyDone();
+    });
+</script>

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html.headers
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts;

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt
@@ -1,0 +1,5 @@
+http://localhost:8800/WebKit/content-security-policy/sandbox-manifest-blocked.html - didFinishLoading
+CONSOLE MESSAGE: Origin null is not allowed by Access-Control-Allow-Origin. Status code: 200
+http://localhost:8800/WebKit/content-security-policy/manifest.json - didFailLoadingWithError: <NSError domain , code 0, failing URL "http://localhost:8800/WebKit/content-security-policy/manifest.json">
+CONSOLE MESSAGE: Fetched manifest: http://localhost:8800/WebKit/content-security-policy/manifest.json
+

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html
@@ -1,0 +1,13 @@
+<head>
+    <link rel="manifest" href="manifest.json" />
+</head>
+<script>
+    testRunner?.dumpAsText();
+    testRunner?.dumpResourceLoadCallbacks();
+    testRunner?.waitUntilDone();
+    testRunner?.getApplicationManifestThen(() => {
+        const elem = document.querySelector("link");
+        console.log(`Fetched manifest: ${elem.href}`);
+        testRunner.notifyDone();
+    });
+</script>

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html.headers
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts;

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -126,6 +126,8 @@ webkit.org/b/259089 imported/w3c/web-platform-tests/css/css-ui/text-overflow-028
 
 http/tests/security/contentSecurityPolicy/manifest-src-allowed.html [ Pass ]
 http/tests/security/contentSecurityPolicy/manifest-src-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html [ Pass ]
 applicationmanifest/ [ Pass ]
 
 # Skipped because of <rdar://problem/45388584>.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -100,6 +100,8 @@ imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https.html
 
 http/tests/security/contentSecurityPolicy/manifest-src-allowed.html [ Pass ]
 http/tests/security/contentSecurityPolicy/manifest-src-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html [ Pass ]
 applicationmanifest/ [ Pass ]
 
 webkit.org/b/187183 http/tests/security/pasteboard-file-url.html [ Pass ]

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -203,8 +203,12 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     
     if (!u_isprint(codePoint)
         || u_isUWhiteSpace(codePoint)
-        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT)
-        || ublock_getCode(codePoint) == UBLOCK_IPA_EXTENSIONS)
+        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT))
+        return true;
+
+    auto block = ublock_getCode(codePoint);
+    if (block == UBLOCK_IPA_EXTENSIONS
+        || block == UBLOCK_DESERET)
         return true;
 
     switch (codePoint) {
@@ -214,6 +218,10 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     /* 0x0131 LATIN SMALL LETTER DOTLESS I is intentionally not considered a lookalike character because it is visually distinguishable from i and it has legitimate use in the Turkish language. */
     case 0x01C0: /* LATIN LETTER DENTAL CLICK */
     case 0x01C3: /* LATIN LETTER RETROFLEX CLICK */
+    case 0x1E9C: /* LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE */
+    case 0x1E9D: /* LATIN SMALL LETTER LONG S WITH HIGH STROKE */
+    case 0x1EFE: /* LATIN CAPITAL LETTER Y WITH LOOP */
+    case 0x1EFF: /* LATIN SMALL LETTER Y WITH LOOP */
     case 0x0237: /* LATIN SMALL LETTER DOTLESS J */
     case 0x0251: /* LATIN SMALL LETTER ALPHA */
     case 0x0261: /* LATIN SMALL LETTER SCRIPT G */

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -205,7 +205,6 @@ void AXLogger::log(const String& collectionName, const AXObjectCache::DeferredCo
         [&size] (const WeakHashSet<HTMLTableElement, WeakPtrImplWithEventTargetData>& typedCollection) { size = typedCollection.computeSize(); },
         [&size] (const WeakHashSet<AccessibilityTable>& typedCollection) { size = typedCollection.computeSize(); },
         [&size] (const WeakListHashSet<Node, WeakPtrImplWithEventTargetData>& typedCollection) { size = typedCollection.computeSize(); },
-        [&size] (const WeakHashMap<Element, String, WeakPtrImplWithEventTargetData>& typedCollection) { size = typedCollection.computeSize(); },
         [] (auto&) {
             ASSERT_NOT_REACHED();
             return;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -233,6 +233,7 @@ public:
         , WeakHashSet<AccessibilityTable>
         , WeakListHashSet<Node, WeakPtrImplWithEventTargetData>
         , WeakHashMap<Element, String, WeakPtrImplWithEventTargetData>>;
+    void deferFocusedUIElementChangeIfNeeded(Node* oldFocusedNode, Node* newFocusedNode);
     void deferModalChange(Element*);
     void deferMenuListValueChange(Element*);
     void deferNodeAddedOrRemoved(Node*);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -980,7 +980,7 @@ void AXIsolatedObject::fillChildrenVectorForProperty(AXPropertyName propertyName
 void AXIsolatedObject::updateBackingStore()
 {
     // This method can be called on either the main or the AX threads.
-    if (auto tree = this->tree())
+    if (RefPtr tree = this->tree())
         tree->applyPendingChanges();
     // AXIsolatedTree::applyPendingChanges can cause this object and / or the AXIsolatedTree to be destroyed.
     // Make sure to protect `this` with a Ref before adding more logic to this function.

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -194,6 +194,7 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
     page->settings().setHTMLParserScriptingFlagPolicy(HTMLParserScriptingFlagPolicy::Enabled);
     page->settings().setPluginsEnabled(false);
     page->settings().setAcceleratedCompositingEnabled(false);
+    page->settings().setLinkPreloadEnabled(false);
 
     auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
     if (!localMainFrame)

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -67,6 +67,8 @@ bool ApplicationManifestLoader::startLoading()
 #endif
 
     auto credentials = m_useCredentials ? FetchOptions::Credentials::Include : FetchOptions::Credentials::Omit;
+    // The "linked resource fetch setup steps" are defined as part of:
+    // https://html.spec.whatwg.org/#link-type-manifest
     auto options = ResourceLoaderOptions(
         SendCallbackPolicy::SendCallbacks,
         ContentSniffingPolicy::SniffContent,
@@ -75,12 +77,13 @@ bool ApplicationManifestLoader::startLoading()
         ClientCredentialPolicy::CannotAskClientForCredentials,
         credentials,
         SecurityCheckPolicy::DoSecurityCheck,
-        FetchOptions::Mode::NoCors,
+        FetchOptions::Mode::Cors,
         CertificateInfoPolicy::DoNotIncludeCertificateInfo,
         ContentSecurityPolicyImposition::DoPolicyCheck,
         DefersLoadingPolicy::AllowDefersLoading,
         CachingPolicy::AllowCaching);
     options.destination = FetchOptions::Destination::Manifest;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     CachedResourceRequest request(WTFMove(resourceRequest), options);
 
     auto cachedResource = frame->document()->cachedResourceLoader().requestApplicationManifest(WTFMove(request));

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -163,6 +163,10 @@ TEST(WTF_URLExtras, URLExtras_Spoof)
         "xn--n-uwf"_s, // 'n' U+0E01
         "xn--3hb112n"_s, // U+065B
         "xn--a-ypc062v"_s, // 'a' U+065B
+        "xn--2j8c"_s, // U+1043D
+        "xn--ikg"_s, // U+1E9C
+        "xn--jkg"_s, // U+1E9D
+        "xn--cng"_s, // U+1EFE or U+1EFF
     };
     for (auto& host : punycodedSpoofHosts) {
         auto url = makeString("http://", host, "/").utf8();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -83,7 +83,9 @@ TEST(ApplicationManifest, Basic)
 
     done = false;
     NSDictionary *manifestObject = @{ @"name": @"Test" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    NSString *manifestString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json];
+    [webView synchronouslyLoadHTMLString:manifestString];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
         EXPECT_TRUE([manifest.name isEqualToString:@"Test"]);
         done = true;
@@ -99,7 +101,8 @@ TEST(ApplicationManifest, Basic)
         @"scope": @"http://example.com/app",
         @"theme_color": @"red",
     };
-    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]];
+    json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", json];
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"http://example.com/app/index"]];
     [webView _test_waitForDidFinishNavigation];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
@@ -150,12 +153,13 @@ TEST(ApplicationManifest, DisplayMode)
     }];
 }
 
-TEST(ApplicationManifest, AlwaysFetch)
+TEST(ApplicationManifest, AlwaysFetchData)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject = @{ @"theme_color": @"red" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json]];
 
     {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
@@ -180,8 +184,10 @@ TEST(ApplicationManifest, OnlyFirstManifest)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject1 = @{ @"theme_color": @"red" };
+    NSString *json1 = [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0];
     NSDictionary *manifestObject2 = @{ @"theme_color": @"blue" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0], [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json2 = [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json1, json2]];
 
     {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
@@ -223,8 +229,10 @@ TEST(ApplicationManifest, MediaAttriute)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject1 = @{ @"theme_color": @"blue" };
+    NSString *json1 = [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0];
     NSDictionary *manifestObject2 = @{ @"theme_color": @"red" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"invalid\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"screen\">", [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0], [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json2 = [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"invalid\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"screen\">", json1, json2]];
 
     {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
@@ -266,7 +274,8 @@ TEST(ApplicationManifest, Blocked)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject = @{ @"theme_color": @"red" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<meta http-equiv=\"Content-Security-Policy\" content=\"manifest-src 'none'\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<meta http-equiv=\"Content-Security-Policy\" content=\"manifest-src 'none'\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json]];
 
     EXPECT_NULL([webView themeColor]);
 
@@ -309,7 +318,8 @@ TEST(ApplicationManifest, Icons)
         @"theme_color": @"red",
         @"icons": expectedIcons
     };
-    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", json];
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"http://example.com/app/index"]];
     [webView _test_waitForDidFinishNavigation];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {


### PR DESCRIPTION
#### 44ab01dd7c251c97393b56ba5bca83947b911a13
<pre>
AX: Improve smart pointer hygiene in AXObjectCache and AXIsolatedObject::updateBackingStore
rdar://111341681

Reviewed by Chris Fleizach.

Per <a href="https://github.com/WebKit/WebKit/wiki/Smart-Pointer-Usage-Guidelines">https://github.com/WebKit/WebKit/wiki/Smart-Pointer-Usage-Guidelines</a>, continue refactoring
to replace raw pointer usage with smart pointers where appropriate.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::deferNodeAddedOrRemoved):
(WebCore::AXObjectCache::prepareForDocumentDestruction):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:

Originally-landed-as: 259548.864@safari-7615-branch (c047b91f5ccb). rdar://113582260
Canonical link: <a href="https://commits.webkit.org/266706@main">https://commits.webkit.org/266706@main</a>
</pre>
----------------------------------------------------------------------
#### 1a9dba69538046f2417bbe80b024119652a92a40
<pre>
Expand list of URL spoofing characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=256813">https://bugs.webkit.org/show_bug.cgi?id=256813</a>
rdar://109105078, rdar://109056841, and rdar://109056217

Reviewed by Tim Horton.

U+1E9C and U+1E9D are Medievalist characters, which means they haven&apos;t been used much
in the last several centuries.  They look kind of like &apos;f&apos; and other browsers punycode
encode them when seen in URL hosts, so let&apos;s do the same.  Same with U+1EFE and U+1EFF.

Deseret has been used much more recently, but still not much since the late 1800&apos;s.
There is a sign in a restaurant in the Salt Lake City airport that uses it, but it
seems to be a historical reference.  Classify Deseret like we do the International
Phonetic Alphabet and punycode encode it if seen in URL hosts.

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::isLookalikeCharacter):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST):

Originally-landed-as: 259548.832@safari-7615-branch (aecf4d579f39). rdar://113581615
Canonical link: <a href="https://commits.webkit.org/266705@main">https://commits.webkit.org/266705@main</a>
</pre>
----------------------------------------------------------------------
#### ef41761618aa0f95c860291d02d7bab31e638c62
<pre>
Disable link preload when sanitizing web content
<a href="https://bugs.webkit.org/show_bug.cgi?id=258100">https://bugs.webkit.org/show_bug.cgi?id=258100</a>
rdar://109675198

Reviewed by Chris Dumez.

Otherwise we get a request in the network process with an invalid pageID,
and it MESSAGE_CHECKs and terminates the process.

* Source/WebCore/editing/markup.cpp:
(WebCore::createPageForSanitizingWebContent):

Originally-landed-as: 259548.830@safari-7615-branch (9cd44913c84e). rdar://113581524
Canonical link: <a href="https://commits.webkit.org/266704@main">https://commits.webkit.org/266704@main</a>
</pre>
----------------------------------------------------------------------
#### 8ab0a195bae77ce58336c296af72acdd2b098329
<pre>
Incorrect CORS mode for ApplicationManifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=256686">https://bugs.webkit.org/show_bug.cgi?id=256686</a>
rdar://109154572

Reviewed by Brent Fulgham.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/content-security-policy/manifest.json: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html.headers: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html.headers: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST):

Originally-landed-as: 259548.816@safari-7615-branch (8437c2302b67). rdar://113581463
Canonical link: <a href="https://commits.webkit.org/266703@main">https://commits.webkit.org/266703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9434bfff47a401a055b734b20d583db278921141

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14896 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16984 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13084 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12427 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16485 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13797 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13803 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14554 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12941 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17430 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14942 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13647 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3580 "Passed tests") | 
<!--EWS-Status-Bubble-End-->