### PR TITLE
Simplify frame scheduling logic in RemoteLayerTreeDrawingArea.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -125,8 +125,13 @@ public:
     virtual void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) = 0;
     virtual void addRootFrame(WebCore::FrameIdentifier) { }
     // FIXME: Add a corresponding removeRootFrame.
+
+    // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;
+    // Cause a rendering update to happen at the next suitable time,
+    // as determined by the drawing area.
     virtual bool scheduleRenderingUpdate() { return false; }
+
     virtual void renderingUpdateFramesPerSecondChanged() { }
 
     virtual void willStartRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -56,12 +56,23 @@ public:
     TransactionID nextTransactionID() const { return m_currentTransactionID.next(); }
     TransactionID lastCommittedTransactionID() const { return m_currentTransactionID; }
 
-    bool displayDidRefreshIsPending() const { return m_waitingForBackingStoreSwap; }
-
 protected:
-    void updateRendering();
+    enum class ScheduleRenderingUrgency {
+        // FIXME: There are many consumers of this (and triggerRenderingUpdate), do they all actually need the ASAP behaviour?
+        AsSoonAsPossible,
+        NextSuitableTime,
+    };
+    void scheduleRenderingUpdate(ScheduleRenderingUrgency);
 
 private:
+    enum class State {
+        Idle,
+        WaitingForDisplayDidRefresh,
+        WaitingForUpdateRenderingTimer,
+        WaitingForCallOnMainRunLoop,
+        WaitingForScheduleRenderingTimer,
+    };
+
     // DrawingArea
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const WebCore::IntRect&) override;
@@ -71,8 +82,11 @@ private:
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void addRootFrame(WebCore::FrameIdentifier) final;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
+
+    void updateRendering();
+
     void renderingUpdateFramesPerSecondChanged() final;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
 
@@ -162,13 +176,12 @@ private:
 
     std::optional<WebCore::FloatRect> m_viewExposedRect;
 
+    State m_state { State::Idle };
+
     WebCore::Timer m_updateRenderingTimer;
     bool m_isRenderingSuspended { false };
     bool m_hasDeferredRenderingUpdate { false };
     bool m_inUpdateRendering { false };
-
-    bool m_waitingForBackingStoreSwap { false };
-    bool m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap { false };
 
     OSObjectPtr<dispatch_queue_t> m_commitQueue;
     RefPtr<BackingStoreFlusher> m_pendingBackingStoreFlusher;
@@ -182,7 +195,8 @@ private:
     WebCore::Timer m_scheduleRenderingTimer;
     std::optional<WebCore::FramesPerSecond> m_preferredFramesPerSecond;
     Seconds m_preferredRenderingUpdateInterval;
-    bool m_isScheduled { false };
+
+    bool m_updateRenderingIsPending { false };
 };
 
 inline bool RemoteLayerTreeDrawingArea::addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone> paintMilestones)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -146,7 +146,7 @@ void RemoteLayerTreeDrawingArea::setRootCompositingLayer(WebCore::Frame& frame, 
             rootLayer.contentLayer = rootGraphicsLayer;
     }
     updateRootLayers();
-    triggerRenderingUpdate();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight&, CompletionHandler<void()>&& completionHandler)
@@ -169,7 +169,7 @@ void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool fl
         size = contentSize;
     }
 
-    triggerRenderingUpdate();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
     completionHandler();
 }
 
@@ -223,7 +223,7 @@ void RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen(bool isFrozen)
 
     if (!m_isRenderingSuspended && m_hasDeferredRenderingUpdate) {
         m_hasDeferredRenderingUpdate = false;
-        startRenderingUpdateTimer();
+        scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
     }
 }
 
@@ -233,7 +233,7 @@ void RemoteLayerTreeDrawingArea::forceRepaint()
         return;
 
     m_webPage.corePage()->forceRepaintAllFrames();
-    updateRendering();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingArea::acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier layerID, const String& key, MonotonicTime startTime)
@@ -272,24 +272,23 @@ void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedC
         return;
 
     frameView->setExposedContentRect(exposedContentRect);
-    triggerRenderingUpdate();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingArea::startRenderingUpdateTimer()
 {
-    if (m_updateRenderingTimer.isActive())
+    RELEASE_ASSERT(m_state != State::WaitingForDisplayDidRefresh);
+    if (m_updateRenderingTimer.isActive()) {
+        RELEASE_ASSERT(m_state == State::WaitingForUpdateRenderingTimer);
         return;
+    }
+    m_state = State::WaitingForUpdateRenderingTimer;
     m_updateRenderingTimer.startOneShot(0_s);
 }
 
 void RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
 {
-    if (m_isRenderingSuspended) {
-        m_hasDeferredRenderingUpdate = true;
-        return;
-    }
-
-    startRenderingUpdateTimer();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageDecoding()
@@ -299,22 +298,23 @@ void RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageD
 
 void RemoteLayerTreeDrawingArea::updateRendering()
 {
+    RELEASE_ASSERT(m_updateRenderingIsPending);
+    RELEASE_ASSERT(m_state == State::WaitingForUpdateRenderingTimer);
+    m_updateRenderingIsPending = false;
+
     if (m_isRenderingSuspended) {
         m_hasDeferredRenderingUpdate = true;
         return;
     }
 
-    if (m_waitingForBackingStoreSwap) {
-        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
-        return;
-    }
-
     // This function is not reentrant, e.g. a rAF callback may force repaint.
-    if (m_inUpdateRendering)
-        return;
+    RELEASE_ASSERT(!m_inUpdateRendering);
 
     if (auto* page = m_webPage.corePage(); page && !page->rootFrames().computeSize())
         return;
+
+    RELEASE_ASSERT(!m_updateRenderingTimer.isActive());
+    m_state = State::WaitingForDisplayDidRefresh;
 
     scaleViewToFitDocumentIfNeeded();
 
@@ -369,9 +369,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         layerTransaction.setActivityStateChangeID(std::exchange(m_activityStateChangeID, ActivityStateChangeAsynchronous));
         
         willCommitLayerTree(layerTransaction);
-        
-        m_waitingForBackingStoreSwap = true;
-        
+
         send(Messages::RemoteLayerTreeDrawingAreaProxy::WillCommitLayerTree(layerTransaction.transactionID()));
 
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
@@ -422,7 +420,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
     // FIXME: This should use a counted replacement for setLayerTreeStateIsFrozen, but
     // the callers of that function are not strictly paired.
 
-    auto wasWaitingForBackingStoreSwap = std::exchange(m_waitingForBackingStoreSwap, false);
+    RELEASE_ASSERT(m_state == State::WaitingForDisplayDidRefresh);
 
     if (!WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM)) {
         // This empty transaction serves to trigger CA's garbage collection of IOSurfaces. See <rdar://problem/16110687>
@@ -430,12 +428,10 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
         [CATransaction commit];
     }
 
-    if (m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap || (m_isScheduled && !m_scheduleRenderingTimer.isActive())) {
-        triggerRenderingUpdate();
-        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
-        m_isScheduled = false;
-    } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
-        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
+    m_state = State::Idle;
+    RELEASE_ASSERT(!m_updateRenderingTimer.isActive());
+    if (m_updateRenderingIsPending && !m_scheduleRenderingTimer.isActive())
+        startRenderingUpdateTimer();
     else
         send(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTreeNotTriggered(nextTransactionID()));
 }
@@ -497,7 +493,7 @@ void RemoteLayerTreeDrawingArea::activityStateDidChange(OptionSet<WebCore::Activ
     if (activityStateChangeID != ActivityStateChangeAsynchronous) {
         m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding();
         m_activityStateChangeID = activityStateChangeID;
-        startRenderingUpdateTimer();
+        scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
     }
 
     // FIXME: We may want to match behavior in TiledCoreAnimationDrawingArea by firing these callbacks after the next compositing flush, rather than immediately after
@@ -512,7 +508,7 @@ void RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing(IPC::AsyncReplyID 
     m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding();
 
     m_pendingCallbackIDs.append(callbackID);
-    triggerRenderingUpdate();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDrawingArea)
@@ -526,32 +522,45 @@ void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDraw
 
 void RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired()
 {
-    triggerRenderingUpdate();
-    m_isScheduled = false;
+    if (m_state == State::WaitingForScheduleRenderingTimer)
+        startRenderingUpdateTimer();
+}
+
+void RemoteLayerTreeDrawingArea::scheduleRenderingUpdate(ScheduleRenderingUrgency urgency)
+{
+    if (m_updateRenderingIsPending && urgency != ScheduleRenderingUrgency::AsSoonAsPossible)
+        return;
+
+    tracePoint(RemoteLayerTreeScheduleRenderingUpdate, m_state == State::WaitingForDisplayDidRefresh);
+
+    m_updateRenderingIsPending = true;
+
+    if (m_preferredFramesPerSecond) {
+        if (m_state == State::WaitingForDisplayDidRefresh)
+            return;
+
+        if (urgency == ScheduleRenderingUrgency::AsSoonAsPossible)
+            startRenderingUpdateTimer();
+        else {
+            m_state = State::WaitingForCallOnMainRunLoop;
+            callOnMainRunLoop([self = WeakPtr { this }] () {
+                // It's possible that an ASAP request got ahead of this
+                // and started a rendering update already and we're no
+                // longer waiting for this callback.
+                if (self && self->m_state == State::WaitingForCallOnMainRunLoop)
+                    self->startRenderingUpdateTimer();
+            });
+        }
+    } else if (m_state == State::Idle || m_state == State::WaitingForDisplayDidRefresh) {
+        ASSERT(!m_scheduleRenderingTimer.isActive());
+        m_state = State::WaitingForScheduleRenderingTimer;
+        m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);
+    }
 }
 
 bool RemoteLayerTreeDrawingArea::scheduleRenderingUpdate()
 {
-    if (m_isScheduled)
-        return true;
-
-    tracePoint(RemoteLayerTreeScheduleRenderingUpdate, m_waitingForBackingStoreSwap);
-
-    m_isScheduled = true;
-
-    if (m_preferredFramesPerSecond) {
-        if (displayDidRefreshIsPending())
-            return true;
-
-        callOnMainRunLoop([self = WeakPtr { this }] () {
-            if (self) {
-                self->m_isScheduled = false;
-                self->triggerRenderingUpdate();
-            }
-        });
-    } else
-        m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);
-
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::NextSuitableTime);
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -79,7 +79,7 @@ void RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage(double scale, Float
     FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     unscrolledOrigin.moveBy(-unobscuredContentRect.location());
     m_webPage.scalePage(scale / m_webPage.viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
-    updateRendering();
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::FloatPoint origin)


### PR DESCRIPTION
#### 7dd240a390141ca50bf9be4a02b27bb05df91556
<pre>
Simplify frame scheduling logic in RemoteLayerTreeDrawingArea.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259999">https://bugs.webkit.org/show_bug.cgi?id=259999</a>
&lt;rdar://113657855&gt;

Reviewed by Simon Fraser.

Previously, both scheduleRenderingUpdate and external calls to triggerRenderingUpdate would wait for the next displayDidRefresh
if one was pending. scheduleRenderingUpdate would check for this explicitly at call time. TriggerRenderingUpdate would
always run updateRendering on a 0ms timer, and then check at that point and reschedule (by setting m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap=true).

This reverses the logic of triggerRenderingUpdate to be the same as scheduleRenderingUpdate by making them use the same code (a new scheduleRenderingUpdate function
with an enum to specify the exact behaviour). In very rare cases this could be a behaviour change (since we&apos;re checking state at a different point).

The difference between these two is now more clear, in the case where there isn&apos;t a displayDidRefresh pending, schedule has an extra async task dispatch that trigger
does not. This difference affects performance benchmark results, so trying to remove it is outside the scope of this patch.

It should now never be possible for displayDidRefresh to be pending when updateRendering is called, so m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap is removed.
Setting of m_displayDidRefreshIsPending=true happens earlier, since we can sometimes recurse back in to trigger rendering during a rendering update.

Existing internal callers of triggerRenderingUpdate (and startRenderingUpdateTimer) have been changed to use the enum version of scheduleRenderingUpdate to make it clearer. Most
of these are using the as soon as possible variant, but almost certainly don&apos;t need to and could be changed.

The two call sites that synchronously called updateRendering have also been changed to scheduleRenderingUpdate(AsSoonAsPossible). These likely weren&apos;t synchronous previously (since
updateRendering aborted and rescheduled if displayDidRefresh was pending), but it was non-deterministic. Making them always just schedule seems a lot safer and easier to understand.

Renames m_waitingForBackingStoreSwap to m_displayDidRefreshIsPending since that&apos;s the name of the message
we&apos;re actually waiting for.

The logic in ::displayDidRefresh cleaned up in response to the above changes, since most of the complexity it checked for no longer exists.

* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefreshIsPending const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer):
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::RemoteLayerTreeDrawingArea::forceRepaint):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):

Canonical link: <a href="https://commits.webkit.org/266884@main">https://commits.webkit.org/266884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/314e3152d024892f932a5ac9199f8bdcfe114405

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13955 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16594 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17308 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12777 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16780 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11907 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13382 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3622 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->