### PR TITLE
Add `operator<<` for CG types

### DIFF
--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -84,6 +84,9 @@ public:
     WTF_EXPORT_PRIVATE TextStream& operator<<(id);
 #ifdef __OBJC__
     WTF_EXPORT_PRIVATE TextStream& operator<<(NSArray *);
+    WTF_EXPORT_PRIVATE TextStream& operator<<(CGRect);
+    WTF_EXPORT_PRIVATE TextStream& operator<<(CGSize);
+    WTF_EXPORT_PRIVATE TextStream& operator<<(CGPoint);
 #endif
 #endif
 

--- a/Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm
@@ -51,4 +51,22 @@ TextStream& TextStream::operator<<(NSArray *array)
     return *this << "]";
 }
 
+TextStream& TextStream::operator<<(CGRect rect)
+{
+    *this << "{{" << rect.origin.x << ", " << rect.origin.y << "}, {" << rect.size.width << ", " << rect.size.height << "}}";
+    return *this;
+}
+
+TextStream& TextStream::operator<<(CGSize size)
+{
+    *this << "{" << size.width << ", " << size.height << "}";
+    return *this;
+}
+
+TextStream& TextStream::operator<<(CGPoint point)
+{
+    *this << "{" << point.x << ", " << point.y << "}";
+    return *this;
+}
+
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TextStreamCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TextStreamCocoa.mm
@@ -63,3 +63,22 @@ TEST(WTF_TextStream, id)
     ts << value;
     EXPECT_EQ(ts.release(), "3"_s);
 }
+
+TEST(WTF_TextStream, CoreGraphics)
+{
+    {
+        TextStream ts;
+        ts << CGRectMake(1, 2, 3, 4);
+        EXPECT_EQ(ts.release(), "{{1.00, 2.00}, {3.00, 4.00}}"_s);
+    }
+    {
+        TextStream ts;
+        ts << CGPointMake(1, 2);
+        EXPECT_EQ(ts.release(), "{1.00, 2.00}"_s);
+    }
+    {
+        TextStream ts;
+        ts << CGSizeMake(3, 4);
+        EXPECT_EQ(ts.release(), "{3.00, 4.00}"_s);
+    }
+}


### PR DESCRIPTION
#### 10e44f99e2aa2986ff3d6a5a60f81e329cdf6ced
<pre>
Add `operator&lt;&lt;` for CG types
<a href="https://bugs.webkit.org/show_bug.cgi?id=260009">https://bugs.webkit.org/show_bug.cgi?id=260009</a>
rdar://113667751

Reviewed by Tim Horton.

Instead of having to use `NSStringFromCG*`, now we can just stream CG types directly.

* Source/WTF/wtf/text/TextStream.h:
* Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm:
(WTF::TextStream::operator&lt;&lt;):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TextStreamCocoa.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/266782@main">https://commits.webkit.org/266782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2201cfdf74489f9ce4771d27ebc6ef81ddba2ccd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16538 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17215 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20286 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12620 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16700 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14005 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14933 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13299 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3821 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3554 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17637 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15163 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13845 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3631 "Passed tests") | 
<!--EWS-Status-Bubble-End-->