### PR TITLE
Let compiler generate bit offsets for LayerChange enum values

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -33,6 +33,23 @@ namespace WebKit {
 class RemoteLayerBackingStore;
 class RemoteLayerBackingStoreProperties;
 
+enum class LayerChangeIndex : size_t {
+    EventRegionChanged = 38,
+#if ENABLE(SCROLLING_THREAD)
+    ScrollingNodeIDChanged,
+#endif
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+    SeparatedChanged,
+#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
+    SeparatedPortalChanged,
+    DescendentOfSeparatedPortalChanged,
+#endif
+#endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    VisibleRectChanged,
+#endif
+};
+
 enum class LayerChange : uint64_t {
     NameChanged                         = 1LLU << 0,
     TransformChanged                    = 1LLU << 1,
@@ -72,19 +89,19 @@ enum class LayerChange : uint64_t {
     OpaqueChanged                       = 1LLU << 35,
     ContentsHiddenChanged               = 1LLU << 36,
     UserInteractionEnabledChanged       = 1LLU << 37,
-    EventRegionChanged                  = 1LLU << 38,
+    EventRegionChanged                  = 1LLU << static_cast<size_t>(LayerChangeIndex::EventRegionChanged),
 #if ENABLE(SCROLLING_THREAD)
-    ScrollingNodeIDChanged              = 1LLU << 39,
+    ScrollingNodeIDChanged              = 1LLU << static_cast<size_t>(LayerChangeIndex::ScrollingNodeIDChanged),
 #endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    SeparatedChanged                    = 1LLU << 39,
+    SeparatedChanged                    = 1LLU << static_cast<size_t>(LayerChangeIndex::SeparatedChanged),
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-    SeparatedPortalChanged              = 1LLU << 40,
-    DescendentOfSeparatedPortalChanged  = 1LLU << 41,
+    SeparatedPortalChanged              = 1LLU << static_cast<size_t>(LayerChangeIndex::SeparatedPortalChanged),
+    DescendentOfSeparatedPortalChanged  = 1LLU << static_cast<size_t>(LayerChangeIndex::DescendentOfSeparatedPortalChanged),
 #endif
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    VisibleRectChanged                  = 1LLU << 42,
+    VisibleRectChanged                  = 1LLU << static_cast<size_t>(LayerChangeIndex::VisibleRectChanged),
 #endif
 };
 


### PR DESCRIPTION
#### 130add549cb8585d17f7f3b4ab39930d52ee3648
<pre>
Let compiler generate bit offsets for LayerChange enum values
<a href="https://bugs.webkit.org/show_bug.cgi?id=259976">https://bugs.webkit.org/show_bug.cgi?id=259976</a>

Reviewed by Megan Gardner and Mike Wyrzykowski.

For the bit offsets with ENABLE macros, use a parallel enum to let the compiler
generate the immediate next offsets independent of which features are enabled.

* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:

Canonical link: <a href="https://commits.webkit.org/266732@main">https://commits.webkit.org/266732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66552cc265d08a115a018f0b033b997f6f58fafe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13791 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14993 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17079 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12577 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20180 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13885 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17516 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1746 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->