### PR TITLE
REGRESSION(260575@main): YouTube videos sometimes do not resize properly in fullscreen and theater modes

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -73,7 +73,7 @@ public:
     void setLayerHostView(RetainPtr<PlatformView>&& layerHostView) { m_layerHostView = WTFMove(layerHostView); }
 
     WebAVPlayerLayer *playerLayer() const { return m_playerLayer.get(); }
-    void setPlayerLayer(RetainPtr<WebAVPlayerLayer>&& playerLayer) { m_playerLayer = WTFMove(playerLayer); }
+    void setPlayerLayer(RetainPtr<WebAVPlayerLayer>&&);
 
 #if PLATFORM(IOS_FAMILY)
     WebAVPlayerLayerView *playerView() const { return m_playerView.get(); }

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -209,6 +209,12 @@ void VideoFullscreenModelContext::removeClient(VideoFullscreenModelClient& clien
     m_clients.remove(&client);
 }
 
+void VideoFullscreenModelContext::setPlayerLayer(RetainPtr<WebAVPlayerLayer>&& playerLayer)
+{
+    m_playerLayer = WTFMove(playerLayer);
+    [m_playerLayer setVideoDimensions:m_videoDimensions];
+}
+
 void VideoFullscreenModelContext::setVideoDimensions(const WebCore::FloatSize& videoDimensions)
 {
     if (m_videoDimensions == videoDimensions)


### PR DESCRIPTION
#### e1c50afade41377b00036a3bb01d37d5d78a7015
<pre>
REGRESSION(260575@main): YouTube videos sometimes do not resize properly in fullscreen and theater modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=260025">https://bugs.webkit.org/show_bug.cgi?id=260025</a>
rdar://112780721

Reviewed by Mike Wyrzykowski.

WebAVPlayerLayer needs to know its video&apos;s dimensions in order to properly lay out its sublayers.
When video dimensions change, VideoFullscreenManagerProxy caches the dimensions in its
VideoFullscreenModelContext, updates the WebAVPlayerLayer with the new dimensions, and calls
-setNeedsLayout on the layer to trigger a re-layout of its sublayers. However, in rare cases, video
dimensions can change before the WebAVPlayerLayer is created. While VideoFullscreenModelContext
would cache the dimensions, the WebAVPlayerLayer would not be told about these cached dimensions
when it was created, leading it to believe the video had dimensions of 0x0 during -layoutSublayers.

Fixed this by setting VideoFullscreenModelContext&apos;s cached video dimensions on the WebAVPlayerLayer
at creation time to ensure it always lays out with the most recent video dimensions sent to it from
the WebContent process.

No new tests as I couldn&apos;t determine a way to capture the necessary timing in a test.

* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::setPlayerLayer):

Canonical link: <a href="https://commits.webkit.org/266807@main">https://commits.webkit.org/266807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d7a0dc97c8dcd5c78047c43901d5e3804548bc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13894 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16537 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17234 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12702 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20296 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16710 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11847 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13301 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3576 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->