### PR TITLE
[GStreamer][WebCodecs] Refactor to push samples on the harness

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -52,7 +52,7 @@ public:
     void flush(Function<void()>&&);
     void close() { m_isClosed = true; }
 
-    bool isStarted() const { return m_harness->isStarted(); }
+    bool isConfigured() const { return !!m_inputCaps; }
 
 private:
     GStreamerInternalVideoDecoder(const String& codecName, const VideoDecoder::Config&, VideoDecoder::OutputCallback&&, VideoDecoder::PostTaskCallback&&, GRefPtr<GstElement>&&);
@@ -63,6 +63,7 @@ private:
     RefPtr<GStreamerElementHarness> m_harness;
     FloatSize m_presentationSize;
     bool m_isClosed { false };
+    GRefPtr<GstCaps> m_inputCaps;
 };
 
 bool GStreamerVideoDecoder::create(const String& codecName, const Config& config, CreateCallback&& callback, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback)
@@ -81,7 +82,7 @@ bool GStreamerVideoDecoder::create(const String& codecName, const Config& config
 
     GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element));
-    if (!decoder->m_internalDecoder->isStarted()) {
+    if (!decoder->m_internalDecoder->isConfigured()) {
         GST_WARNING("Internal video decoder failed to configure for codec %s", codecName.ascii().data());
         return false;
     }
@@ -138,46 +139,46 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
     configureVideoDecoderForHarnessing(element);
 
     GST_DEBUG_OBJECT(element.get(), "Configuring decoder for codec %s", codecName.ascii().data());
-    GRefPtr<GstCaps> inputCaps;
     const char* parser = nullptr;
     if (codecName.startsWith("avc1"_s)) {
-        inputCaps = adoptGRef(gst_caps_new_simple("video/x-h264", "stream-format", G_TYPE_STRING, "avc", "alignment", G_TYPE_STRING, "au", nullptr));
+        m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-h264", "stream-format", G_TYPE_STRING, "avc", "alignment", G_TYPE_STRING, "au", nullptr));
         parser = "h264parse";
         if (auto codecData = wrapSpanData(config.description))
-            gst_caps_set_simple(inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
+            gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
     } else if (codecName.startsWith("av01"_s)) {
-        inputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "stream-format", G_TYPE_STRING, "obu-stream", "alignment", G_TYPE_STRING, "frame", nullptr));
+        m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "stream-format", G_TYPE_STRING, "obu-stream", "alignment", G_TYPE_STRING, "frame", nullptr));
         parser = "av1parse";
     } else if (codecName.startsWith("vp8"_s))
-        inputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp8"));
+        m_inputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp8"));
     else if (codecName.startsWith("vp09"_s)) {
-        inputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
+        m_inputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
         parser = "vp9parse";
     } else if (codecName.startsWith("hvc1"_s)) {
-        inputCaps = adoptGRef(gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "hvc1", "alignment", G_TYPE_STRING, "au", nullptr));
+        m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "hvc1", "alignment", G_TYPE_STRING, "au", nullptr));
         parser = "h265parse";
         if (auto codecData = wrapSpanData(config.description))
-            gst_caps_set_simple(inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
+            gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
     } else if (codecName.startsWith("hev1"_s)) {
-        inputCaps = adoptGRef(gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "hev1", "alignment", G_TYPE_STRING, "au", nullptr));
+        m_inputCaps = adoptGRef(gst_caps_new_simple("video/x-h265", "stream-format", G_TYPE_STRING, "hev1", "alignment", G_TYPE_STRING, "au", nullptr));
         parser = "h265parse";
         if (auto codecData = wrapSpanData(config.description))
-            gst_caps_set_simple(inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
+            gst_caps_set_simple(m_inputCaps.get(), "codec_data", GST_TYPE_BUFFER, codecData.get(), nullptr);
     } else {
         WTFLogAlways("Codec %s not wired in yet", codecName.ascii().data());
         return;
     }
 
     if (config.width && config.height)
-        gst_caps_set_simple(inputCaps.get(), "width", G_TYPE_INT, config.width, "height", G_TYPE_INT, config.height, nullptr);
+        gst_caps_set_simple(m_inputCaps.get(), "width", G_TYPE_INT, config.width, "height", G_TYPE_INT, config.height, nullptr);
 
     GRefPtr<GstElement> harnessedElement;
     auto* factory = gst_element_get_factory(element.get());
-    if (parser && !gst_element_factory_can_sink_all_caps(factory, inputCaps.get())) {
+    if (parser && !gst_element_factory_can_sink_all_caps(factory, m_inputCaps.get())) {
         // The decoder won't accept the input caps, so put a parser in front.
         auto* parserElement = makeGStreamerElement(parser, nullptr);
         if (!parserElement) {
             GST_WARNING_OBJECT(element.get(), "Required parser %s not found, decoding will fail", parser);
+            m_inputCaps.clear();
             return;
         }
         harnessedElement = gst_bin_new(nullptr);
@@ -209,7 +210,6 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
             m_outputCallback(VideoDecoder::DecodedFrame { WTFMove(videoFrame), static_cast<int64_t>(GST_BUFFER_PTS(outputBuffer.get())), GST_BUFFER_DURATION(outputBuffer.get()) });
         });
     });
-    m_harness->start(WTFMove(inputCaps));
 }
 
 void GStreamerInternalVideoDecoder::decode(std::span<const uint8_t> frameData, bool isKeyFrame, int64_t timestamp, std::optional<uint64_t> duration, VideoDecoder::DecodeCallback&& callback)
@@ -231,7 +231,8 @@ void GStreamerInternalVideoDecoder::decode(std::span<const uint8_t> frameData, b
     if (duration)
         GST_BUFFER_DURATION(buffer.get()) = *duration;
 
-    auto result = m_harness->pushBuffer(WTFMove(buffer));
+    // FIXME: Maybe configure segment here, could be useful for reverse playback.
+    auto result = m_harness->pushSample(adoptGRef(gst_sample_new(buffer.get(), m_inputCaps.get(), nullptr, nullptr)));
     m_postTaskCallback([protectedThis = Ref { *this }, callback = WTFMove(callback), result]() mutable {
         if (protectedThis->m_isClosed)
             return;


### PR DESCRIPTION
#### 164aa4e39b317d71cbd408dcaa124282838b4d2f
<pre>
[GStreamer][WebCodecs] Refactor to push samples on the harness
<a href="https://bugs.webkit.org/show_bug.cgi?id=260037">https://bugs.webkit.org/show_bug.cgi?id=260037</a>

Reviewed by Xabier Rodriguez-Calvar.

This delays the element harness startup until the first decode task is fired. It&apos;s also in line with
the upcoming audio decoder workflow and potentially more future-proof, specially if we plan to
support reverse decoding later on.

* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::isConfigured const):
(WebCore::GStreamerVideoDecoder::create):
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::decode):
(WebCore::GStreamerInternalVideoDecoder::isStarted const): Deleted.

Canonical link: <a href="https://commits.webkit.org/266943@main">https://commits.webkit.org/266943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7467b2a43bcbf461519895c38319b71ceb6c1c8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15611 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17697 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20682 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14453 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13728 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18072 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->