### PR TITLE
[image-set] border-image should fall back to border if the image is invalid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>image-set() is an invalid image if all options are invalid</title>
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#invalid-image">
+<link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#border-image-source">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+  #target {
+      width: 100px;
+      height: 100px;
+      box-sizing: border-box;
+      background-color: red;
+      border: 50px solid green;
+      border-image: 1 / 10px image-set(url('data:image/png;base64,') type('image/unknown'));
+  }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id="target"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
@@ -32,6 +32,8 @@ PASS Property background-image value 'image-set(url('http://localhost/example.pn
 PASS Property background-image value '-webkit-image-set(url('http://localhost/example.png') calc(6dppx / 3))'
 PASS Property background-image value 'image-set(url('http://localhost/example.png') calc(100dpi - 4dpi))'
 PASS Property background-image value '-webkit-image-set(url('http://localhost/example.png') calc(100dpi - 4dpi))'
-FAIL Property background-image value 'image-set(url('http://localhost/example.png') calc(37dpcm + 0.79532dpcm))' assert_equals: expected "image-set(url(\"http://localhost/example.png\") 1dppx)" but got "image-set(url(\"http://localhost/example.png\") 1.000001dppx)"
-FAIL Property background-image value '-webkit-image-set(url('http://localhost/example.png') calc(37dpcm + 0.79532dpcm))' assert_equals: expected "image-set(url(\"http://localhost/example.png\") 1dppx)" but got "image-set(url(\"http://localhost/example.png\") 1.000001dppx)"
+PASS Property background-image value 'image-set(url('http://localhost/example.png') calc(37dpcm + 0.79532dpcm))'
+PASS Property background-image value '-webkit-image-set(url('http://localhost/example.png') calc(37dpcm + 0.79532dpcm))'
+PASS Property background-image value 'image-set(url('http://localhost/example.png') calc(-1 * 1x))'
+PASS Property background-image value '-webkit-image-set(url('http://localhost/example.png') calc(-1 * 1x))'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub.html
@@ -38,7 +38,16 @@ function test_calculated_resolution_units() {
   test_computed_value_variants(
     'background-image',
     "image-set(url('http://{{host}}/example.png') calc(37dpcm + 0.79532dpcm))",
-    'image-set(url("http://{{host}}/example.png") 1dppx)'
+    [
+      'image-set(url("http://{{host}}/example.png") 1dppx)',
+      'image-set(url("http://{{host}}/example.png") 1.000001dppx)'
+    ]
+  );
+
+  test_computed_value_variants(
+    'background-image',
+    "image-set(url('http://{{host}}/example.png') calc(-1 * 1x))",
+    'image-set(url("http://{{host}}/example.png") 0dppx)'
   );
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-calc-x-rendering-2-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-calc-x-rendering-2.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-calc-x-rendering-expected.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt
@@ -32,6 +32,8 @@ PASS Property background-image value 'image-set(url('http://web-platform.test/ex
 PASS Property background-image value '-webkit-image-set(url('http://web-platform.test/example.png') calc(6dppx / 3))'
 PASS Property background-image value 'image-set(url('http://web-platform.test/example.png') calc(100dpi - 4dpi))'
 PASS Property background-image value '-webkit-image-set(url('http://web-platform.test/example.png') calc(100dpi - 4dpi))'
-FAIL Property background-image value 'image-set(url('http://web-platform.test/example.png') calc(37dpcm + 0.79532dpcm))' assert_equals: expected "image-set(url(\"http://web-platform.test/example.png\") 1dppx)" but got "image-set(url(\"http://web-platform.test/example.png\") 1.000001dppx)"
-FAIL Property background-image value '-webkit-image-set(url('http://web-platform.test/example.png') calc(37dpcm + 0.79532dpcm))' assert_equals: expected "image-set(url(\"http://web-platform.test/example.png\") 1dppx)" but got "image-set(url(\"http://web-platform.test/example.png\") 1.000001dppx)"
+PASS Property background-image value 'image-set(url('http://web-platform.test/example.png') calc(37dpcm + 0.79532dpcm))'
+PASS Property background-image value '-webkit-image-set(url('http://web-platform.test/example.png') calc(37dpcm + 0.79532dpcm))'
+PASS Property background-image value 'image-set(url('http://web-platform.test/example.png') calc(-1 * 1x))'
+PASS Property background-image value '-webkit-image-set(url('http://web-platform.test/example.png') calc(-1 * 1x))'
 

--- a/Source/WebCore/rendering/style/StyleInvalidImage.h
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.h
@@ -39,6 +39,7 @@ public:
 
     bool operator==(const StyleImage&) const final { return false; }
     bool equals(const StyleInvalidImage&) const { return false; }
+    bool canRender(const RenderElement*, float) const final { return false; }
 
     static constexpr bool isFixedSize = true;
 


### PR DESCRIPTION
#### 0cb488dc32c401acec4cf7f3dff58511b68489eb
<pre>
[image-set] border-image should fall back to border if the image is invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=259990">https://bugs.webkit.org/show_bug.cgi?id=259990</a>
rdar://113646392

Reviewed by Tim Nguyen.

If the image-set represents an invalid image it behaves as a zero-sized
transparent image. We can accomplish this by returning false from
StyleInvalidImage::canRender. In the case of border-image, we check to
see if we can render the image and if not we will behave as if we don&apos;t
have a border-image at all. This will then fall back to the border
property value, if present.

Also update image-set WPT as of upstream commit
cccad108b803ef9541ee164a306a9d694c831e01

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-all-options-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-computed.sub-expected.txt:
* Source/WebCore/rendering/style/StyleInvalidImage.h:

Canonical link: <a href="https://commits.webkit.org/266749@main">https://commits.webkit.org/266749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2146fa99cd7780e3982bf95abd85c6097bf2594a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16397 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15042 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15338 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17131 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12621 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16617 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13932 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14547 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3530 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->