### PR TITLE
Add core logic needed for concurrent sweeping

### DIFF
--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -528,6 +528,7 @@ heap/CodeBlockSet.cpp
 heap/CollectionScope.cpp
 heap/CollectorPhase.cpp
 heap/CompleteSubspace.cpp
+heap/ConcurrentSweeper.cpp
 heap/ConservativeRoots.cpp
 heap/DeferGC.cpp
 heap/DestructionMode.cpp

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -131,8 +131,11 @@ public:
     
     MarkedBlock::Handle* findEmptyBlockToSteal();
     
-    MarkedBlock::Handle* findBlockToSweep();
+    MarkedBlock::Handle* findBlockToSweep() { return findBlockToSweep(Locker(bitvectorLock()), m_unsweptCursor); }
+    MarkedBlock::Handle* findBlockToSweep(const AbstractLocker&, unsigned& unsweptCursor);
     
+    void didFinishUsingBlock(MarkedBlock::Handle*);
+
     Subspace* subspace() const { return m_subspace; }
     MarkedSpace& markedSpace() const;
     

--- a/Source/JavaScriptCore/heap/BlockDirectoryBits.h
+++ b/Source/JavaScriptCore/heap/BlockDirectoryBits.h
@@ -33,12 +33,13 @@ namespace JSC {
 
 #define FOR_EACH_BLOCK_DIRECTORY_BIT(macro) \
     macro(live, Live) /* The set of block indices that have actual blocks. */\
-    macro(empty, Empty) /* The set of all blocks that have no live objects. */ \
+    macro(empty, Empty) /* The set of all blocks that have no live objects and are not free listed. */ \
     macro(allocated, Allocated) /* The set of all blocks that are full of live objects. */\
     macro(canAllocateButNotEmpty, CanAllocateButNotEmpty) /* The set of all blocks are neither empty nor retired (i.e. are more than minMarkedBlockUtilization full). */ \
     macro(destructible, Destructible) /* The set of all blocks that may have destructors to run. */\
     macro(eden, Eden) /* The set of all blocks that have new objects since the last GC. */\
     macro(unswept, Unswept) /* The set of all blocks that could be swept by the incremental sweeper. */\
+    macro(inUse, InUse) /* This tells us if a block is currently being allocated from or swept. This acts like a lock bit. */\
     \
     /* These are computed during marking. */\
     macro(markingNotEmpty, MarkingNotEmpty) /* The set of all blocks that are not empty. */ \

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -64,7 +64,7 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
     // surprises and the algorithm here is pretty easy. Only this code has to hold the lock, to
     // prevent simultaneously BlockDirectory creations from multiple threads. This code ensures
     // that any "forEachAllocator" traversals will only see this allocator after it's initialized
-    // enough: it will have 
+    // enough.
     Locker locker { m_space.directoryLock() };
     if (Allocator allocator = m_allocatorForSizeStep[index])
         return allocator;

--- a/Source/JavaScriptCore/heap/ConcurrentSweeper.cpp
+++ b/Source/JavaScriptCore/heap/ConcurrentSweeper.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "ConcurrentSweeper.h"
+
+#include "DeferGCInlines.h"
+#include "HeapInlines.h"
+#include "MarkedBlock.h"
+#include "VM.h"
+
+
+namespace JSC {
+
+ConcurrentSweeper::ConcurrentSweeper(const AbstractLocker& locker, VM&, Box<Lock> lock, Ref<AutomaticThreadCondition>&& condition)
+    // FIXME: This should probably have its own thread type even if it's just nominally different from Compiler.
+    : AutomaticThread(locker, WTFMove(lock), WTFMove(condition), ThreadType::Compiler)
+{
+}
+
+ConcurrentSweeper::~ConcurrentSweeper()
+{
+}
+
+Ref<ConcurrentSweeper> ConcurrentSweeper::create(VM& vm)
+{
+    Box<Lock> lock = Box<Lock>::create();
+    Locker locker(*lock);
+    return adoptRef(*new ConcurrentSweeper(locker, vm, lock, AutomaticThreadCondition::create()));
+}
+
+auto ConcurrentSweeper::poll(const AbstractLocker&) -> PollResult
+{
+    if (m_shouldStop)
+        return PollResult::Stop;
+
+    if (m_currentDirectory)
+        return PollResult::Work;
+
+    if (m_directoriesToSweep.isEmpty())
+        return PollResult::Wait;
+
+    m_currentDirectory = m_directoriesToSweep.takeFirst();
+    return PollResult::Work;
+}
+
+auto ConcurrentSweeper::work() -> WorkResult
+{
+    Locker locker(m_rightToSweep);
+
+    MarkedBlock::Handle* handle;
+    {
+        Locker locker(m_currentDirectory->bitvectorLock());
+        handle = m_currentDirectory->findBlockToSweep(locker, m_currentMarkedBlockIndex);
+    }
+
+    if (!handle) {
+        m_currentDirectory = nullptr;
+        return WorkResult::Continue;
+    }
+
+    handle->sweepConcurrently();
+    return WorkResult::Continue;
+}
+
+void ConcurrentSweeper::notifyPushedDirectories(AbstractLocker& locker)
+{
+    condition().notifyAll(locker);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/heap/ConcurrentSweeper.h
+++ b/Source/JavaScriptCore/heap/ConcurrentSweeper.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <wtf/AutomaticThread.h>
+
+namespace JSC {
+
+class Heap;
+class BlockDirectory;
+
+class ConcurrentSweeper final : public AutomaticThread {
+    WTF_MAKE_NONCOPYABLE(ConcurrentSweeper);
+    ConcurrentSweeper(const AbstractLocker&, VM&, Box<Lock>, Ref<AutomaticThreadCondition>&&);
+public:
+    ~ConcurrentSweeper();
+
+    static Ref<ConcurrentSweeper> create(VM&);
+
+    void suspendSweeping() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+    {
+        m_rightToSweep.lock();
+        m_isSuspended = true;
+    }
+
+    void resumeSweeping() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+    {
+        m_isSuspended = false;
+        m_rightToSweep.unlock();
+    }
+
+    bool isSuspended() const { return m_isSuspended; }
+
+    void shouldStop() { m_shouldStop = true; }
+    bool isStopped() const { return m_shouldStop; }
+
+    Lock& lock() { return AutomaticThread::lock(); }
+    // Requires lock();
+    void pushDirectoryToSweep(AbstractLocker&, BlockDirectory* directory)
+    {
+        m_directoriesToSweep.append(directory);
+    }
+    void notifyPushedDirectories(AbstractLocker&);
+
+    const char* name() const override { return "Concurrent Sweeper"; }
+private:
+    PollResult poll(const AbstractLocker&) override;
+    WorkResult work() override;
+
+    // This should probably be a Darwin's OSUnfairLock because that supports priority boosting which we don't support here.
+    Lock m_rightToSweep;
+    // FIXME: Handle the worklist growing faster than we empty it and blowing up.
+    Deque<BlockDirectory*> m_directoriesToSweep;
+    BlockDirectory* m_currentDirectory { nullptr };
+    unsigned m_currentMarkedBlockIndex { 0 };
+
+    bool m_isSuspended { false };
+    bool m_shouldStop { false };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -25,6 +25,7 @@
 #include "CodeBlock.h"
 #include "CodeBlockSetInlines.h"
 #include "CollectingScope.h"
+#include "ConcurrentSweeper.h"
 #include "ConservativeRoots.h"
 #include "EdenGCActivityCallback.h"
 #include "Exception.h"
@@ -395,6 +396,9 @@ Heap::Heap(VM& vm, HeapType heapType)
             m_scheduler = makeUnique<StochasticSpaceTimeMutatorScheduler>(*this);
         else
             m_scheduler = makeUnique<SpaceTimeMutatorScheduler>(*this);
+
+        if (Options::useConcurrentSweeper() && heapType == HeapType::Large)
+            m_concurrentSweeper = ConcurrentSweeper::create(vm);
     } else {
         // We simulate turning off concurrent GC by making the scheduler say that the world
         // should always be stopped when the collector is running.
@@ -487,6 +491,18 @@ void Heap::lastChanceToFinalize()
             m_collectContinuouslyCondition.notifyOne();
         }
         m_collectContinuouslyThread->waitForCompletion();
+    }
+
+    if (m_concurrentSweeper) {
+        {
+            Locker locker { m_concurrentSweeper->lock() };
+            m_concurrentSweeper->shouldStop();
+            m_concurrentSweeper->notifyPushedDirectories(locker);
+        }
+        m_concurrentSweeper->join();
+        // Make sure to clear the concurrent sweeper since we could still be running a collection and
+        // we don't want to notify it's thread after stopping.
+        m_concurrentSweeper = nullptr;
     }
 
     dataLogIf(Options::logGC(), "1");
@@ -1632,6 +1648,17 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         removeDeadCompilerWorklistEntries();
     }
 
+    if (m_concurrentSweeper) {
+        Locker locker(m_concurrentSweeper->lock());
+        bool didPushDirectory = false;
+        dateInstanceSpace.forEachDirectory([&] (BlockDirectory& directory) {
+            didPushDirectory = true;
+            m_concurrentSweeper->pushDirectoryToSweep(locker, &directory);
+        });
+        if (didPushDirectory)
+            m_concurrentSweeper->notifyPushedDirectories(locker);
+    }
+
     notifyIncrementalSweeper();
     
     m_codeBlocks->iterateCurrentlyExecuting(
@@ -1745,12 +1772,14 @@ void Heap::stopThePeriphery(GCConductor conn)
         dataLog("FATAL: world already stopped.\n");
         RELEASE_ASSERT_NOT_REACHED();
     }
-    
+
     if (m_mutatorDidRun)
         m_mutatorExecutionVersion++;
     
     m_mutatorDidRun = false;
 
+    if (m_concurrentSweeper)
+        m_concurrentSweeper->suspendSweeping();
     suspendCompilerThreads();
     m_worldIsStopped = true;
 
@@ -1822,6 +1851,8 @@ NEVER_INLINE void Heap::resumeThePeriphery()
         visitor->updateMutatorIsStopped();
     
     resumeCompilerThreads();
+    if (m_concurrentSweeper)
+        m_concurrentSweeper->resumeSweeping();
 }
 
 bool Heap::stopTheMutator()

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -61,6 +61,7 @@ namespace JSC {
 class CodeBlock;
 class CodeBlockSet;
 class CollectingScope;
+class ConcurrentSweeper;
 class ConservativeRoots;
 class GCDeferralContext;
 class EdenGCActivityCallback;
@@ -330,6 +331,7 @@ public:
     JS_EXPORT_PRIVATE void setGarbageCollectionTimerEnabled(bool);
 
     JS_EXPORT_PRIVATE IncrementalSweeper& sweeper();
+    ConcurrentSweeper* concurrentSweeper() { return m_concurrentSweeper.get(); }
 
     void addObserver(HeapObserver* observer) { m_observers.append(observer); }
     void removeObserver(HeapObserver* observer) { m_observers.removeFirst(observer); }
@@ -828,6 +830,7 @@ private:
     RefPtr<FullGCActivityCallback> m_fullActivityCallback;
     RefPtr<GCActivityCallback> m_edenActivityCallback;
     Ref<IncrementalSweeper> m_sweeper;
+    RefPtr<ConcurrentSweeper> m_concurrentSweeper;
     Ref<StopIfNecessaryTimer> m_stopIfNecessaryTimer;
 
     Vector<HeapObserver*> m_observers;

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -115,6 +115,7 @@ bool IncrementalSweeper::sweepNextBlock(VM& vm, SweepTrigger trigger)
     if (block) {
         DeferGCForAWhile deferGC(vm);
         block->sweep(nullptr);
+        m_currentDirectory->didFinishUsingBlock(block);
         if (trigger == SweepTrigger::Timer)
             vm.heap.objectSpace().freeOrShrinkBlock(block);
         return true;

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -79,6 +79,11 @@ void IsoSubspace::didBeginSweepingToFreeList(MarkedBlock::Handle* block)
         });
 }
 
+void IsoSubspace::didBeginSweepingToFreeListConcurrently(MarkedBlock::Handle*)
+{
+    ASSERT(m_cellSets.isEmpty());
+}
+
 void* IsoSubspace::tryAllocateFromLowerTier()
 {
     auto revive = [&] (PreciseAllocation* allocation) {

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -63,6 +63,7 @@ private:
     void didResizeBits(unsigned newSize) override;
     void didRemoveBlock(unsigned blockIndex) override;
     void didBeginSweepingToFreeList(MarkedBlock::Handle*) override;
+    void didBeginSweepingToFreeListConcurrently(MarkedBlock::Handle*) override;
 
     BlockDirectory m_directory;
     std::unique_ptr<IsoMemoryAllocatorBase> m_isoAlignedMemoryAllocator;

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -147,6 +147,7 @@ public:
         // the block. If it's not set and the block has nothing marked, then we'll make the
         // mistake of making a pop freelist rather than a bump freelist.
         void sweep(FreeList*);
+        void sweepConcurrently();
         
         // This is to be called by Subspace.
         template<typename DestroyFunc>
@@ -230,8 +231,6 @@ public:
         
         template<bool, EmptyMode, SweepMode, SweepDestructionMode, ScribbleMode, NewlyAllocatedMode, MarksMode, typename DestroyFunc>
         void specializedSweep(FreeList*, EmptyMode, SweepMode, SweepDestructionMode, ScribbleMode, NewlyAllocatedMode, MarksMode, const DestroyFunc&);
-        
-        void setIsFreeListed();
         
         unsigned m_atomsPerCell { std::numeric_limits<unsigned>::max() };
         unsigned m_startAtom { std::numeric_limits<unsigned>::max() }; // Exact location of the first allocatable atom.

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -141,5 +141,10 @@ void Subspace::didBeginSweepingToFreeList(MarkedBlock::Handle*)
 {
 }
 
+void Subspace::didBeginSweepingToFreeListConcurrently(MarkedBlock::Handle*)
+{
+}
+
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -96,6 +96,7 @@ public:
     virtual void didResizeBits(unsigned newSize);
     virtual void didRemoveBlock(unsigned blockIndex);
     virtual void didBeginSweepingToFreeList(MarkedBlock::Handle*);
+    virtual void didBeginSweepingToFreeListConcurrently(MarkedBlock::Handle*);
 
     bool isIsoSubspace() const { return m_isIsoSubspace; }
 

--- a/Source/JavaScriptCore/runtime/DateInstanceCache.h
+++ b/Source/JavaScriptCore/runtime/DateInstanceCache.h
@@ -29,11 +29,11 @@
 #include <array>
 #include <wtf/GregorianDateTime.h>
 #include <wtf/HashFunctions.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
 
-class DateInstanceData : public RefCounted<DateInstanceData> {
+class DateInstanceData : public ThreadSafeRefCounted<DateInstanceData> {
 public:
     static Ref<DateInstanceData> create() { return adoptRef(*new DateInstanceData); }
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -703,6 +703,9 @@ void Options::notifyOptionsChanged()
         Options::scribbleFreeCells() = true;
     }
 
+    if (Options::sweepSynchronously())
+        Options::useConcurrentSweeper() = false;
+
     if (Options::reservedZoneSize() < minimumReservedZoneSize)
         Options::reservedZoneSize() = minimumReservedZoneSize;
     if (Options::softReservedZoneSize() < Options::reservedZoneSize() + minimumReservedZoneSize)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -192,6 +192,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, verboseSanitizeStack, false, Normal, nullptr) \
     v(Bool, useGenerationalGC, true, Normal, nullptr) \
     v(Bool, useConcurrentGC, true, Normal, nullptr) \
+    v(Bool, useConcurrentSweeper, true, Normal, "Enables the concurrent sweeper for the main VM") \
     v(Bool, collectContinuously, false, Normal, nullptr) \
     v(Double, collectContinuouslyPeriodMS, 1, Normal, nullptr) \
     v(Bool, forceFencedBarrier, false, Normal, nullptr) \

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -178,6 +178,9 @@ protected:
     // For example, when you have thread pool, you can decrease active threads moderately.
     virtual bool shouldSleep(const AbstractLocker&) { return true; }
     
+    Lock& lock() { return *m_lock; }
+    AutomaticThreadCondition& condition() { return m_condition.get(); }
+
 private:
     friend class AutomaticThreadCondition;
     


### PR DESCRIPTION
#### c4921d78b8f11af94a5791d5d54cfe8c5b3b0841
<pre>
Add core logic needed for concurrent sweeping
<a href="https://bugs.webkit.org/show_bug.cgi?id=259980">https://bugs.webkit.org/show_bug.cgi?id=259980</a>

Reviewed by NOBODY (OOPS!).

This patch adds the core support needed to do concurrent sweeping. Currently,
this sweeping is limited to Date instance objects, however, the idea is to
add more support in later patches.

The core idea is that the heap will push BlockDirectories to the ConcurrentSweeper
thread during the end phase of the GC. Right now this is limited to Date instances
but as we identify more objects to destroy concurrently we can add them.

To make sure the sweeper thread and the mutator don&apos;t clobber each other this patch
adds a new bit to BlockDirectory that tracks when a MarkedBlock is &quot;in use&quot;. Being in
use means that the MarkedBlock is actively being swept or allocated out of. Additionally,
we need to make sure that we don&apos;t see a tear when updating the BlockDirectory bits. This is done by
holding the BlockDirectory&apos;s bit vector lock when reading/writing the following bit fields:

1) empty
2) destructable
3) unswept
4) inUse

The other bit fields are not read/writen from the sweeper thread and thus don&apos;t require locking.

Note, that the concurrent sweeper doesn&apos;t sweep weak blocks because it&apos;s not thread safe to do so.
This is ok though because when the main thread goes to allocate out of a marked block it always does
another sweep to build the free list, which will clear these weak impls.

* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::findEmptyBlockToSteal):
(JSC::BlockDirectory::findBlockForAllocation):
(JSC::BlockDirectory::tryAllocateBlock):
(JSC::BlockDirectory::addBlock):
(JSC::BlockDirectory::stopAllocating):
(JSC::BlockDirectory::endMarking):
(JSC::BlockDirectory::snapshotUnsweptForEdenCollection):
(JSC::BlockDirectory::snapshotUnsweptForFullCollection):
(JSC::BlockDirectory::findBlockToSweep):
(JSC::BlockDirectory::sweep):
(JSC::BlockDirectory::shrink):
(JSC::BlockDirectory::didFinishUsingBlock):
* Source/JavaScriptCore/heap/BlockDirectory.h:
(JSC::BlockDirectory::findBlockToSweep):
* Source/JavaScriptCore/heap/BlockDirectoryBits.h:
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::allocatorForSlow):
* Source/JavaScriptCore/heap/ConcurrentSweeper.cpp: Added.
(JSC::ConcurrentSweeper::ConcurrentSweeper):
(JSC::ConcurrentSweeper::~ConcurrentSweeper):
(JSC::ConcurrentSweeper::create):
(JSC::ConcurrentSweeper::poll):
(JSC::ConcurrentSweeper::work):
(JSC::ConcurrentSweeper::notifyPushedDirectories):
* Source/JavaScriptCore/heap/ConcurrentSweeper.h: Added.
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
(JSC::Heap::lastChanceToFinalize):
(JSC::Heap::runEndPhase):
(JSC::Heap::stopThePeriphery):
(JSC::Heap::resumeThePeriphery):
* Source/JavaScriptCore/heap/Heap.h:
(JSC::Heap::concurrentSweeper):
* Source/JavaScriptCore/heap/HeapCellType.cpp:
(JSC::DefaultDestroyFunc::operator() const):
* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::sweepNextBlock):
* Source/JavaScriptCore/heap/IsoHeapCellType.h:
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::didBeginSweepingToFreeListConcurrently):
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::unsweepWithNoNewlyAllocated):
(JSC::MarkedBlock::Handle::stopAllocating):
(JSC::MarkedBlock::Handle::lastChanceToFinalize):
(JSC::MarkedBlock::Handle::resumeAllocating):
(JSC::MarkedBlock::Handle::didConsumeFreeList):
(JSC::MarkedBlock::Handle::sweep):
(JSC::MarkedBlock::Handle::sweepConcurrently):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
(JSC::MarkedBlock::Handle::setIsFreeListed):
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::didBeginSweepingToFreeListConcurrently):
* Source/JavaScriptCore/heap/Subspace.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/AutomaticThread.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4921d78b8f11af94a5791d5d54cfe8c5b3b0841

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14720 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16529 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17203 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20274 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12612 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16688 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11840 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14920 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13288 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3816 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17626 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15151 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13833 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3626 "Passed tests") | 
<!--EWS-Status-Bubble-End-->