### PR TITLE
Import WPT tests for module import in workers with CSP

### DIFF
--- a/LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp-expected.txt
+++ b/LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL worker-src 'self' directive should disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS worker-src * directive should allow cross origin static import.
+FAIL script-src 'self' directive should disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS script-src * directive should allow cross origin static import.
+PASS worker-src * directive should override script-src 'self' directive and allow cross origin static import.
+FAIL worker-src 'self' directive should override script-src * directive and disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+FAIL script-src 'self' directive should disallow cross origin dynamic import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS script-src * directive should allow cross origin dynamic import.
+PASS worker-src 'self' directive should not take effect on dynamic import.
+

--- a/LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp.html
+++ b/LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<title>DedicatedWorker: CSP for ES Modules</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+async function openWindow(url) {
+  const win = window.open(url, '_blank');
+  add_result_callback(() => win.close());
+  const msg_event = await new Promise(resolve => window.onmessage = resolve);
+  assert_equals(msg_event.data, 'LOADED');
+  return win;
+}
+
+function import_csp_test(
+    cspHeader, importType, expectedImportedModules, description) {
+  // Append CSP header to windowURL for static import tests since static import
+  // scripts should obey Window's CSP.
+  const windowURL = `resources/new-worker-window.html` +
+      `${importType === 'static'
+          ? '?pipe=header(Content-Security-Policy, ' + cspHeader + ')'
+          : ''}`;
+  // Append CSP header to scriptURL for dynamic import tests since dynamic
+  // import scripts should obey Worker script's responce's CSP.
+  const scriptURL = `${importType}-import-remote-origin-script-worker.sub.js` +
+      `${importType === 'dynamic'
+          ? '?pipe=header(Content-Security-Policy, ' + cspHeader + ')'
+          : ''}`;
+  promise_test(async () => {
+    const win = await openWindow(windowURL);
+    // Ask the window to start a dedicated worker.
+    win.postMessage(scriptURL, '*');
+    const msg_event = await new Promise(resolve => window.onmessage = resolve);
+    assert_array_equals(msg_event.data, expectedImportedModules);
+  }, description);
+}
+
+// Tests for static import.
+//
+// Static import should obey the worker-src directive and the script-src
+// directive. If the both directives are specified, the worker-src directive
+// should be prioritized.
+//
+// Step 1: "If the result of executing 6.6.1.11 Get the effective directive for
+// request on request is "worker-src", and policy contains a directive whose
+// name is "worker-src", return "Allowed"."
+// "Note: If worker-src is present, we’ll defer to it when handling worker
+// requests."
+// https://w3c.github.io/webappsec-csp/#script-src-pre-request
+
+import_csp_test(
+    "worker-src 'self' 'unsafe-inline'",
+    "static",
+    ['ERROR'],
+    "worker-src 'self' directive should disallow cross origin static import.");
+
+import_csp_test(
+    "worker-src * 'unsafe-inline'",
+    "static",
+    ["export-on-load-script.js"],
+    "worker-src * directive should allow cross origin static import.")
+
+import_csp_test(
+    "script-src 'self' 'unsafe-inline'",
+    "static",
+    ['ERROR'],
+    "script-src 'self' directive should disallow cross origin static import.");
+
+import_csp_test(
+    "script-src * 'unsafe-inline'",
+    "static",
+    ["export-on-load-script.js"],
+    "script-src * directive should allow cross origin static import.")
+
+import_csp_test(
+    "worker-src *; script-src 'self' 'unsafe-inline'",
+    "static",
+    ["export-on-load-script.js"],
+    "worker-src * directive should override script-src 'self' directive and " +
+        "allow cross origin static import.");
+
+import_csp_test(
+    "worker-src 'self'; script-src * 'unsafe-inline'",
+    "static",
+    ['ERROR'],
+    "worker-src 'self' directive should override script-src * directive and " +
+        "disallow cross origin static import.");
+
+// Tests for dynamic import.
+//
+// Dynamic import should obey the script-src directive instead of the worker-src
+// directive according to the specs:
+//
+// Dynamic import has the "script" destination.
+// Step 2.4: "Fetch a module script graph given url, ..., "script", ..."
+// https://html.spec.whatwg.org/multipage/webappapis.html#hostimportmoduledynamically(referencingscriptormodule,-specifier,-promisecapability)
+//
+// The "script" destination should obey the script-src CSP directive.
+// Step 2: "If request's destination is script-like:"
+// https://w3c.github.io/webappsec-csp/#script-src-pre-request
+
+import_csp_test(
+    "script-src 'self' 'unsafe-inline'",
+    "dynamic",
+    ['ERROR'],
+    "script-src 'self' directive should disallow cross origin dynamic import.");
+
+import_csp_test(
+    "script-src * 'unsafe-inline'",
+    "dynamic",
+    ["export-on-load-script.js"],
+    "script-src * directive should allow cross origin dynamic import.")
+
+import_csp_test(
+    "worker-src 'self' 'unsafe-inline'",
+    "dynamic",
+    ["export-on-load-script.js"],
+    "worker-src 'self' directive should not take effect on dynamic import.");
+
+</script>

--- a/LayoutTests/http/wpt/workers/modules/resources/dynamic-import-remote-origin-script-worker.sub.js
+++ b/LayoutTests/http/wpt/workers/modules/resources/dynamic-import-remote-origin-script-worker.sub.js
@@ -1,0 +1,17 @@
+// Import a remote origin script.
+const importUrl =
+    'https://127.0.0.1:{{ports[https][0]}}/workers/modules/resources/export-on-load-script.js';
+if ('DedicatedWorkerGlobalScope' in self &&
+    self instanceof DedicatedWorkerGlobalScope) {
+  import(importUrl)
+      .then(module => postMessage(module.importedModules))
+      .catch(e => postMessage(['ERROR']));
+} else if (
+    'SharedWorkerGlobalScope' in self &&
+    self instanceof SharedWorkerGlobalScope) {
+  onconnect = e => {
+    import(importUrl)
+        .then(module => e.ports[0].postMessage(module.importedModules))
+        .catch(error => e.ports[0].postMessage(['ERROR']));
+  };
+}

--- a/LayoutTests/http/wpt/workers/modules/resources/export-on-load-script.js
+++ b/LayoutTests/http/wpt/workers/modules/resources/export-on-load-script.js
@@ -1,0 +1,1 @@
+export const importedModules = ['export-on-load-script.js'];

--- a/LayoutTests/http/wpt/workers/modules/resources/new-shared-worker-window.html
+++ b/LayoutTests/http/wpt/workers/modules/resources/new-shared-worker-window.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>SharedWorker: new SharedWorker()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let worker;
+
+// Create a new shared worker for a given script url.
+window.onmessage = e => {
+  worker = new SharedWorker(e.data.scriptURL,
+                            { name: e.data.name, type: 'module' });
+  worker.port.onmessage = msg => window.opener.postMessage(msg.data, '*');
+  worker.onerror = err => {
+    window.opener.postMessage(['ERROR'], '*');
+    err.preventDefault();
+  };
+}
+window.opener.postMessage('LOADED', '*');
+</script>

--- a/LayoutTests/http/wpt/workers/modules/resources/new-worker-window.html
+++ b/LayoutTests/http/wpt/workers/modules/resources/new-worker-window.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>DedicatedWorker: new Worker()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let worker;
+
+// Creates a new dedicated worker for a given script url.
+window.onmessage = e => {
+  worker = new Worker(e.data, { type: 'module' });
+  worker.postMessage('start');
+  worker.onmessage = msg => window.opener.postMessage(msg.data, '*');
+  worker.onerror = err => {
+      window.opener.postMessage(['ERROR'], '*');
+      err.preventDefault();
+  };
+};
+window.opener.postMessage('LOADED', '*');
+</script>

--- a/LayoutTests/http/wpt/workers/modules/resources/static-import-remote-origin-script-worker.sub.js
+++ b/LayoutTests/http/wpt/workers/modules/resources/static-import-remote-origin-script-worker.sub.js
@@ -1,0 +1,20 @@
+// Import a remote origin script.
+import * as module from 'https://127.0.0.1:{{ports[https][0]}}/workers/modules/resources/export-on-load-script.py';
+if ('DedicatedWorkerGlobalScope' in self &&
+    self instanceof DedicatedWorkerGlobalScope) {
+  self.onmessage = e => {
+    e.target.postMessage(module.importedModules);
+  };
+} else if (
+    'SharedWorkerGlobalScope' in self &&
+    self instanceof SharedWorkerGlobalScope) {
+  self.onconnect = e => {
+    e.ports[0].postMessage(module.importedModules);
+  };
+} else if (
+    'ServiceWorkerGlobalScope' in self &&
+    self instanceof ServiceWorkerGlobalScope) {
+  self.onmessage = e => {
+    e.source.postMessage(module.importedModules);
+  };
+}

--- a/LayoutTests/http/wpt/workers/modules/shared-worker-import-csp-expected.txt
+++ b/LayoutTests/http/wpt/workers/modules/shared-worker-import-csp-expected.txt
@@ -1,0 +1,11 @@
+
+FAIL worker-src 'self' directive should disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS worker-src * directive should allow cross origin static import.
+FAIL script-src 'self' directive should disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS script-src * directive should allow cross origin static import.
+PASS worker-src * directive should override script-src 'self' directive and allow cross origin static import.
+FAIL worker-src 'self' directive should override script-src * directive and disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+FAIL script-src 'self' directive should disallow cross origin dynamic import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS script-src * directive should allow cross origin dynamic import.
+PASS worker-src 'self' directive should not take effect on dynamic import.
+

--- a/LayoutTests/http/wpt/workers/modules/shared-worker-import-csp.html
+++ b/LayoutTests/http/wpt/workers/modules/shared-worker-import-csp.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<title>SharedWorker: CSP for ES Modules</title>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+// This Set is for checking a shared worker in each test is newly created.
+const existingWorkers = new Set();
+
+async function openWindow(url) {
+  const win = window.open(url, '_blank');
+  add_result_callback(() => win.close());
+  const msgEvent = await new Promise(resolve => window.onmessage = resolve);
+  assert_equals(msgEvent.data, 'LOADED');
+  return win;
+}
+
+function import_csp_test(
+    cspHeader, importType, expectedImportedModules, description) {
+  // Append CSP header to windowURL for static import tests since static import
+  // scripts should obey Window's CSP.
+  const windowURL = `resources/new-shared-worker-window.html` +
+      `${importType === 'static'
+          ? '?pipe=header(Content-Security-Policy, ' + cspHeader + ')'
+          : ''}`;
+  // Append CSP header to scriptURL for dynamic import tests since dynamic
+  // import scripts should obey SharedWorker script's responce's CSP.
+  const scriptURL = `${importType}-import-remote-origin-script-worker.sub.js` +
+      `${importType === 'dynamic'
+          ? '?pipe=header(Content-Security-Policy, ' + cspHeader + ')'
+          : ''}`;
+  promise_test(async () => {
+    // Open a window that has the given CSP header.
+    const win = await openWindow(windowURL);
+    // Construct a unique name for SharedWorker.
+    const name = `${cspHeader}_${importType}`;
+    const workerProperties = { scriptURL, name };
+    // Check if this shared worker is newly created.
+    assert_false(existingWorkers.has(workerProperties));
+    existingWorkers.add(workerProperties);
+
+    // Ask the window to start a shared worker with the given CSP header.
+    // The shared worker doesn't inherits the window's CSP header.
+    // https://w3c.github.io/webappsec-csp/#initialize-global-object-csp
+    win.postMessage(workerProperties, '*');
+    const msg_event = await new Promise(resolve => window.onmessage = resolve);
+    assert_array_equals(msg_event.data, expectedImportedModules);
+  }, description);
+}
+
+// Tests for static import.
+//
+// Static import should obey the worker-src directive and the script-src
+// directive. If the both directives are specified, the worker-src directive
+// should be prioritized.
+//
+// "The script-src directive acts as a default fallback for all script-like
+// destinations (including worker-specific destinations if worker-src is not
+// present)."
+// https://w3c.github.io/webappsec-csp/#directive-script-src
+
+import_csp_test(
+    "worker-src 'self' 'unsafe-inline'", "static",
+    ['ERROR'],
+    "worker-src 'self' directive should disallow cross origin static import.");
+
+import_csp_test(
+    "worker-src * 'unsafe-inline'", "static",
+    ["export-on-load-script.js"],
+    "worker-src * directive should allow cross origin static import.");
+
+import_csp_test(
+    "script-src 'self' 'unsafe-inline'", "static",
+    ['ERROR'],
+    "script-src 'self' directive should disallow cross origin static import.");
+
+import_csp_test(
+    "script-src * 'unsafe-inline'", "static",
+    ["export-on-load-script.js"],
+    "script-src * directive should allow cross origin static import.");
+
+import_csp_test(
+    "worker-src *; script-src 'self' 'unsafe-inline'", "static",
+    ["export-on-load-script.js"],
+    "worker-src * directive should override script-src 'self' directive and " +
+        "allow cross origin static import.");
+
+import_csp_test(
+    "worker-src 'self'; script-src * 'unsafe-inline'", "static",
+    ['ERROR'],
+    "worker-src 'self' directive should override script-src * directive and " +
+        "disallow cross origin static import.");
+
+// Tests for dynamic import.
+//
+// Dynamic import should obey SharedWorker script's CSP instead of parent
+// Window's CSP.
+//
+// Dynamic import should obey the script-src directive instead of the worker-src
+// directive according to the specs:
+//
+// Dynamic import has the "script" destination.
+// Step 3: "Fetch a single module script graph given url, ..., "script", ..."
+// https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-import()-module-script-graph
+//
+// The "script" destination should obey the script-src CSP directive.
+// "The script-src directive acts as a default fallback for all script-like
+// destinations (including worker-specific destinations if worker-src is not
+// present)."
+// https://w3c.github.io/webappsec-csp/#directive-script-src
+
+import_csp_test(
+    "script-src 'self' 'unsafe-inline'", "dynamic",
+    ['ERROR'],
+    "script-src 'self' directive should disallow cross origin dynamic import.");
+
+import_csp_test(
+    "script-src * 'unsafe-inline'", "dynamic",
+    ["export-on-load-script.js"],
+    "script-src * directive should allow cross origin dynamic import.");
+
+import_csp_test(
+    "worker-src 'self' 'unsafe-inline'", "dynamic",
+    ["export-on-load-script.js"],
+    "worker-src 'self' directive should not take effect on dynamic import.");
+
+</script>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -95,6 +95,7 @@ imported/w3c/web-platform-tests/fetch [ Skip ]
 # Shared workers are only implemented for WebKit2.
 http/tests/navigation/page-cache-shared-worker.html [ Skip ]
 http/tests/workers/shared [ Skip ]
+http/wpt/workers/modules/shared-worker-import-csp.html [ Skip ]
 imported/w3c/web-platform-tests/WebCryptoAPI/historical.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-allowed.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html [ Skip ]


### PR DESCRIPTION
#### 87c3092f56729c608acddd96308fc198fd3aae77
<pre>
Import WPT tests for module import in workers with CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=260005">https://bugs.webkit.org/show_bug.cgi?id=260005</a>

Reviewed by Tim Nguyen.

Import WPT tests for module import in workers with CSP, and tweak them to
make sure they run with our test infrastructure.

* LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp-expected.txt: Added.
* LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp.html: Added.
* LayoutTests/http/wpt/workers/modules/resources/dynamic-import-remote-origin-script-worker.sub.js: Added.
(else):
* LayoutTests/http/wpt/workers/modules/resources/export-on-load-script.js: Added.
* LayoutTests/http/wpt/workers/modules/resources/new-shared-worker-window.html: Added.
* LayoutTests/http/wpt/workers/modules/resources/new-worker-window.html: Added.
* LayoutTests/http/wpt/workers/modules/resources/static-import-remote-origin-script-worker.sub.js: Added.
(else):
* LayoutTests/http/wpt/workers/modules/shared-worker-import-csp.html: Added.

Canonical link: <a href="https://commits.webkit.org/266801@main">https://commits.webkit.org/266801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617b2735709f3fb02a6db2f70ff85ed0bc671249

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13918 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15174 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17249 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20313 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16729 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14035 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13180 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3572 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->