### PR TITLE
Support text-wrap balance in legacy line layout

### DIFF
--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -75,6 +75,7 @@ public:
 
     static void appendRunsForObject(BidiRunList<BidiRun>*, int start, int end, RenderObject&, InlineBidiResolver&);
     static void updateLogicalWidthForAlignment(RenderBlockFlow&, const TextAlignMode&, const LegacyRootInlineBox*, BidiRun* trailingSpaceRun, float& logicalLeft, float& totalLogicalWidth, float& availableLogicalWidth, int expansionOpportunityCount);
+    std::optional<LayoutUnit> computeTextWrapBalanceWidthConstraint(LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom);
 
 private:
     std::unique_ptr<LegacyRootInlineBox> createRootInlineBox();

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -77,7 +77,7 @@ void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& 
     resolver.commitExplicitEmbedding();
 }
 
-LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, FloatingObject* lastFloatFromPreviousLine, unsigned consecutiveHyphenatedLines, WordMeasurements& wordMeasurements)
+LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, FloatingObject* lastFloatFromPreviousLine, unsigned consecutiveHyphenatedLines, WordMeasurements& wordMeasurements, std::optional<LayoutUnit> widthOverride)
 {
     reset();
 
@@ -85,7 +85,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
 
     bool appliedStartWidth = resolver.position().offset();
 
-    LineWidth width(m_block, lineInfo.isFirstLine(), requiresIndent(lineInfo.isFirstLine(), lineInfo.previousLineBrokeCleanly(), m_block.style()));
+    LineWidth width(m_block, lineInfo.isFirstLine(), requiresIndent(lineInfo.isFirstLine(), lineInfo.previousLineBrokeCleanly(), m_block.style()), widthOverride);
 
     skipLeadingWhitespace(resolver, lineInfo, lastFloatFromPreviousLine, width);
 

--- a/Source/WebCore/rendering/line/LineBreaker.h
+++ b/Source/WebCore/rendering/line/LineBreaker.h
@@ -50,7 +50,7 @@ public:
         reset();
     }
 
-    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, FloatingObject* lastFloatFromPreviousLine, unsigned consecutiveHyphenatedLines, WordMeasurements&);
+    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, FloatingObject* lastFloatFromPreviousLine, unsigned consecutiveHyphenatedLines, WordMeasurements&, std::optional<LayoutUnit> widthOverride = std::nullopt);
 
     bool lineWasHyphenated() { return m_hyphenated; }
     const Vector<RenderBox*>& positionedObjects() { return m_positionedObjects; }

--- a/Source/WebCore/rendering/line/LineLayoutState.h
+++ b/Source/WebCore/rendering/line/LineLayoutState.h
@@ -153,6 +153,9 @@ public:
 
     FloatList& floatList() { return m_floatList; }
 
+    std::optional<LayoutUnit> widthOverride() const { return m_widthOverride; }
+    void setWidthOverride(std::optional<LayoutUnit> widthOverride) { m_widthOverride = widthOverride; }
+
 private:
     LineInfo m_lineInfo;
     LayoutUnit m_endLineLogicalTop;
@@ -166,6 +169,8 @@ private:
     // FIXME: Should this be a range object instead of two ints?
     LayoutUnit& m_repaintLogicalTop;
     LayoutUnit& m_repaintLogicalBottom;
+
+    std::optional<LayoutUnit> m_widthOverride;
 
     RenderBlockFlow::MarginInfo m_marginInfo;
 

--- a/Source/WebCore/rendering/line/LineWidth.h
+++ b/Source/WebCore/rendering/line/LineWidth.h
@@ -45,7 +45,7 @@ enum IndentTextOrNot { DoNotIndentText, IndentText };
 
 class LineWidth {
 public:
-    LineWidth(RenderBlockFlow&, bool isFirstLine, IndentTextOrNot shouldIndentText);
+    LineWidth(RenderBlockFlow&, bool isFirstLine, IndentTextOrNot shouldIndentText, std::optional<LayoutUnit> widthOverride = std::nullopt);
 
     bool fitsOnLine(bool ignoringTrailingSpace = false) const;
     bool fitsOnLineIncludingExtraWidth(float extra) const;
@@ -95,6 +95,7 @@ private:
     float m_left { 0 };
     float m_right { 0 };
     float m_availableWidth { 0 };
+    std::optional<LayoutUnit> m_widthOverride { std::nullopt };
     bool m_isFirstLine { true };
     bool m_hasCommitted { false };
     bool m_hasCommittedReplaced { false };


### PR DESCRIPTION
#### 2d2564d2f60de56a564e8e69969de9b0ee69156d
<pre>
Support text-wrap balance in legacy line layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=259958">https://bugs.webkit.org/show_bug.cgi?id=259958</a>
rdar://113595624

Reviewed by NOBODY (OOPS!).

This patch implements `text-wrap: balance` in legacy line layout. It currently
uses a binary search to find the minimum width constraint for line boxes that
preserves the number of lines used in normal wrapping behavior. This
approach does accomodate floats (or other types of intrusive content
such as initial-letter). This also does not accomodate forced line breaks.

There is no line limit imposed on this implementation, although
performance is roughly an order of magnitude slower than non-balanced
line layout. Given a fixed containing width, the time complexity of this
algorithm is linear with respect to the number of inline items.

* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
(WebCore::LegacyLineLayout::layoutLineBoxes):
(WebCore::LegacyLineLayout::computeTextWrapBalanceWidthConstraint):
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::nextLineBreak):
* Source/WebCore/rendering/line/LineBreaker.h:
* Source/WebCore/rendering/line/LineLayoutState.h:
(WebCore::LineLayoutState::widthOverride const):
(WebCore::LineLayoutState::setWidthOverride):
* Source/WebCore/rendering/line/LineWidth.cpp:
(WebCore::LineWidth::LineWidth):
(WebCore::LineWidth::updateLineDimension):
(WebCore::LineWidth::computeAvailableWidthFromLeftAndRight):
* Source/WebCore/rendering/line/LineWidth.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d2564d2f60de56a564e8e69969de9b0ee69156d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16844 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15763 "Passed tests") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16765 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17606 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20607 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12179 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->