### PR TITLE
Add support for the alarms Web Extension API.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -184,6 +184,7 @@ $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
 $(PROJECT_DIR)/Shared/Databases/IndexedDB/WebIDBResult.serialization.in
 $(PROJECT_DIR)/Shared/DisplayListArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/EditorState.serialization.in
+$(PROJECT_DIR)/Shared/Extensions/WebExtensionAlarmParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionControllerParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionEventListenerType.serialization.in
@@ -368,6 +369,7 @@ $(PROJECT_DIR)/WebProcess/Cache/WebCacheStorageConnection.messages.in
 $(PROJECT_DIR)/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -46,6 +46,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -489,6 +489,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/BackgroundFetchState.serialization.in \
 	Shared/DisplayListArgumentCoders.serialization.in \
 	Shared/EditorState.serialization.in \
+	Shared/Extensions/WebExtensionAlarmParameters.serialization.in \
 	Shared/Extensions/WebExtensionContextParameters.serialization.in \
 	Shared/Extensions/WebExtensionControllerParameters.serialization.in \
 	Shared/Extensions/WebExtensionEventListenerType.serialization.in \
@@ -641,6 +642,7 @@ BINDINGS_SCRIPTS = \
 #
 
 EXTENSION_INTERFACES = \
+    WebExtensionAPIAlarms \
     WebExtensionAPIEvent \
     WebExtensionAPIExtension \
     WebExtensionAPINamespace \

--- a/Source/WebKit/Shared/Extensions/WebExtensionAlarmParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionAlarmParameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,21 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPINamespace {
+#pragma once
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    readonly attribute WebExtensionAPIExtension extension;
+#include <wtf/Forward.h>
+#include <wtf/MonotonicTime.h>
 
-    readonly attribute WebExtensionAPIRuntime runtime;
+namespace WebKit {
 
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
-
-    [Dynamic] readonly attribute WebExtensionAPITest test;
-
+struct WebExtensionAlarmParameters {
+    String name;
+    Seconds initialInterval;
+    Seconds repeatInterval;
+    MonotonicTime nextScheduledTime;
 };
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionAlarmParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionAlarmParameters.serialization.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+struct WebKit::WebExtensionAlarmParameters {
+    String name;
+    Seconds initialInterval;
+    Seconds repeatInterval;
+    MonotonicTime nextScheduledTime;
+}
+
+#endif

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -553,6 +553,7 @@ UIProcess/Automation/WebAutomationSession.cpp @no-unify
 UIProcess/Downloads/DownloadProxy.cpp
 UIProcess/Downloads/DownloadProxyMap.cpp
 
+UIProcess/Extensions/WebExtensionAlarm.cpp
 UIProcess/Extensions/WebExtensionContext.cpp
 UIProcess/Extensions/WebExtensionController.cpp
 UIProcess/Extensions/WebExtensionControllerConfiguration.cpp

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionAlarm.h"
+#import "WebExtensionContextProxy.h"
+#import "WebExtensionContextProxyMessages.h"
+
+namespace WebKit {
+
+void WebExtensionContext::alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval)
+{
+    m_alarmMap.set(name, WebExtensionAlarm::create(name, initialInterval, repeatInterval, [&](const WebExtensionAlarm& alarm) {
+        fireAlarmsEventIfNeeded(alarm);
+    }));
+}
+
+void WebExtensionContext::alarmsGet(const String& name, CompletionHandler<void(std::optional<WebExtensionAlarmParameters>)>&& completionHandler)
+{
+    if (auto* alarm = m_alarmMap.get(name))
+        completionHandler(alarm->parameters());
+    else
+        completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::alarmsClear(const String& name, CompletionHandler<void()>&& completionHandler)
+{
+    m_alarmMap.remove(name);
+
+    completionHandler();
+}
+
+void WebExtensionContext::alarmsGetAll(CompletionHandler<void(Vector<WebExtensionAlarmParameters>&&)>&& completionHandler)
+{
+    Vector<WebExtensionAlarmParameters> alarms;
+    alarms.reserveInitialCapacity(m_alarmMap.size());
+
+    for (auto& alarm : m_alarmMap.values())
+        alarms.uncheckedAppend(alarm->parameters());
+
+    completionHandler(WTFMove(alarms));
+}
+
+void WebExtensionContext::alarmsClearAll(CompletionHandler<void()>&& completionHandler)
+{
+    m_alarmMap.clear();
+
+    completionHandler();
+}
+
+void WebExtensionContext::fireAlarmsEventIfNeeded(const WebExtensionAlarm& alarm)
+{
+    auto type = WebExtensionEventListenerType::AlarmsOnAlarm;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchAlarmEvent(alarm.parameters()));
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -33,6 +33,7 @@
 #include "APIUserStyleSheet.h"
 #include "MessageReceiver.h"
 #include "WebExtension.h"
+#include "WebExtensionAlarm.h"
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionController.h"
 #include "WebExtensionEventListenerType.h"
@@ -92,6 +93,8 @@ public:
 
     using UserScriptVector = Vector<Ref<API::UserScript>>;
     using UserStyleSheetVector = Vector<Ref<API::UserStyleSheet>>;
+
+    using AlarmInfoMap = HashMap<String, double>;
 
     using PermissionsSet = WebExtension::PermissionsSet;
     using MatchPatternSet = WebExtension::MatchPatternSet;
@@ -287,15 +290,23 @@ private:
     void testYielded(String message, String sourceURL, unsigned lineNumber);
     void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
+    // Alarms APIs
+    void alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval);
+    void alarmsGet(const String& name, CompletionHandler<void(std::optional<WebExtensionAlarmParameters>)>&&);
+    void alarmsClear(const String& name, CompletionHandler<void()>&&);
+    void alarmsGetAll(CompletionHandler<void(Vector<WebExtensionAlarmParameters>&&)>&&);
+    void alarmsClearAll(CompletionHandler<void()>&&);
+    void fireAlarmsEventIfNeeded(const WebExtensionAlarm&);
+
     // Event APIs
     void addListener(WebPageProxyIdentifier, WebExtensionEventListenerType);
     void removeListener(WebPageProxyIdentifier, WebExtensionEventListenerType);
 
     // Permissions APIs
     void permissionsGetAll(CompletionHandler<void(Vector<String> permissions, Vector<String> origins)>&&);
-    void permissionsContains(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
-    void permissionsRequest(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
-    void permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler);
+    void permissionsContains(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&&);
+    void permissionsRequest(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&&);
+    void permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&&);
     void firePermissionsEventListenerIfNecessary(WebExtensionEventListenerType, const PermissionsSet&, const MatchPatternSet&);
 
     // IPC::MessageReceiver.
@@ -356,6 +367,8 @@ private:
 
     HashMap<Ref<WebExtensionMatchPattern>, UserScriptVector> m_injectedScriptsPerPatternMap;
     HashMap<Ref<WebExtensionMatchPattern>, UserStyleSheetVector> m_injectedStyleSheetsPerPatternMap;
+
+    HashMap<String, Ref<WebExtensionAlarm>> m_alarmMap;
 };
 
 template<typename T>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -33,6 +33,13 @@ messages -> WebExtensionContext {
     TestYielded(String message, String sourceURL, unsigned lineNumber);
     TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
+    // Alarms APIs
+    AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval);
+    AlarmsGet(String name) -> (std::optional<WebKit::WebExtensionAlarmParameters> alarmInfo);
+    AlarmsClear(String name) -> ();
+    AlarmsGetAll() -> (Vector<WebKit::WebExtensionAlarmParameters> alarms);
+    AlarmsClearAll() -> ();
+
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type);
     RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -30,6 +30,7 @@
 
 #include "WebExtensionControllerParameters.h"
 #include "WebExtensionControllerProxyMessages.h"
+#include "WebPageProxy.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -406,6 +406,11 @@
 		1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE971288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C20936022318CB000026A39 /* NSAttributedString.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C20935E22318CB000026A39 /* NSAttributedString.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1C2184022233872800BAC700 /* NSAttributedStringPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C2B4D422A817D7200C528A1 /* WebExtensionAlarmParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2B4D412A817D6B00C528A1 /* WebExtensionAlarmParameters.h */; };
+		1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */; };
+		1C2B4D4B2A819D0D00C528A1 /* JSWebExtensionAPIAlarms.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C3BEB502887492F00E66E38 /* WebExtensionControllerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3BEB492887492600E66E38 /* WebExtensionControllerMessages.h */; };
 		1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3BEB4E2887492700E66E38 /* WebExtensionControllerProxyMessages.h */; };
 		1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C3BEB4A2887492600E66E38 /* WebExtensionControllerMessageReceiver.cpp */; };
@@ -3367,6 +3372,16 @@
 		1C20935E22318CB000026A39 /* NSAttributedString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSAttributedString.h; sourceTree = "<group>"; };
 		1C20935F22318CB000026A39 /* NSAttributedString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSAttributedString.mm; sourceTree = "<group>"; };
 		1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSAttributedStringPrivate.h; sourceTree = "<group>"; };
+		1C2B4D3C2A8091FF00C528A1 /* WebExtensionAlarm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionAlarm.cpp; sourceTree = "<group>"; };
+		1C2B4D3D2A8091FF00C528A1 /* WebExtensionAlarm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAlarm.h; sourceTree = "<group>"; };
+		1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIAlarmsCocoa.mm; sourceTree = "<group>"; };
+		1C2B4D402A817D6A00C528A1 /* WebExtensionAlarmParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAlarmParameters.serialization.in; sourceTree = "<group>"; };
+		1C2B4D412A817D6B00C528A1 /* WebExtensionAlarmParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAlarmParameters.h; sourceTree = "<group>"; };
+		1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIAlarmsCocoa.mm; sourceTree = "<group>"; };
+		1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIAlarms.h; sourceTree = "<group>"; };
+		1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIAlarms.idl; sourceTree = "<group>"; };
+		1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIAlarms.h; sourceTree = "<group>"; };
+		1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIAlarms.mm; sourceTree = "<group>"; };
 		1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerParameters.h; sourceTree = "<group>"; };
 		1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerIdentifier.h; sourceTree = "<group>"; };
 		1C3BEB492887492600E66E38 /* WebExtensionControllerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerMessages.h; sourceTree = "<group>"; };
@@ -8490,6 +8505,7 @@
 		1C1549802926E7CC001B9E5B /* API */ = {
 			isa = PBXGroup;
 			children = (
+				1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */,
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
 				B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */,
 				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
@@ -8512,6 +8528,7 @@
 			isa = PBXGroup;
 			children = (
 				1C5DC4502908A9D00061EC62 /* Cocoa */,
+				1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */,
 				B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */,
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
@@ -8528,6 +8545,7 @@
 		1C5DC4502908A9D00061EC62 /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */,
 				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
@@ -8668,6 +8686,7 @@
 		1C9DD98F28FA19A30093BDB0 /* Interfaces */ = {
 			isa = PBXGroup;
 			children = (
+				1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */,
 				B6544F7C29357B1B00034EB0 /* WebExtensionAPIEvent.idl */,
 				1C9DD99028FA19A30093BDB0 /* WebExtensionAPIExtension.idl */,
 				1C9DD9A428FA19A30093BDB0 /* WebExtensionAPINamespace.idl */,
@@ -8981,6 +9000,8 @@
 			children = (
 				1C627476288A1DDE00CED3A2 /* Cocoa */,
 				1C3BEB5E2888710500E66E38 /* WebExtension.h */,
+				1C2B4D3C2A8091FF00C528A1 /* WebExtensionAlarm.cpp */,
+				1C2B4D3D2A8091FF00C528A1 /* WebExtensionAlarm.h */,
 				1C0234C128A00E7D00AC1E5B /* WebExtensionContext.cpp */,
 				1C0234C228A00E7D00AC1E5B /* WebExtensionContext.h */,
 				1C0234C328A00E7E00AC1E5B /* WebExtensionContext.messages.in */,
@@ -11874,6 +11895,8 @@
 			children = (
 				337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */,
 				337822462947FBA4002106BB /* _WKWebExtensionUtilities.mm */,
+				1C2B4D412A817D6B00C528A1 /* WebExtensionAlarmParameters.h */,
+				1C2B4D402A817D6A00C528A1 /* WebExtensionAlarmParameters.serialization.in */,
 				1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */,
 				1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */,
 				1CBEE26128F334D6006D1A02 /* WebExtensionContextParameters.serialization.in */,
@@ -13269,6 +13292,8 @@
 				0F5562DE27EE28D000953585 /* GPUProcessMessages.h */,
 				0F5562E827EE28D200953585 /* GPUProcessProxyMessageReceiver.cpp */,
 				0F5562E427EE28D100953585 /* GPUProcessProxyMessages.h */,
+				1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */,
+				1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */,
 				B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */,
 				B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */,
 				1C5DC462290B1C470061EC62 /* JSWebExtensionAPIExtension.h */,
@@ -14859,6 +14884,8 @@
 				BC111B5D112F629800337BAB /* WebEventFactory.h in Headers */,
 				86DD519028EF28E800DF2A58 /* WebEventModifier.h in Headers */,
 				F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */,
+				1C2B4D422A817D7200C528A1 /* WebExtensionAlarmParameters.h in Headers */,
+				1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */,
 				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
@@ -17011,6 +17038,7 @@
 				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
+				1C2B4D4B2A819D0D00C528A1 /* JSWebExtensionAPIAlarms.mm in Sources */,
 				B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */,
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
@@ -17337,6 +17365,7 @@
 				E3866B0B2399A2DD00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp in Sources */,
 				E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */,
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
+				1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */,
 				B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */,
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
@@ -17346,6 +17375,7 @@
 				3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */,
 				33F68340293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
+				1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
 				B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */,
 				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIAlarms.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+#import "MessageSenderInlines.h"
+#import "WebExtensionAPINamespace.h"
+#import "WebExtensionContextMessages.h"
+#import "WebExtensionContextProxy.h"
+#import "WebProcess.h"
+#import "_WKWebExtensionUtilities.h"
+#import <wtf/DateMath.h>
+
+namespace WebKit {
+
+static NSString *whenKey = @"when";
+static NSString *delayInMinutesKey = @"delayInMinutes";
+static NSString *periodInMinutesKey = @"periodInMinutes";
+
+static NSString *nameKey = @"name";
+static NSString *scheduledTimeKey = @"scheduledTime";
+
+static NSString *emptyAlarmName = @"";
+
+static inline NSDictionary *toAPI(const WebExtensionAlarmParameters& alarm)
+{
+    NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:3];
+
+    result[nameKey] = static_cast<NSString *>(alarm.name);
+    result[scheduledTimeKey] = @(floor(alarm.nextScheduledTime.approximateWallTime().secondsSinceEpoch().milliseconds()));
+
+    if (alarm.repeatInterval)
+        result[periodInMinutesKey] = @(alarm.repeatInterval.minutes());
+
+    return [result copy];
+}
+
+static inline NSDictionary *toAPI(const std::optional<WebExtensionAlarmParameters>& alarm)
+{
+    return alarm ? toAPI(alarm.value()) : nil;
+}
+
+static inline NSArray *toAPI(const Vector<WebExtensionAlarmParameters>& alarms)
+{
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:alarms.size()];
+
+    for (auto& alarm : alarms)
+        [result addObject:toAPI(alarm)];
+
+    return [result copy];
+}
+
+void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create
+
+    RELEASE_LOG_INFO(Extensions, "alarms.create()");
+
+    static NSArray<NSString *> *optionalKeys = @[
+        whenKey,
+        delayInMinutesKey,
+        periodInMinutesKey,
+    ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        whenKey: NSNumber.class,
+        delayInMinutesKey: NSNumber.class,
+        periodInMinutesKey: NSNumber.class,
+    };
+
+    if (![_WKWebExtensionUtilities validateContentsOfDictionary:alarmInfo requiredKeys:nil optionalKeys:optionalKeys keyToExpectedValueType:types outExceptionString:outExceptionString])
+        return;
+
+    Seconds when = Seconds::fromMilliseconds(objectForKey<NSNumber>(alarmInfo, whenKey).doubleValue);
+    Seconds delay = Seconds::fromMinutes(objectForKey<NSNumber>(alarmInfo, delayInMinutesKey).doubleValue);
+    Seconds period = Seconds::fromMinutes(objectForKey<NSNumber>(alarmInfo, periodInMinutesKey).doubleValue);
+    Seconds currentTime = Seconds::fromMilliseconds(jsCurrentTime());
+
+    Seconds initialInterval;
+    Seconds repeatInterval;
+
+    if (when)
+        initialInterval = when - currentTime;
+    else if (delay)
+        initialInterval = delay;
+
+    if (period) {
+        repeatInterval = period;
+
+        if (!initialInterval)
+            initialInterval = repeatInterval;
+    }
+
+    if (!extensionContext().inTestingMode()) {
+        // Enforce a minimum of 1 minute intervals outside of testing.
+        initialInterval = std::max(initialInterval, 1_min);
+        repeatInterval = repeatInterval ? std::max(repeatInterval, 1_min) : 0_s;
+    }
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::AlarmsCreate(name ?: emptyAlarmName, initialInterval, repeatInterval), extensionContext().identifier());
+}
+
+void WebExtensionAPIAlarms::get(NSString *name, Ref<WebExtensionCallbackHandler>&& callback)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get
+
+    RELEASE_LOG_INFO(Extensions, "alarms.get()");
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGet(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionAlarmParameters> alarm) {
+        callback->call(toAPI(alarm));
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAlarms::getAll(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll
+
+    RELEASE_LOG_INFO(Extensions, "alarms.getAll()");
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionAlarmParameters> alarms) {
+        callback->call(toAPI(alarms));
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAlarms::clear(NSString *name, Ref<WebExtensionCallbackHandler>&& callback)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear
+
+    RELEASE_LOG_INFO(Extensions, "alarms.clear()");
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClear(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTFMove(callback)]() {
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAlarms::clearAll(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
+
+    RELEASE_LOG_INFO(Extensions, "alarms.clearAll()");
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClearAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)]() {
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+WebExtensionAPIEvent& WebExtensionAPIAlarms::onAlarm()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
+
+    if (!m_onAlarm)
+        m_onAlarm = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::AlarmsOnAlarm);
+
+    return *m_onAlarm;
+}
+
+void WebExtensionContextProxy::dispatchAlarmEvent(const WebExtensionAlarmParameters& alarm)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
+
+    RELEASE_LOG_INFO(Extensions, "alarms.onAlarm dispatched");
+
+    NSDictionary *alarmDictionary = toAPI(alarm);
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.alarms().onAlarm().invokeListenersWithArgument(alarmDictionary);
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -38,18 +38,20 @@ namespace WebKit {
 
 bool WebExtensionAPINamespace::isPropertyAllowed(String name, WebPage*)
 {
-    if (name == "permissions"_s)
-        return true;
-
     // This property is only allowed in testing contexts.
     if (name == "test"_s)
         return extensionContext().inTestingMode();
 
-    if (name == "webNavigation"_s)
-        return [objectForKey<NSArray>(extensionContext().manifest(), @"permissions", true, NSString.class) containsObject:_WKWebExtensionPermissionWebNavigation];
+    // FIXME: https://webkit.org/b/259914 This should be a hasPermission: call to extensionContext() and updated with actually granted permissions from the UI process.
+    auto *permissions = objectForKey<NSArray>(extensionContext().manifest(), @"permissions", true, NSString.class);
+    return [permissions containsObject:static_cast<NSString *>(name)];
+}
 
-    ASSERT_NOT_REACHED();
-    return false;
+WebExtensionAPIAlarms& WebExtensionAPINamespace::alarms()
+{
+    if (!m_alarms)
+        m_alarms = WebExtensionAPIAlarms::create(forMainWorld(), runtime(), extensionContext());
+    return *m_alarms;
 }
 
 WebExtensionAPIExtension& WebExtensionAPINamespace::extension()

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,21 +23,39 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPINamespace {
+#pragma once
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    readonly attribute WebExtensionAPIExtension extension;
+#include "JSWebExtensionAPIAlarms.h"
+#include "WebExtensionAPIEvent.h"
+#include "WebExtensionAPIObject.h"
 
-    readonly attribute WebExtensionAPIRuntime runtime;
+OBJC_CLASS NSDictionary;
+OBJC_CLASS NSString;
 
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
+namespace WebKit {
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
+class WebExtensionAPIAlarms : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAlarms, alarms);
 
-    [Dynamic] readonly attribute WebExtensionAPITest test;
+public:
+#if PLATFORM(COCOA)
+    void createAlarm(NSString *name, NSDictionary *alarmInfo, NSString **outExceptionString);
 
+    void get(NSString *name, Ref<WebExtensionCallbackHandler>&&);
+    void getAll(Ref<WebExtensionCallbackHandler>&&);
+
+    void clear(NSString *name, Ref<WebExtensionCallbackHandler>&&);
+    void clearAll(Ref<WebExtensionCallbackHandler>&&);
+
+    WebExtensionAPIEvent& onAlarm();
+
+private:
+    RefPtr<WebExtensionAPIEvent> m_onAlarm;
+#endif
 };
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,19 +25,19 @@
 
 [
     Conditional=WK_WEB_EXTENSIONS,
+    MainWorldOnly,
     ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPINamespace {
+] interface WebExtensionAPIAlarms {
 
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+    [RaisesException, ImplementedAs=createAlarm] void create([Optional] DOMString name, [NSDictionary] any alarmInfo);
 
-    readonly attribute WebExtensionAPIExtension extension;
+    void get([Optional] DOMString name, [Optional, CallbackHandler] function callback);
+    void getAll([Optional, CallbackHandler] function callback);
 
-    readonly attribute WebExtensionAPIRuntime runtime;
+    void clear([Optional] DOMString name, [Optional, CallbackHandler] function callback);
+    void clearAll([Optional, CallbackHandler] function callback);
 
-    [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
-
-    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
-
-    [Dynamic] readonly attribute WebExtensionAPITest test;
+    // Fired when an alarm has elapsed.
+    readonly attribute WebExtensionAPIEvent onAlarm;
 
 };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -44,6 +44,7 @@ namespace WebKit {
 class WebExtensionAPINamespace;
 class WebExtensionMatchPattern;
 class WebFrame;
+struct WebExtensionAlarmParameters;
 
 class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -83,6 +84,9 @@ public:
 private:
     explicit WebExtensionContextProxy(const WebExtensionContextParameters&);
 
+    // Alarms support
+    void dispatchAlarmEvent(const WebExtensionAlarmParameters&);
+
     // webNavigation support
     void dispatchWebNavigationOnBeforeNavigateEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
     void dispatchWebNavigationOnCommittedEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
@@ -91,7 +95,7 @@ private:
     void dispatchWebNavigationOnErrorOccurredEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
 
     // Permissions support
-    void dispatchPermissionsEvent(const WebKit::WebExtensionEventListenerType&, HashSet<String> permissions, HashSet<String> origins);
+    void dispatchPermissionsEvent(const WebExtensionEventListenerType&, HashSet<String> permissions, HashSet<String> origins);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -26,6 +26,9 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionContextProxy {
+    // Alarms support
+    DispatchAlarmEvent(struct WebKit::WebExtensionAlarmParameters alarmInfo)
+
     // Permissions support
     DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -286,6 +286,7 @@ Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
 Tests/WebKitCocoa/WKWebExtension.mm
+Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
 Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
 Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2061,6 +2061,7 @@
 		1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIExtension.mm; sourceTree = "<group>"; };
 		1C1549DA293A6D7F001B9E5B /* WKWebExtensionControllerConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionControllerConfiguration.mm; sourceTree = "<group>"; };
 		1C24DEEC263001DE00450D07 /* TextStyleFontSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextStyleFontSize.mm; sourceTree = "<group>"; };
+		1C2B4D4C2A81F42800C528A1 /* WKWebExtensionAPIAlarms.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIAlarms.mm; sourceTree = "<group>"; };
 		1C2B817E1C891E4200A5529F /* CancelFontSubresource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresource.mm; sourceTree = "<group>"; };
 		1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresourcePlugIn.mm; sourceTree = "<group>"; };
 		1C2B81841C8924A200A5529F /* webfont.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = webfont.html; sourceTree = "<group>"; };
@@ -4184,6 +4185,7 @@
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,
 				1CFAA40828947999009F894D /* WKWebExtension.mm */,
+				1C2B4D4C2A81F42800C528A1 /* WKWebExtensionAPIAlarms.mm */,
 				B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */,
 				1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */,
 				330E135E2943C92000367438 /* WKWebExtensionAPINamespace.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionUtilities.h"
+
+namespace TestWebKitAPI {
+
+static auto *alarmsManifest = @{
+    @"manifest_version": @3,
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"permissions": @[ @"alarms" ],
+};
+
+TEST(WKWebExtensionAPIAlarms, DelaySingleShot)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"const startDate = Date.now()",
+        @"const delayInMilliseconds = 100",
+        @"var fireCount = 0",
+
+        @"function listener(alarmInfo) {",
+        @"  browser.test.assertEq(typeof alarmInfo.name, 'string')",
+        @"  browser.test.assertEq(typeof alarmInfo.scheduledTime, 'number')",
+        @"  browser.test.assertEq(typeof alarmInfo.periodInMinutes, 'undefined')",
+
+        @"  browser.test.assertEq(alarmInfo.name, 'single')",
+        @"  browser.test.assertTrue(alarmInfo.scheduledTime >= startDate + delayInMilliseconds, 'Scheduled date should be the registered date plus delay or later.')",
+
+        @"  if (fireCount++)",
+        @"      browser.test.notifyFail('This listener should not have been called more than once.')",
+        @"}",
+
+        // Test
+        @"browser.test.assertFalse(browser.alarms.onAlarm.hasListener(listener), 'Should not have onAlarm listener.')",
+
+        @"browser.alarms.onAlarm.addListener(listener)",
+        @"browser.test.assertTrue(browser.alarms.onAlarm.hasListener(listener), 'Should have onAlarm listener.')",
+
+        @"browser.alarms.create('single', { delayInMinutes: (delayInMilliseconds / 1000 / 60) })",
+
+        @"setTimeout(() => {",
+        @"  if (fireCount === 1)",
+        @"      browser.test.notifyPass()",
+        @"  else",
+        @"      browser.test.notifyFail('This timeout should have been called after the alarm fired once.')",
+        @"}, 500)",
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, DelayRepeating)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"const startDate = Date.now()",
+        @"const delayInMilliseconds = 100",
+        @"const periodInMilliseconds = 150",
+        @"const periodInMinutes = (periodInMilliseconds / 1000 / 60)",
+        @"var fireCount = 0",
+
+        @"function listener(alarmInfo) {",
+        @"  browser.test.assertEq(typeof alarmInfo.name, 'string')",
+        @"  browser.test.assertEq(typeof alarmInfo.scheduledTime, 'number')",
+        @"  browser.test.assertEq(typeof alarmInfo.periodInMinutes, 'number')",
+
+        @"  browser.test.assertEq(alarmInfo.name, 'repeat')",
+        @"  browser.test.assertTrue(alarmInfo.scheduledTime >= startDate + (!fireCount ? delayInMilliseconds : periodInMilliseconds), 'Scheduled date should be the registered date plus delay or later.')",
+        @"  browser.test.assertEq(alarmInfo.periodInMinutes, periodInMinutes)",
+
+        @"  if (++fireCount < 3)",
+        @"      return",
+
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        // Test
+        @"browser.test.assertFalse(browser.alarms.onAlarm.hasListener(listener), 'Should not have onAlarm listener.')",
+
+        @"browser.alarms.onAlarm.addListener(listener)",
+        @"browser.test.assertTrue(browser.alarms.onAlarm.hasListener(listener), 'Should have onAlarm listener.')",
+
+        @"browser.alarms.create('repeat', { delayInMinutes: (delayInMilliseconds / 1000 / 60), periodInMinutes })",
+
+        // The listener firing will indicate that the test passed.
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, WhenSingleShot)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"const startDate = Date.now()",
+        @"const delayInMilliseconds = 100",
+        @"var fireCount = 0",
+
+        @"function listener(alarmInfo) {",
+        @"  browser.test.assertEq(typeof alarmInfo.name, 'string')",
+        @"  browser.test.assertEq(typeof alarmInfo.scheduledTime, 'number')",
+        @"  browser.test.assertEq(typeof alarmInfo.periodInMinutes, 'undefined')",
+
+        @"  browser.test.assertEq(alarmInfo.name, 'when')",
+        @"  browser.test.assertTrue(alarmInfo.scheduledTime >= startDate + delayInMilliseconds, 'Scheduled date should be the registered date plus delay or later.')",
+
+        @"  if (fireCount++)",
+        @"      browser.test.notifyFail('This listener should not have been called more than once.')",
+        @"}",
+
+        // Test
+        @"browser.test.assertFalse(browser.alarms.onAlarm.hasListener(listener), 'Should not have onAlarm listener.')",
+
+        @"browser.alarms.onAlarm.addListener(listener)",
+        @"browser.test.assertTrue(browser.alarms.onAlarm.hasListener(listener), 'Should have onAlarm listener.')",
+
+        @"browser.alarms.create('when', { when: (startDate + delayInMilliseconds) })",
+
+        @"setTimeout(() => {",
+        @"  if (fireCount === 1)",
+        @"      browser.test.notifyPass()",
+        @"  else",
+        @"      browser.test.notifyFail('This timeout should have been called after the alarm fired once.')",
+        @"}, 500)",
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, WhenRepeating)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"const startDate = Date.now()",
+        @"const delayInMilliseconds = 100",
+        @"const periodInMilliseconds = 150",
+        @"const periodInMinutes = (periodInMilliseconds / 1000 / 60)",
+        @"var fireCount = 0",
+
+        @"function listener(alarmInfo) {",
+        @"  browser.test.assertEq(typeof alarmInfo.name, 'string')",
+        @"  browser.test.assertEq(typeof alarmInfo.scheduledTime, 'number')",
+        @"  browser.test.assertEq(typeof alarmInfo.periodInMinutes, 'number')",
+
+        @"  browser.test.assertEq(alarmInfo.name, 'repeat')",
+        @"  browser.test.assertTrue(alarmInfo.scheduledTime >= startDate + (!fireCount ? delayInMilliseconds : periodInMilliseconds), 'Scheduled date should be the registered date plus delay or later.')",
+        @"  browser.test.assertEq(alarmInfo.periodInMinutes, periodInMinutes)",
+
+        @"  if (++fireCount < 3)",
+        @"      return",
+
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        // Test
+        @"browser.test.assertFalse(browser.alarms.onAlarm.hasListener(listener), 'Should not have onAlarm listener.')",
+
+        @"browser.alarms.onAlarm.addListener(listener)",
+        @"browser.test.assertTrue(browser.alarms.onAlarm.hasListener(listener), 'Should have onAlarm listener.')",
+
+        @"browser.alarms.create('repeat', { when: (startDate + delayInMilliseconds), periodInMinutes })",
+
+        // The listener firing will indicate that the test passed.
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, ClearSingleAlarm)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"function listener(alarmInfo) {",
+        @"  browser.test.assertEq(alarmInfo.name, 'two', 'Should only be called for alarm two.')",
+
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        // Test
+        @"browser.alarms.onAlarm.addListener(listener)",
+
+        @"browser.alarms.create('one', { delayInMinutes: 0.01 })",
+        @"browser.alarms.create('two', { delayInMinutes: 0.1 })",
+
+        @"browser.alarms.clear('one')",
+
+        // The listener firing will indicate that the test passed.
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, GetSingleAlarm)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Test
+        @"browser.alarms.create('one', { delayInMinutes: 1 })",
+        @"browser.alarms.create('two', { delayInMinutes: 1, periodInMinutes: 1 })",
+
+        @"let result = await browser.alarms.get('one')",
+
+        @"browser.test.assertEq(result.name, 'one')",
+        @"browser.test.assertEq(typeof result.scheduledTime, 'number')",
+        @"browser.test.assertEq(typeof result.periodInMinutes, 'undefined')",
+
+        @"result = await browser.alarms.get('two')",
+
+        @"browser.test.assertEq(result.name, 'two')",
+        @"browser.test.assertEq(typeof result.scheduledTime, 'number')",
+        @"browser.test.assertEq(typeof result.periodInMinutes, 'number')",
+        @"browser.test.assertEq(result.periodInMinutes, 1)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, ClearAllAlarms)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"function listener(alarmInfo) {",
+        @"  browser.test.notifyFail('This listener should not have been called.')",
+        @"}",
+
+        // Test
+        @"browser.alarms.onAlarm.addListener(listener)",
+
+        @"browser.alarms.create('one', { delayInMinutes: 0.01 })",
+        @"browser.alarms.create('two', { delayInMinutes: 0.1 })",
+
+        @"await browser.alarms.clearAll()",
+
+        @"setTimeout(() => {",
+        @"  browser.test.notifyPass()",
+        @"}, 500)",
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, GetAllAlarms)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Test
+        @"browser.alarms.create('one', { delayInMinutes: 1 })",
+        @"browser.alarms.create('two', { delayInMinutes: 1, periodInMinutes: 1 })",
+
+        @"let result = await browser.alarms.getAll()",
+
+        @"browser.test.assertEq(result.length, 2)",
+        @"browser.test.assertTrue(result[0].name === 'one' || result[0].name === 'two')",
+        @"browser.test.assertEq(typeof result[0].scheduledTime, 'number')",
+        @"browser.test.assertEq(typeof result[0].periodInMinutes, result[0].name === 'one' ? 'undefined' : 'number')",
+
+        @"browser.test.assertTrue(result[1].name === 'one' || result[1].name === 'two')",
+        @"browser.test.assertEq(typeof result[1].scheduledTime, 'number')",
+        @"browser.test.assertEq(typeof result[1].periodInMinutes, result[1].name === 'one' ? 'undefined' : 'number')",
+
+        @"await browser.alarms.clear('one')",
+
+        @"result = await browser.alarms.getAll()",
+        @"browser.test.assertEq(result.length, 1)",
+        @"browser.test.assertEq(result[0].name, 'two')",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAlarms, UnnamedAlarm)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"function listener(alarmInfo) {",
+        @"  browser.test.assertEq(alarmInfo.name, '', 'Should only be called for alarm with an empty string name.')",
+
+        @"  browser.test.notifyPass('This listener should have been called.')",
+        @"}",
+
+        // Test
+        @"browser.alarms.onAlarm.addListener(listener)",
+
+        @"browser.alarms.create({ delayInMinutes: 0.01 })",
+
+        // The listener firing will indicate that the test passed.
+    ]);
+
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -29,8 +29,8 @@
 #import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
+#import "UIKitSPI.h"
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
-#import <pal/spi/ios/UIKitSPI.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 @implementation WKWebView (WKWebViewGetContents)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -63,7 +63,7 @@ namespace TestWebKitAPI::Util {
 
 #ifdef __OBJC__
 
-inline NSString *constructScript(NSArray *lines) { return [lines componentsJoinedByString:@";\n"]; }
+inline NSString *constructScript(NSArray *lines) { return [lines componentsJoinedByString:@"\n"]; }
 
 #endif
 

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -351,6 +351,25 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 - (void)removeEmojiAlternatives;
 @end
 
+@interface NSTextBlock : NSObject
+@end
+
+@interface NSTextTable : NSTextBlock
+@end
+
+@interface NSTextTableBlock : NSTextBlock
+- (NSTextTable *)table;
+- (NSInteger)startingColumn;
+- (NSInteger)startingRow;
+- (NSUInteger)numberOfColumns;
+- (NSInteger)columnSpan;
+- (NSInteger)rowSpan;
+@end
+
+@interface NSParagraphStyle ()
+- (NSArray<NSTextBlock *> *)textBlocks;
+@end
+
 @interface UIResponder (Internal)
 - (void)_share:(id)sender;
 @property (nonatomic, readonly) BOOL _requiresKeyboardWhenFirstResponder;


### PR DESCRIPTION
#### de4ab2c5684f9ed12ea189d1d30aa1499c1207e6
<pre>
Add support for the alarms Web Extension API.
<a href="https://webkit.org/b/259950">https://webkit.org/b/259950</a>
rdar://problem/113592049

Reviewed by Brian Weinstein.

Implements the browser.alarms namespace and added API tests for all the supported methods.
Documentation: <a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms">https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms</a>

* Source/WebKit/DerivedSources-input.xcfilelist: Added alarm files.
* Source/WebKit/DerivedSources-output.xcfilelist: Ditto.
* Source/WebKit/DerivedSources.make: Added WebExtensionAPIAlarms interface.
* Source/WebKit/Shared/Extensions/WebExtensionAlarmParameters.h: Added.
* Source/WebKit/Shared/Extensions/WebExtensionAlarmParameters.serialization.in: Added.
* Source/WebKit/Sources.txt: Added alarm files.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm: Added.
(WebKit::WebExtensionContext::alarmsCreate):
(WebKit::WebExtensionContext::alarmsGet):
(WebKit::WebExtensionContext::alarmsClear):
(WebKit::WebExtensionContext::alarmsGetAll):
(WebKit::WebExtensionContext::alarmsClearAll):
(WebKit::WebExtensionContext::fireAlarmsEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp: Added.
(WebKit::WebExtensionAlarm::schedule):
(WebKit::WebExtensionAlarm::fire):
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.h: Added.
(WebKit::WebExtensionAlarm::create):
(WebKit::WebExtensionAlarm::WebExtensionAlarm):
(WebKit::WebExtensionAlarm::parameters const):
(WebKit::WebExtensionAlarm::name const):
(WebKit::WebExtensionAlarm::initialInterval const):
(WebKit::WebExtensionAlarm::repeatInterval const):
(WebKit::WebExtensionAlarm::nextScheduledTime const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in: Added alarm messages.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added new files.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm: Added.
(WebKit::toAPI):
(WebKit::WebExtensionAPIAlarms::createAlarm):
(WebKit::WebExtensionAPIAlarms::get):
(WebKit::WebExtensionAPIAlarms::getAll):
(WebKit::WebExtensionAPIAlarms::clear):
(WebKit::WebExtensionAPIAlarms::clearAll):
(WebKit::WebExtensionAPIAlarms::onAlarm):
(WebKit::WebExtensionContextProxy::dispatchAlarmEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Added FIXME and check permissions for alarms too.
(WebKit::WebExtensionAPINamespace::alarms): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h: Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl: Added.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl: Added alarms.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in: Added alarm messages.
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm: Added.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
(TestWebKitAPI::Util::constructScript): Stop adding semicolons, it can cause mysterious errors.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm: Use &quot;UIKitSPI.h&quot; since it was conflicting
with &lt;pal/spi/ios/UIKitSPI.h&gt; due to unified sources shifting around.
* Tools/TestWebKitAPI/ios/UIKitSPI.h: Add missing interfaces needed by WKWebViewGetContents.mm.

Canonical link: <a href="https://commits.webkit.org/266742@main">https://commits.webkit.org/266742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b23b72598d032612112fa4410f61b8cf5c0460f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16388 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15033 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14821 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/17122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/17122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/17122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1751 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->