### PR TITLE
[git-webkit] Change hooks to use relative path to project

### DIFF
--- a/Tools/Scripts/hooks/pre-commit
+++ b/Tools/Scripts/hooks/pre-commit
@@ -4,9 +4,7 @@ import os
 import subprocess
 import sys
 
-LOCATION = r'{{ location }}'
-SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
-
+SCRIPTS = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'Tools', 'Scripts'))
 
 def files(staged=True):
     try:

--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -12,8 +12,7 @@ if sys.stdout.isatty() and os.path.exists('/dev/tty'):
 else:
     TTY = None
 
-LOCATION = r'{{ location }}'
-SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
+SCRIPTS = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'Tools', 'Scripts'))
 sys.path.append(SCRIPTS)
 
 REMOTE_RE = re.compile(r'{{ remote_re }}')

--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -5,9 +5,8 @@ import re
 import subprocess
 import sys
 
-LOCATION = r'{{ location }}'
 SPACING = 8
-SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
+SCRIPTS = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'Tools', 'Scripts'))
 CHERRY_PICKING_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
 CHERRY_PICK_COMMIT_RE = re.compile(r'^(?P<a>\S+)( \((?P<b>\S+)\))?$')
 REFNAME_RE = re.compile(r'^refs/remotes/(?P<remote>[^/ ]+)/(?P<branch>\S+)$')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -190,7 +190,6 @@ class InstallHooks(Command):
             with open(source_path, 'r') as f:
                 from jinja2 import Template
                 contents = Template(f.read()).render(
-                    location=source_path,
                     python=os.path.basename(sys.executable),
                     prefer_radar=bool(radar.Tracker.radarclient()),
                     default_pre_push_mode="'{}'".format(getattr(args, 'mode', cls.MODES[0])),


### PR DESCRIPTION
#### 8e23e63d4e5ab36d697e3a5336ee2405aa4cbcab
<pre>
[git-webkit] Change hooks to use relative path to project
<a href="https://bugs.webkit.org/show_bug.cgi?id=259983">https://bugs.webkit.org/show_bug.cgi?id=259983</a>

Reviewed by NOBODY (OOPS!).

This removes edge-cases like if the directory has been moved, renamed,
or ran in a different filesystem namespace.

* Tools/Scripts/hooks/pre-commit:
* Tools/Scripts/hooks/pre-push:
* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e23e63d4e5ab36d697e3a5336ee2405aa4cbcab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14612 "Failed to checkout and rebase branch from PR 16528") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/14923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15270 "Failed to checkout and rebase branch from PR 16528") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16359 "Failed to checkout and rebase branch from PR 16528") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14747 "Failed to checkout and rebase branch from PR 16528") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17439 "Failed to checkout and rebase branch from PR 16528") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15005 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/16359 "Failed to checkout and rebase branch from PR 16528") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14793 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/17439 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/15270 "Failed to checkout and rebase branch from PR 16528") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17094 "Failed to checkout and rebase branch from PR 16528") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14715 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/17439 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/15270 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/17094 "Failed to checkout and rebase branch from PR 16528") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/17439 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/15270 "Failed to checkout and rebase branch from PR 16528") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/17094 "Failed to checkout and rebase branch from PR 16528") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/15005 "Failed to checkout and rebase branch from PR 16528") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14511 "Failed to checkout and rebase branch from PR 16528") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/15270 "Failed to checkout and rebase branch from PR 16528") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->