### PR TITLE
Deduplicate ImmutableStyleProperties

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -143,7 +143,10 @@ String CSSFontFaceSrcResourceValue::customCSSText() const
 
 bool CSSFontFaceSrcResourceValue::equals(const CSSFontFaceSrcResourceValue& other) const
 {
-    return m_location.specifiedURLString == m_location.specifiedURLString && m_format == other.m_format && m_technologies == other.m_technologies;
+    return m_location == other.m_location
+        && m_format == other.m_format
+        && m_technologies == other.m_technologies
+        && m_loadedFromOpaqueSource == other.m_loadedFromOpaqueSource;
 }
 
 }

--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -107,4 +107,10 @@ String CSSFunctionValue::customCSSText() const
     return result.toString();
 }
 
+bool CSSFunctionValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_name);
+    return CSSValueContainingVector::addDerivedHash(hasher);
+}
+
 }

--- a/Source/WebCore/css/CSSFunctionValue.h
+++ b/Source/WebCore/css/CSSFunctionValue.h
@@ -46,12 +46,16 @@ public:
     bool equals(const CSSFunctionValue& other) const { return m_name == other.m_name && itemsEqual(other); }
 
 private:
+    friend bool CSSValue::addHash(Hasher&) const;
+
     CSSFunctionValue(CSSValueID name, CSSValueListBuilder);
     explicit CSSFunctionValue(CSSValueID name);
     CSSFunctionValue(CSSValueID name, Ref<CSSValue>);
     CSSFunctionValue(CSSValueID name, Ref<CSSValue>, Ref<CSSValue>);
     CSSFunctionValue(CSSValueID name, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
     CSSFunctionValue(CSSValueID name, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
+
+    bool addDerivedHash(Hasher&) const;
 
     CSSValueID m_name { };
 };

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -42,6 +42,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderStyle.h"
 #include "RenderView.h"
+#include <wtf/Hasher.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/StringBuilder.h>
@@ -1508,6 +1509,109 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
         break;
     }
     return false;
+}
+
+bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, primitiveUnitType());
+
+    switch (primitiveUnitType()) {
+    case CSSUnitType::CSS_UNKNOWN:
+        break;
+    case CSSUnitType::CSS_NUMBER:
+    case CSSUnitType::CSS_INTEGER:
+    case CSSUnitType::CSS_PERCENTAGE:
+    case CSSUnitType::CSS_EMS:
+    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_PX:
+    case CSSUnitType::CSS_CM:
+    case CSSUnitType::CSS_DPPX:
+    case CSSUnitType::CSS_X:
+    case CSSUnitType::CSS_DPI:
+    case CSSUnitType::CSS_DPCM:
+    case CSSUnitType::CSS_MM:
+    case CSSUnitType::CSS_IN:
+    case CSSUnitType::CSS_PT:
+    case CSSUnitType::CSS_PC:
+    case CSSUnitType::CSS_DEG:
+    case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_GRAD:
+    case CSSUnitType::CSS_MS:
+    case CSSUnitType::CSS_S:
+    case CSSUnitType::CSS_HZ:
+    case CSSUnitType::CSS_KHZ:
+    case CSSUnitType::CSS_TURN:
+    case CSSUnitType::CSS_VW:
+    case CSSUnitType::CSS_VH:
+    case CSSUnitType::CSS_VMIN:
+    case CSSUnitType::CSS_VMAX:
+    case CSSUnitType::CSS_VB:
+    case CSSUnitType::CSS_VI:
+    case CSSUnitType::CSS_SVW:
+    case CSSUnitType::CSS_SVH:
+    case CSSUnitType::CSS_SVMIN:
+    case CSSUnitType::CSS_SVMAX:
+    case CSSUnitType::CSS_SVB:
+    case CSSUnitType::CSS_SVI:
+    case CSSUnitType::CSS_LVW:
+    case CSSUnitType::CSS_LVH:
+    case CSSUnitType::CSS_LVMIN:
+    case CSSUnitType::CSS_LVMAX:
+    case CSSUnitType::CSS_LVB:
+    case CSSUnitType::CSS_LVI:
+    case CSSUnitType::CSS_DVW:
+    case CSSUnitType::CSS_DVH:
+    case CSSUnitType::CSS_DVMIN:
+    case CSSUnitType::CSS_DVMAX:
+    case CSSUnitType::CSS_DVB:
+    case CSSUnitType::CSS_DVI:
+    case CSSUnitType::CSS_FR:
+    case CSSUnitType::CSS_Q:
+    case CSSUnitType::CSS_LHS:
+    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_DIMENSION:
+    case CSSUnitType::CSS_CQW:
+    case CSSUnitType::CSS_CQH:
+    case CSSUnitType::CSS_CQI:
+    case CSSUnitType::CSS_CQB:
+    case CSSUnitType::CSS_CQMIN:
+    case CSSUnitType::CSS_CQMAX:
+        add(hasher, m_value.number);
+        break;
+    case CSSUnitType::CSS_PROPERTY_ID:
+        add(hasher, m_value.propertyID);
+        break;
+    case CSSUnitType::CSS_VALUE_ID:
+        add(hasher, m_value.valueID);
+        break;
+    case CSSUnitType::CSS_STRING:
+    case CSSUnitType::CustomIdent:
+    case CSSUnitType::CSS_URI:
+    case CSSUnitType::CSS_ATTR:
+    case CSSUnitType::CSS_COUNTER_NAME:
+    case CSSUnitType::CSS_FONT_FAMILY:
+        add(hasher, String { m_value.string });
+        break;
+    case CSSUnitType::CSS_RGBCOLOR:
+        add(hasher, color());
+        break;
+    case CSSUnitType::CSS_CALC:
+        add(hasher, m_value.calc);
+        break;
+    case CSSUnitType::CSS_UNRESOLVED_COLOR:
+        add(hasher, m_value.unresolvedColor);
+        break;
+    case CSSUnitType::CSS_IDENT:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_NUMBER:
+    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+    return true;
 }
 
 // https://drafts.css-houdini.org/css-properties-values-api/#dependency-cycles

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -196,6 +196,7 @@ private:
     friend class CSSValuePool;
     friend class StaticCSSValuePool;
     friend LazyNeverDestroyed<CSSPrimitiveValue>;
+    friend bool CSSValue::addHash(Hasher&) const;
 
     explicit CSSPrimitiveValue(CSSPropertyID);
     explicit CSSPrimitiveValue(Color);
@@ -218,6 +219,8 @@ private:
     std::optional<double> doubleValueInternal(CSSUnitType targetUnitType) const;
 
     double computeLengthDouble(const CSSToLengthConversionData&) const;
+
+    bool addDerivedHash(Hasher&) const;
 
     ALWAYS_INLINE String serializeInternal() const;
     NEVER_INLINE String formatNumberValue(ASCIILiteral suffix) const;
@@ -429,6 +432,8 @@ inline int CSSValue::integer() const
     ASSERT(isInteger());
     return downcast<CSSPrimitiveValue>(*this).intValue();
 }
+
+void add(Hasher&, const CSSPrimitiveValue&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -80,6 +80,7 @@
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
 #include "EventTarget.h"
+#include <wtf/Hasher.h>
 
 namespace WebCore {
 
@@ -281,6 +282,25 @@ bool CSSValue::equals(const CSSValue& other) const
     return false;
 }
 
+bool CSSValue::addHash(Hasher& hasher) const
+{
+    // To match equals() a single item list could have the same hash as the item.
+    // FIXME: Some Style::Builder functions can only handle list values.
+
+    add(hasher, classType());
+
+    return visitDerived([&](auto& typedThis) {
+        return typedThis.addDerivedHash(hasher);
+    });
+}
+
+// FIXME: Add custom hash functions for all derived classes and remove this function.
+bool CSSValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, this);
+    return false;
+}
+
 bool CSSValue::isCSSLocalURL(StringView relativeURL)
 {
     return relativeURL.isEmpty() || relativeURL.startsWith('#');
@@ -337,6 +357,11 @@ Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclara
     default:
         return DeprecatedCSSOMComplexValue::create(*this, styleDeclaration);
     }
+}
+
+void add(Hasher& hasher, const CSSValue& value)
+{
+    value.addHash(hasher);
 }
 
 }

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -26,6 +26,10 @@
 #include <wtf/Vector.h>
 #include <wtf/text/ASCIILiteral.h>
 
+namespace WTF {
+class Hasher;
+}
+
 namespace WebCore {
 
 class CSSPrimitiveValue;
@@ -150,6 +154,9 @@ public:
 
     bool equals(const CSSValue&) const;
     bool operator==(const CSSValue& other) const { return equals(other); }
+
+    // Returns false if the hash is computed from the CSSValue pointer instead of the underlying values.
+    bool addHash(Hasher&) const;
 
     // https://www.w3.org/TR/css-values-4/#local-urls
     // Empty URLs and fragment-only URLs should not be resolved relative to the base URL.
@@ -286,6 +293,7 @@ private:
     template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&) const;
 
     static inline bool customTraverseSubresources(const Function<bool(const CachedResource&)>&);
+    bool addDerivedHash(Hasher&) const;
 
     mutable unsigned m_refCount { refCountIncrement };
 
@@ -346,6 +354,8 @@ inline bool compareCSSValue(const Ref<CSSValueType>& first, const Ref<CSSValueTy
 {
     return first.get().equals(second);
 }
+
+void add(Hasher&, const CSSValue&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -22,6 +22,7 @@
 #include "CSSValueList.h"
 
 #include "CSSPrimitiveValue.h"
+#include <wtf/Hasher.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -257,6 +258,17 @@ bool CSSValueList::equals(const CSSValueList& other) const
 bool CSSValueContainingVector::containsSingleEqualItem(const CSSValue& other) const
 {
     return size() == 1 && (*this)[0].equals(other);
+}
+
+bool CSSValueContainingVector::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, separator());
+
+    for (auto& item : *this) {
+        if (!item.addHash(hasher))
+            return false;
+    }
+    return true;
 }
 
 bool CSSValueContainingVector::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -74,6 +74,8 @@ public:
     const CSSValue* itemWithoutBoundsCheck(unsigned index) const { return &(*this)[index]; }
 
 protected:
+    friend bool CSSValue::addHash(Hasher&) const;
+
     CSSValueContainingVector(ClassType, ValueSeparator);
     CSSValueContainingVector(ClassType, ValueSeparator, CSSValueListBuilder);
     CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>);
@@ -81,6 +83,8 @@ protected:
     CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
     CSSValueContainingVector(ClassType, ValueSeparator, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>, Ref<CSSValue>);
     ~CSSValueContainingVector();
+
+    bool addDerivedHash(Hasher&) const;
 
 private:
     unsigned m_size { 0 };
@@ -110,6 +114,8 @@ public:
     bool equals(const CSSValueList&) const;
 
 private:
+    friend void add(Hasher&, const CSSValueList&);
+
     explicit CSSValueList(ValueSeparator);
     CSSValueList(ValueSeparator, CSSValueListBuilder);
     CSSValueList(ValueSeparator, Ref<CSSValue>);
@@ -134,6 +140,8 @@ inline const CSSValue& CSSValueContainingVector::operator[](unsigned index) cons
         return *m_inlineStorage[index];
     return *m_additionalStorage[index - maxInlineSize];
 }
+
+void add(Hasher&, const CSSValueContainingVector&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "CSSValuePair.h"
+#include <wtf/Hasher.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -62,6 +63,12 @@ bool CSSValuePair::equals(const CSSValuePair& other) const
         && m_coalesceIdenticalValues == other.m_coalesceIdenticalValues
         && m_first->equals(other.m_first)
         && m_second->equals(other.m_second);
+}
+
+bool CSSValuePair::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_valueSeparator, m_coalesceIdenticalValues);
+    return m_first->addHash(hasher) && m_second->addHash(hasher);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -41,8 +41,12 @@ public:
     bool equals(const CSSValuePair&) const;
 
 private:
+    friend bool CSSValue::addHash(Hasher&) const;
+
     enum class IdenticalValueSerialization : bool { DoNotCoalesce, Coalesce };
     CSSValuePair(Ref<CSSValue>, Ref<CSSValue>, IdenticalValueSerialization);
+
+    bool addDerivedHash(Hasher&) const;
 
     // FIXME: Store coalesce bit in CSSValue to cut down on object size.
     bool m_coalesceIdenticalValues { true };

--- a/Source/WebCore/css/ImmutableStyleProperties.h
+++ b/Source/WebCore/css/ImmutableStyleProperties.h
@@ -36,6 +36,7 @@ public:
 
     WEBCORE_EXPORT ~ImmutableStyleProperties();
     static Ref<ImmutableStyleProperties> create(const CSSProperty* properties, unsigned count, CSSParserMode);
+    static Ref<ImmutableStyleProperties> createDeduplicating(const CSSProperty* properties, unsigned count, CSSParserMode);
 
     unsigned propertyCount() const { return m_arraySize; }
     bool isEmpty() const { return !propertyCount(); }
@@ -49,6 +50,8 @@ public:
     int findCustomPropertyIndex(StringView propertyName) const;
 
     static constexpr size_t objectSize(unsigned propertyCount);
+
+    static void clearDeduplicationMap();
 
     void* m_storage;
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -55,7 +55,7 @@ Ref<ImmutableStyleProperties> StyleProperties::immutableCopyIfNeeded() const
     if (is<ImmutableStyleProperties>(*this))
         return downcast<ImmutableStyleProperties>(const_cast<StyleProperties&>(*this));
     const MutableStyleProperties& mutableThis = downcast<MutableStyleProperties>(*this);
-    return ImmutableStyleProperties::create(mutableThis.m_propertyVector.data(), mutableThis.m_propertyVector.size(), cssParserMode());
+    return ImmutableStyleProperties::createDeduplicating(mutableThis.m_propertyVector.data(), mutableThis.m_propertyVector.size(), cssParserMode());
 }
 
 String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -134,7 +134,7 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     filterProperties(true, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(false, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
 
-    Ref<ImmutableStyleProperties> result = ImmutableStyleProperties::create(results.data() + unusedEntries, results.size() - unusedEntries, mode);
+    Ref<ImmutableStyleProperties> result = ImmutableStyleProperties::createDeduplicating(results.data() + unusedEntries, results.size() - unusedEntries, mode);
     parsedProperties.clear();
     return result;
 }

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -40,6 +40,7 @@
 #include "HRTFElevation.h"
 #include "HTMLMediaElement.h"
 #include "HTMLNameCache.h"
+#include "ImmutableStyleProperties.h"
 #include "InlineStyleSheetOwner.h"
 #include "InspectorInstrumentation.h"
 #include "LayoutIntegrationLineLayout.h"
@@ -87,6 +88,7 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
 
     InlineStyleSheetOwner::clearCache();
     HTMLNameCache::clear();
+    ImmutableStyleProperties::clearDeduplicationMap();
 }
 
 static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCache maintainBackForwardCache, MaintainMemoryCache maintainMemoryCache)


### PR DESCRIPTION
#### b94dfacbb5ecf3d9e2378224f12a5784c8e068ab
<pre>
Deduplicate ImmutableStyleProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=259972">https://bugs.webkit.org/show_bug.cgi?id=259972</a>
rdar://113622930

Reviewed by Alan Baradlay.

It is common for the same style declarations to repeat. On some sites &gt;50% of declarations are duplicates.

This patch add support for hashing simple CSSValues. This mechanism may have
other uses in future too.

* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::equals const):

Also fix equality comparison here.

* Source/WebCore/css/CSSFunctionValue.cpp:
(WebCore::CSSFunctionValue::addDerivedHash const):
* Source/WebCore/css/CSSFunctionValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::addDerivedHash const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
(WebCore::CSSValue::addHash const):
(WebCore::CSSValue::addDerivedHash const):
(WebCore::add):
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::addDerivedHash const):
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/CSSValuePair.cpp:
(WebCore::CSSValuePair::addDerivedHash const):
* Source/WebCore/css/CSSValuePair.h:
* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::deduplicationMap):
(WebCore::ImmutableStyleProperties::createDeduplicating):

Deduplicate using a map.

(WebCore::ImmutableStyleProperties::clearDeduplicationMap):
* Source/WebCore/css/ImmutableStyleProperties.h:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::immutableCopyIfNeeded const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::createStyleProperties):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):

Canonical link: <a href="https://commits.webkit.org/266770@main">https://commits.webkit.org/266770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c5bdbba121c1ecbb704f13b0dda209f01a7b9a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16530 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17206 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14825 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20272 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12614 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16686 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13996 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13992 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14924 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14620 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13137 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3818 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17629 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15154 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13836 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3628 "Passed tests") | 
<!--EWS-Status-Bubble-End-->