### PR TITLE
Add support for "from-image" to ImageBitmapOptions.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL createImageBitmap from an HTMLCanvasElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLCanvasElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from an HTMLVideoElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from an HTMLVideoElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLVideoElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an HTMLVideoElement from a data URL imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a bitmap HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a bitmap HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a vector HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a vector HTMLImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap
 FAIL createImageBitmap from a vector HTMLImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 3 but got 255
 FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
@@ -15,10 +15,10 @@ FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "from-ima
 FAIL createImageBitmap from a vector SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL createImageBitmap from an OffscreenCanvas imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS createImageBitmap from an OffscreenCanvas imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from an ImageData imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from an ImageData imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageData imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from an ImageBitmap imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from an ImageBitmap imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from an ImageBitmap imageOrientation: "flipY", and drawImage on the created ImageBitmap
-FAIL createImageBitmap from a Blob imageOrientation: "from-image", and drawImage on the created ImageBitmap promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap from a Blob imageOrientation: "from-image", and drawImage on the created ImageBitmap
 PASS createImageBitmap from a Blob imageOrientation: "flipY", and drawImage on the created ImageBitmap
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-sizeOverflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-sizeOverflow-expected.txt
@@ -4,6 +4,6 @@ PASS createImageBitmap does not crash or reject the promise when passing very la
 PASS createImageBitmap does not crash or reject the promise when passing very large sw
 PASS createImageBitmap does not crash or reject the promise when passing very large sh
 PASS createImageBitmap does not crash or reject the promise when passing very large sx, sy, sw and sh
-FAIL createImageBitmap throws an InvalidStateError error with big imageBitmap scaled up in big height promise_rejects_dom: function "function() { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
-FAIL createImageBitmap throws an InvalidStateError error with big imageBitmap scaled up in big width promise_rejects_dom: function "function() { throw e }" threw object "TypeError: Type error" that is not a DOMException InvalidStateError: property "code" is equal to undefined, expected 11
+FAIL createImageBitmap throws an InvalidStateError error with big imageBitmap scaled up in big height assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL createImageBitmap throws an InvalidStateError error with big imageBitmap scaled up in big width assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -887,7 +887,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
     // If no cropping, resizing, flipping, etc. are needed, then simply use the
     // resulting ImageBuffer directly.
     auto alphaPremultiplication = alphaPremultiplicationForPremultiplyAlpha(options.premultiplyAlpha);
-    if (sourceRectangle.returnValue().location().isZero() && sourceRectangle.returnValue().size() == imageData->size() && sourceRectangle.returnValue().size() == outputSize && options.orientation == ImageBitmapOptions::Orientation::None) {
+    if (sourceRectangle.returnValue().location().isZero() && sourceRectangle.returnValue().size() == imageData->size() && sourceRectangle.returnValue().size() == outputSize && options.orientation != ImageBitmapOptions::Orientation::FlipY) {
         bitmapData->putPixelBuffer(imageData->pixelBuffer(), sourceRectangle.releaseReturnValue(), { }, alphaPremultiplication);
 
         OptionSet<SerializationState> serializationState = SerializationState::OriginClean;

--- a/Source/WebCore/html/ImageBitmapOptions.h
+++ b/Source/WebCore/html/ImageBitmapOptions.h
@@ -31,12 +31,12 @@
 namespace WebCore {
 
 struct ImageBitmapOptions {
-    enum class Orientation { None, FlipY };
+    enum class Orientation { FromImage, FlipY,  None };
     enum class PremultiplyAlpha { None, Premultiply, Default };
     enum class ColorSpaceConversion { None, Default };
     enum class ResizeQuality { Pixelated, Low, Medium, High };
 
-    Orientation orientation { Orientation::None };
+    Orientation orientation { Orientation::FromImage };
     PremultiplyAlpha premultiplyAlpha { PremultiplyAlpha::Default };
     ColorSpaceConversion colorSpaceConversion { ColorSpaceConversion::Default };
     std::optional<unsigned> resizeWidth;

--- a/Source/WebCore/html/ImageBitmapOptions.idl
+++ b/Source/WebCore/html/ImageBitmapOptions.idl
@@ -23,13 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-enum ImageOrientation { "none", "flipY" };
+enum ImageOrientation { "from-image", "flipY", "none" };
 enum PremultiplyAlpha { "none", "premultiply", "default" };
 enum ColorSpaceConversion { "none", "default" };
 enum ResizeQuality { "pixelated", "low", "medium", "high" };
 
 dictionary ImageBitmapOptions {
-    [ImplementedAs=orientation] ImageOrientation imageOrientation = "none";
+    [ImplementedAs=orientation] ImageOrientation imageOrientation = "from-image";
     PremultiplyAlpha premultiplyAlpha = "default";
     ColorSpaceConversion colorSpaceConversion = "default";
     [EnforceRange] unsigned long resizeWidth;


### PR DESCRIPTION
#### 556e20c0b0053bc5c7f6d1a5635ad2467c6bade8
<pre>
Add support for &quot;from-image&quot; to ImageBitmapOptions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=250476">https://bugs.webkit.org/show_bug.cgi?id=250476</a>

Reviewed by Tim Nguyen.

&quot;none&quot; is deprecated, and has been renamed to &quot;from-image&quot;.
This adds the new &quot;from-image&quot; value, with the same behaviour as &quot;none&quot;.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-sizeOverflow-expected.txt:
* Source/WebCore/html/ImageBitmapOptions.h:
* Source/WebCore/html/ImageBitmapOptions.idl:

Canonical link: <a href="https://commits.webkit.org/266893@main">https://commits.webkit.org/266893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d152577e4aad280a9748b1dbc5f1a087878bc562

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17444 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20460 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16901 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12026 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13504 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->