### PR TITLE
[macOS] Remove linen texture when zoomed or rubber banding

### DIFF
--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -90,11 +90,6 @@ public:
     virtual void paintTickmarks(GraphicsContext&, Scrollbar&, const IntRect&) { }
     virtual void paintOverhangAreas(ScrollView&, GraphicsContext&, const IntRect&, const IntRect&, const IntRect&) { }
 
-#if HAVE(RUBBER_BANDING)
-    virtual void setUpOverhangAreasLayerContents(GraphicsLayer*, const Color&) { }
-    virtual void setUpContentShadowLayer(GraphicsLayer*) { }
-#endif
-
     virtual ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart);
     virtual bool shouldSnapBackToDragOrigin(Scrollbar&, const PlatformMouseEvent&) { return false; }
     virtual bool shouldDragDocumentInsteadOfThumb(Scrollbar&, const PlatformMouseEvent&) { return false; }

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -1033,7 +1033,6 @@ TextStream& operator<<(TextStream& ts, const GraphicsLayer::CustomAppearance& cu
 {
     switch (customAppearance) {
     case GraphicsLayer::CustomAppearance::None: ts << "none"; break;
-    case GraphicsLayer::CustomAppearance::ScrollingOverhang: ts << "scrolling-overhang"; break;
     case GraphicsLayer::CustomAppearance::ScrollingShadow: ts << "scrolling-shadow"; break;
     }
     return ts;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -593,7 +593,6 @@ public:
 
     enum class CustomAppearance : uint8_t {
         None,
-        ScrollingOverhang,
         ScrollingShadow
     };
     virtual void setCustomAppearance(CustomAppearance customAppearance) { m_customAppearance = customAppearance; }
@@ -850,7 +849,6 @@ template<> struct EnumTraits<WebCore::GraphicsLayer::CustomAppearance> {
     using values = EnumValues<
         WebCore::GraphicsLayer::CustomAppearance,
         WebCore::GraphicsLayer::CustomAppearance::None,
-        WebCore::GraphicsLayer::CustomAppearance::ScrollingOverhang,
         WebCore::GraphicsLayer::CustomAppearance::ScrollingShadow
     >;
 };

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1064,11 +1064,7 @@ void PlatformCALayerCocoa::updateCustomAppearance(GraphicsLayer::CustomAppearanc
 #if HAVE(RUBBER_BANDING)
     switch (appearance) {
     case GraphicsLayer::CustomAppearance::None:
-        ScrollbarThemeMac::removeOverhangAreaBackground(platformLayer());
         ScrollbarThemeMac::removeOverhangAreaShadow(platformLayer());
-        break;
-    case GraphicsLayer::CustomAppearance::ScrollingOverhang:
-        ScrollbarThemeMac::setUpOverhangAreaBackground(platformLayer());
         break;
     case GraphicsLayer::CustomAppearance::ScrollingShadow:
         ScrollbarThemeMac::setUpOverhangAreaShadow(platformLayer());

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -72,9 +72,6 @@ public:
     bool isLayoutDirectionRTL(Scrollbar&);
 
 #if HAVE(RUBBER_BANDING)
-    WEBCORE_EXPORT static void setUpOverhangAreaBackground(CALayer *, const Color& customBackgroundColor = Color());
-    WEBCORE_EXPORT static void removeOverhangAreaBackground(CALayer *);
-
     WEBCORE_EXPORT static void setUpOverhangAreaShadow(CALayer *);
     WEBCORE_EXPORT static void removeOverhangAreaShadow(CALayer *);
 #endif
@@ -94,11 +91,6 @@ protected:
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
     bool shouldDragDocumentInsteadOfThumb(Scrollbar&, const PlatformMouseEvent&) override;
     int scrollbarPartToHIPressedState(ScrollbarPart);
-
-#if HAVE(RUBBER_BANDING)
-    void setUpOverhangAreasLayerContents(GraphicsLayer*, const Color&) override;
-    void setUpContentShadowLayer(GraphicsLayer*) override;
-#endif
 };
 
 }

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -68,10 +68,6 @@ using WebCore::ScrollbarThemeMac;
 using WebCore::scrollbarMap;
 using WebCore::ScrollbarToScrollerImpMap;
 
-@interface NSColor (WebNSColorDetails)
-+ (NSImage *)_linenPatternImage;
-@end
-
 @interface WebScrollbarPrefsObserver : NSObject
 {
 }
@@ -585,38 +581,6 @@ void ScrollbarThemeMac::paintScrollCorner(ScrollableArea& area, GraphicsContext&
 }
 
 #if HAVE(RUBBER_BANDING)
-static RetainPtr<CGColorRef> linenBackgroundColor()
-{
-    NSImage *image = nil;
-    CGImageRef cgImage = nullptr;
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-    image = [NSColor _linenPatternImage];
-    cgImage = [image CGImageForProposedRect:NULL context:NULL hints:nil];
-    END_BLOCK_OBJC_EXCEPTIONS
-    
-    if (!cgImage)
-        return nullptr;
-
-    RetainPtr<CGPatternRef> pattern = adoptCF(CGPatternCreateWithImage2(cgImage, CGAffineTransformIdentity, kCGPatternTilingNoDistortion));
-    RetainPtr<CGColorSpaceRef> colorSpace = adoptCF(CGColorSpaceCreatePattern(0));
-
-    const CGFloat alpha = 1.0;
-    return adoptCF(CGColorCreateWithPattern(colorSpace.get(), pattern.get(), &alpha));
-}
-
-void ScrollbarThemeMac::setUpOverhangAreaBackground(CALayer *layer, const Color& customBackgroundColor)
-{
-    static CGColorRef cachedLinenBackgroundColor = linenBackgroundColor().leakRef();
-    // We operate on the CALayer directly here, since GraphicsLayer doesn't have the concept
-    // of pattern images, and we know that WebCore won't touch this layer.
-    layer.backgroundColor = customBackgroundColor.isValid() ? cachedCGColor(customBackgroundColor).get() : cachedLinenBackgroundColor;
-}
-
-void ScrollbarThemeMac::removeOverhangAreaBackground(CALayer *layer)
-{
-    layer.backgroundColor = nil;
-}
-
 void ScrollbarThemeMac::setUpOverhangAreaShadow(CALayer *layer)
 {
     static const CGFloat shadowOpacity = 0.66;
@@ -638,18 +602,6 @@ void ScrollbarThemeMac::removeOverhangAreaShadow(CALayer *layer)
 {
     layer.shadowPath = nil;
     layer.shadowOpacity = 0;
-}
-
-void ScrollbarThemeMac::setUpOverhangAreasLayerContents(GraphicsLayer* graphicsLayer, const Color& customBackgroundColor)
-{
-    ScrollbarThemeMac::setUpOverhangAreaBackground(graphicsLayer->platformLayer(), customBackgroundColor);
-}
-
-void ScrollbarThemeMac::setUpContentShadowLayer(GraphicsLayer* graphicsLayer)
-{
-    // We operate on the CALayer directly here, since GraphicsLayer doesn't have the concept
-    // of shadows, and we know that WebCore won't touch this layer.
-    setUpOverhangAreaShadow(graphicsLayer->platformLayer());
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4157,9 +4157,6 @@ void RenderLayerCompositor::updateLayerForOverhangAreasBackgroundColor()
         })();
         m_layerForOverhangAreas->setBackgroundColor(backgroundColor);
     }
-
-    if (!backgroundColor.isValid())
-        m_layerForOverhangAreas->setCustomAppearance(GraphicsLayer::CustomAppearance::ScrollingOverhang);
 }
 
 #endif // HAVE(RUBBER_BANDING)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -134,11 +134,7 @@ static void updateCustomAppearance(CALayer *layer, GraphicsLayer::CustomAppearan
 #if HAVE(RUBBER_BANDING)
     switch (customAppearance) {
     case GraphicsLayer::CustomAppearance::None:
-        ScrollbarThemeMac::removeOverhangAreaBackground(layer);
         ScrollbarThemeMac::removeOverhangAreaShadow(layer);
-        break;
-    case GraphicsLayer::CustomAppearance::ScrollingOverhang:
-        ScrollbarThemeMac::setUpOverhangAreaBackground(layer);
         break;
     case GraphicsLayer::CustomAppearance::ScrollingShadow:
         ScrollbarThemeMac::setUpOverhangAreaShadow(layer);


### PR DESCRIPTION
#### b0c474278a21a86b9016c195b12a99c53bd6c45f
<pre>
[macOS] Remove linen texture when zoomed or rubber banding
<a href="https://bugs.webkit.org/show_bug.cgi?id=260002">https://bugs.webkit.org/show_bug.cgi?id=260002</a>
rdar://113648503

Reviewed by Simon Fraser.

When running on OS X Mavericks 10.9 and earlier, web views used to draw a gray linen texture when zoomed out or
rubber banding. This design has been replaced with a flat color since the OS X Yosemite 10.10, but we continue
to draw the linen texture, only to have it covered by an opaque foreground layer.

In popup windows, this linen texture may unexpectedly become visible in some circumstances on macOS Sonoma. To
reduce resource usage and remove a source of layout bugs, drop the linen texture implementation completely.

* Source/WebCore/platform/ScrollbarTheme.h:
(WebCore::ScrollbarTheme::setUpOverhangAreasLayerContents): Deleted.
(WebCore::ScrollbarTheme::setUpContentShadowLayer): Deleted.
Removed since these are no longer used on supported versions of macOS.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::operator&lt;&lt;):
Remove the ScrollingOverhang appearance since we no longer need to draw any linen.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
Same as above.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::updateCustomAppearance):
Do not set up or remove the linen overhang area background.

* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::linenBackgroundColor): Deleted.
(WebCore::ScrollbarThemeMac::setUpOverhangAreaBackground): Deleted.
(WebCore::ScrollbarThemeMac::removeOverhangAreaBackground): Deleted.
(WebCore::ScrollbarThemeMac::setUpOverhangAreasLayerContents): Deleted.
(WebCore::ScrollbarThemeMac::setUpContentShadowLayer): Deleted.
Remove code to set up and update the linen overhang area background.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateLayerForOverhangAreasBackgroundColor):
Stop setting a custom linen appearance for the overhang area.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::updateCustomAppearance):
Do not set up or remove the linen overhang area background.

Canonical link: <a href="https://commits.webkit.org/266752@main">https://commits.webkit.org/266752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/013b06406a53d03deb7d4698137c06e7590a9c13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16412 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13845 "Failed to checkout and rebase branch from PR 16545") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15057 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17146 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20233 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16634 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13946 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13241 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3532 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->