### PR TITLE
Extend update a `style` block algorithm to non-HTML documents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style_type_svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style_type_svg-expected.txt
@@ -1,7 +1,7 @@
 
 PASS With no type attribute, the style should apply
 PASS With an empty type attribute, the style should apply
-FAIL With a mixed-case type attribute, the style should apply assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS With a mixed-case type attribute, the style should apply
 PASS With a whitespace-surrounded type attribute, the style should not apply
 PASS With a charset parameter in the type attribute, the style should not apply
 

--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -145,14 +145,12 @@ void InlineStyleSheetOwner::clearSheet()
     sheet->clearOwnerNode();
 }
 
-inline bool isValidCSSContentType(Element& element, const AtomString& type)
+inline bool isValidCSSContentType(const AtomString& type)
 {
+    // https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block
     if (type.isEmpty())
         return true;
-    // FIXME: Should MIME types really be case sensitive in XML documents? Doesn't seem like they should,
-    // even though other things are case sensitive in that context. MIME types should never be case sensitive.
-    // We should verify this and then remove the isHTMLElement check here.
-    return element.isHTMLElement() ? equalLettersIgnoringASCIICase(type, "text/css"_s) : type == cssContentTypeAtom();
+    return equalLettersIgnoringASCIICase(type, "text/css"_s);
 }
 
 void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
@@ -165,7 +163,7 @@ void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
         clearSheet();
     }
 
-    if (!isValidCSSContentType(element, m_contentType))
+    if (!isValidCSSContentType(m_contentType))
         return;
 
     ASSERT(document.contentSecurityPolicy());


### PR DESCRIPTION
#### c9ef47f60cc9b60d99d982269b3373da8217fc7b
<pre>
Extend update a `style` block algorithm to non-HTML documents

<a href="https://bugs.webkit.org/show_bug.cgi?id=259979">https://bugs.webkit.org/show_bug.cgi?id=259979</a>

Reviewed by Tim Nguyen and Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Web-Spec [1].

[1] <a href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block</a>

This PR extends MIME Types to be non-case sensitive for non-HTML Documents
matching Gecko and also remove related &apos;FIXME&apos;.

* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(isValidCSSContentType): Remove FIXME and update &apos;return&apos; as per commit
(InlineStyleSheetOwner::createSheet): Remove use of &apos;element&apos; parameter
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style_type_svg-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/266744@main">https://commits.webkit.org/266744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a740ac16054c3bbb57c84a94b7e7fb5e712eb8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16390 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14823 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17124 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13220 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1753 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->