### PR TITLE
Make MediaKeysStorage directory name private

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -162,18 +162,7 @@ std::optional<String> CDM::sanitizeSessionId(const String& sessionId)
 String CDM::storageDirectory() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (!document)
-        return emptyString();
-
-    auto* page = document->page();
-    if (!page || page->usesEphemeralSession())
-        return emptyString();
-
-    auto storageDirectory = document->settings().mediaKeysStorageDirectory();
-    if (storageDirectory.isEmpty())
-        return emptyString();
-
-    return FileSystem::pathByAppendingComponent(storageDirectory, document->securityOrigin().data().databaseIdentifier());
+    return document ? document->mediaKeysStorageDirectory() : emptyString();
 }
 
 }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -794,18 +794,7 @@ void MediaKeySession::sessionClosed()
 String MediaKeySession::mediaKeysStorageDirectory() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (!document)
-        return emptyString();
-
-    auto* page = document->page();
-    if (!page || page->usesEphemeralSession())
-        return emptyString();
-
-    auto storageDirectory = document->settings().mediaKeysStorageDirectory();
-    if (storageDirectory.isEmpty())
-        return emptyString();
-
-    return FileSystem::pathByAppendingComponent(storageDirectory, document->securityOrigin().data().databaseIdentifier());
+    return document ? document->mediaKeysStorageDirectory() : emptyString();
 }
 
 CDMKeyGroupingStrategy MediaKeySession::keyGroupingStrategy() const

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -233,18 +233,7 @@ void WebKitMediaKeySession::sendError(MediaKeyErrorCode errorCode, uint32_t syst
 String WebKitMediaKeySession::mediaKeysStorageDirectory() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (!document)
-        return emptyString();
-
-    auto* page = document->page();
-    if (!page || page->usesEphemeralSession())
-        return emptyString();
-
-    auto storageDirectory = document->settings().mediaKeysStorageDirectory();
-    if (storageDirectory.isEmpty())
-        return emptyString();
-
-    return FileSystem::pathByAppendingComponent(storageDirectory, document->securityOrigin().data().databaseIdentifier());
+    return document ? document->mediaKeysStorageDirectory() : emptyString();
 }
 
 bool WebKitMediaKeySession::virtualHasPendingActivity() const

--- a/Source/WebCore/Modules/storage/DummyStorageProvider.h
+++ b/Source/WebCore/Modules/storage/DummyStorageProvider.h
@@ -74,7 +74,23 @@ private:
         return *m_connection;
     }
 
+    String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData& origin) final
+    {
+        if (m_mediaKeysStorageDirectory.isEmpty())
+            return emptyString();
+
+        auto originDirectory = FileSystem::pathByAppendingComponent(m_mediaKeysStorageDirectory, origin.databaseIdentifier());
+        FileSystem::makeAllDirectories(originDirectory);
+        return originDirectory;
+    }
+
+    void setMediaKeysStorageDirectory(const String& directory) final
+    {
+        m_mediaKeysStorageDirectory = directory;
+    }
+
     RefPtr<DummyStorageConnection> m_connection;
+    String m_mediaKeysStorageDirectory;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/storage/StorageProvider.h
+++ b/Source/WebCore/Modules/storage/StorageProvider.h
@@ -27,6 +27,7 @@
 
 namespace WebCore {
 
+class SecurityOriginData;
 class StorageConnection;
 
 class StorageProvider {
@@ -34,6 +35,8 @@ public:
     StorageProvider() = default;
     virtual ~StorageProvider() = default;
     virtual StorageConnection& storageConnection() = 0;
+    virtual String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData&) = 0;
+    virtual void setMediaKeysStorageDirectory(const String&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9714,6 +9714,15 @@ void Document::updateContentRelevancyForScrollIfNeeded(const Element& scrollAnch
     return m_contentVisibilityDocumentState->updateContentRelevancyForScrollIfNeeded(scrollAnchor);
 }
 
+String Document::mediaKeysStorageDirectory()
+{
+    auto* currentPage = page();
+    if (!currentPage)
+        return emptyString();
+
+    return currentPage->ensureMediaKeysStorageDirectoryForOrigin(securityOrigin().data());
+}
+
 } // namespace WebCore
 
 #undef DOCUMENT_RELEASE_LOG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1799,6 +1799,8 @@ public:
     void scheduleContentRelevancyUpdate(ContentRelevancy);
     void updateContentRelevancyForScrollIfNeeded(const Element& scrollAnchor);
 
+    String mediaKeysStorageDirectory();
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2985,15 +2985,7 @@ void HTMLMediaElement::mediaPlayerKeyNeeded(const SharedBuffer& initData)
 
 String HTMLMediaElement::mediaPlayerMediaKeysStorageDirectory() const
 {
-    auto* page = document().page();
-    if (!page || page->usesEphemeralSession())
-        return emptyString();
-
-    String storageDirectory = document().settings().mediaKeysStorageDirectory();
-    if (storageDirectory.isEmpty())
-        return emptyString();
-
-    return FileSystem::pathByAppendingComponent(storageDirectory, document().securityOrigin().data().databaseIdentifier());
+    return document().mediaKeysStorageDirectory();
 }
 
 void HTMLMediaElement::webkitSetMediaKeys(WebKitMediaKeys* mediaKeys)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4511,6 +4511,19 @@ void Page::removeRootFrame(LocalFrame& frame)
     m_rootFrames.remove(frame);
 }
 
+String Page::ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData& origin)
+{
+    if (usesEphemeralSession())
+        return emptyString();
+
+    return m_storageProvider->ensureMediaKeysStorageDirectoryForOrigin(origin);
+}
+
+void Page::setMediaKeysStorageDirectory(const String& directory)
+{
+    m_storageProvider->setMediaKeysStorageDirectory(directory);
+}
+
 void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::optional<FrameIdentifier> triggeringFrame) const
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1058,6 +1058,8 @@ public:
 
     void opportunisticallyRunIdleCallbacks();
     void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+    String ensureMediaKeysStorageDirectoryForOrigin(const SecurityOriginData&);
+    WEBCORE_EXPORT void setMediaKeysStorageDirectory(const String&);
 
     bool isWaitingForLoadToFinish() const { return m_isWaitingForLoadToFinish; }
 

--- a/Source/WebCore/storage/StorageUtilities.h
+++ b/Source/WebCore/storage/StorageUtilities.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <optional>
+#include <wtf/FileSystem.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -35,6 +36,7 @@ namespace StorageUtilities {
 
 WEBCORE_EXPORT std::optional<ClientOrigin> readOriginFromFile(const String& path);
 WEBCORE_EXPORT bool writeOriginToFile(const String& path, const ClientOrigin&);
+WEBCORE_EXPORT String encodeSecurityOriginForFileName(FileSystem::Salt, const SecurityOriginData&);
 
 } // namespace StorageUtilities
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebProcessDataStoreParameters.h
+++ b/Source/WebKit/Shared/WebProcessDataStoreParameters.h
@@ -28,6 +28,7 @@
 #include "SandboxExtension.h"
 #include <WebCore/NetworkStorageSession.h>
 #include <pal/SessionID.h>
+#include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
 
 namespace WebKit {
@@ -44,6 +45,7 @@ struct WebProcessDataStoreParameters {
     SandboxExtension::Handle mediaCacheDirectoryExtensionHandle;
     String mediaKeyStorageDirectory;
     SandboxExtension::Handle mediaKeyStorageDirectoryExtensionHandle;
+    FileSystem::Salt mediaKeysStorageSalt;
     String javaScriptConfigurationDirectory;
     SandboxExtension::Handle javaScriptConfigurationDirectoryExtensionHandle;
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::WebProcessDataStoreParameters {
     WebKit::SandboxExtension::Handle mediaCacheDirectoryExtensionHandle;
     String mediaKeyStorageDirectory;
     WebKit::SandboxExtension::Handle mediaKeyStorageDirectoryExtensionHandle;
+    FileSystem::Salt mediaKeysStorageSalt;
     String javaScriptConfigurationDirectory;
     WebKit::SandboxExtension::Handle javaScriptConfigurationDirectoryExtensionHandle;
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -746,6 +746,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
         if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(mediaKeyStorageDirectory, SandboxExtension::Type::ReadWrite))
             mediaKeyStorageDirectoryExtensionHandle = WTFMove(*handle);
     }
+    auto mediaKeyStorageSalt = websiteDataStore.mediaKeysStorageSalt();
 
     String javaScriptConfigurationDirectory;
     if (!m_javaScriptConfigurationDirectory.isEmpty())
@@ -789,6 +790,7 @@ WebProcessDataStoreParameters WebProcessPool::webProcessDataStoreParameters(WebP
         WTFMove(mediaCacheDirectoryExtensionHandle),
         WTFMove(mediaKeyStorageDirectory),
         WTFMove(mediaKeyStorageDirectoryExtensionHandle),
+        WTFMove(mediaKeyStorageSalt),
         WTFMove(javaScriptConfigurationDirectory),
         WTFMove(javaScriptConfigurationDirectoryExtensionHandle),
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -290,6 +290,7 @@ public:
 #if ENABLE(ARKIT_INLINE_PREVIEW)
     const String& resolvedModelElementCacheDirectory() const { return m_resolvedConfiguration->modelElementCacheDirectory(); }
 #endif
+    FileSystem::Salt mediaKeysStorageSalt() const;
 
     static void setCachedProcessSuspensionDelayForTesting(Seconds);
 
@@ -511,9 +512,9 @@ private:
     // Will create a temporary process pool is none exists yet.
     HashSet<RefPtr<WebProcessPool>> ensureProcessPools() const;
 
-    static Vector<WebCore::SecurityOriginData> mediaKeyOrigins(const String& mediaKeysStorageDirectory);
-    static void removeMediaKeys(const String& mediaKeysStorageDirectory, WallTime modifiedSince);
-    static void removeMediaKeys(const String& mediaKeysStorageDirectory, const HashSet<WebCore::SecurityOriginData>&);
+    static Vector<WebCore::SecurityOriginData> mediaKeysStorageOrigins(const String& mediaKeysStorageDirectory);
+    static void removeMediaKeysStorage(const String& mediaKeysStorageDirectory, WallTime modifiedSince);
+    static void removeMediaKeysStorage(const String& mediaKeysStorageDirectory, const HashSet<WebCore::SecurityOriginData>&, const FileSystem::Salt&);
 
     void registerWithSessionIDMap();
     bool hasActivePages();
@@ -535,6 +536,8 @@ private:
     String resolvedContainerCachesNetworkingDirectory();
     String parentBundleDirectory() const;
 #endif
+
+    String migrateMediaKeysStorageIfNecessary(const String& directory);
 
     const PAL::SessionID m_sessionID;
 
@@ -609,6 +612,7 @@ private:
     CompletionHandler<void(String&&)> m_completionHandlerForRemovalFromNetworkProcess;
 
     bool m_inspectionForServiceWorkersAllowed { true };
+    FileSystem::Salt m_mediaKeysStorageSalt;
 };
 
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -676,7 +676,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         makeUniqueRef<WebSpeechRecognitionProvider>(pageID),
         makeUniqueRef<MediaRecorderProvider>(*this),
         WebProcess::singleton().broadcastChannelRegistry(),
-        makeUniqueRef<WebStorageProvider>(),
+        makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt()),
         makeUniqueRef<WebModelPlayerProvider>(*this),
         WebProcess::singleton().badgeClient(),
         m_historyItemClient.copyRef(),
@@ -953,11 +953,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     for (auto& mimeType : parameters.mimeTypesWithCustomContentProviders)
         m_mimeTypesWithCustomContentProviders.add(mimeType);
 
-
-#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    if (WebMediaKeyStorageManager* manager = webProcess.supplement<WebMediaKeyStorageManager>())
-        m_page->settings().setMediaKeysStorageDirectory(manager->mediaKeyStorageDirectory());
-#endif
     if (parameters.viewScaleFactor != 1)
         scaleView(parameters.viewScaleFactor);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -661,6 +661,8 @@ void WebProcess::setWebsiteDataStoreParameters(WebProcessDataStoreParameters&& p
     
 #endif
 
+    m_mediaKeysStorageDirectory = parameters.mediaKeyStorageDirectory;
+    m_mediaKeysStorageSalt = parameters.mediaKeysStorageSalt;
     for (auto& supplement : m_supplements.values())
         supplement->setWebsiteDataStore(parameters);
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -428,6 +428,9 @@ public:
     const OptionSet<DMABufRendererBufferMode>& dmaBufRendererBufferMode() const { return m_dmaBufRendererBufferMode; }
 #endif
 
+    String mediaKeysStorageDirectory() const { return m_mediaKeysStorageDirectory; }
+    FileSystem::Salt mediaKeysStorageSalt() const { return m_mediaKeysStorageSalt; }
+
 private:
     WebProcess();
     ~WebProcess();
@@ -808,6 +811,8 @@ private:
     bool m_imageAnimationEnabled { true };
 
     HashSet<WebCore::RegistrableDomain> m_allowedFirstPartiesForCookies;
+    String m_mediaKeysStorageDirectory;
+    FileSystem::Salt m_mediaKeysStorageSalt;
 
     HashMap<WebTransportSessionIdentifier, WeakPtr<WebTransportSession>> m_webTransportSessions;
 };

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2925,7 +2925,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    settings.setMediaKeysStorageDirectory([preferences mediaKeysStorageDirectory]);
+    _private->page->setMediaKeysStorageDirectory([preferences mediaKeysStorageDirectory]);
 #endif
 
     // FIXME: Is this relevent to WebKitLegacy? If not, we should remove it.


### PR DESCRIPTION
#### aa8f2cebaa0975801430b2421afc68884d0b3911
<pre>
Make MediaKeysStorage directory name private
<a href="https://bugs.webkit.org/show_bug.cgi?id=259985">https://bugs.webkit.org/show_bug.cgi?id=259985</a>
rdar://99984441

Reviewed by Brent Fulgham.

MediaKeysStorage uses domain string as directory name, and that could reveal information about what sites are visisted.
This patch makes MediaKeysStorage start to use hashed origin string for directory name instead.

API test: WKWebsiteDataStore.FetchAndDeleteMediaKeysData

* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
(WebCore::CDM::storageDirectory const):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::mediaKeysStorageDirectory const):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
(WebCore::WebKitMediaKeySession::mediaKeysStorageDirectory const):
* Source/WebCore/Modules/storage/DummyStorageProvider.h:
* Source/WebCore/Modules/storage/StorageProvider.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::mediaKeysStorageDirectory):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerMediaKeysStorageDirectory const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::ensureMediaKeysStorageDirectoryForOrigin):
(WebCore::Page::setMediaKeysStorageDirectory):
* Source/WebCore/page/Page.h:
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::encodeSecurityOriginForFileName):
* Source/WebCore/storage/StorageUtilities.h:
* Source/WebKit/Shared/WebProcessDataStoreParameters.h:
* Source/WebKit/Shared/WebProcessDataStoreParameters.serialization.in:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::webProcessDataStoreParameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::computeMediaKeyFile):
(WebKit::WebsiteDataStore::migrateMediaKeysStorageIfNecessary):
(WebKit::WebsiteDataStore::resolveDirectoriesIfNecessary):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::mediaKeysStorageOrigins):
(WebKit::WebsiteDataStore::removeMediaKeysStorage):
(WebKit::WebsiteDataStore::mediaKeysStorageSalt const):
(WebKit::WebsiteDataStore::mediaKeyOrigins): Deleted.
(WebKit::WebsiteDataStore::removeMediaKeys): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageProvider.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setWebsiteDataStoreParameters):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::mediaKeysStorageDirectory const):
(WebKit::WebProcess::mediaKeysStorageSalt const):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _preferencesChanged:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:

Canonical link: <a href="https://commits.webkit.org/268737@main">https://commits.webkit.org/268737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f54fb4d34d594aebf510de442a1387c4db3152b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22896 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24578 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22548 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16190 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18275 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->