### PR TITLE
Replace EventLoopTimerPtr with EventLoopTimerHandle

### DIFF
--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -113,8 +113,6 @@ void AlternativeTextController::startAlternativeTextUITimer(AlternativeTextType 
     if (type == AlternativeTextType::Correction)
         m_rangeWithAlternative = std::nullopt;
     m_type = type;
-    if (m_timer)
-        m_document.eventLoop().cancelScheduledTask(m_timer);
     m_timer = m_document.eventLoop().scheduleTask(correctionPanelTimerInterval, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
         if (!weakThis)
             return;
@@ -124,9 +122,7 @@ void AlternativeTextController::startAlternativeTextUITimer(AlternativeTextType 
 
 void AlternativeTextController::stopAlternativeTextUITimer()
 {
-    if (m_timer)
-        m_document.eventLoop().cancelScheduledTask(m_timer);
-    m_timer = 0;
+    m_timer = nullptr;
     m_rangeWithAlternative = std::nullopt;
 }
 

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -27,6 +27,7 @@
 
 #include "AlternativeTextClient.h"
 #include "DocumentMarker.h"
+#include "EventLoop.h"
 #include "Position.h"
 #include <variant>
 #include <wtf/Noncopyable.h>
@@ -45,8 +46,6 @@ class VisibleSelection;
 struct DictationAlternative;
 struct SimpleRange;
 struct TextCheckingResult;
-
-using EventLoopTimerPtr = uintptr_t;
 
 #if USE(AUTOCORRECTION_PANEL)
 // These backslashes are for making style checker happy.
@@ -120,7 +119,7 @@ private:
     FloatRect rootViewRectForRange(const SimpleRange&) const;
     void markPrecedingWhitespaceForDeletedAutocorrectionAfterCommand(EditCommand*);
 
-    EventLoopTimerPtr m_timer { 0 };
+    EventLoopTimerHandle m_timer;
     std::optional<SimpleRange> m_rangeWithAlternative;
     bool m_isActive { };
     bool m_isDismissedByEditing { };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5748,14 +5748,9 @@ void WebGLRenderingContextBase::maybeRestoreContextSoon(Seconds timeout)
     if (!scriptExecutionContext)
         return;
 
-    if (m_restoreTimer) {
-        scriptExecutionContext->eventLoop().cancelScheduledTask(m_restoreTimer);
-        m_restoreTimer = 0;
-    }
-
     m_restoreTimer = scriptExecutionContext->eventLoop().scheduleTask(timeout, TaskSource::WebGL, [weakThis = WeakPtr { *this }] {
         if (CheckedPtr checkedThis = weakThis.get()) {
-            checkedThis->m_restoreTimer = 0;
+            checkedThis->m_restoreTimer = nullptr;
             checkedThis->maybeRestoreContext();
         }
     });

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBGL)
 
 #include "ActivityStateChangeObserver.h"
+#include "EventLoop.h"
 #include "ExceptionOr.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GraphicsContextGL.h"
@@ -155,8 +156,6 @@ using WebGLCanvas = std::variant<RefPtr<HTMLCanvasElement>>;
 #if ENABLE(MEDIA_STREAM)
 class VideoFrame;
 #endif
-
-using EventLoopTimerPtr = uintptr_t;
 
 class InspectorScopedShaderProgramHighlight {
 public:
@@ -619,7 +618,7 @@ protected:
     RefPtr<WebGLContextGroup> m_contextGroup;
     Lock m_objectGraphLock;
 
-    EventLoopTimerPtr m_restoreTimer { 0 };
+    EventLoopTimerHandle m_restoreTimer;
     GCGLErrorCodeSet m_errors;
     bool m_needsUpdate;
     bool m_markedCanvasDirty;

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "EventLoop.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
 #include "ThreadableLoaderClient.h"
@@ -44,8 +45,6 @@ namespace WebCore {
 class MessageEvent;
 class TextResourceDecoder;
 class ThreadableLoader;
-
-using EventLoopTimerPtr = uintptr_t;
 
 class EventSource final : public RefCounted<EventSource>, public EventTarget, private ThreadableLoaderClient, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(EventSource);
@@ -115,7 +114,7 @@ private:
 
     Ref<TextResourceDecoder> m_decoder;
     RefPtr<ThreadableLoader> m_loader;
-    EventLoopTimerPtr m_connectTimer { 0 };
+    EventLoopTimerHandle m_connectTimer;
     Vector<UChar> m_receiveBuffer;
     bool m_discardTrailingNewline { false };
     bool m_requestInFlight { false };

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -118,10 +118,7 @@ void XMLHttpRequestProgressEventThrottle::flushProgressEvent()
 
     m_hasPendingThrottledProgressEvent = false;
     // We stop the timer as this is called when no more events are supposed to occur.
-    if (m_dispatchThrottledProgressEventTimer) {
-        m_target.scriptExecutionContext()->eventLoop().cancelRepeatingTask(m_dispatchThrottledProgressEventTimer);
-        m_dispatchThrottledProgressEventTimer = 0;
-    }
+    m_dispatchThrottledProgressEventTimer = nullptr;
 
     dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, m_lengthComputable, m_loaded, m_total));
 }
@@ -131,8 +128,7 @@ void XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFir
     ASSERT(m_dispatchThrottledProgressEventTimer);
     if (!m_hasPendingThrottledProgressEvent) {
         // No progress event was queued since the previous dispatch, we can safely stop the timer.
-        m_target.scriptExecutionContext()->eventLoop().cancelRepeatingTask(m_dispatchThrottledProgressEventTimer);
-        m_dispatchThrottledProgressEventTimer = 0;
+        m_dispatchThrottledProgressEventTimer = nullptr;
         return;
     }
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "EventLoop.h"
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -34,8 +35,6 @@ namespace WebCore {
 
 class Event;
 class XMLHttpRequest;
-
-using EventLoopTimerPtr = uintptr_t;
 
 enum ProgressEventAction {
     DoNotFlushProgressEvent,
@@ -70,7 +69,7 @@ private:
     unsigned long long m_loaded { 0 };
     unsigned long long m_total { 0 };
 
-    EventLoopTimerPtr m_dispatchThrottledProgressEventTimer { 0 };
+    EventLoopTimerHandle m_dispatchThrottledProgressEventTimer;
 
     bool m_hasPendingThrottledProgressEvent { false };
     bool m_lengthComputable { false };


### PR DESCRIPTION
#### 6b2ef317d683b7556731218374d70c5aa3aaf76c
<pre>
Replace EventLoopTimerPtr with EventLoopTimerHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=259955">https://bugs.webkit.org/show_bug.cgi?id=259955</a>

Reviewed by Wenson Hsieh.

This PR replaces EventLoopTimerPtr, which is a type cast of EventLoopTimer*,
with a proper EventLoopTimerHandle which knows how to clean up itself at the end.

EventLoopTimerHandle is simply a wrapper around RefPtr&lt;EventLoopTimer&gt; now that
EventLoopTimer is reference counted.

This PR also removes cancelScheduledTask and cancelRepeatingTask from EventLoop
and EventLoopTaskGroup as the timer is automatically deleted when the handle dies.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTimerHandle::EventLoopTimerHandle):
(WebCore::EventLoopTimerHandle::~EventLoopTimerHandle):
(WebCore::EventLoopTimerHandle::operator=):
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::cancelScheduledTask): Deleted.
(WebCore::EventLoop::removeScheduledTimer):
(WebCore::EventLoop::didExecuteScheduledTask): Deleted.
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoop::cancelRepeatingTask): Deleted.
(WebCore::EventLoop::removeRepeatingTimer):
(WebCore::EventLoopTaskGroup::scheduleTask):.
(WebCore::EventLoopTaskGroup::cancelScheduledTask): Deleted.
(WebCore::EventLoopTaskGroup::didExecuteScheduledTask): Deleted.
(WebCore::EventLoopTaskGroup::removeScheduledTimer):
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::cancelRepeatingTask): Deleted.
(WebCore::EventLoopTaskGroup::removeRepeatingTimer):
* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoopTimerHandle::operator UnspecifiedBoolType const):
(WebCore::EventLoopTimerHandle::unspecifiedBoolTypeInstance const):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::stopAlternativeTextUITimer):
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::scheduleInitialConnect):
(WebCore::EventSource::scheduleReconnect):
(WebCore::EventSource::close):
* Source/WebCore/page/EventSource.h:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::flushProgressEvent):
(WebCore::XMLHttpRequestProgressEventThrottle::dispatchThrottledProgressEventTimerFired):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h:

Canonical link: <a href="https://commits.webkit.org/266715@main">https://commits.webkit.org/266715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec8656b15063375d654ed972d9763293ebd4952c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16302 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14943 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17040 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13125 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13290 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13843 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17472 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1737 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->