### PR TITLE
[CSS] @font-palette-values family-name supports multiple values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 2;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette">A</div>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette">A</div>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 2;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette">A</div>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette">A</div>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>font-palette multiple family-name and @font-palette-values</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-palette-prop">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-palette-values">
+<link rel="match" href="font-palette-36-ref.html">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+@font-face {
+    font-family: "foo bar";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+@font-face {
+    font-family: foo;
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font", "foo bar", foo;
+    base-palette: light;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette;">A</div>
+<div style="font: 48px foo; font-palette: --MyPalette;">A</div>
+<div style="font: 48px 'foo bar'; font-palette: --MyPalette;">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS CSS Fonts Module Level 4: parsing @font-palette-values
-PASS CSS Fonts Module Level 4: parsing @font-palette-values 1
+FAIL CSS Fonts Module Level 4: parsing @font-palette-values 1 assert_equals: expected -1 but got 27
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 2
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 3
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 4

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
@@ -31,5 +31,5 @@ PASS CSS Fonts Module Level 4: parsing @font-palette-values 28
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 29
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 30
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 31
-FAIL CSS Fonts Module Level 4: parsing @font-palette-values 32 assert_equals: expected "foo, bar, baz" but got ""
+PASS CSS Fonts Module Level 4: parsing @font-palette-values 32
 

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -33,6 +33,7 @@
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -42,9 +43,7 @@ CSSFontPaletteValuesRule::CSSFontPaletteValuesRule(StyleRuleFontPaletteValues& f
 {
 }
 
-CSSFontPaletteValuesRule::~CSSFontPaletteValuesRule()
-{
-}
+CSSFontPaletteValuesRule::~CSSFontPaletteValuesRule() = default;
 
 String CSSFontPaletteValuesRule::name() const
 {
@@ -53,7 +52,10 @@ String CSSFontPaletteValuesRule::name() const
 
 String CSSFontPaletteValuesRule::fontFamily() const
 {
-    return m_fontPaletteValuesRule->fontFamily();
+    auto serialize = [] (auto& family) {
+        return serializeFontFamily(family.string());
+    };
+    return makeStringByJoining(m_fontPaletteValuesRule->fontFamilies().map(serialize).span(), ", "_s);
 }
 
 String CSSFontPaletteValuesRule::basePalette() const
@@ -87,9 +89,9 @@ String CSSFontPaletteValuesRule::overrideColors() const
 String CSSFontPaletteValuesRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@font-palette-values ", m_fontPaletteValuesRule->name(), " { ");
-    if (!m_fontPaletteValuesRule->fontFamily().isNull())
-        builder.append("font-family: ", m_fontPaletteValuesRule->fontFamily(), "; ");
+    builder.append("@font-palette-values ", name(), " { ");
+    if (!m_fontPaletteValuesRule->fontFamilies().isEmpty())
+        builder.append("font-family: ", fontFamily(), "; ");
 
     if (m_fontPaletteValuesRule->basePalette()) {
         switch (m_fontPaletteValuesRule->basePalette()->type) {

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -245,11 +245,12 @@ void CSSFontSelector::addFontPaletteValuesRule(const StyleRuleFontPaletteValues&
     auto& name = fontPaletteValuesRule.name();
     ASSERT(!name.isNull());
 
-    auto& fontFamily = fontPaletteValuesRule.fontFamily();
-    if (fontFamily.isNull())
+    auto& fontFamilies = fontPaletteValuesRule.fontFamilies();
+    if (fontFamilies.isEmpty())
         return;
 
-    m_paletteMap.set(std::make_pair(fontFamily, name), fontPaletteValuesRule.fontPaletteValues());
+    for (auto& fontFamily : fontFamilies)
+        m_paletteMap.set(std::make_pair(fontFamily, name), fontPaletteValuesRule.fontPaletteValues());
 
     ++m_version;
 }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9686,13 +9686,13 @@
         "@font-palette-values": {
             "font-family": {
                 "codegen-properties": {
-                    "parser-function": "consumeFamilyName",
-                    "parser-grammar-unused": "<family-name>",
+                    "parser-function": "consumeFamilyNameList",
+                    "parser-grammar-unused": "<family-name>#",
                     "parser-grammar-unused-reason": "Needs support for special 'family-name' processing."
                 },
                 "specification": {
                     "category": "css-fonts-4",
-                    "url": "https://www.w3.org/TR/css-fonts-4/#font-family-2-desc"
+                    "url": "https://drafts.csswg.org/css-fonts-4/#font-family-2-desc"
                 }
             },
             "base-palette": {

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -411,15 +411,15 @@ Ref<StyleRuleFontFeatureValues> StyleRuleFontFeatureValues::create(const Vector<
     return adoptRef(*new StyleRuleFontFeatureValues(fontFamilies, WTFMove(values)));
 }
 
-Ref<StyleRuleFontPaletteValues> StyleRuleFontPaletteValues::create(const AtomString& name, const AtomString& fontFamily, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors)
+Ref<StyleRuleFontPaletteValues> StyleRuleFontPaletteValues::create(const AtomString& name, Vector<AtomString>&& fontFamilies, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors)
 {
-    return adoptRef(*new StyleRuleFontPaletteValues(name, fontFamily, basePalette, WTFMove(overrideColors)));
+    return adoptRef(*new StyleRuleFontPaletteValues(name, WTFMove(fontFamilies), basePalette, WTFMove(overrideColors)));
 }
 
-StyleRuleFontPaletteValues::StyleRuleFontPaletteValues(const AtomString& name, const AtomString& fontFamily, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors)
+StyleRuleFontPaletteValues::StyleRuleFontPaletteValues(const AtomString& name, Vector<AtomString>&& fontFamilies, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors)
     : StyleRuleBase(StyleRuleType::FontPaletteValues)
     , m_name(name)
-    , m_fontFamily(fontFamily)
+    , m_fontFamilies(WTFMove(fontFamilies))
     , m_fontPaletteValues(basePalette, WTFMove(overrideColors))
 {
 }

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -196,10 +196,10 @@ private:
 
 class StyleRuleFontPaletteValues final : public StyleRuleBase {
 public:
-    static Ref<StyleRuleFontPaletteValues> create(const AtomString& name, const AtomString& fontFamily, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&&);
+    static Ref<StyleRuleFontPaletteValues> create(const AtomString& name, Vector<AtomString>&& fontFamilies, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&&);
 
     const AtomString& name() const { return m_name; }
-    const AtomString& fontFamily() const { return m_fontFamily; }
+    const Vector<AtomString>& fontFamilies() const { return m_fontFamilies; }
     const FontPaletteValues& fontPaletteValues() const { return m_fontPaletteValues; }
     std::optional<FontPaletteIndex> basePalette() const { return m_fontPaletteValues.basePalette(); }
     const Vector<FontPaletteValues::OverriddenColor>& overrideColors() const { return m_fontPaletteValues.overrideColors(); }
@@ -207,11 +207,11 @@ public:
     Ref<StyleRuleFontPaletteValues> copy() const { return adoptRef(*new StyleRuleFontPaletteValues(*this)); }
 
 private:
-    StyleRuleFontPaletteValues(const AtomString& name, const AtomString& fontFamily, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors);
+    StyleRuleFontPaletteValues(const AtomString& name, Vector<AtomString>&& fontFamilies, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors);
     StyleRuleFontPaletteValues(const StyleRuleFontPaletteValues&) = default;
 
     AtomString m_name;
-    AtomString m_fontFamily;
+    Vector<AtomString> m_fontFamilies;
     FontPaletteValues m_fontPaletteValues;
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -76,6 +76,7 @@
 #include "CSSTimingFunctionValue.h"
 #include "CSSTransformListValue.h"
 #include "CSSUnresolvedColor.h"
+#include "CSSValueKeywords.h"
 #include "CSSValuePair.h"
 #include "CSSValuePool.h"
 #include "CSSVariableData.h"
@@ -4884,7 +4885,7 @@ AtomString consumeFamilyNameRaw(CSSParserTokenRange& range)
     return concatenateFamilyName(range);
 }
 
-Vector<AtomString> consumeFamilyNameList(CSSParserTokenRange& range)
+Vector<AtomString> consumeFamilyNameListRaw(CSSParserTokenRange& range)
 {
     Vector<AtomString> result;
     do {
@@ -5516,6 +5517,13 @@ RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range)
     if (familyName.isNull())
         return nullptr;
     return CSSValuePool::singleton().createFontFamilyValue(familyName);
+}
+
+RefPtr<CSSValue> consumeFamilyNameList(CSSParserTokenRange& range)
+{
+    return consumeCommaSeparatedListWithoutSingleValueOptimization(range, [] (auto& range) {
+        return consumeFamilyName(range);
+    });
 }
 
 static RefPtr<CSSValue> consumeGenericFamily(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -198,7 +198,8 @@ std::optional<CSSValueID> consumeFontStretchKeywordValueRaw(CSSParserTokenRange&
 AtomString concatenateFamilyName(CSSParserTokenRange&);
 AtomString consumeFamilyNameRaw(CSSParserTokenRange&);
 // https://drafts.csswg.org/css-fonts-4/#family-name-value
-Vector<AtomString> consumeFamilyNameList(CSSParserTokenRange&);
+Vector<AtomString> consumeFamilyNameListRaw(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeFamilyNameList(CSSParserTokenRange&);
 std::optional<FontRaw> consumeFontRaw(CSSParserTokenRange&, CSSParserMode);
 const AtomString& genericFontFamily(CSSValueID);
 WebKitFontFamilyNames::FamilyNamesIndex genericFontFamilyIndex(CSSValueID);


### PR DESCRIPTION
#### 83db139305cad9bc26aae1844c44a43b12e5d986
<pre>
[CSS] @font-palette-values family-name supports multiple values
<a href="https://bugs.webkit.org/show_bug.cgi?id=252569">https://bugs.webkit.org/show_bug.cgi?id=252569</a>
rdar://105975619

Reviewed by Tim Nguyen.

This patch allows @font-palette-values family-name descriptor to have
a list of family names (per spec).

<a href="https://drafts.csswg.org/css-fonts-4/#family-name-syntax">https://drafts.csswg.org/css-fonts-4/#family-name-syntax</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-36.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt:
* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
(WebCore::CSSFontPaletteValuesRule::fontFamily const):
(WebCore::CSSFontPaletteValuesRule::cssText const):
(WebCore::CSSFontPaletteValuesRule::~CSSFontPaletteValuesRule): Deleted.
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontPaletteValuesRule):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleFontPaletteValues::create):
(WebCore::StyleRuleFontPaletteValues::StyleRuleFontPaletteValues):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFamilyNameListRaw):
(WebCore::CSSPropertyParserHelpers::consumeFamilyNameList):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:

Canonical link: <a href="https://commits.webkit.org/267411@main">https://commits.webkit.org/267411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/906090869eecf2c6b17ca36162bfe50eeb9862c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15455 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17807 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19034 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14338 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21728 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14218 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19412 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15718 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13326 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18038 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14896 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3953 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19265 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19258 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15521 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4071 "Passed tests") | 
<!--EWS-Status-Bubble-End-->