### PR TITLE
[Win] WebCore::instanceHandle() always returns a null HINSTANCE

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -143,7 +143,6 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/win/SystemInfo.h
     platform/win/WCDataObject.h
     platform/win/WebCoreBundleWin.h
-    platform/win/WebCoreInstanceHandle.h
     platform/win/WebCoreTextRenderer.h
     platform/win/WindowMessageBroadcaster.h
     platform/win/WindowMessageListener.h

--- a/Source/WebCore/platform/win/WebCoreInstanceHandle.cpp
+++ b/Source/WebCore/platform/win/WebCoreInstanceHandle.cpp
@@ -28,17 +28,22 @@
 
 namespace WebCore {
 
-// The global DLL or application instance used for all windows.
-HINSTANCE s_instanceHandle = nullptr;
-
-void setInstanceHandle(HINSTANCE instanceHandle)
-{
-    s_instanceHandle = instanceHandle;
-}
+HINSTANCE s_instanceHandle;
 
 HINSTANCE instanceHandle()
 {
+    ASSERT(s_instanceHandle);
     return s_instanceHandle;
 }
 
 } // namespace WebCore
+
+BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD reason, LPVOID)
+{
+    switch (reason) {
+    case DLL_PROCESS_ATTACH:
+        WebCore::s_instanceHandle = hInstance;
+        break;
+    }
+    return true;
+}

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -130,6 +130,8 @@ list(APPEND WebKit_SOURCES
 
     WebProcess/win/WebProcessMainWin.cpp
     WebProcess/win/WebProcessWin.cpp
+
+    win/WebKitDLL.cpp
 )
 
 list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -34,6 +34,7 @@
 #include "PageClientImpl.h"
 #include "WKAPICast.h"
 #include "WebFramePolicyListenerProxy.h"
+#include "WebKitDLL.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
 #include "WebPreferences.h"
@@ -44,7 +45,6 @@
 #include <WebCore/InspectorFrontendClientLocal.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/WebCoreBundleWin.h>
-#include <WebCore/WebCoreInstanceHandle.h>
 #include <WebCore/WindowMessageBroadcaster.h>
 #include <WebKit/WKPage.h>
 #include <wtf/FileSystem.h>
@@ -204,7 +204,7 @@ bool WebInspectorUIProxy::registerWindowClass()
     wcex.lpfnWndProc = wndProc;
     wcex.cbClsExtra = 0;
     wcex.cbWndExtra = 0;
-    wcex.hInstance = WebCore::instanceHandle();
+    wcex.hInstance = instanceHandle();
     wcex.hIcon = 0;
     wcex.hCursor = LoadCursor(0, IDC_ARROW);
     wcex.hbrBackground = 0;
@@ -377,7 +377,7 @@ void WebInspectorUIProxy::platformDetach()
         registerWindowClass();
         m_inspectorDetachWindow = ::CreateWindowEx(0, WebInspectorUIProxyClassName, 0, WS_OVERLAPPEDWINDOW,
             CW_USEDEFAULT, CW_USEDEFAULT, initialWindowWidth, initialWindowHeight,
-            0, 0, WebCore::instanceHandle(), 0);
+            0, 0, instanceHandle(), 0);
         ::SetProp(m_inspectorDetachWindow, WebInspectorUIProxyPointerProp, reinterpret_cast<HANDLE>(this));
     }
 

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -32,6 +32,7 @@
 
 #include "NativeWebMouseEvent.h"
 #include "PlatformPopupMenuData.h"
+#include "WebKitDLL.h"
 #include "WebView.h"
 #include <WebCore/BitmapInfo.h>
 #include <WebCore/GDIUtilities.h>
@@ -39,7 +40,6 @@
 #include <WebCore/HWndDC.h>
 #include <WebCore/PlatformMouseEvent.h>
 #include <WebCore/ScrollbarTheme.h>
-#include <WebCore/WebCoreInstanceHandle.h>
 #include <windowsx.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -37,6 +37,7 @@
 #include "WebContextMenuProxyWin.h"
 #include "WebEditCommandProxy.h"
 #include "WebEventFactory.h"
+#include "WebKitDLL.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
@@ -49,7 +50,6 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/Region.h>
-#include <WebCore/WebCoreInstanceHandle.h>
 #include <WebCore/WindowMessageBroadcaster.h>
 #include <wtf/FileSystem.h>
 #include <wtf/SoftLinking.h>

--- a/Source/WebKit/win/WebKitDLL.cpp
+++ b/Source/WebKit/win/WebKitDLL.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WebKitDLL.h"
 
-#include "windows.h"
+namespace WebKit {
 
-namespace WebCore {
+HINSTANCE s_instanceHandle;
 
-HINSTANCE instanceHandle();
-    
+HINSTANCE instanceHandle()
+{
+    ASSERT(s_instanceHandle);
+    return s_instanceHandle;
+}
+
+} // namespace WebKit
+
+BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD reason, LPVOID)
+{
+    switch (reason) {
+    case DLL_PROCESS_ATTACH:
+        WebKit::s_instanceHandle = hInstance;
+        break;
+    }
+    return true;
 }

--- a/Source/WebKit/win/WebKitDLL.h
+++ b/Source/WebKit/win/WebKitDLL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "windows.h"
+#include <windows.h>
 
-namespace WebCore {
+namespace WebKit {
 
 HINSTANCE instanceHandle();
-    
-}
+
+} // namespace WebKit


### PR DESCRIPTION
#### a7bd570e6391a2721126dd5baa4c5251109dfdd6
<pre>
[Win] WebCore::instanceHandle() always returns a null HINSTANCE
<a href="https://bugs.webkit.org/show_bug.cgi?id=260013">https://bugs.webkit.org/show_bug.cgi?id=260013</a>

Reviewed by Don Olmstead.

WebCore::instanceHandle() doesn&apos;t work as expected in Winodws WebKit2
because WebCore::setInstanceHandle is called from nowhere.

HINSTANCE is used for CreateWindow and RegisterClass. The document
&lt;<a href="https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-wndclassa">https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-wndclassa</a>&gt; says:

&gt; A handle to the instance that contains the window procedure for the class.

Added DllMain for WebCore.dll and WebKit2.dll to get HINSTANCE of
them.

* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/platform/win/WebCoreInstanceHandle.cpp:
(WebCore::instanceHandle):
(DllMain):
(WebCore::setInstanceHandle): Deleted.
* Source/WebCore/platform/win/WebCoreInstanceHandle.h:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::registerWindowClass):
(WebKit::WebInspectorUIProxy::platformDetach):
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebView.cpp:
* Source/WebKit/win/WebKitDLL.cpp: Copied from Source/WebCore/platform/win/WebCoreInstanceHandle.cpp.
(WebKit::instanceHandle):
(DllMain):
* Source/WebKit/win/WebKitDLL.h: Copied from Source/WebCore/platform/win/WebCoreInstanceHandle.h.

Canonical link: <a href="https://commits.webkit.org/266769@main">https://commits.webkit.org/266769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e093b63be2d3e7b800d3f10868d18d0d410b121c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16518 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17191 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13266 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20259 "3 flakes 88 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16674 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11819 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17614 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1764 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->