### PR TITLE
[JSC] Limit wasm function return type counts to 1000

### DIFF
--- a/JSTests/wasm/stress/big-tuple-args.js
+++ b/JSTests/wasm/stress/big-tuple-args.js
@@ -3,7 +3,7 @@
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 
-const N = 4095 + 32
+const N = 1000;
 
 let wat = `
 (module

--- a/JSTests/wasm/stress/big-tuple.js
+++ b/JSTests/wasm/stress/big-tuple.js
@@ -3,7 +3,7 @@
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 
-const N = 4095 + 32
+const N = 1000
 
 let wat = `
 (module

--- a/JSTests/wasm/stress/too-many-return-types.js
+++ b/JSTests/wasm/stress/too-many-return-types.js
@@ -1,0 +1,30 @@
+import Builder from '../Builder.js'
+import * as assert from '../assert.js'
+
+{
+    const b = new Builder();
+    const returns = [];
+    const maxFunctionReturns = 50000;
+    for (let i = 0; i < maxFunctionReturns; ++i)
+        returns[i] = "i32";
+    let cont = b
+        .Type().End()
+        .Function().End()
+        .Export()
+            .Function("loop")
+        .End()
+        .Code()
+            .Function("loop", { params: ["i32"], ret: returns });
+    for (var i = 0; i < maxFunctionReturns; ++i)
+        cont = cont.I32Const(1);
+    cont = cont.Return().End().End();
+    const bin = b.WebAssembly().get();
+    var exception;
+    try {
+        const module = new WebAssembly.Module(bin);
+    } catch (e) {
+        exception = "" + e;
+    }
+
+    assert.eq(exception, "CompileError: WebAssembly.Module doesn't parse at byte 19: return count of Type at index 0 is too big 50000 maximum 1000 (evaluating 'new WebAssembly.Module(bin)')");
+}

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -54,6 +54,7 @@ constexpr size_t maxModuleSize = 1024 * 1024 * 1024;
 constexpr size_t maxFunctionSize = 7654321;
 constexpr size_t maxFunctionLocals = 50000;
 constexpr size_t maxFunctionParams = 1000;
+constexpr size_t maxFunctionReturns = 1000;
 
 constexpr size_t maxTableEntries = 10000000;
 constexpr unsigned maxTables = 1000000;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -777,8 +777,8 @@ auto SectionParser::parseI32InitExpr(std::optional<I32InitExpr>& initExpr, ASCII
 auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>& functionSignature) -> PartialResult
 {
     uint32_t argumentCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(argumentCount), "can't get ", position, "th Type's argument count");
-    WASM_PARSER_FAIL_IF(argumentCount > maxFunctionParams, position, "th argument count is too big ", argumentCount, " maximum ", maxFunctionParams);
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(argumentCount), "can't get Type's argument count at index ", position);
+    WASM_PARSER_FAIL_IF(argumentCount > maxFunctionParams, "argument count of Type at index ", position, " is too big ", argumentCount, " maximum ", maxFunctionParams);
     Vector<Type> argumentTypes;
     WASM_PARSER_FAIL_IF(!argumentTypes.tryReserveCapacity(argumentCount), "can't allocate enough memory for Type section's ", position, "th signature");
 
@@ -789,10 +789,11 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
     }
 
     uint32_t returnCount;
-    WASM_PARSER_FAIL_IF(!parseVarUInt32(returnCount), "can't get ", position, "th Type's return count");
+    WASM_PARSER_FAIL_IF(!parseVarUInt32(returnCount), "can't get Type's return count at index ", position);
+    WASM_PARSER_FAIL_IF(returnCount > maxFunctionReturns, "return count of Type at index ", position, " is too big ", returnCount, " maximum ", maxFunctionReturns);
 
     Vector<Type, 1> returnTypes;
-    WASM_PARSER_FAIL_IF(!returnTypes.tryReserveCapacity(argumentCount), "can't allocate enough memory for Type section's ", position, "th signature");
+    WASM_PARSER_FAIL_IF(!returnTypes.tryReserveCapacity(returnCount), "can't allocate enough memory for Type section's ", position, "th signature");
     for (unsigned i = 0; i < returnCount; ++i) {
         Type value;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, value), "can't get ", i, "th Type's return value");


### PR DESCRIPTION
#### abb3206604d2870d3f29155f57b3a142f7171375
<pre>
[JSC] Limit wasm function return type counts to 1000
<a href="https://bugs.webkit.org/show_bug.cgi?id=259957">https://bugs.webkit.org/show_bug.cgi?id=259957</a>
rdar://113595096

Reviewed by Justin Michaud and Keith Miller.

This patch integrates wasm function&apos;s return type count limits, 1000, this number is aligned to V8 and SpiderMonkey.
We also fix the existing bug about returnCount in WasmSectionParser. This is harmless since it is just &quot;reserve&quot; capacity, but anyway this was wrong.

* JSTests/wasm/stress/too-many-return-types.js: Added.
(import.Builder.from.string_appeared_here.import.as.assert.from.string_appeared_here.catch):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseFunctionType):

Canonical link: <a href="https://commits.webkit.org/266709@main">https://commits.webkit.org/266709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eee1bc59be243ca296dbbb2c625d57f331de2f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16285 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14926 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17014 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13107 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/12450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16509 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13826 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13829 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14583 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13120 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17458 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14972 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1733 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13673 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3588 "Passed tests") | 
<!--EWS-Status-Bubble-End-->