### PR TITLE
Externalize Timer::alignedFireTime

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -96,7 +96,7 @@ namespace IDBClient {
 class IDBConnectionProxy;
 }
 
-class ScriptExecutionContext : public SecurityContext, public CanMakeWeakPtr<ScriptExecutionContext>, public CanMakeCheckedPtr {
+class ScriptExecutionContext : public SecurityContext, public CanMakeCheckedPtr, public TimerAlignment {
 public:
     explicit ScriptExecutionContext(ScriptExecutionContextIdentifier = { });
     virtual ~ScriptExecutionContext();
@@ -250,6 +250,9 @@ public:
 
     void didChangeTimerAlignmentInterval();
     virtual Seconds domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) const;
+
+    // TimerAlignment
+    std::optional<MonotonicTime> alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const final;
 
     virtual EventTarget* errorEventTarget() = 0;
 

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -75,7 +75,6 @@ private:
     // SuspendableTimerBase
     void fired() override;
     void didStop() override;
-    WEBCORE_EXPORT std::optional<MonotonicTime> alignedFireTime(MonotonicTime) const override;
 
     // ActiveDOMObject API.
     const char* activeDOMObjectName() const override;

--- a/Source/WebCore/page/SuspendableTimer.h
+++ b/Source/WebCore/page/SuspendableTimer.h
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 // Do not use this class for new code. Use EventLoop's scheduleTask and scheduleRepeatingTask instead.
-class SuspendableTimerBase : private TimerBase, public ActiveDOMObject {
+class SuspendableTimerBase : public TimerBase, public ActiveDOMObject {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit SuspendableTimerBase(ScriptExecutionContext*);

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -478,8 +478,8 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
     // Keep heap valid while changing the next-fire time.
     MonotonicTime oldTime = nextFireTime();
     // Don't realign zero-delay timers.
-    if (newTime) {
-        if (auto newAlignedTime = alignedFireTime(newTime))
+    if (auto* alignment = m_alignment.get(); newTime && alignment) {
+        if (auto newAlignedTime = alignment->alignedFireTime(m_hasReachedMaxNestingLevel, newTime))
             newTime = newAlignedTime.value();
     }
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -41,6 +41,12 @@
 
 namespace WebCore {
 
+class TimerAlignment : public CanMakeWeakPtr<TimerAlignment> {
+public:
+    virtual ~TimerAlignment() = default;
+    virtual std::optional<MonotonicTime> alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime) const = 0;
+};
+
 class TimerBase {
     WTF_MAKE_NONCOPYABLE(TimerBase);
     WTF_MAKE_FAST_ALLOCATED;
@@ -64,6 +70,12 @@ public:
     Seconds nextUnalignedFireInterval() const;
     Seconds repeatInterval() const { return m_repeatInterval; }
 
+    void setTimerAlignment(TimerAlignment& alignment) { m_alignment = alignment; }
+    TimerAlignment* timerAlignment() { return m_alignment.get(); }
+
+    bool hasReachedMaxNestingLevel() const { return m_hasReachedMaxNestingLevel; }
+    void setHasReachedMaxNestingLevel(bool value) { m_hasReachedMaxNestingLevel = value; }
+
     void augmentFireInterval(Seconds delta) { setNextFireTime(m_heapItem->time + delta); }
     void augmentRepeatInterval(Seconds delta) { augmentFireInterval(delta); m_repeatInterval += delta; }
 
@@ -73,8 +85,6 @@ public:
 
 private:
     virtual void fired() = 0;
-
-    virtual std::optional<MonotonicTime> alignedFireTime(MonotonicTime) const { return std::nullopt; }
 
     void checkConsistency() const;
     void checkHeapIndex() const;
@@ -97,8 +107,10 @@ private:
 
     MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
 
+    WeakPtr<TimerAlignment> m_alignment;
     MonotonicTime m_unalignedNextFireTime; // m_nextFireTime not considering alignment interval
     Seconds m_repeatInterval; // 0 if not repeating
+    bool m_hasReachedMaxNestingLevel { false };
 
     RefPtr<ThreadTimerHeapItem> m_heapItem;
     Ref<Thread> m_thread { Thread::current() };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1432,7 +1432,11 @@ ExceptionOr<bool> Internals::isTimerThrottled(int timeoutId)
     if (timer->intervalClampedToMinimum() > timer->m_originalInterval)
         return true;
 
-    return !!timer->alignedFireTime(MonotonicTime { });
+    auto* alignment = timer->timerAlignment();
+    if (!alignment)
+        return false;
+
+    return !!alignment->alignedFireTime(timer->hasReachedMaxNestingLevel(), MonotonicTime { });
 }
 
 String Internals::requestAnimationFrameThrottlingReasons() const


### PR DESCRIPTION
#### cf15c62f09b9d24360ad457dc410559d1fcf7529
<pre>
Externalize Timer::alignedFireTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=259997">https://bugs.webkit.org/show_bug.cgi?id=259997</a>

Reviewed by Wenson Hsieh.

This PR replaces Timer::alignedFireTime with ScriptExecutionContext::alignedFireTime
with TimerAlignment abstract interface as a preparation to integrate DOM timers with
HTML5 event loop.

* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::DOMTimer):
(WebCore::DOMTimer::fired):
(WebCore::ScriptExecutionContext::alignedFireTime const):
(WebCore::DOMTimer::alignedFireTime const): Deleted.
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/SuspendableTimer.h:
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::setNextFireTime):
* Source/WebCore/platform/Timer.h:
(WebCore::TimerAlignment): Added.
(WebCore::TimerBase::setTimerAlignment):
(WebCore::TimerBase::timerAlignment):
(WebCore::TimerBase::hasReachedMaxNestingLevel const):
(WebCore::TimerBase::setHasReachedMaxNestingLevel):
(WebCore::TimerBase::alignedFireTime const): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isTimerThrottled):

Canonical link: <a href="https://commits.webkit.org/266751@main">https://commits.webkit.org/266751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b801c363e05855f4a281142e4c2327df9035bc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16414 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15059 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15355 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17148 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13230 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16646 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13948 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17580 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1758 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->