### PR TITLE
[GTK][WPE] Fix clang warning in `WebKitDownloadClient::legacyDidCancel()`

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp
@@ -111,7 +111,7 @@ private:
         m_download = nullptr;
     }
 
-    void legacyDidCancel(WebKit::DownloadProxy&)
+    void legacyDidCancel(WebKit::DownloadProxy&) override
     {
         ASSERT(m_download);
         webkitDownloadCancelled(m_download.get());


### PR DESCRIPTION
#### 26d006a96ab65b4db540f4fbaa02de7bb655416f
<pre>
[GTK][WPE] Fix clang warning in `WebKitDownloadClient::legacyDidCancel()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=260023">https://bugs.webkit.org/show_bug.cgi?id=260023</a>

Reviewed by Philippe Normand.

`WebKitDownloadClient::legacyDidCancel()` should be marked as `override`.

* Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp:

Canonical link: <a href="https://commits.webkit.org/266786@main">https://commits.webkit.org/266786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29949dee615bbdbfaae369445bb134e9c8c28ebd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13880 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16527 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17202 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12684 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20271 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16684 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11839 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13287 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3558 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->