### PR TITLE
[visionOS] Videos on apple.com are not shown in compatibility mode when using a mobile UA

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -873,19 +873,19 @@ static FloatSize fullscreenPreferencesScreenSize(CGFloat preferredWidth)
 FloatSize WebPageProxy::availableScreenSize()
 {
 #if PLATFORM(VISION)
-    return fullscreenPreferencesScreenSize(m_preferences->mediaPreferredFullscreenWidth());
-#else
-    return WebCore::availableScreenSize();
+    if (PAL::currentUserInterfaceIdiomIsVision())
+        return fullscreenPreferencesScreenSize(m_preferences->mediaPreferredFullscreenWidth());
 #endif
+    return WebCore::availableScreenSize();
 }
 
 FloatSize WebPageProxy::overrideScreenSize()
 {
 #if PLATFORM(VISION)
-    return fullscreenPreferencesScreenSize(m_preferences->mediaPreferredFullscreenWidth());
-#else
-    return WebCore::overrideScreenSize();
+    if (PAL::currentUserInterfaceIdiomIsVision())
+        return fullscreenPreferencesScreenSize(m_preferences->mediaPreferredFullscreenWidth());
 #endif
+    return WebCore::overrideScreenSize();
 }
 
 float WebPageProxy::textAutosizingWidth()


### PR DESCRIPTION
#### 0a8efe4a7da6d481bcd89a820c5e0e75078d7578
<pre>
[visionOS] Videos on apple.com are not shown in compatibility mode when using a mobile UA
<a href="https://bugs.webkit.org/show_bug.cgi?id=260027">https://bugs.webkit.org/show_bug.cgi?id=260027</a>
rdar://112638189

Reviewed by Mike Wyrzykowski, Megan Gardner and Tim Horton.

apple.com product pages (like <a href="https://www.apple.com/apple-vision-pro/)">https://www.apple.com/apple-vision-pro/)</a> often
have a &quot;Watch the film&quot; button that displays a video and begins playback.

Depending on the user agent, as well as the relationship between screen
size (`Screen.availWidth` and `Screen.availHeight`) and viewport size, apple.com
uses different logic (JavaScript + DOM structure) for the video flow.

On the mobile site, apple.com simply begins playback on a 1x1 &lt;video&gt;. On iPhone,
this results in the video entering fullscreen automatically, as the `playsinline`
is missing. On the desktop site, apple.com simply shows the video inline, and sizes
it to fill the viewport.

Importantly, a mobile UA is not enough to get apple.com&apos;s mobile site, they also
account for screen size. Due to our screen size override on visionOS, added in
258005@main, and the fact that apps running compatibility mode report other sizes
as if they were an iPad, apple.com ends up using the mobile logic. This logic
fails, as visionOS/iPadOS do not have automatic fullscreen on playback, leaving
a 1x1 &lt;video&gt; element behind.

To fix, do not apply the screen size override in compatibility mode. Apps in
compatibility mode have the exact same fullscreen behavior as iPad, and the
fix in 258005@main is unnecessary there.

Note that the same bug can occur in Safari, depending on the size the window
is resized to. However, that is an existing site issue that will require a
fix by apple.com.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::availableScreenSize):
(WebKit::WebPageProxy::overrideScreenSize):

Canonical link: <a href="https://commits.webkit.org/266780@main">https://commits.webkit.org/266780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2901b3b8d49ee516f1f015ad617025e3fa6266e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16518 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15176 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17251 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13495 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14037 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13329 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1767 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->