### PR TITLE
REGRESSION (259904@main): @math operation cannot trigger in Quip app

### DIFF
--- a/LayoutTests/fast/forms/shadow-tree-exposure-live-range-expected.txt
+++ b/LayoutTests/fast/forms/shadow-tree-exposure-live-range-expected.txt
@@ -17,31 +17,31 @@ PASS getSelection().type is "None"
 
 Add an input element.
 
-PASS getSelection().anchorNode is null
-PASS getSelection().anchorOffset is 0
-PASS getSelection().focusNode is null
-PASS getSelection().focusOffset is 0
+PASS getSelection().anchorNode is container
+PASS getSelection().anchorOffset is 1
+PASS getSelection().focusNode is container
+PASS getSelection().focusOffset is 1
 PASS getSelection().isCollapsed is true
-PASS getSelection().rangeCount is 0
-PASS getSelection().baseNode is null
-PASS getSelection().baseOffset is 0
-PASS getSelection().extentNode is null
-PASS getSelection().extentOffset is 0
-PASS getSelection().type is "None"
+PASS getSelection().rangeCount is 1
+PASS getSelection().baseNode is container
+PASS getSelection().baseOffset is 1
+PASS getSelection().extentNode is container
+PASS getSelection().extentOffset is 1
+PASS getSelection().type is "Range"
 
 Add a textarea element.
 
-PASS getSelection().anchorNode is null
-PASS getSelection().anchorOffset is 0
-PASS getSelection().focusNode is null
-PASS getSelection().focusOffset is 0
+PASS getSelection().anchorNode is container
+PASS getSelection().anchorOffset is 2
+PASS getSelection().focusNode is container
+PASS getSelection().focusOffset is 2
 PASS getSelection().isCollapsed is true
-PASS getSelection().rangeCount is 0
-PASS getSelection().baseNode is null
-PASS getSelection().baseOffset is 0
-PASS getSelection().extentNode is null
-PASS getSelection().extentOffset is 0
-PASS getSelection().type is "None"
+PASS getSelection().rangeCount is 1
+PASS getSelection().baseNode is container
+PASS getSelection().baseOffset is 2
+PASS getSelection().extentNode is container
+PASS getSelection().extentOffset is 2
+PASS getSelection().type is "Range"
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/forms/shadow-tree-exposure-live-range.html
+++ b/LayoutTests/fast/forms/shadow-tree-exposure-live-range.html
@@ -35,18 +35,18 @@ input.value = "text";
 input.focus();
 input.select();
 
-shouldBe("getSelection().anchorNode", "null");
-shouldBe("getSelection().anchorOffset", "0");
-shouldBe("getSelection().focusNode", "null");
-shouldBe("getSelection().focusOffset", "0");
+shouldBe("getSelection().anchorNode", "container");
+shouldBe("getSelection().anchorOffset", "1");
+shouldBe("getSelection().focusNode", "container");
+shouldBe("getSelection().focusOffset", "1");
 shouldBe("getSelection().isCollapsed", "true");
-shouldBe("getSelection().rangeCount", "0");
+shouldBe("getSelection().rangeCount", "1");
 
-shouldBe("getSelection().baseNode", "null");
-shouldBe("getSelection().baseOffset", "0");
-shouldBe("getSelection().extentNode", "null");
-shouldBe("getSelection().extentOffset", "0");
-shouldBeEqualToString("getSelection().type", "None");
+shouldBe("getSelection().baseNode", "container");
+shouldBe("getSelection().baseOffset", "1");
+shouldBe("getSelection().extentNode", "container");
+shouldBe("getSelection().extentOffset", "1");
+shouldBeEqualToString("getSelection().type", "Range");
 
 debug("\nAdd a textarea element.\n");
 
@@ -56,18 +56,18 @@ textarea.value = "text";
 textarea.focus();
 textarea.select();
 
-shouldBe("getSelection().anchorNode", "null");
-shouldBe("getSelection().anchorOffset", "0");
-shouldBe("getSelection().focusNode", "null");
-shouldBe("getSelection().focusOffset", "0");
+shouldBe("getSelection().anchorNode", "container");
+shouldBe("getSelection().anchorOffset", "2");
+shouldBe("getSelection().focusNode", "container");
+shouldBe("getSelection().focusOffset", "2");
 shouldBe("getSelection().isCollapsed", "true");
-shouldBe("getSelection().rangeCount", "0");
+shouldBe("getSelection().rangeCount", "1");
 
-shouldBe("getSelection().baseNode", "null");
-shouldBe("getSelection().baseOffset", "0");
-shouldBe("getSelection().extentNode", "null");
-shouldBe("getSelection().extentOffset", "0");
-shouldBeEqualToString("getSelection().type", "None");
+shouldBe("getSelection().baseNode", "container");
+shouldBe("getSelection().baseOffset", "2");
+shouldBe("getSelection().extentNode", "container");
+shouldBe("getSelection().extentOffset", "2");
+shouldBeEqualToString("getSelection().type", "Range");
 
 document.body.removeChild(container);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
@@ -8,14 +8,14 @@ PASS Collapse selection into text in the open shadow DOM
 PASS Collapse selection into text in <div contenteditable> in the open shadow DOM
 PASS Set focus to <object> in the open shadow DOM
 PASS Set focus to <p tabindex="0"> in the open shadow DOM
-FAIL SelectAll in the open shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
-FAIL SelectAll in the <div contenteditable> in the open shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
+FAIL SelectAll in the open shadow DOM assert_in_array: Only all children of the open shadow DOM should be selected value "(<body>, 3)" not in array ["(#document-fragment, 0) - (#document-fragment, 2)", "(#text \"text\", 0) - (#text \"paragraph\", 9)"]
+FAIL SelectAll in the <div contenteditable> in the open shadow DOM assert_in_array: value "(<body>, 3)" not in array ["(<div>, 0) - (<div>, 1)", "(#text \"editable\", 0) - (#text \"editable\", 8)"]
 PASS Collapse selection into text in the closed shadow DOM
 PASS Collapse selection into text in <div contenteditable> in the closed shadow DOM
 PASS Set focus to <object> in the closed shadow DOM
 PASS Set focus to <p tabindex="0"> in the closed shadow DOM
-FAIL SelectAll in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
-FAIL SelectAll in the <div contenteditable> in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
+FAIL SelectAll in the closed shadow DOM assert_in_array: Only all children of the closed shadow DOM should be selected value "(<body>, 7)" not in array ["(#document-fragment, 0) - (#document-fragment, 2)", "(#text \"text\", 0) - (#text \"paragraph\", 9)"]
+FAIL SelectAll in the <div contenteditable> in the closed shadow DOM assert_in_array: value "(<body>, 7)" not in array ["(<div>, 0) - (<div>, 1)", "(#text \"editable\", 0) - (#text \"editable\", 8)"]
 PASS Focus after Collapse selection into text in the open shadow DOM
 PASS Typing "A" after Collapse selection into text in the open shadow DOM
 PASS Focus after Collapse selection into text in <div contenteditable> in the open shadow DOM

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
@@ -8,14 +8,14 @@ PASS Collapse selection into text in the open shadow DOM
 PASS Collapse selection into text in <div contenteditable> in the open shadow DOM
 PASS Set focus to <object> in the open shadow DOM
 PASS Set focus to <p tabindex="0"> in the open shadow DOM
-FAIL SelectAll in the open shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
-FAIL SelectAll in the <div contenteditable> in the open shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
+FAIL SelectAll in the open shadow DOM assert_in_array: Only all children of the open shadow DOM should be selected value "(<body>, 3)" not in array ["(#document-fragment, 0) - (#document-fragment, 2)", "(#text \"text\", 0) - (#text \"paragraph\", 9)"]
+FAIL SelectAll in the <div contenteditable> in the open shadow DOM assert_in_array: value "(<body>, 3)" not in array ["(<div>, 0) - (<div>, 1)", "(#text \"editable\", 0) - (#text \"editable\", 8)"]
 PASS Collapse selection into text in the closed shadow DOM
 PASS Collapse selection into text in <div contenteditable> in the closed shadow DOM
 PASS Set focus to <object> in the closed shadow DOM
 PASS Set focus to <p tabindex="0"> in the closed shadow DOM
-FAIL SelectAll in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
-FAIL SelectAll in the <div contenteditable> in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
+FAIL SelectAll in the closed shadow DOM assert_in_array: Only all children of the closed shadow DOM should be selected value "(<body>, 7)" not in array ["(#document-fragment, 0) - (#document-fragment, 2)", "(#text \"text\", 0) - (#text \"paragraph\", 9)"]
+FAIL SelectAll in the <div contenteditable> in the closed shadow DOM assert_in_array: value "(<body>, 7)" not in array ["(<div>, 0) - (<div>, 1)", "(#text \"editable\", 0) - (#text \"editable\", 8)"]
 PASS Focus after Collapse selection into text in the open shadow DOM
 PASS Typing "A" after Collapse selection into text in the open shadow DOM
 PASS Focus after Collapse selection into text in <div contenteditable> in the open shadow DOM

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
@@ -8,14 +8,14 @@ PASS Collapse selection into text in the open shadow DOM
 PASS Collapse selection into text in <div contenteditable> in the open shadow DOM
 PASS Set focus to <object> in the open shadow DOM
 PASS Set focus to <p tabindex="0"> in the open shadow DOM
-FAIL SelectAll in the open shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
-FAIL SelectAll in the <div contenteditable> in the open shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
+FAIL SelectAll in the open shadow DOM assert_in_array: Only all children of the open shadow DOM should be selected value "(<body>, 3)" not in array ["(#document-fragment, 0) - (#document-fragment, 2)", "(#text \"text\", 0) - (#text \"paragraph\", 9)"]
+FAIL SelectAll in the <div contenteditable> in the open shadow DOM assert_in_array: value "(<body>, 3)" not in array ["(<div>, 0) - (<div>, 1)", "(#text \"editable\", 0) - (#text \"editable\", 8)"]
 PASS Collapse selection into text in the closed shadow DOM
 PASS Collapse selection into text in <div contenteditable> in the closed shadow DOM
 PASS Set focus to <object> in the closed shadow DOM
 PASS Set focus to <p tabindex="0"> in the closed shadow DOM
-FAIL SelectAll in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
-FAIL SelectAll in the <div contenteditable> in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
+FAIL SelectAll in the closed shadow DOM assert_in_array: Only all children of the closed shadow DOM should be selected value "(<body>, 7)" not in array ["(#document-fragment, 0) - (#document-fragment, 2)", "(#text \"text\", 0) - (#text \"paragraph\", 9)"]
+FAIL SelectAll in the <div contenteditable> in the closed shadow DOM assert_in_array: value "(<body>, 7)" not in array ["(<div>, 0) - (<div>, 1)", "(#text \"editable\", 0) - (#text \"editable\", 8)"]
 PASS Focus after Collapse selection into text in the open shadow DOM
 PASS Typing "A" after Collapse selection into text in the open shadow DOM
 PASS Focus after Collapse selection into text in <div contenteditable> in the open shadow DOM


### PR DESCRIPTION
#### 457eb4252b1fe6cf602a8cd1a7ceef05195e579b
<pre>
REGRESSION (259904@main): @math operation cannot trigger in Quip app
<a href="https://bugs.webkit.org/show_bug.cgi?id=259944">https://bugs.webkit.org/show_bug.cgi?id=259944</a>
rdar://113229516

Reviewed by Ryosuke Niwa.

Currently, the `@math` feature in Quip is broken in Safari with Live Range Selection enabled; this
is because Quip&apos;s JavaScript editor focuses an input element, and expects `selection.rangeCount` to
return `1` instead of `0` (the latter of which causes Quip to believe that the user is no longer
editing the text field, and therefore leads to Quip dismissing the input field immediately after
presenting it).

This happens because the `rangeCount` and ranges we expose on `DOMSelection` are different with live
range selection in Safari 17, as opposed to both Safari 16 and Chrome (testing against both stable
and canary). Whereas we used to expose a single range that was collapsed to the start of the text
field, we now expose no ranges at all.

To avoid this incompatibility, we restore shipping behavior when the selection is inside of shadow
roots, by exposing a selection range that&apos;s equivalent to a caret before the shadow host.

See also: &lt;w3c/selection-api#166&gt;.

Test: fast/forms/shadow-tree-exposure-live-range.html

* LayoutTests/fast/forms/shadow-tree-exposure-live-range-expected.txt:
* LayoutTests/fast/forms/shadow-tree-exposure-live-range.html:

Rebaseline this layout test, such that it verifies that the ranges exposed via the Selection API
have the same behavior without live ranges, vs. with live ranges enabled; this also matches the
behavior in latest Chrome Canary.

* LayoutTests/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt:

Rebaseline a WPT — attempts to change the selection in a UA shadow root in this test now result in
the wrong base/anchor nodes and offsets after this patch, rather than the `IndexSizeError`s we
currently get.

* Source/WebCore/page/DOMSelection.cpp:
(WebCore::selectionShadowAncestor):

Remove an assertion that&apos;s no longer relevant, now that we use this in both live/legacy codepaths.

(WebCore::DOMSelection::type const):

Keep both `fast/forms/shadow-tree-exposure-live-range.html` and
`editing/selection/user-select-js-property.html` passing by adjusting our logic for returning the
selection type. Currently, a selection in a shadow root always results in a type of `None`, but this
diverges from Chrome (and Safari 16&apos;s) behavior, which returns the actual type of the selected
range, regardless of whether it&apos;s in the shadow tree.

(WebCore::DOMSelection::rangeCount const):

This is the main fix — return a `rangeCount` of 1 in the case where there are no associated live
ranges, if the range is still inside a shadow root.

(WebCore::createLiveRangeBeforeShadowHostWithSelection):
(WebCore::DOMSelection::getRangeAt):

Keep `getRangeAt` consistent with `rangeCount` by returning the caret range at the start of the
shadow host in the case where the selected range is in the shadow tree.

(WebCore::DOMSelection::shadowAdjustedNode const):
(WebCore::DOMSelection::shadowAdjustedOffset const):

These methods need to be adjusted as well, to keep the `(base|anchor|focus|extent)(Node|Offset)`
properties consistent with the `rangeCount` and selection ranges in the case where the selection is
inside of a shadow root. Since the behavior with or without live ranges when the selection is in a
shadow tree is now consistent, we no longer require live-range-specific codepaths, so we can
simplify this code a bit by just removing the `liveRangeSelectionEnabled()` checks.

Canonical link: <a href="https://commits.webkit.org/266781@main">https://commits.webkit.org/266781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c520b5c8612aff051b6219b45c3eed292280921

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17207 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20275 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11843 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13138 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3555 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->