### PR TITLE
[WGSL] Add new pass to sort global variables, structs and functions

### DIFF
--- a/Source/WebGPU/WGSL/GlobalSorting.cpp
+++ b/Source/WebGPU/WGSL/GlobalSorting.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GlobalSorting.h"
+
+#include "ASTIdentifierExpression.h"
+#include "ASTVariableStatement.h"
+#include "ASTVisitor.h"
+#include "ContextProviderInlines.h"
+#include "WGSLShaderModule.h"
+#include <wtf/DataLog.h>
+#include <wtf/Deque.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace WGSL {
+
+template<typename ASTNode>
+class Graph {
+public:
+    class Edge;
+    struct EdgeHash;
+    struct EdgeHashTraits;
+    using EdgeSet = HashSet<Edge, EdgeHash, EdgeHashTraits>;
+
+    class Node {
+    public:
+        Node()
+            : m_astNode(nullptr)
+        {
+        }
+
+        Node(ASTNode& astNode)
+            : m_astNode(&astNode)
+        {
+        }
+
+        ASTNode& astNode() const { return *m_astNode; }
+        EdgeSet& incomingEdges() { return m_incomingEdges; }
+        EdgeSet& outgoingEdges() { return m_outgoingEdges; }
+
+    private:
+        ASTNode* m_astNode;
+        EdgeSet m_incomingEdges;
+        EdgeSet m_outgoingEdges;
+    };
+
+    class Edge {
+        friend EdgeHash;
+        friend EdgeHashTraits;
+    public:
+        Edge()
+            : m_source(nullptr)
+            , m_target(nullptr)
+        {
+        }
+
+        Edge(Node& source, Node& target)
+            : m_source(&source)
+            , m_target(&target)
+        {
+        }
+
+        void remove(Graph& graph)
+        {
+            m_source->outgoingEdges().remove(*this);
+            m_target->incomingEdges().remove(*this);
+            graph.edges().remove(*this);
+        }
+
+        Node& source() const { return *m_source; }
+        Node& target() const { return *m_target; }
+
+        bool operator==(const Edge& other) const
+        {
+            return m_source == other.m_source && m_target == other.m_target;
+        }
+
+    private:
+        Node* m_source;
+        Node* m_target;
+    };
+
+    struct EdgeHashTraits : HashTraits<Edge> {
+        static constexpr bool emptyValueIsZero = true;
+        static void constructDeletedValue(Edge& slot) { slot.m_source = bitwise_cast<Node*>(static_cast<intptr_t>(-1)); }
+        static bool isDeletedValue(const Edge& edge) { return edge.m_source == bitwise_cast<Node*>(static_cast<intptr_t>(-1)); }
+    };
+
+    struct EdgeHash {
+        static unsigned hash(const Edge& edge)
+        {
+            return WTF::TupleHash<Node*, Node*>::hash(std::tuple(edge.m_source, edge.m_target));
+        }
+        static bool equal(const Edge& a, const Edge& b)
+        {
+            return a == b;
+        }
+        static constexpr bool safeToCompareToEmptyOrDeleted = true;
+    };
+
+    Graph(size_t capacity)
+        : m_nodes(capacity)
+    {
+    }
+
+    FixedVector<Node>& nodes() { return m_nodes; }
+    Node* addNode(unsigned index, ASTNode& astNode)
+    {
+        if (m_nodeMap.find(astNode.name()) != m_nodeMap.end())
+            return nullptr;
+
+        m_nodes[index] = Node(astNode);
+        auto* node = &m_nodes[index];
+        m_nodeMap.add(astNode.name(), node);
+        return node;
+    }
+    Node* getNode(const AST::Identifier& identifier)
+    {
+        auto it = m_nodeMap.find(identifier);
+        if (it == m_nodeMap.end())
+            return nullptr;
+        return it->value;
+    }
+
+    EdgeSet& edges() { return m_edges; }
+    void addEdge(Node& source, Node& target)
+    {
+        auto result = m_edges.add(Edge(source, target));
+        Edge& edge = *result.iterator;
+        source.outgoingEdges().add(edge);
+        target.incomingEdges().add(edge);
+    }
+
+    void topologicalSort();
+
+private:
+    FixedVector<Node> m_nodes;
+    HashMap<String, Node*> m_nodeMap;
+    EdgeSet m_edges;
+};
+
+struct Empty { };
+
+template<typename ASTNode>
+class GraphBuilder : public AST::Visitor, public ContextProvider<Empty> {
+public:
+    static void visit(Graph<ASTNode>&, typename Graph<ASTNode>::Node&);
+
+    using AST::Visitor::visit;
+
+    void visit(AST::Function&) override;
+    void visit(AST::VariableStatement&) override;
+    void visit(AST::CompoundStatement&) override;
+    void visit(AST::IdentifierExpression&) override;
+    void visit(AST::NamedTypeName&) override;
+
+private:
+    GraphBuilder(Graph<ASTNode>&, typename Graph<ASTNode>::Node&);
+
+    void introduceVariable(AST::Identifier&);
+    void readVariable(AST::Identifier&) const;
+
+    Graph<ASTNode>& m_graph;
+    typename Graph<ASTNode>::Node& m_currentNode;
+};
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(Graph<ASTNode>& graph, typename Graph<ASTNode>::Node& node)
+{
+    GraphBuilder(graph, node).visit(node.astNode());
+}
+
+template<typename ASTNode>
+GraphBuilder<ASTNode>::GraphBuilder(Graph<ASTNode>& graph, typename Graph<ASTNode>::Node& node)
+    : m_graph(graph)
+    , m_currentNode(node)
+{
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(AST::Function& function)
+{
+    ContextScope functionScope(this);
+
+    for (auto& parameter : function.parameters()) {
+        AST::Visitor::visit(parameter.typeName());
+        introduceVariable(parameter.name());
+    }
+
+    AST::Visitor::visit(function.body());
+
+    if (function.maybeReturnType())
+        AST::Visitor::visit(*function.maybeReturnType());
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(AST::VariableStatement& variable)
+{
+    introduceVariable(variable.variable().name());
+    AST::Visitor::visit(variable);
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(AST::CompoundStatement& statement)
+{
+    ContextScope blockScope(this);
+    AST::Visitor::visit(statement);
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(AST::IdentifierExpression& identifier)
+{
+    readVariable(identifier.identifier());
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(AST::NamedTypeName& type)
+{
+    readVariable(type.name());
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::introduceVariable(AST::Identifier& name)
+{
+    ContextProvider::introduceVariable(name, { });
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::readVariable(AST::Identifier& name) const
+{
+    if (ContextProvider::readVariable(name))
+        return;
+    if (auto* node = m_graph.getNode(name))
+        m_graph.addEdge(*node, m_currentNode);
+}
+
+
+template<typename T>
+std::optional<FailedCheck> reorder(typename T::List& list)
+{
+    Graph<T> graph(list.size());
+    Vector<typename Graph<T>::Node*> graphNodeList;
+    graphNodeList.reserveCapacity(list.size());
+    unsigned index = 0;
+    for (auto& node : list) {
+        auto* graphNode = graph.addNode(index++, node);
+        if (!graphNode) {
+            // This is unfortunately duplicated between this pass and the type checker
+            // since here we only cover redeclarations of the same type (e.g. two
+            // variables with the same name), while the type checker will also identify
+            // redeclarations of different types (e.g. a variable and a struct with the
+            // same name)
+            return FailedCheck { Vector<Error> { Error(makeString("redeclaration of '", node.name(), "'"), node.span()) }, { } };
+        }
+        graphNodeList.append(graphNode);
+    }
+
+    for (auto* graphNode : graphNodeList)
+        GraphBuilder<T>::visit(graph, *graphNode);
+
+    list.clear();
+    Deque<typename Graph<T>::Node> queue;
+    for (auto& node : graph.nodes()) {
+        if (node.incomingEdges().isEmpty())
+            queue.append(node);
+    }
+    while (!queue.isEmpty()) {
+        auto node = queue.takeFirst();
+        list.append(node.astNode());
+        for (auto edge : node.outgoingEdges()) {
+            auto& target = edge.target();
+            edge.remove(graph);
+            if (target.incomingEdges().isEmpty())
+                queue.append(target);
+        }
+    }
+    if (graph.edges().isEmpty())
+        return std::nullopt;
+
+    typename Graph<T>::Node* cycleNode = nullptr;
+    for (auto& node : graph.nodes()) {
+        if (!node.incomingEdges().isEmpty()) {
+            cycleNode = &node;
+            break;
+        }
+    }
+    ASSERT(cycleNode);
+    StringBuilder error;
+    auto* node = cycleNode;
+    HashSet<typename Graph<T>::Node*> visited;
+    while (true) {
+        ASSERT(!node->incomingEdges().isEmpty());
+        visited.add(node);
+        node = &node->incomingEdges().random()->source();
+        if (visited.contains(node)) {
+            cycleNode = node;
+            break;
+        }
+    }
+    error.append("encountered a dependency cycle: ", cycleNode->astNode().name());
+    do {
+        ASSERT(!node->incomingEdges().isEmpty());
+        node = &node->incomingEdges().random()->source();
+        error.append(" -> ", node->astNode().name());
+    } while (node != cycleNode);
+    return FailedCheck { Vector<Error> { Error(error.toString(), cycleNode->astNode().span()) }, { } };
+}
+
+std::optional<FailedCheck> reorderGlobals(ShaderModule& module)
+{
+    if (auto maybeError = reorder<AST::Structure>(module.structures()))
+        return *maybeError;
+    if (auto maybeError = reorder<AST::Variable>(module.variables()))
+        return *maybeError;
+    if (auto maybeError = reorder<AST::Function>(module.functions()))
+        return *maybeError;
+    return std::nullopt;
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/GlobalSorting.h
+++ b/Source/WebGPU/WGSL/GlobalSorting.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WGSL.h"
+
+namespace WGSL {
+
+class ShaderModule;
+
+std::optional<FailedCheck> reorderGlobals(ShaderModule&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-const.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-const.wgsl
@@ -1,0 +1,4 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: encountered a dependency cycle: a -> a
+const a = a * 2;

--- a/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-function.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-function.wgsl
@@ -1,0 +1,12 @@
+// RUN: %not %wgslc | %check
+
+@compute @workgroup_size(1)
+fn main() {
+  _ = f();
+}
+
+// CHECK-L: encountered a dependency cycle: f -> f
+fn f() -> i32 {
+  _ = f();
+  return g();
+}

--- a/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-struct.wgsl
@@ -1,0 +1,6 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: encountered a dependency cycle: S -> S
+struct S {
+    s: S
+}

--- a/Source/WebGPU/WGSL/tests/invalid/reordering-cycle.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/reordering-cycle.wgsl
@@ -1,0 +1,7 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: encountered a dependency cycle: y -> x -> w -> z -> y
+const y = x * 2;
+const z = y;
+const w = z;
+const x = w;

--- a/Source/WebGPU/WGSL/tests/invalid/reordering-redeclaration.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/reordering-redeclaration.wgsl
@@ -1,0 +1,5 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: redeclaration of 'y'
+const y = x * 2;
+const y = 2;

--- a/Source/WebGPU/WGSL/tests/valid/reordering.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/reordering.wgsl
@@ -1,0 +1,24 @@
+// RUN: %metal-compile main
+
+const x = y * 2;
+const y = 3;
+
+struct T {
+    s: S,
+};
+
+struct S {
+    x: i32,
+}
+
+@compute @workgroup_size(1)
+fn main()
+{
+    _ = helper();
+}
+
+fn helper() -> i32
+{
+    _ = T(S(y));
+    return 0;
+}

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		979240C029753B2A0050EA2C /* PhaseTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240BC29753B2A0050EA2C /* PhaseTimer.h */; };
 		979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C629769AC00050EA2C /* EntryPointRewriter.h */; };
 		979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240C729769AC00050EA2C /* EntryPointRewriter.cpp */; };
+		979EDBB12A826B2800B4B7D0 /* GlobalSorting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979EDBAF2A826B2800B4B7D0 /* GlobalSorting.cpp */; };
+		979EDBB22A826B2800B4B7D0 /* GlobalSorting.h in Headers */ = {isa = PBXBuildFile; fileRef = 979EDBB02A826B2800B4B7D0 /* GlobalSorting.h */; };
 		97BCD6AE29D7422B00A82577 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
 		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
@@ -422,6 +424,8 @@
 		979240BC29753B2A0050EA2C /* PhaseTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhaseTimer.h; sourceTree = "<group>"; };
 		979240C629769AC00050EA2C /* EntryPointRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntryPointRewriter.h; sourceTree = "<group>"; };
 		979240C729769AC00050EA2C /* EntryPointRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntryPointRewriter.cpp; sourceTree = "<group>"; };
+		979EDBAF2A826B2800B4B7D0 /* GlobalSorting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalSorting.cpp; sourceTree = "<group>"; };
+		979EDBB02A826B2800B4B7D0 /* GlobalSorting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalSorting.h; sourceTree = "<group>"; };
 		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
 		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
@@ -596,6 +600,8 @@
 				978A912B298AB8EE00B37E5E /* ContextProviderInlines.h */,
 				979240C729769AC00050EA2C /* EntryPointRewriter.cpp */,
 				979240C629769AC00050EA2C /* EntryPointRewriter.h */,
+				979EDBAF2A826B2800B4B7D0 /* GlobalSorting.cpp */,
+				979EDBB02A826B2800B4B7D0 /* GlobalSorting.h */,
 				97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */,
 				97F547B7298055D90011D79A /* GlobalVariableRewriter.h */,
 				338BB2D527B6B68700E066AB /* Lexer.cpp */,
@@ -839,6 +845,7 @@
 				978A912A298AB60200B37E5E /* ContextProvider.h in Headers */,
 				978A912C298AB8EE00B37E5E /* ContextProviderInlines.h in Headers */,
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
+				979EDBB22A826B2800B4B7D0 /* GlobalSorting.h in Headers */,
 				97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
 				978A9126298A4E8400B37E5E /* MangleNames.h in Headers */,
@@ -1070,6 +1077,7 @@
 				97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */,
 				97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */,
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
+				979EDBB12A826B2800B4B7D0 /* GlobalSorting.cpp in Sources */,
 				97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
 				978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */,


### PR DESCRIPTION
#### 46e2ecf4659831e5fbcf6701f47670a99c952590
<pre>
[WGSL] Add new pass to sort global variables, structs and functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=259984">https://bugs.webkit.org/show_bug.cgi?id=259984</a>
rdar://113639825

Reviewed by Dan Glastonbury.

Constands, structs and functions can refer to other declarations of the same type
defined later at the program, e.g. `const y = x * 2; const x = 1;` is a valid program.
To simplify things, we add a new pass, which will be the first pass to run after parsing.
The pass sorts the declarations and detects cycles. This way, the rest of the compiler
doesn&apos;t need to be concerned with ordering.

* Source/WebGPU/WGSL/GlobalSorting.cpp: Added.
(WGSL::Graph::Node::Node):
(WGSL::Graph::Node::astNode const):
(WGSL::Graph::Node::incomingEdges):
(WGSL::Graph::Node::outgoingEdges):
(WGSL::Graph::Edge::Edge):
(WGSL::Graph::Edge::remove):
(WGSL::Graph::Edge::source const):
(WGSL::Graph::Edge::target const):
(WGSL::Graph::Edge::operator== const):
(WGSL::Graph::EdgeHashTraits::constructDeletedValue):
(WGSL::Graph::EdgeHashTraits::isDeletedValue):
(WGSL::Graph::EdgeHash::hash):
(WGSL::Graph::EdgeHash::equal):
(WGSL::Graph::Graph):
(WGSL::Graph::nodes):
(WGSL::Graph::addNode):
(WGSL::Graph::getNode):
(WGSL::Graph::edges):
(WGSL::Graph::addEdge):
(WGSL::GraphBuilder&lt;ASTNode&gt;::visit):
(WGSL::GraphBuilder&lt;ASTNode&gt;::GraphBuilder):
(WGSL::GraphBuilder&lt;ASTNode&gt;::introduceVariable):
(WGSL::GraphBuilder&lt;ASTNode&gt;::readVariable const):
(WGSL::reorder):
(WGSL::reorderGlobals):
* Source/WebGPU/WGSL/GlobalSorting.h: Added.
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
* Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-const.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-function.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/reordering-cycle-self-struct.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/reordering-cycle.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/reordering-redeclaration.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/reordering.wgsl: Added.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/266862@main">https://commits.webkit.org/266862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/491b5158d6bfa2f1360382dcaa000a51730ca924

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14099 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15391 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17468 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12920 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12048 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13526 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3611 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->