### PR TITLE
Crash under ReportingScope::unregisterReportingObserver()

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -77,10 +77,7 @@ ReportingObserver::ReportingObserver(ScriptExecutionContext& scriptExecutionCont
 {
 }
 
-ReportingObserver::~ReportingObserver()
-{
-    disconnect();
-}
+ReportingObserver::~ReportingObserver() = default;
 
 void ReportingObserver::disconnect()
 {

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -65,7 +65,7 @@ void ReportingScope::registerReportingObserver(ReportingObserver& observer)
 
 void ReportingScope::unregisterReportingObserver(ReportingObserver& observer)
 {
-    m_reportingObservers.removeFirstMatching([&observer](auto item) {
+    m_reportingObservers.removeFirstMatching([&observer](auto& item) {
         return item.ptr() == &observer;
     });
 }


### PR DESCRIPTION
#### a7dc74b15bbc34e5eddff0d376fc0f1d18ed815e
<pre>
Crash under ReportingScope::unregisterReportingObserver()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260038">https://bugs.webkit.org/show_bug.cgi?id=260038</a>
rdar://113533957

Reviewed by David Kilzer.

The ReportingScope keeps the ReportingObservers alive via its `m_reportingObservers`
vector. The crash would happen because ReportingScope::removeAllObservers() would
call clear() on this vector, which may cause ReportingObserver objects to get
destroyed. In turn, the ReportingObserver destructor would call
ReportingScope::unregisterReportingObserver() to unregister itself. This would
try to modify the vector while it is in the middle of getting cleared.

To address the issue, the ReportingObserver destructor no longer attempts to
unregister itself from the ReportingScope. Since the ReportingScope keeps a
strong reference to the observers, there is no way the observer is still
registered if its destructor gets called.

* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::~ReportingObserver): Deleted.
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::unregisterReportingObserver):

Canonical link: <a href="https://commits.webkit.org/266791@main">https://commits.webkit.org/266791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a56c55759b41cd8a4c6d7a26073938c1be012a44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16522 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15180 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17255 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20316 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13333 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3566 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->