### PR TITLE
run-benchmarks occasionally fails to download Speedometer3

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -2,6 +2,7 @@ import logging
 import tempfile
 import os
 import re
+import requests
 import shutil
 import subprocess
 import sys
@@ -10,11 +11,6 @@ import tarfile
 from webkitpy.benchmark_runner.utils import get_path_from_project_root, force_remove
 from webkitpy.benchmark_runner.github_downloader import GithubDownloadTask
 from zipfile import ZipFile
-
-if sys.version_info > (3, 0):
-    from urllib.request import urlretrieve
-else:
-    from urllib import urlretrieve
 
 
 _log = logging.getLogger(__name__)
@@ -87,7 +83,11 @@ class BenchmarkBuilder(object):
 
         archive_path = os.path.join(self._web_root, 'archive.' + archive_type)
         _log.info('Downloading %s to %s' % (archive_url, archive_path))
-        urlretrieve(archive_url, archive_path)
+        with requests.get(archive_url, stream=True, allow_redirects=True) as response:
+            response.raise_for_status()
+            with open(archive_path, 'wb') as archive_file:
+                for chunk in response.iter_content(chunk_size=1024):
+                    archive_file.write(chunk)
 
         if archive_type == 'zip':
             with ZipFile(archive_path, 'r') as archive:


### PR DESCRIPTION
#### c2e669da7d0077db7d0ec1eb14b33788effe9354
<pre>
run-benchmarks occasionally fails to download Speedometer3
<a href="https://bugs.webkit.org/show_bug.cgi?id=260044">https://bugs.webkit.org/show_bug.cgi?id=260044</a>
rdar://problem/113717485

Reviewed by Jonathan Bedard.

Occasionally, urllib will fail to find its CAcert (or discover that it is invalid); our other benchmarks use requests to pull from Github, which uses certifi&apos;s CAcert in the background. This is why we haven&apos;t hit this issue much in the past.

This patch changes urlretrieve to requests.get in order to use certifi&apos;s CAcert under the hood. It also adds chunked downloading - which will help if we ever need to download large file archives for benchmarks.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder._fetch_remote_archive):

Canonical link: <a href="https://commits.webkit.org/266796@main">https://commits.webkit.org/266796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a36d2aff689d80a459a0db30fab183e8847037

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16544 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17278 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14899 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13348 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13515 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14063 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13354 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3565 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->