### PR TITLE
Modernize remote scrolling coordinator code

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
-#include "ScrollingCoordinator.h"
 #include "ScrollingStateNode.h"
 #include <wtf/RefPtr.h>
  
@@ -101,7 +100,7 @@ private:
     bool isValid() const;
     void traverse(const ScrollingStateNode&, const Function<void(const ScrollingStateNode&)>&) const;
 
-    AsyncScrollingCoordinator* m_scrollingCoordinator;
+    ThreadSafeWeakPtr<AsyncScrollingCoordinator> m_scrollingCoordinator;
     // Contains all the nodes we know about (those in the m_rootStateNode tree, and in m_unparentedNodes subtrees).
     StateNodeMap m_stateNodeMap;
     // Owns roots of unparented subtrees.

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -503,6 +503,18 @@ bool ArgumentCoder<ScrollingStatePositionedNode>::decode(Decoder& decoder, Scrol
 
 namespace WebKit {
 
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching)
+    : m_scrollingStateTree(WTFMove(scrollingStateTree))
+    , m_clearScrollLatching(clearScrollLatching) { }
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&) = default;
+
+RemoteScrollingCoordinatorTransaction& RemoteScrollingCoordinatorTransaction::operator=(RemoteScrollingCoordinatorTransaction&&) = default;
+
+RemoteScrollingCoordinatorTransaction::~RemoteScrollingCoordinatorTransaction() = default;
+
 static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingStateNode& stateNode, int& encodedNodeCount)
 {
     ++encodedNodeCount;
@@ -561,53 +573,49 @@ void RemoteScrollingCoordinatorTransaction::encode(IPC::Encoder& encoder) const
         encoder << Vector<ScrollingNodeID>();
 }
 
-bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder, RemoteScrollingCoordinatorTransaction& transaction)
+auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std::optional<RemoteScrollingCoordinatorTransaction>
 {
-    return transaction.decode(decoder);
-}
-
-bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder)
-{
-    if (!decoder.decode(m_clearScrollLatching))
-        return false;
+    bool clearScrollLatching;
+    if (!decoder.decode(clearScrollLatching))
+        return std::nullopt;
 
     int numNodes;
     if (!decoder.decode(numNodes))
-        return false;
+        return std::nullopt;
 
     bool hasNewRootNode;
     if (!decoder.decode(hasNewRootNode))
-        return false;
+        return std::nullopt;
     
-    m_scrollingStateTree = makeUnique<ScrollingStateTree>();
+    auto scrollingStateTree = makeUnique<ScrollingStateTree>();
 
     bool hasChangedProperties;
     if (!decoder.decode(hasChangedProperties))
-        return false;
+        return std::nullopt;
 
-    m_scrollingStateTree->setHasChangedProperties(hasChangedProperties);
+    scrollingStateTree->setHasChangedProperties(hasChangedProperties);
 
     for (int i = 0; i < numNodes; ++i) {
         ScrollingNodeType nodeType;
         if (!decoder.decode(nodeType))
-            return false;
+            return std::nullopt;
 
         ScrollingNodeID nodeID;
         if (!decoder.decode(nodeID))
-            return false;
+            return std::nullopt;
 
         ScrollingNodeID parentNodeID;
         if (!decoder.decode(parentNodeID))
-            return false;
+            return std::nullopt;
 
-        auto createdNodeID = m_scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
+        auto createdNodeID = scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
         if (createdNodeID != nodeID)
-            return false;
+            return std::nullopt;
 
-        auto newNode = m_scrollingStateTree->stateNodeForID(nodeID);
+        auto newNode = scrollingStateTree->stateNodeForID(nodeID);
         ASSERT(newNode);
         if (newNode->nodeType() != nodeType)
-            return false;
+            return std::nullopt;
 
         ASSERT(!parentNodeID || newNode->parent());
         
@@ -615,38 +623,38 @@ bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder)
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe:
             if (!decoder.decode(downcast<ScrollingStateFrameScrollingNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         case ScrollingNodeType::FrameHosting:
             if (!decoder.decode(downcast<ScrollingStateFrameHostingNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         case ScrollingNodeType::Overflow:
             if (!decoder.decode(downcast<ScrollingStateOverflowScrollingNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         case ScrollingNodeType::OverflowProxy:
             if (!decoder.decode(downcast<ScrollingStateOverflowScrollProxyNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         case ScrollingNodeType::Fixed:
             if (!decoder.decode(downcast<ScrollingStateFixedNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         case ScrollingNodeType::Sticky:
             if (!decoder.decode(downcast<ScrollingStateStickyNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         case ScrollingNodeType::Positioned:
             if (!decoder.decode(downcast<ScrollingStatePositionedNode>(*newNode)))
-                return false;
+                return std::nullopt;
             break;
         }
     }
 
-    m_scrollingStateTree->setHasNewRootStateNode(hasNewRootNode);
+    scrollingStateTree->setHasNewRootStateNode(hasNewRootNode);
 
-    return true;
+    return { RemoteScrollingCoordinatorTransaction { WTFMove(scrollingStateTree), clearScrollLatching } };
 }
 
 #if !defined(NDEBUG) || !LOG_DISABLED

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -27,25 +27,31 @@
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 
-#include <WebCore/ScrollingStateTree.h>
-
 namespace IPC {
 class Decoder;
 class Encoder;
+}
+
+namespace WebCore {
+class ScrollingStateTree;
 }
 
 namespace WebKit {
 
 class RemoteScrollingCoordinatorTransaction {
 public:
-    void setStateTreeToEncode(std::unique_ptr<WebCore::ScrollingStateTree> stateTree) { m_scrollingStateTree = WTFMove(stateTree); }
+    RemoteScrollingCoordinatorTransaction();
+    RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&&, bool);
+    RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&);
+    RemoteScrollingCoordinatorTransaction& operator=(RemoteScrollingCoordinatorTransaction&&);
+    ~RemoteScrollingCoordinatorTransaction();
+
     std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() { return m_scrollingStateTree; }
 
     void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, RemoteScrollingCoordinatorTransaction&);
+    static std::optional<RemoteScrollingCoordinatorTransaction> decode(IPC::Decoder&);
 
     bool clearScrollLatching() const { return m_clearScrollLatching; }
-    void setClearScrollLatching(bool clearLatching) { m_clearScrollLatching = clearLatching; }
 
 #if !defined(NDEBUG) || !LOG_DISABLED
     String description() const;
@@ -53,8 +59,6 @@ public:
 #endif
 
 private:
-    WARN_UNUSED_RETURN bool decode(IPC::Decoder&);
-    
     std::unique_ptr<WebCore::ScrollingStateTree> m_scrollingStateTree;
     
     // Data encoded here should be "imperative" (valid just for one transaction). Stateful things should live on scrolling tree nodes.

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -377,7 +377,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
 #if ENABLE(ASYNC_SCROLLING)
         if (m_webPage.scrollingCoordinator())
-            downcast<RemoteScrollingCoordinator>(*m_webPage.scrollingCoordinator()).buildTransaction(scrollingTransaction);
+            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*m_webPage.scrollingCoordinator()).buildTransaction();
 #endif
         transactions.uncheckedAppend({ WTFMove(layerTransaction), WTFMove(scrollingTransaction) });
     }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -29,9 +29,6 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/AsyncScrollingCoordinator.h>
-#include <WebCore/ScrollTypes.h>
-#include <WebCore/ScrollingConstraints.h>
-#include <WebCore/Timer.h>
 
 namespace IPC {
 class Decoder;
@@ -51,7 +48,7 @@ public:
         return adoptRef(*new RemoteScrollingCoordinator(page));
     }
 
-    void buildTransaction(RemoteScrollingCoordinatorTransaction&);
+    RemoteScrollingCoordinatorTransaction buildTransaction();
 
     void scrollingStateInUIProcessChanged(const RemoteScrollingUIState&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -46,6 +46,7 @@
 #import <WebCore/RenderView.h>
 #import <WebCore/ScrollbarsController.h>
 #import <WebCore/ScrollingStateFrameScrollingNode.h>
+#import <WebCore/ScrollingStateTree.h>
 #import <WebCore/ScrollingTreeFixedNodeCocoa.h>
 #import <WebCore/ScrollingTreeStickyNodeCocoa.h>
 #import <WebCore/WheelEventTestMonitor.h>
@@ -102,12 +103,14 @@ void RemoteScrollingCoordinator::setScrollPinningBehavior(ScrollPinningBehavior)
     // FIXME: send to the UI process.
 }
 
-void RemoteScrollingCoordinator::buildTransaction(RemoteScrollingCoordinatorTransaction& transaction)
+RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransaction()
 {
     willCommitTree();
 
-    transaction.setClearScrollLatching(std::exchange(m_clearScrollLatchingInNextTransaction, false));
-    transaction.setStateTreeToEncode(scrollingStateTree()->commit(LayerRepresentation::PlatformLayerIDRepresentation));
+    return {
+        scrollingStateTree()->commit(LayerRepresentation::PlatformLayerIDRepresentation),
+        std::exchange(m_clearScrollLatchingInNextTransaction, false)
+    };
 }
 
 // Notification from the UI process that we scrolled.


### PR DESCRIPTION
#### 3a348283c6c0b9d2dca551b74e2d7a9ff00db420
<pre>
Modernize remote scrolling coordinator code
<a href="https://bugs.webkit.org/show_bug.cgi?id=259993">https://bugs.webkit.org/show_bug.cgi?id=259993</a>
rdar://113651997

Reviewed by Simon Fraser.

Remove some unnecessary headers including other headers.
Use ThreadSafeWeakPtr instead of storing a raw pointer.
Make RemoteScrollingCoordinatorTransaction::decode return std::optional.
Use return value instead of out-param in RemoteScrollingCoordinator::buildTransaction.

* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::setHasChangedProperties):
(WebCore::ScrollingStateTree::createUnparentedNode):
(WebCore::ScrollingStateTree::insertNode):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction):
(WebKit::RemoteScrollingCoordinatorTransaction::decode):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
(WebKit::RemoteScrollingCoordinatorTransaction::clearScrollLatching const):
(WebKit::RemoteScrollingCoordinatorTransaction::setStateTreeToEncode): Deleted.
(WebKit::RemoteScrollingCoordinatorTransaction::setClearScrollLatching): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::buildTransaction):

Canonical link: <a href="https://commits.webkit.org/266779@main">https://commits.webkit.org/266779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c293511c2c8ba590a73388c1bd59e13c7f6eb56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14637 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16474 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17119 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20210 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16609 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11787 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13215 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17553 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1766 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->