### PR TITLE
TransformOperation subclasses should verify deserialized type

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1129,8 +1129,7 @@ void KeyframeEffect::computedNeedsForcedLayout()
         if (keyframeStyle->hasTransform()) {
             auto& transformOperations = keyframeStyle->transform();
             for (const auto& operation : transformOperations.operations()) {
-                if (operation->isTranslateTransformOperationType()) {
-                    auto translation = downcast<TranslateTransformOperation>(operation.get());
+                if (auto* translation = dynamicDowncast<TranslateTransformOperation>(operation.get())) {
                     if (translation->x().isPercent() || translation->y().isPercent()) {
                         m_needsForcedLayout = true;
                         return;

--- a/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
@@ -65,4 +65,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::IdentityTransformOperation, type() == WebCore::TransformOperation::Type::Identity)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::IdentityTransformOperation, WebCore::TransformOperation::Type::Identity ==)

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
@@ -69,4 +69,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::Matrix3DTransformOperation, type() == WebCore::TransformOperation::Type::Matrix3D)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::Matrix3DTransformOperation, WebCore::TransformOperation::Type::Matrix3D ==)

--- a/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
@@ -89,4 +89,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::MatrixTransformOperation, type() == WebCore::TransformOperation::Type::Matrix)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::MatrixTransformOperation, WebCore::TransformOperation::Type::Matrix ==)

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
@@ -84,4 +84,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::PerspectiveTransformOperation, type() == WebCore::TransformOperation::Type::Perspective)
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::PerspectiveTransformOperation, WebCore::TransformOperation::Type::Perspective ==)

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -41,7 +41,7 @@ RotateTransformOperation::RotateTransformOperation(double x, double y, double z,
     , m_z(z)
     , m_angle(angle)
 {
-    ASSERT(isRotateTransformOperationType());
+    RELEASE_ASSERT(isRotateTransformOperationType(type));
 }
 
 bool RotateTransformOperation::operator==(const TransformOperation& other) const

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -85,4 +85,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::RotateTransformOperation, isRotateTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::RotateTransformOperation, WebCore::TransformOperation::isRotateTransformOperationType)

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp
@@ -38,7 +38,7 @@ ScaleTransformOperation::ScaleTransformOperation(double sx, double sy, double sz
     , m_y(sy)
     , m_z(sz)
 {
-    ASSERT(isScaleTransformOperationType());
+    RELEASE_ASSERT(isScaleTransformOperationType(type));
 }
 
 bool ScaleTransformOperation::operator==(const TransformOperation& other) const

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
@@ -80,4 +80,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::ScaleTransformOperation, isScaleTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::ScaleTransformOperation, WebCore::TransformOperation::isScaleTransformOperationType)

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp
@@ -37,7 +37,7 @@ SkewTransformOperation::SkewTransformOperation(double angleX, double angleY, Tra
     , m_angleX(angleX)
     , m_angleY(angleY)
 {
-    ASSERT(isSkewTransformOperationType());
+    RELEASE_ASSERT(isSkewTransformOperationType(type));
 }
 
 bool SkewTransformOperation::operator==(const TransformOperation& other) const

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
@@ -68,4 +68,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::SkewTransformOperation, isSkewTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::SkewTransformOperation, WebCore::TransformOperation::isSkewTransformOperationType)

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -107,24 +107,38 @@ public:
     
     virtual bool isRepresentableIn2D() const { return true; }
 
-    bool isRotateTransformOperationType() const
+    static bool isRotateTransformOperationType(Type type)
     {
-        return type() == Type::RotateX || type() == Type::RotateY || type() == Type::RotateZ || type() == Type::Rotate || type() == Type::Rotate3D;
+        return type == Type::RotateX
+            || type == Type::RotateY
+            || type == Type::RotateZ
+            || type == Type::Rotate
+            || type == Type::Rotate3D;
     }
 
-    bool isScaleTransformOperationType() const
+    static bool isScaleTransformOperationType(Type type)
     {
-        return type() == Type::ScaleX || type() == Type::ScaleY || type() == Type::ScaleZ || type() == Type::Scale || type() == Type::Scale3D;
+        return type == Type::ScaleX
+            || type == Type::ScaleY
+            || type == Type::ScaleZ
+            || type == Type::Scale
+            || type == Type::Scale3D;
     }
 
-    bool isSkewTransformOperationType() const
+    static bool isSkewTransformOperationType(Type type)
     {
-        return type() == Type::SkewX || type() == Type::SkewY || type() == Type::Skew;
+        return type == Type::SkewX
+            || type == Type::SkewY
+            || type == Type::Skew;
     }
 
-    bool isTranslateTransformOperationType() const
+    static bool isTranslateTransformOperationType(Type type)
     {
-        return type() == Type::TranslateX || type() == Type::TranslateY || type() == Type::TranslateZ || type() == Type::Translate || type() == Type::Translate3D;
+        return type == Type::TranslateX
+            || type == Type::TranslateY
+            || type == Type::TranslateZ
+            || type == Type::Translate
+            || type == Type::Translate3D;
     }
     
     virtual void dump(WTF::TextStream&) const = 0;
@@ -173,5 +187,5 @@ template<> struct EnumTraits<WebCore::TransformOperation::Type> {
 
 #define SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(ToValueTypeName, predicate) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \
-    static bool isType(const WebCore::TransformOperation& operation) { return operation.predicate; } \
+    static bool isType(const WebCore::TransformOperation& operation) { return predicate(operation.type()); } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp
@@ -39,7 +39,7 @@ TranslateTransformOperation::TranslateTransformOperation(const Length& tx, const
     , m_y(ty)
     , m_z(tz)
 {
-    ASSERT(isTranslateTransformOperationType());
+    RELEASE_ASSERT(isTranslateTransformOperationType(type));
 }
 
 bool TranslateTransformOperation::operator==(const TransformOperation& other) const

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -91,4 +91,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::TranslateTransformOperation, isTranslateTransformOperationType())
+SPECIALIZE_TYPE_TRAITS_TRANSFORMOPERATION(WebCore::TranslateTransformOperation, WebCore::TransformOperation::isTranslateTransformOperationType)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2433,7 +2433,7 @@ header: <WebCore/KeyboardScroll.h>
     WebCore::Length x();
     WebCore::Length y();
     WebCore::Length z();
-    WebCore::TransformOperation::Type type();
+    [Validator='WebCore::TransformOperation::isTranslateTransformOperationType(*type)'] WebCore::TransformOperation::Type type();
 }
 
 [RefCounted] class WebCore::RotateTransformOperation {
@@ -2441,20 +2441,20 @@ header: <WebCore/KeyboardScroll.h>
     double y();
     double z();
     double angle();
-    WebCore::TransformOperation::Type type();
+    [Validator='WebCore::TransformOperation::isRotateTransformOperationType(*type)'] WebCore::TransformOperation::Type type();
 }
 
 [RefCounted] class WebCore::ScaleTransformOperation {
     double x();
     double y();
     double z();
-    WebCore::TransformOperation::Type type();
+    [Validator='WebCore::TransformOperation::isScaleTransformOperationType(*type)'] WebCore::TransformOperation::Type type();
 }
 
 [RefCounted] class WebCore::SkewTransformOperation {
     double angleX();
     double angleY();
-    WebCore::TransformOperation::Type type();
+    [Validator='WebCore::TransformOperation::isSkewTransformOperationType(*type)'] WebCore::TransformOperation::Type type();
 }
 
 [RefCounted] class WebCore::PerspectiveTransformOperation {


### PR DESCRIPTION
#### 9790360a4547ded45277e7fea9f30791b010eb05
<pre>
TransformOperation subclasses should verify deserialized type
<a href="https://bugs.webkit.org/show_bug.cgi?id=255629">https://bugs.webkit.org/show_bug.cgi?id=255629</a>
rdar://108161092

Reviewed by David Kilzer.

The type needs to line up with the same types used by the is, downcast, and dynamicDowncast functions.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computedNeedsForcedLayout):
* Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::RotateTransformOperation):
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.cpp:
(WebCore::ScaleTransformOperation::ScaleTransformOperation):
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.cpp:
(WebCore::SkewTransformOperation::SkewTransformOperation):
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
(WebCore::TransformOperation::isRotateTransformOperationType):
(WebCore::TransformOperation::isScaleTransformOperationType):
(WebCore::TransformOperation::isSkewTransformOperationType):
(WebCore::TransformOperation::isTranslateTransformOperationType):
(WebCore::TransformOperation::isRotateTransformOperationType const): Deleted.
(WebCore::TransformOperation::isScaleTransformOperationType const): Deleted.
(WebCore::TransformOperation::isSkewTransformOperationType const): Deleted.
(WebCore::TransformOperation::isTranslateTransformOperationType const): Deleted.
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp:
(WebCore::TranslateTransformOperation::TranslateTransformOperation):
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Originally-landed-as: 259548.723@safari-7615-branch (9e8e582627a8). rdar://113595196
Canonical link: <a href="https://commits.webkit.org/266727@main">https://commits.webkit.org/266727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bcb1645bec15672cc3f31a15748c10b4e34d487

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16390 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17009 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20115 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16506 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13824 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13115 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3523 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->