### PR TITLE
Add the change event for the Cookie Store API

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1827,6 +1827,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/t
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/audio_loop_base.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/networkState_during_progress.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-fallback-failed-cross-origin-navigation.sub.html [ Failure Pass ]
+webkit.org/b/260103 imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html [ Pass Failure ]
 
 # Newly importing W3C tests needed support for reftest-wait.
 webkit.org/b/186045 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-rendering-after-controls-added.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
@@ -1,9 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT HTTP set/overwrite/delete observed in CookieStore Test timed out
-NOTRUN CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies
-NOTRUN CookieStore set/overwrite/delete observed in HTTP headers
-NOTRUN HTTP headers agreed with CookieStore on encoding non-ASCII cookies
-NOTRUN Binary HTTP set/overwrite/delete observed in CookieStore
+PASS HTTP set/overwrite/delete observed in CookieStore
+FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies assert_equals: Cookie we wrote using HTTP in cookie jar expected "HTTP-🍪=🔵" but got "HTTP-ðª=ðµ"
+PASS CookieStore set/overwrite/delete observed in HTTP headers
+FAIL HTTP headers agreed with CookieStore on encoding non-ASCII cookies assert_equals: HTTP cookie jar contains only cookie we set expected "🍪=🔵" but got ""
+FAIL Binary HTTP set/overwrite/delete observed in CookieStore assert_equals: Binary cookie we wrote using HTTP in cookie jar expected "HTTP-cookie=value\ufffd" but got "HTTP-cookie=valueï¿½"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT cookieStore fires change event for cookie set by cookieStore.set() Test timed out
+PASS cookieStore fires change event for cookie set by cookieStore.set()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT cookieStore fires change event for cookie deleted by cookieStore.delete() Test timed out
+PASS cookieStore fires change event for cookie deleted by cookieStore.delete()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT cookieStore fires change event for cookie overwritten by cookieStore.set() Test timed out
+PASS cookieStore fires change event for cookie overwritten by cookieStore.set()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT HttpOnly cookies are not observed Test timed out
-NOTRUN HttpOnly cookies can not be set by document.cookie
-NOTRUN HttpOnly cookies can not be set by CookieStore
+PASS HttpOnly cookies are not observed
+PASS HttpOnly cookies can not be set by document.cookie
+PASS HttpOnly cookies can not be set by CookieStore
 

--- a/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt
+++ b/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt
@@ -2,5 +2,5 @@
 PASS document.cookie set/overwrite/delete observed by CookieStore
 PASS CookieStore set/overwrite/delete observed by document.cookie
 FAIL CookieStore agrees with document.cookie on encoding non-ASCII cookies assert_equals: Cookie we wrote using document.cookie in cookie jar expected (string) "DOCUMENT-🍪=🔵" but got (undefined) undefined
-PASS document.cookie agrees with CookieStore on encoding non-ASCII cookies
+FAIL document.cookie agrees with CookieStore on encoding non-ASCII cookies assert_equals: Empty cookie jar after CookieStore delete expected (undefined) undefined but got (string) "DOCUMENT-🍪=🔵"
 

--- a/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
+++ b/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
@@ -1,0 +1,7 @@
+
+PASS HTTP set/overwrite/delete observed in CookieStore
+FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies assert_equals: Cookie we wrote using HTTP in cookie jar expected (string) "HTTP-🍪=🔵" but got (undefined) undefined
+PASS CookieStore set/overwrite/delete observed in HTTP headers
+FAIL HTTP headers agreed with CookieStore on encoding non-ASCII cookies assert_equals: HTTP cookie jar contains only cookie we set expected "🍪=🔵" but got ""
+FAIL Binary HTTP set/overwrite/delete observed in CookieStore assert_equals: Binary cookie we wrote using HTTP in cookie jar expected (string) "HTTP-cookie=value\ufffd" but got (undefined) undefined
+

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.idl
@@ -30,6 +30,6 @@
     SecureContext
 ] interface CookieChangeEvent : Event {
     constructor([AtomString] DOMString type, optional CookieChangeEventInit eventInitDict = {});
-    [SameObject] readonly attribute FrozenArray<CookieListItem> changed;
-    [SameObject] readonly attribute FrozenArray<CookieListItem> deleted;
+    [CachedAttribute, SameObject] readonly attribute FrozenArray<CookieListItem> changed;
+    [CachedAttribute, SameObject] readonly attribute FrozenArray<CookieListItem> deleted;
 };

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.h
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.h
@@ -37,14 +37,13 @@ struct CookieListItem {
     CookieListItem() = default;
 
     CookieListItem(Cookie&& cookie)
+        : name(WTFMove(cookie.name))
+        , value(WTFMove(cookie.value))
+        , domain(WTFMove(cookie.domain))
+        , path(WTFMove(cookie.path))
+        , expires(cookie.expires)
+        , secure(cookie.secure)
     {
-        name = WTFMove(cookie.name);
-        value = WTFMove(cookie.value);
-        domain = WTFMove(cookie.domain);
-        path = WTFMove(cookie.path);
-        expires = cookie.expires.has_value() ? std::optional { *cookie.expires } : std::nullopt;
-        secure = cookie.secure;
-
         switch (cookie.sameSite) {
         case Cookie::SameSitePolicy::Strict:
             sameSite = CookieSameSite::Strict;

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -30,6 +30,7 @@
 #include "SameSiteInfo.h"
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -46,7 +47,7 @@ class NetworkStorageSession;
 class StorageSessionProvider;
 struct SameSiteInfo;
 
-class WEBCORE_EXPORT CookieJar : public RefCounted<CookieJar> {
+class WEBCORE_EXPORT CookieJar : public RefCounted<CookieJar>, public CanMakeWeakPtr<CookieJar> {
 public:
     static Ref<CookieJar> create(Ref<StorageSessionProvider>&&);
     


### PR DESCRIPTION
#### 5e29d991fbf6dd8193d81b5fd706b2224ed7caf2
<pre>
Add the change event for the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=260028">https://bugs.webkit.org/show_bug.cgi?id=260028</a>

Reviewed by Chris Dumez.

CookieStore now subclasses CookieChangeListener so that when an
event listener changes, it can register (or unregister) itself
as a listener. If it is registered and a cookie changed, the
relevant function (cookiesAdded or cookiesDeleted) will be called
to fire a change event.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt:
* LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt: Added.
* LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt: Added.
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.idl:
* Source/WebCore/Modules/cookie-store/CookieListItem.h:
(WebCore::CookieListItem::CookieListItem):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::CookieStore):
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::set):
(WebCore::CookieStore::cookiesAdded):
(WebCore::CookieStore::cookiesDeleted):
(WebCore::CookieStore::stop):
(WebCore::CookieStore::virtualHasPendingActivity const):
(WebCore::CookieStore::eventListenersDidChange):
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/loader/CookieJar.h:

Canonical link: <a href="https://commits.webkit.org/266850@main">https://commits.webkit.org/266850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aafa4567f05c9138315af26ca4da2d355bb35f8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16657 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15563 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20417 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16854 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11971 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13448 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3604 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->