### PR TITLE
[JSC] Make profiling check-pointing longer for mega functions

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2488,7 +2488,7 @@ int32_t CodeBlock::codeTypeThresholdMultiplier() const
     return 1;
 }
 
-double CodeBlock::optimizationThresholdScalingFactor()
+double CodeBlock::optimizationThresholdScalingFactor() const
 {
     // This expression arises from doing a least-squares fit of
     //

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -856,6 +856,8 @@ public:
 
     bool loopHintsAreEligibleForFuzzingEarlyReturn() { return m_unlinkedCode->loopHintsAreEligibleForFuzzingEarlyReturn(); }
 
+    double optimizationThresholdScalingFactor() const;
+
 protected:
     void finalizeLLIntInlineCaches();
 #if ENABLE(JIT)
@@ -879,8 +881,6 @@ private:
     CodeBlock* specialOSREntryBlockOrNull();
     
     void noticeIncomingCall(CallFrame* callerFrame);
-    
-    double optimizationThresholdScalingFactor();
 
     void updateAllNonLazyValueProfilePredictionsAndCountLiveness(const ConcurrentJSLocker&, unsigned& numberOfLiveNonArgumentValueProfiles, unsigned& numberOfSamplesInProfiles);
 

--- a/Source/JavaScriptCore/bytecode/ExecutionCounter.cpp
+++ b/Source/JavaScriptCore/bytecode/ExecutionCounter.cpp
@@ -98,6 +98,33 @@ int32_t applyMemoryUsageHeuristicsAndConvertToInt(int32_t value, CodeBlock* code
     return static_cast<int32_t>(doubleResult);
 }
 
+int32_t maximumExecutionCountsBetweenCheckpoints(CountingVariant countingVariant, CodeBlock* codeBlock)
+{
+    switch (countingVariant) {
+    case CountingForBaseline: {
+        int32_t threshold = Options::maximumExecutionCountsBetweenCheckpointsForBaseline();
+        UNUSED_PARAM(codeBlock);
+#if ENABLE(JIT)
+        if (codeBlock) {
+            // If the CodeBlock becomes particularly mega sized, then updating profiles become huge cost.
+            // We would like to avoid updating profiles repeatedly for that function, so we relax checkpoint period longer.
+            // We do not need to make checkpoint period longer for CountingForUpperTiers since they do not update profiles.
+            if (static_cast<int32_t>(codeBlock->bytecodeCost()) >= Options::highCostBaselineProfilingFunctionBytecodeCost()) {
+                double factor = std::max(std::sqrt(codeBlock->optimizationThresholdScalingFactor()), 1.0);
+                return toInt32(threshold * factor);
+            }
+        }
+#endif
+        return threshold;
+    }
+    case CountingForUpperTiers:
+        return Options::maximumExecutionCountsBetweenCheckpointsForUpperTiers();
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return 0;
+    }
+}
+
 template<CountingVariant countingVariant>
 bool ExecutionCounter<countingVariant>::hasCrossedThreshold(CodeBlock* codeBlock) const
 {
@@ -123,7 +150,7 @@ bool ExecutionCounter<countingVariant>::hasCrossedThreshold(CodeBlock* codeBlock
     
     double actualCount = static_cast<double>(m_totalCount) + m_counter;
     double desiredCount = modifiedThreshold - static_cast<double>(
-        std::min(m_activeThreshold, maximumExecutionCountsBetweenCheckpoints())) / 2;
+        std::min(m_activeThreshold, maximumExecutionCountsBetweenCheckpoints(countingVariant, codeBlock))) / 2;
     
     bool result = actualCount >= desiredCount;
     
@@ -159,7 +186,7 @@ bool ExecutionCounter<countingVariant>::setThreshold(CodeBlock* codeBlock)
         return true;
     }
 
-    threshold = clippedThreshold(threshold);
+    threshold = clippedThreshold(codeBlock, threshold);
     
     m_counter = static_cast<int32_t>(-threshold);
         

--- a/Source/JavaScriptCore/bytecode/ExecutionCounter.h
+++ b/Source/JavaScriptCore/bytecode/ExecutionCounter.h
@@ -40,6 +40,7 @@ enum CountingVariant {
 
 double applyMemoryUsageHeuristics(int32_t value, CodeBlock*);
 int32_t applyMemoryUsageHeuristicsAndConvertToInt(int32_t value, CodeBlock*);
+int32_t maximumExecutionCountsBetweenCheckpoints(CountingVariant, CodeBlock*);
 
 inline int32_t formattedTotalExecutionCount(float value)
 {
@@ -72,23 +73,10 @@ public:
         m_totalCount = memoryUsageAdjustedThreshold;
     }
 
-    static int32_t maximumExecutionCountsBetweenCheckpoints()
-    {
-        switch (countingVariant) {
-        case CountingForBaseline:
-            return Options::maximumExecutionCountsBetweenCheckpointsForBaseline();
-        case CountingForUpperTiers:
-            return Options::maximumExecutionCountsBetweenCheckpointsForUpperTiers();
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-            return 0;
-        }
-    }
-    
     template<typename T>
-    static T clippedThreshold(T threshold)
+    static T clippedThreshold(CodeBlock* codeBlock, T threshold)
     {
-        int32_t maxThreshold = maximumExecutionCountsBetweenCheckpoints();
+        int32_t maxThreshold = maximumExecutionCountsBetweenCheckpoints(countingVariant, codeBlock);
         if (threshold > maxThreshold)
             threshold = maxThreshold;
         return threshold;

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -120,10 +120,10 @@ void handleExitCounts(VM& vm, CCallHelpers& jit, const OSRExitBase& exit)
     int32_t clippedValue;
     switch (jit.codeBlock()->jitType()) {
     case JITType::DFGJIT:
-        clippedValue = BaselineExecutionCounter::clippedThreshold(targetValue);
+        clippedValue = BaselineExecutionCounter::clippedThreshold(jit.codeBlock(), targetValue);
         break;
     case JITType::FTLJIT:
-        clippedValue = UpperTierExecutionCounter::clippedThreshold(targetValue);
+        clippedValue = UpperTierExecutionCounter::clippedThreshold(jit.codeBlock(), targetValue);
         break;
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -327,6 +327,7 @@ bool canUseWebAssemblyFastMemory();
     \
     v(Int32, maximumExecutionCountsBetweenCheckpointsForBaseline, 1000, Normal, nullptr) \
     v(Int32, maximumExecutionCountsBetweenCheckpointsForUpperTiers, 50000, Normal, nullptr) \
+    v(Int32, highCostBaselineProfilingFunctionBytecodeCost, 10000, Normal, nullptr) \
     \
     v(Unsigned, likelyToTakeSlowCaseMinimumCount, 20, Normal, nullptr) \
     v(Unsigned, couldTakeSlowCaseMinimumCount, 10, Normal, nullptr) \


### PR DESCRIPTION
#### c323bd22eabf78d8dcf13b84666c8bb83855444d
<pre>
[JSC] Make profiling check-pointing longer for mega functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260010">https://bugs.webkit.org/show_bug.cgi?id=260010</a>
rdar://113668308

Reviewed by Justin Michaud.

While we designed our profiling collection with &quot;they are cheap&quot; assumption, this is not true for some mega-sized functions.
There are some mega-sized functions, which can be generated by toolings etc., has massive amount of ValueProfiles, and causing
very long stop for profile update.

In this patch, we attempt to avoid this pathological case. When function size exceeds the threshold, we categorize it as mega-sized,
and we relax maximumExecutionCountsBetweenCheckpoints more larger. Because we do profiling update on each checkpoint, making it longer
means less frequent profiling update.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::optimizationThresholdScalingFactor const):
(JSC::CodeBlock::optimizationThresholdScalingFactor): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/ExecutionCounter.cpp:
(JSC::maximumExecutionCountsBetweenCheckpoints):
(JSC::ExecutionCounter&lt;countingVariant&gt;::hasCrossedThreshold const):
(JSC::ExecutionCounter&lt;countingVariant&gt;::setThreshold):
* Source/JavaScriptCore/bytecode/ExecutionCounter.h:
(JSC::ExecutionCounter::clippedThreshold):
(JSC::ExecutionCounter::maximumExecutionCountsBetweenCheckpoints): Deleted.
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::handleExitCounts):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/266819@main">https://commits.webkit.org/266819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba63d5a22a7833ba227d5e8592b26e83d011be2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17316 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20362 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12694 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16792 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14103 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11914 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15034 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13390 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3836 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17722 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15264 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1778 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13943 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3646 "Passed tests") | 
<!--EWS-Status-Bubble-End-->