### PR TITLE
In some macOS VM configurations, layer content is sometimes missing

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -299,10 +299,9 @@ static IntSize computeMaximumSurfaceSize()
 {
     auto maxSize = IntSize { clampToInteger(IOSurfaceGetPropertyMaximum(kIOSurfaceWidth)), clampToInteger(IOSurfaceGetPropertyMaximum(kIOSurfaceHeight)) };
 
-#if PLATFORM(IOS_FAMILY)
     // On iOS, there's an additional 8K clamp in CA (rdar://101936907).
+    // On some macOS VMs, IOSurfaceGetPropertyMaximum() returns INT_MAX (rdar://113661708).
     maxSize.clampToMaximumSize(fallbackMaxSurfaceDimension());
-#endif
 
     if (maxSize.isZero())
         maxSize = fallbackMaxSurfaceDimension();


### PR DESCRIPTION
#### 223cdceb76379ccf7c9094c58312bbd5ec3fb944
<pre>
In some macOS VM configurations, layer content is sometimes missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=260003">https://bugs.webkit.org/show_bug.cgi?id=260003</a>
&lt;rdar://112875397&gt;

Reviewed by Tim Horton.

In some macOS VM configs without accelerated graphics, IOSurfaceGetPropertyMaximum()
returns INT_MAX. This resulted in `TileController::computeTileSize()` sometimes computing
negative tile widths, which resulted in missing content.

Fix by clamping to fallbackMaxSurfaceDimension(), which is something we already did on iOS;
on macOS this will clamp to a max of 32K, which prevents the INT_MAX causing math errors.

* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::computeMaximumSurfaceSize):

Canonical link: <a href="https://commits.webkit.org/266767@main">https://commits.webkit.org/266767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/221d2717b28e59cd03dfceb79a3c3d9b2d1046ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13847 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17150 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12640 "3 flakes 8 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20234 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16637 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13245 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3544 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->