### PR TITLE
Basic support for SVGImageElement in createImageBitmap

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_svg_image_1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_svg_image_1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Load a 100x100 image to a SVG image and draw it to a 100x100 canvas. assert_equals: Red channel of the pixel at (0, 0) expected 253 but got 255
+PASS Load a 100x100 image to a SVG image and draw it to a 100x100 canvas.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage-expected.txt
@@ -24,16 +24,16 @@ PASS createImageBitmap from a vector HTMLImageElement scaled down, and drawImage
 PASS createImageBitmap from a vector HTMLImageElement scaled up, and drawImage on the created ImageBitmap
 PASS createImageBitmap from a vector HTMLImageElement resized, and drawImage on the created ImageBitmap
 PASS createImageBitmap from a vector HTMLImageElement with negative sw/sh, and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a bitmap SVGImageElement, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement scaled down, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement scaled up, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement resized, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement with negative sw/sh, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement scaled down, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement scaled up, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement resized, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement with negative sw/sh, and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a bitmap SVGImageElement, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement scaled down, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement scaled up, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement resized, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a bitmap SVGImageElement with negative sw/sh, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement scaled down, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement scaled up, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement resized, and drawImage on the created ImageBitmap
+PASS createImageBitmap from a vector SVGImageElement with negative sw/sh, and drawImage on the created ImageBitmap
 PASS createImageBitmap from an OffscreenCanvas, and drawImage on the created ImageBitmap
 PASS createImageBitmap from an OffscreenCanvas scaled down, and drawImage on the created ImageBitmap
 PASS createImageBitmap from an OffscreenCanvas scaled up, and drawImage on the created ImageBitmap

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
@@ -10,9 +10,9 @@ PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "flipY",
 PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 FAIL createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 3 but got 255
 FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
 FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 3 but got 255
 FAIL createImageBitmap from an OffscreenCanvas imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS createImageBitmap from an OffscreenCanvas imageOrientation: "flipY", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageData imageOrientation: "from-image", and drawImage on the created ImageBitmap

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args-expected.txt
@@ -34,28 +34,20 @@ PASS createImageBitmap with a vector HTMLImageElement source and a value of 0 in
 PASS createImageBitmap with a vector HTMLImageElement source and a value of 0 in resizeHeight
 PASS createImageBitmap with a vector HTMLImageElement source and a value between 0 and 1 in resizeWidth
 PASS createImageBitmap with a vector HTMLImageElement source and a value between 0 and 1 in resizeHeight
-FAIL createImageBitmap with a bitmap SVGImageElement source and sw set to 0 promise_rejects_js: function "function() { throw e }" threw object "TypeError: Type error" ("TypeError") expected instance of function "function RangeError() {
-    [native code]
-}" ("RangeError")
-FAIL createImageBitmap with a bitmap SVGImageElement source and sh set to 0 promise_rejects_js: function "function() { throw e }" threw object "TypeError: Type error" ("TypeError") expected instance of function "function RangeError() {
-    [native code]
-}" ("RangeError")
-FAIL createImageBitmap with a bitmap SVGImageElement source and oversized (unallocatable) crop region assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a bitmap SVGImageElement source and a value of 0 int resizeWidth assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a bitmap SVGImageElement source and a value of 0 in resizeHeight assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a bitmap SVGImageElement source and a value between 0 and 1 in resizeWidth assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a bitmap SVGImageElement source and a value between 0 and 1 in resizeHeight assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a vector SVGImageElement source and sw set to 0 promise_rejects_js: function "function() { throw e }" threw object "TypeError: Type error" ("TypeError") expected instance of function "function RangeError() {
-    [native code]
-}" ("RangeError")
-FAIL createImageBitmap with a vector SVGImageElement source and sh set to 0 promise_rejects_js: function "function() { throw e }" threw object "TypeError: Type error" ("TypeError") expected instance of function "function RangeError() {
-    [native code]
-}" ("RangeError")
-FAIL createImageBitmap with a vector SVGImageElement source and oversized (unallocatable) crop region assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a vector SVGImageElement source and a value of 0 int resizeWidth assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a vector SVGImageElement source and a value of 0 in resizeHeight assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a vector SVGImageElement source and a value between 0 and 1 in resizeWidth assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap with a vector SVGImageElement source and a value between 0 and 1 in resizeHeight assert_throws_dom: function "() => { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+PASS createImageBitmap with a bitmap SVGImageElement source and sw set to 0
+PASS createImageBitmap with a bitmap SVGImageElement source and sh set to 0
+FAIL createImageBitmap with a bitmap SVGImageElement source and oversized (unallocatable) crop region assert_equals: expected 100000000 but got 20
+PASS createImageBitmap with a bitmap SVGImageElement source and a value of 0 int resizeWidth
+PASS createImageBitmap with a bitmap SVGImageElement source and a value of 0 in resizeHeight
+PASS createImageBitmap with a bitmap SVGImageElement source and a value between 0 and 1 in resizeWidth
+PASS createImageBitmap with a bitmap SVGImageElement source and a value between 0 and 1 in resizeHeight
+PASS createImageBitmap with a vector SVGImageElement source and sw set to 0
+PASS createImageBitmap with a vector SVGImageElement source and sh set to 0
+FAIL createImageBitmap with a vector SVGImageElement source and oversized (unallocatable) crop region assert_equals: expected 100000000 but got 20
+PASS createImageBitmap with a vector SVGImageElement source and a value of 0 int resizeWidth
+PASS createImageBitmap with a vector SVGImageElement source and a value of 0 in resizeHeight
+PASS createImageBitmap with a vector SVGImageElement source and a value between 0 and 1 in resizeWidth
+PASS createImageBitmap with a vector SVGImageElement source and a value between 0 and 1 in resizeHeight
 PASS createImageBitmap with an OffscreenCanvas source and sw set to 0
 PASS createImageBitmap with an OffscreenCanvas source and sh set to 0
 FAIL createImageBitmap with an OffscreenCanvas source and oversized (unallocatable) crop region assert_equals: expected 100000000 but got 20

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub-expected.txt
@@ -4,13 +4,14 @@ CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has bee
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 
 PASS cross-origin HTMLImageElement: origin unclear getImageData
 PASS cross-origin HTMLImageElement: origin unclear 2dContext.drawImage
 PASS cross-origin HTMLImageElement: origin unclear bitmaprenderer.transferFromImageBitmap
-FAIL cross-origin SVGImageElement: origin unclear getImageData promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL cross-origin SVGImageElement: origin unclear 2dContext.drawImage promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL cross-origin SVGImageElement: origin unclear bitmaprenderer.transferFromImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS cross-origin SVGImageElement: origin unclear getImageData
+PASS cross-origin SVGImageElement: origin unclear 2dContext.drawImage
+PASS cross-origin SVGImageElement: origin unclear bitmaprenderer.transferFromImageBitmap
 PASS cross-origin HTMLVideoElement: origin unclear getImageData
 PASS cross-origin HTMLVideoElement: origin unclear 2dContext.drawImage
 PASS cross-origin HTMLVideoElement: origin unclear bitmaprenderer.transferFromImageBitmap

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
@@ -4,8 +4,8 @@ PASS Serialize ImageBitmap created from an HTMLVideoElement
 PASS Serialize ImageBitmap created from an HTMLVideoElement from a data URL
 PASS Serialize ImageBitmap created from a bitmap HTMLImageElement
 PASS Serialize ImageBitmap created from a vector HTMLImageElement
-FAIL Serialize ImageBitmap created from a bitmap SVGImageElement promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Serialize ImageBitmap created from a vector SVGImageElement promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Serialize ImageBitmap created from a bitmap SVGImageElement
+PASS Serialize ImageBitmap created from a vector SVGImageElement
 PASS Serialize ImageBitmap created from an OffscreenCanvas
 PASS Serialize ImageBitmap created from an ImageData
 PASS Serialize ImageBitmap created from an ImageBitmap

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
@@ -4,8 +4,8 @@ PASS Transfer ImageBitmap created from an HTMLVideoElement
 PASS Transfer ImageBitmap created from an HTMLVideoElement from a data URL
 PASS Transfer ImageBitmap created from a bitmap HTMLImageElement
 PASS Transfer ImageBitmap created from a vector HTMLImageElement
-FAIL Transfer ImageBitmap created from a bitmap SVGImageElement promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Transfer ImageBitmap created from a vector SVGImageElement promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Transfer ImageBitmap created from a bitmap SVGImageElement
+PASS Transfer ImageBitmap created from a vector SVGImageElement
 PASS Transfer ImageBitmap created from an OffscreenCanvas
 PASS Transfer ImageBitmap created from an ImageData
 PASS Transfer ImageBitmap created from an ImageBitmap

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt
@@ -10,18 +10,20 @@ CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has bee
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
 Setting fillStyle to a pattern of an unclean canvas makes the canvas origin-unclean
 
 
 PASS cross-origin HTMLImageElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
-FAIL cross-origin SVGImageElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean assert_throws_dom: function "function() { canvas.toDataURL(); }" did not throw
+PASS cross-origin SVGImageElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS unclean HTMLCanvasElement: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS unclean ImageBitmap: Setting fillStyle to an origin-unclean pattern makes the canvas origin-unclean
 PASS cross-origin HTMLImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
-FAIL cross-origin SVGImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean assert_throws_dom: function "function() { canvas.toDataURL(); }" did not throw
+PASS cross-origin SVGImageElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 PASS cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 PASS redirected to cross-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean
 PASS redirected to same-origin HTMLVideoElement: Setting fillStyle to an origin-unclean offscreen canvas pattern makes the canvas origin-unclean

--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.idl
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.idl
@@ -31,6 +31,7 @@ typedef (HTMLImageElement
     or HTMLVideoElement
 #endif
     or HTMLCanvasElement
+    or SVGImageElement
     or ImageBitmap
 #if defined(ENABLE_OFFSCREEN_CANVAS) && ENABLE_OFFSCREEN_CANVAS
     or OffscreenCanvas

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.idl
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.idl
@@ -31,6 +31,7 @@ typedef (HTMLImageElement
     or HTMLVideoElement
 #endif
     or HTMLCanvasElement
+    or SVGImageElement
     or ImageBitmap
 #if defined(ENABLE_OFFSCREEN_CANVAS) && ENABLE_OFFSCREEN_CANVAS
     or OffscreenCanvas

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.idl
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.idl
@@ -31,6 +31,7 @@ typedef (HTMLImageElement
     or HTMLVideoElement
 #endif
     or HTMLCanvasElement
+    or SVGImageElement
     or ImageBitmap
 #if defined(ENABLE_OFFSCREEN_CANVAS) && ENABLE_OFFSCREEN_CANVAS
     or OffscreenCanvas

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -41,6 +41,7 @@ using JSC::ArrayBuffer;
 namespace WebCore {
 
 class Blob;
+class CachedImage;
 class CanvasBase;
 class CSSStyleImageValue;
 class HTMLCanvasElement;
@@ -54,7 +55,9 @@ class IntSize;
 class OffscreenCanvas;
 #endif
 class PendingImageBitmap;
+class RenderElement;
 class ScriptExecutionContext;
+class SVGImageElement;
 #if ENABLE(WEB_CODECS)
 class WebCodecsVideoFrame;
 #endif
@@ -72,6 +75,7 @@ public:
         RefPtr<HTMLVideoElement>,
 #endif
         RefPtr<HTMLCanvasElement>,
+        RefPtr<SVGImageElement>,
         RefPtr<ImageBitmap>,
 #if ENABLE(OFFSCREEN_CANVAS)
         RefPtr<OffscreenCanvas>,
@@ -129,6 +133,8 @@ private:
     static Ref<ImageBitmap> createBlankImageBuffer(ScriptExecutionContext&, bool originClean);
 
     static void createCompletionHandler(ScriptExecutionContext&, RefPtr<HTMLImageElement>&, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
+    static void createCompletionHandler(ScriptExecutionContext&, RefPtr<SVGImageElement>&, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
+    static void createCompletionHandler(ScriptExecutionContext&, CachedImage*, RenderElement*, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
 #if ENABLE(VIDEO)
     static void createCompletionHandler(ScriptExecutionContext&, RefPtr<HTMLVideoElement>&, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
 #endif

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.idl
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.idl
@@ -31,6 +31,7 @@ typedef (HTMLImageElement
     or HTMLVideoElement
 #endif
     or HTMLCanvasElement
+    or SVGImageElement
     or ImageBitmap
 #if defined(ENABLE_OFFSCREEN_CANVAS) && ENABLE_OFFSCREEN_CANVAS
     or OffscreenCanvas

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -64,20 +64,7 @@ Ref<SVGImageElement> SVGImageElement::create(const QualifiedName& tagName, Docum
 
 CachedImage* SVGImageElement::cachedImage() const
 {
-    const RenderImageResource* resource = nullptr;
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* renderer = dynamicDowncast<RenderSVGImage>(this->renderer()); renderer && renderer->imageResource().cachedImage())
-        resource = &renderer->imageResource();
-#endif
-    if (!resource) {
-        if (auto* renderer = dynamicDowncast<LegacyRenderSVGImage>(this->renderer()); renderer && renderer->imageResource().cachedImage())
-            resource = &renderer->imageResource();
-    }
-
-    if (!resource)
-        return nullptr;
-
-    return resource->cachedImage();
+    return m_imageLoader.image();
 }
 
 bool SVGImageElement::renderingTaintsOrigin() const


### PR DESCRIPTION
#### 7873a1e800d01e459f642ebba2a8044d587ec867
<pre>
Basic support for SVGImageElement in createImageBitmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=260000">https://bugs.webkit.org/show_bug.cgi?id=260000</a>

Reviewed by Said Abou-Hallawa.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-images-to-the-canvas/drawimage_svg_image_1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-origin.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub-expected.txt:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.idl:
* Source/WebCore/Modules/ShapeDetection/FaceDetector.idl:
* Source/WebCore/Modules/ShapeDetection/TextDetector.idl:
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createCompletionHandler):
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/page/WindowOrWorkerGlobalScope.idl:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::cachedImage const):

Canonical link: <a href="https://commits.webkit.org/267218@main">https://commits.webkit.org/267218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3957c9bf6b3d2c616462f12f3fde3057d9be51fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17441 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18490 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21300 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14863 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14598 "5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17842 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14433 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3818 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->