### PR TITLE
Implement createPattern for ImageBitmap.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.globalAlpha.imagepattern-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.globalAlpha.imagepattern-expected.txt
@@ -3,5 +3,5 @@ Actual output:
 Expected output:
 
 
-FAIL Canvas test: 2d.composite.globalAlpha.imagepattern promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Canvas test: 2d.composite.globalAlpha.imagepattern
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation-expected.txt
@@ -7,5 +7,5 @@ FAIL ImageBitmap from file with EXIF rotation, loaded via <img> in DOM, imageOri
 PASS ImageBitmap from file with EXIF rotation, duplicated via createImageBitmap
 PASS ImageBitmap from file with EXIF rotation, duplicated via worker serialization round-trip
 PASS ImageBitmap from file with EXIF rotation, duplicated via worker transfer round-trip
-FAIL ImageBitmap from file with EXIF rotation, duplicated via worker transfer round-trip, while referenced by a CanvasPattern promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS ImageBitmap from file with EXIF rotation, duplicated via worker transfer round-trip, while referenced by a CanvasPattern
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern-expected.txt
@@ -1,5 +1,5 @@
 2d.composite.globalAlpha.imagepattern
 
 
-FAIL OffscreenCanvas test: 2d.composite.globalAlpha.imagepattern promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.composite.globalAlpha.imagepattern
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy-expected.txt
@@ -3,5 +3,5 @@
 Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop-expected.txt
@@ -3,5 +3,5 @@
 Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in-expected.txt
@@ -3,5 +3,5 @@
 Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in-expected.txt
@@ -3,5 +3,5 @@
 Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out-expected.txt
@@ -3,5 +3,5 @@
 Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged. Type error
+PASS Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.basic.image
 
 
-FAIL OffscreenCanvas test: 2d.pattern.basic.image promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.basic.image
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.basic.type
 
 
-FAIL OffscreenCanvas test: 2d.pattern.basic.type promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.basic.type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.crosscanvas
 
 
-FAIL OffscreenCanvas test: 2d.pattern.crosscanvas promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.crosscanvas
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.norepeat.basic
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.norepeat.basic promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.norepeat.basic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.norepeat.coord1
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.norepeat.coord1 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.norepeat.coord1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.norepeat.coord2
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.norepeat.coord2 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.norepeat.coord2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.norepeat.coord3
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.norepeat.coord3 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.norepeat.coord3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.norepeat.outside
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.norepeat.outside promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.norepeat.outside
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image-expected.txt
@@ -3,5 +3,5 @@
 Image patterns do not get flipped when painted
 
 
-FAIL Image patterns do not get flipped when painted promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Image patterns do not get flipped when painted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Image patterns do not get flipped when painted promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Image patterns do not get flipped when painted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeat.basic
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeat.basic promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeat.basic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeat.coord1
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeat.coord1 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeat.coord1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeat.coord2
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeat.coord2 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeat.coord2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeat.coord3
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeat.coord3 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeat.coord3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeat.outside
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeat.outside promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeat.outside
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeatx.basic
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeatx.basic promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeatx.basic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeatx.coord1
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeatx.coord1 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeatx.coord1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeatx.outside
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeatx.outside promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeatx.outside
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeaty.basic
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeaty.basic promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeaty.basic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeaty.coord1
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeaty.coord1 promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeaty.coord1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.paint.repeaty.outside
 
 
-FAIL OffscreenCanvas test: 2d.pattern.paint.repeaty.outside promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.paint.repeaty.outside
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty-expected.txt
@@ -1,5 +1,5 @@
 2d.pattern.repeat.empty
 
 
-FAIL OffscreenCanvas test: 2d.pattern.repeat.empty promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS OffscreenCanvas test: 2d.pattern.repeat.empty
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha-expected.txt
@@ -3,5 +3,5 @@
 Shadows are drawn correctly for partially-transparent fill patterns
 
 
-FAIL Shadows are drawn correctly for partially-transparent fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are drawn correctly for partially-transparent fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Shadows are drawn correctly for partially-transparent fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are drawn correctly for partially-transparent fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic-expected.txt
@@ -3,5 +3,5 @@
 Shadows are drawn for fill patterns
 
 
-FAIL Shadows are drawn for fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are drawn for fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Shadows are drawn for fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are drawn for fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1-expected.txt
@@ -3,5 +3,5 @@
 Shadows are not drawn for transparent fill patterns
 
 
-FAIL Shadows are not drawn for transparent fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are not drawn for transparent fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Shadows are not drawn for transparent fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are not drawn for transparent fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2-expected.txt
@@ -3,5 +3,5 @@
 Shadows are not drawn for transparent parts of fill patterns
 
 
-FAIL Shadows are not drawn for transparent parts of fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are not drawn for transparent parts of fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Shadows are not drawn for transparent parts of fill patterns promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Shadows are not drawn for transparent parts of fill patterns
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
@@ -8,6 +8,8 @@ CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has bee
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 Setting fillStyle to a pattern of an unclean canvas makes the canvas origin-unclean
 
 
@@ -17,12 +19,12 @@ PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean patte
 PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-FAIL unclean ImageBitmap: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS unclean ImageBitmap: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS cross-origin HTMLImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 FAIL cross-origin SVGImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean assert_throws_dom: function "function() { canvas.toDataURL(); }" did not throw
 PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
-FAIL unclean ImageBitmap: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS unclean ImageBitmap: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 

--- a/Source/WebCore/html/ImageBitmapBacking.cpp
+++ b/Source/WebCore/html/ImageBitmapBacking.cpp
@@ -72,8 +72,14 @@ void ImageBitmapBacking::disconnect()
     // FIXME: Rather than storing both the ImageBuffer and the
     // SerializedImageBuffer here, with only one valid at a time,
     // we should have a separate object for the serialized state
-    if (m_bitmapData)
-        m_serializedBitmap = ImageBuffer::sinkIntoSerializedImageBuffer(WTFMove(m_bitmapData));
+    if (m_bitmapData) {
+        if (m_bitmapData->hasOneRef())
+            m_serializedBitmap = ImageBuffer::sinkIntoSerializedImageBuffer(WTFMove(m_bitmapData));
+        else {
+            m_serializedBitmap = ImageBuffer::sinkIntoSerializedImageBuffer(m_bitmapData->clone());
+            m_bitmapData = nullptr;
+        }
+    }
     ASSERT(!m_bitmapData);
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2158,10 +2158,13 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(W
 }
 #endif
 
-ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(ImageBitmap&, bool, bool)
+ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(ImageBitmap& imageBitmap, bool repeatX, bool repeatY)
 {
-    // FIXME: Implement.
-    return Exception { TypeError };
+    RefPtr<ImageBuffer> buffer = imageBitmap.buffer();
+    if (!buffer)
+        return Exception { InvalidStateError };
+
+    return RefPtr<CanvasPattern> { CanvasPattern::create({ buffer.releaseNonNull() }, repeatX, repeatY, imageBitmap.originClean()) };
 }
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(CSSStyleImageValue&, bool, bool)


### PR DESCRIPTION
#### 7bfd3e0384c0a1067d3b3942df2c1760c49c7172
<pre>
Implement createPattern for ImageBitmap.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259963">https://bugs.webkit.org/show_bug.cgi?id=259963</a>
&lt;rdar://113606883&gt;

Reviewed by Said Abou-Hallawa.

ImageBitmapBacking::disconnect now makes a copy of the ImageBuffer if there are other references to it.

This happens when you create a pattern from an ImageBitmap, and then try to serialize the ImageBitmap to a worker.
We still need to put the ImageBitmap into detached state (by clearing m_bitmapData), but also need non-shared pixel data to
transfer access to a different thread (covered by existing assertions).

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.globalAlpha.imagepattern-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt:
* Source/WebCore/html/ImageBitmapBacking.cpp:
(WebCore::ImageBitmapBacking::disconnect):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::createPattern):

Canonical link: <a href="https://commits.webkit.org/266858@main">https://commits.webkit.org/266858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572891d3f3837818762208f58649b798d10a5fa8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16307 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17056 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20152 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16548 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11833 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13141 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3608 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->