### PR TITLE
Fail navigations to about: scheme if the URL is not "about:blank" or "about:srcdoc"

### DIFF
--- a/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates-expected.txt
+++ b/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates-expected.txt
@@ -3,7 +3,7 @@ Tests opening a new about://webkit.org window and accessing its document
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS e.name is "SecurityError"
+PASS Navigation didn't happen
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates.html
+++ b/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates.html
@@ -7,6 +7,7 @@
         jsTestIsAsync = true;
 
         var newWindow;
+        let checkAttempts = 0;
 
         if (window.testRunner) {
             if (testRunner.setShouldDecideNavigationPolicyAfterDelay)
@@ -23,8 +24,14 @@
         {
             try {
                 newWindow.document;
+                checkAttempts++;
                 if (newWindow.document.URL != "about:blank") {
                     testFailed("Managed to access the document at URL " + newWindow.document.URL);
+                    finish();
+                    return;
+                }
+                if (checkAttempts == 200) {
+                    testPassed("Navigation didn't happen");
                     finish();
                 }
             } catch (_e) {

--- a/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-expected.txt
+++ b/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-expected.txt
@@ -3,7 +3,7 @@ Tests opening a new about://webkit.org window and accessing its document
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS e.name is "SecurityError"
+PASS Navigation didn't happen
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document.html
+++ b/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document.html
@@ -7,6 +7,7 @@
         jsTestIsAsync = true;
 
         var newWindow;
+        let checkAttempts = 0;
 
         function finish()
         {
@@ -18,8 +19,14 @@
         {
             try {
                 newWindow.document;
+                checkAttempts++;
                 if (newWindow.document.URL != "about:blank") {
                     testFailed("Managed to access the document at URL " + newWindow.document.URL);
+                    finish();
+                    return;
+                }
+                if (checkAttempts == 200) {
+                    testPassed("Navigation didn't happen");
                     finish();
                 }
             } catch (_e) {

--- a/LayoutTests/http/tests/security/about-url-host.html
+++ b/LayoutTests/http/tests/security/about-url-host.html
@@ -5,19 +5,22 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
-function test() {
-    try {
-        if (window.internals) {
-            const host = internals.windowLocationHost(testFrame.contentWindow);
-            document.body.innerHTML = host === "" ? "PASS" : "FAIL, got " + host;
-        }
-    } catch (e) {
-        console.log(e);
-    }
 
-    if (window.testRunner)
-        testRunner.notifyDone();
+onload = () => {
+     setTimeout(() => {
+         try {
+             if (window.internals) {
+                 const host = internals.windowLocationHost(testFrame.contentWindow);
+                 document.body.innerHTML = host === "" ? "PASS" : "FAIL, got " + host;
+             }
+         } catch (e) {
+             console.log(e);
+         }
+
+         if (window.testRunner)
+             testRunner.notifyDone();
+     }, 100);
 }
 </script>
-<iframe id="testFrame" onload="test()" src="about://example.org"></iframe>
+<iframe id="testFrame" src="about://example.org"></iframe>
 </body>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2105,6 +2105,11 @@ void DocumentLoader::startLoadingMainResource()
 
     Ref<DocumentLoader> protectedThis(*this);
 
+    if (m_request.url().protocolIsAbout() && !(m_request.url().isAboutBlank() || m_request.url().isAboutSrcDoc())) {
+        cancelMainResourceLoad(frameLoader()->client().cannotShowURLError(m_request));
+        return;
+    }
+
     if (maybeLoadEmpty()) {
         DOCUMENTLOADER_RELEASE_LOG("startLoadingMainResource: Returning empty document");
         return;


### PR DESCRIPTION
#### 3c3163e71f647db507949ecebad35d0f2ffb33f3
<pre>
Fail navigations to about: scheme if the URL is not &quot;about:blank&quot; or &quot;about:srcdoc&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=259946">https://bugs.webkit.org/show_bug.cgi?id=259946</a>
rdar://57966056

Reviewed by Brent Fulgham.

Fail navigations to about: scheme if the URL is not &quot;about:blank&quot; or &quot;about:srcdoc&quot;.
This matches what Blink and Gecko are doing.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/267754@main">https://commits.webkit.org/267754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3041aee0ee28322ebfe8f81e2dec9aecbd01df6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17245 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18184 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21072 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17580 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12646 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->