### PR TITLE
Re-import css/css-contain WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4886,8 +4886,11 @@ imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visib
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-first-observation.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
+
+# Style containment
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -1279,6 +1279,7 @@
         "web-platform-tests/css/css-contain/crashtests/contain-nested-crash-002.html",
         "web-platform-tests/css/css-contain/crashtests/contain-nested-crash-003.html",
         "web-platform-tests/css/css-contain/crashtests/contain-nested-crash-004.html",
+        "web-platform-tests/css/css-contain/crashtests/contain-nested-relayout-boundary.html",
         "web-platform-tests/css/css-counter-styles/arabic-indic/css3-counter-styles-101-ref.html",
         "web-platform-tests/css/css-counter-styles/arabic-indic/css3-counter-styles-102-ref.html",
         "web-platform-tests/css/css-counter-styles/arabic-indic/css3-counter-styles-103-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt
@@ -1,0 +1,12 @@
+
+FAIL style(--my-prop: foo) assert_equals: expected "true" but got ""
+FAIL style(--my-prop: foo - bar ()) assert_equals: expected "true" but got ""
+FAIL style(not ((--foo: calc(10px + 2em)) and ((--foo: url(x))))) assert_equals: expected "true" but got ""
+FAIL style((--foo: bar) or (--bar: 10px)) assert_equals: expected "true" but got ""
+FAIL style(--my-prop:) assert_equals: expected "true" but got ""
+FAIL style(--my-prop: ) assert_equals: expected "true" but got ""
+FAIL style(--foo: bar !important) assert_equals: expected "true" but got ""
+FAIL style(--foo) assert_equals: expected "true" but got ""
+PASS style(--foo: bar;)
+PASS style(style(--foo: bar))
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<title>@container: style queries parsing</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-rule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<div style="container-name:name">
+  <main id="main"></main>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  function cleanup_main() {
+    while (main.firstChild)
+      main.firstChild.remove();
+  }
+
+  function set_style(text) {
+    let style = document.createElement('style');
+    style.innerText = text;
+    main.append(style);
+    return style;
+  }
+
+  function test_rule_valid(query) {
+    test(t => {
+      t.add_cleanup(cleanup_main);
+      let style = set_style(`@container ${query} {}`);
+      assert_equals(style.sheet.rules.length, 1);
+    }, query);
+  }
+
+  function test_condition_invalid(condition) {
+    test(t => {
+      t.add_cleanup(cleanup_main);
+      let style = set_style(`@container name ${condition} {}`);
+      assert_equals(style.sheet.rules.length, 0);
+    }, condition);
+  }
+
+  // Tests that 1) the condition parses, and 2) is either "unknown" or not, as
+  // specified.
+  function test_condition_valid(condition, unknown) {
+    test(t => {
+      t.add_cleanup(cleanup_main);
+      let style = set_style(`
+        @container name ${condition} {}
+        @container name (${condition}) or (not (${condition})) { main { --match:true; } }
+      `);
+      assert_equals(style.sheet.rules.length, 2);
+      const expected = unknown ? '' : 'true';
+      assert_equals(getComputedStyle(main).getPropertyValue('--match'), expected);
+    }, condition);
+  }
+
+  function test_condition_known(condition) {
+    test_condition_valid(condition, false /* unknown */);
+  }
+
+  function test_condition_unknown(condition) {
+    test_condition_valid(condition, true /* unknown */);
+  }
+
+  test_condition_known('style(--my-prop: foo)');
+  test_condition_known('style(--my-prop: foo - bar ())');
+  test_condition_known('style(not ((--foo: calc(10px + 2em)) and ((--foo: url(x)))))');
+  test_condition_known('style((--foo: bar) or (--bar: 10px))');
+  test_condition_known('style(--my-prop:)');
+  test_condition_known('style(--my-prop: )');
+  test_condition_known('style(--foo: bar !important)');
+  test_condition_known('style(--foo)');
+
+  test_condition_unknown('style(--foo: bar;)');
+  test_condition_unknown('style(style(--foo: bar))');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-ineligible-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-ineligible-container-expected.txt
@@ -1,0 +1,11 @@
+
+PASS /* basic */
+FAIL display: table assert_equals: width expected "30px" but got "20px"
+FAIL display: table-cell assert_equals: width expected "30px" but got "20px"
+FAIL display: inline assert_equals: width expected "30px" but got "80px"
+FAIL display: contents assert_equals: width expected "30px" but got "80px"
+FAIL display: none assert_equals: width expected "30px" but got "80px"
+PASS container-type: normal
+PASS container-type: inline-size
+PASS container-type: inline-size; writing-mode: vertical-lr
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-ineligible-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-ineligible-container.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Container Relative Units: ineligible container</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-lengths">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+  #grandparent, #parent { container-type: size; }
+  #grandparent { width: 300px; height: 250px; }
+  #parent { width: 200px; height: 150px; }
+  #target { width: 10cqw; height: 10cqh; }
+</style>
+<div id="log"></div>
+<div id="grandparent">
+  <div id="parent">
+    <div id="target"></div>
+  </div>
+</div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<script>
+  setup(() => assert_implements_container_queries());
+  const cases = {
+    "/* basic */": [20, 15],
+    "display: table": [30, 25],
+    "display: table-cell": [30, 25],
+    "display: inline": [30, 25],
+    "display: contents": [30, 25],
+    "display: none": [30, 25],
+    "container-type: normal": [30, 25],
+    "container-type: inline-size": [20, 25],
+    "container-type: inline-size; writing-mode: vertical-lr": [30, 15],
+  };
+  const parent = document.getElementById("parent");
+  const target = document.getElementById("target");
+  const cs = getComputedStyle(target);
+  for (let [style, [width, height]] of Object.entries(cases)) {
+    test(() => {
+      parent.style.cssText = style;
+      assert_equals(cs.width, width + "px", "width");
+      assert_equals(cs.height, height + "px", "height");
+    }, style);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/chrome-bug-1429955-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/chrome-bug-1429955-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="help" href="https://crbug.com/1429955.html">
+<div id="mc" style="display:list-item; width:0; columns:2; container-type:size;">
+  <div id="abs" style="position:absolute; container-type:inline-size;">line</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/dialog-backdrop-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/dialog-backdrop-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+  html {
+    overflow: hidden;
+  }
+
+  dialog {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+  }
+
+  @container (width > 1px) {
+    dialog::backdrop {
+      margin: 10px;
+      background-color: green;
+    }
+  }
+</style>
+<dialog id=dialog>
+  Hello World
+</dialog>
+<script>
+  dialog.showModal();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/dirty-rowgroup-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/dirty-rowgroup-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<div style='container-type: size;'></div>
+<table>
+  <tbody id='id_0'></tbody>
+    <th id='id_1'>
+      <tr>
+        <th></th>
+      </tr>
+    </th>
+</table>
+<script>
+  const tbody = document.getElementById('id_0')
+  tbody.getBoundingClientRect();
+  const theader = document.getElementById('id_1')
+  tbody.outerText = 'foo';
+  theader.setAttribute('rowspan', 100)
+  tbody.getBoundingClientRect();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/iframe-init-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/iframe-init-crash.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<audio controls style='container-type: size'></audio>
+<iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/reversed-ol-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/reversed-ol-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Don't crash with intermediate container in reversed list</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#containment-style">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#containment-style">
+<link rel="help" href="https://crbug.com/1377644">
+<style>
+.container {
+  container-type: size;
+}
+
+/* Prevent double layout due to scrollbar speculation */
+html {
+  overflow: hidden;
+}
+
+@container (width > 1px) {
+  .item {
+    display: list-item;
+  }
+}
+</style>
+<ol reversed>
+  <li>A</li>
+  <div class=container>
+    <div class=item>
+      B
+    </div>
+  </div>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/size-change-during-transition-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/size-change-during-transition-crash.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>Container Queries - Size change during transitions crash</title>
+<script src="/common/reftest-wait.js"></script>
+<link rel="help" href="https://crbug.com/1451359">
+<style>
+  #outer {
+    container-type: inline-size;
+    width: 100px;
+  }
+  #inner {
+    background-color: black;
+    transition: background-color 60s;
+  }
+  #inner.target {
+    background-color: white;
+  }
+  @container (width > 200px) {
+    #inner.target  {
+      background-color: lime;
+    }
+  }
+</style>
+<p>Pass if no crash.</p>
+<div id="outer">
+  <div id="inner">Look at my background</div>
+</div>
+<script>
+  inner.offsetTop;
+  inner.className = "target";
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      outer.style.width = "300px";
+      takeScreenshot();
+    });
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html style="background:green">
+<title>CSS Test Reference</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>CSS Container Queries Test: ::backdrop appearing conditionally on dialog container</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-queries">
+<link rel="match" href="top-layer-dialog-backdrop-ref.html">
+<style>
+  html {
+    /* Prevent multiple layout passes due to scrollbars */
+    overflow: hidden;
+    background: red;
+  }
+  dialog {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+    visibility: hidden;
+  }
+  dialog::backdrop {
+    display: none;
+    background-color: green;
+  }
+  @container (width > 1px) {
+    dialog::backdrop {
+      display: block;
+    }
+  }
+</style>
+<dialog id="dialog"></dialog>
+<script>
+  dialog.showModal();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-remove-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-remove-expected.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html style="background:green">
+<title>CSS Test Reference</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-remove.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-remove.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>CSS Container Queries Test: ::backdrop disappearing conditionally on dialog container</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-queries">
+<link rel="match" href="top-layer-dialog-backdrop-ref.html">
+<style>
+  html {
+    /* Prevent multiple layout passes due to scrollbars */
+    overflow: hidden;
+    background: green;
+  }
+  dialog {
+    container-type: size;
+    width: 100px;
+    height: 100px;
+    visibility: hidden;
+  }
+  dialog::backdrop {
+    display: block;
+    background-color: red;
+  }
+  @container (width > 1px) {
+    dialog::backdrop {
+      display: none;
+    }
+  }
+</style>
+<dialog id="dialog"></dialog>
+<script>
+  dialog.showModal();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt
@@ -4,9 +4,11 @@ PASS rem units respond to changes
 FAIL ex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL rex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL ch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL cap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL rch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL lh units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 PASS rlh units respond to changes
 FAIL ic units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL ric units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL rcap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic.html
@@ -157,6 +157,30 @@ test_template(document.currentScript.previousElementSibling, (t) => {
 
 <template>
   <style>
+    @import url("/fonts/ahem.css");
+    main { font-family: 'Ahem'; font-size: 10px; }
+    main.larger { font-size: 20px; }
+    @container (width <= 7cap) {
+      #test { color: green }
+    }
+  </style>
+  <div id="container">
+    <div>
+      <div id="test"></div>
+    </div>
+  </div>
+</template>
+<script>
+test_template(document.currentScript.previousElementSibling, (t) => {
+  t.add_cleanup(() => main.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  main.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'cap units respond to changes');
+</script>
+
+<template>
+  <style>
     :root { font-size: 10px; }
     :root.larger { font-size: 20px; }
     @container (width <= 15rch) {
@@ -277,4 +301,28 @@ test_template(document.currentScript.previousElementSibling, (t) => {
   document.documentElement.classList.add("larger");
   assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
 }, 'ric units respond to changes');
+</script>
+
+<template>
+  <style>
+    @import url("/fonts/ahem.css");
+    :root { font-family: 'Ahem'; font-size: 10px; }
+    :root.larger { font-size: 20px; }
+    @container (width <= 7rcap) {
+      #test { color: green }
+    }
+  </style>
+  <div id="container">
+    <div style="font-family: monospace;">
+      <div id="test"></div>
+    </div>
+  </div>
+</template>
+<script>
+test_template(document.currentScript.previousElementSibling, (t) => {
+  t.add_cleanup(() => document.documentElement.classList.remove("larger"));
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, red);
+  document.documentElement.classList.add("larger");
+  assert_equals(getComputedStyle(main.querySelector("#test")).color, green);
+}, 'rcap units respond to changes');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-expected.txt
@@ -9,4 +9,6 @@ PASS ic relative inline-size
 FAIL ric relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS lh relative inline-size
 PASS rlh relative inline-size
+FAIL cap relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL rcap relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units.html
@@ -5,7 +5,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/cq-testcommon.js"></script>
 <style>
-  :root { font-size: 10px; line-height: 10px; }
+  @import url("/fonts/ahem.css");
+  :root { font-family: 'Ahem'; font-size: 10px; line-height: 10px; }
   #em_container {
     container-type: inline-size;
     width: 100px;
@@ -16,6 +17,11 @@
     font-size: 50px;
     width: 10ex;
     height: 50rex;
+  }
+  #cap_container {
+    container-type: inline-size;
+    font-size: 50px;
+    width: 10cap;
   }
   #ch_container {
     container-type: inline-size;
@@ -38,10 +44,16 @@
   @container (width: 10rem) {
     #rem_test { color: green }
   }
+  @container (width: 10cap) {
+    #cap_test { color: green }
+  }
+  @container (width: 50rcap) {
+    #rcap_test { color: green }
+  }
   @container (width: 10ex) {
     #ex_test { color: green }
   }
-  @container (49rex <= width <= 100rex) {
+  @container (width: 50rex) {
     #rex_test { color: green }
   }
   @container (width: 10ch) {
@@ -66,6 +78,10 @@
 <div id="em_container">
   <div id="em_test"></div>
   <div id="rem_test"></div>
+</div>
+<div id="cap_container">
+  <div id="cap_test"></div>
+  <div id="rcap_test"></div>
 </div>
 <div id="ex_container">
   <div id="ex_test"></div>
@@ -97,4 +113,6 @@
   test(() => assert_equals(getComputedStyle(ric_test).color, green), "ric relative inline-size");
   test(() => assert_equals(getComputedStyle(lh_test).color, green), "lh relative inline-size");
   test(() => assert_equals(getComputedStyle(rlh_test).color, green), "rlh relative inline-size");
+  test(() => assert_equals(getComputedStyle(cap_test).color, green), "cap relative inline-size");
+  test(() => assert_equals(getComputedStyle(rcap_test).color, green), "rcap relative inline-size");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inheritance-from-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inheritance-from-container.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Containers and inheritance</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-queries">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support/cq-testcommon.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-query-containers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-query-containers-expected.txt
@@ -1,0 +1,34 @@
+
+PASS test1 - inline - 0b000
+PASS test2 - inline - 0b001
+PASS test3 - inline - 0b010
+PASS test4 - inline - 0b011
+PASS test5 - inline - 0b100
+PASS test6 - inline - 0b101
+PASS test7 - inline - 0b110
+PASS test8 - inline - 0b111
+PASS test9 - contents - 0b000
+PASS test10 - contents - 0b001
+PASS test11 - contents - 0b010
+PASS test12 - contents - 0b011
+PASS test13 - contents - 0b100
+PASS test14 - contents - 0b101
+PASS test15 - contents - 0b110
+PASS test16 - contents - 0b111
+PASS test17 - table-cell - 0b000
+PASS test18 - table-cell - 0b001
+PASS test19 - table-cell - 0b010
+PASS test20 - table-cell - 0b011
+PASS test21 - table-cell - 0b100
+PASS test22 - table-cell - 0b101
+PASS test23 - table-cell - 0b110
+PASS test24 - table-cell - 0b111
+PASS test25 - table - 0b000
+PASS test26 - table - 0b001
+PASS test27 - table - 0b010
+PASS test28 - table - 0b011
+PASS test29 - table - 0b100
+PASS test30 - table - 0b101
+PASS test31 - table - 0b110
+PASS test32 - table - 0b111
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-query-containers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-query-containers.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<title>Nested query containers affecting each other</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#size-container">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#containment-size">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  body > section {
+    contain: strict;
+    width: 500px;
+  }
+</style>
+<body>
+<script>
+promise_setup(() => {
+  assert_implements_container_queries();
+  return new Promise(resolve => {
+    addEventListener("load", () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          document.body.className = "run";
+          resolve();
+        });
+      });
+    }, {once: true});
+  });
+});
+
+function booleanTuples(n) {
+  const tuple = new Array(n);
+  function* recursion(i) {
+    if (i == n) {
+      yield tuple.slice();
+      return;
+    }
+    tuple[i] = false;
+    yield* recursion(i + 1);
+    tuple[i] = true;
+    yield* recursion(i + 1);
+  }
+  return recursion(0);
+}
+
+// The following display values evaluate container queries to unknown.
+const testCases = [
+  {
+    display: "inline",
+    expected: {
+      width: depth => depth % 2 ? 0 : 500 - depth,
+      height: depth => 0,
+    },
+  },
+  {
+    display: "contents",
+    expected: {
+      width: depth => depth % 2 ? 0 : 500 - depth,
+      height: depth => 0,
+    },
+  },
+  {
+    display: "table-cell",
+    expected: {
+      width: depth => depth % 2 ? 2 : 0,
+      height: depth => depth % 2 ? 2 : 0,
+    },
+  },
+  {
+    display: "table",
+    expected: {
+      width: depth => depth % 2 ? 4 : 0,
+      height: depth => depth % 2 ? 4 : 0,
+    },
+  },
+];
+
+let testNum = 1;
+for (let testCase of testCases) {
+  for (let tuple of booleanTuples(3)) {
+    const section = document.createElement("section");
+    const id = "test" + testNum;
+    section.id = id;
+    const style = document.createElement("style");
+    style.textContent = `
+      :where(body${tuple[0] ? ".run" : ""}) > #${id} {
+        container-type: size;
+        container-name: name;
+      }
+      :where(body${tuple[1] ? ".run" : ""}) > #${id} div {
+        container-type: size;
+        container-name: name;
+        border: solid;
+        border-width: 1px;
+      }
+      @container name (width >= 0) {
+        :where(body${tuple[2] ? ".run" : ""}) > #${id} div {
+          display: ${testCase.display};
+          border-style: dotted;
+        }
+      }
+    `;
+    section.appendChild(style);
+    section.insertAdjacentHTML(
+      "beforeend",
+      "<div><div><div><div><div><div></div></div></div></div></div></div>"
+    );
+    document.body.appendChild(section);
+    promise_test(async function() {
+      let div = section.querySelector("div");
+      let depth = 1;
+      while (div) {
+        const cs = getComputedStyle(div);
+        assert_equals(cs.display, depth % 2 ? testCase.display : "block");
+        assert_equals(cs.borderStyle, depth % 2 ? "dotted" : "solid", "borderStyle");
+        assert_equals(div.clientWidth, testCase.expected.width(depth), "clientWidth");
+        assert_equals(div.clientHeight, testCase.expected.height(depth), "clientHeight");
+        div = div.firstElementChild;
+        depth += 1;
+      }
+    }, id + " - " + testCase.display + " - 0b" + tuple.map(Number).join(""));
+    testNum += 1;
+  }
+}
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006-expected.txt
@@ -1,0 +1,12 @@
+First-line
+First-line
+
+FAIL Originating element container for ::before assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::after assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::marker assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::first-line assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::first-letter assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for outer ::first-line assert_equals: expected "30px" but got "40px"
+FAIL Originating element container for outer ::first-letter assert_equals: expected "30px" but got "40px"
+FAIL Originating element container for ::backdrop assert_equals: ::backdrop rendered expected "10px" but got "30px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<title>@container: originating element container for pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-queries">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  .container { container-type: inline-size; }
+  #target { display: list-item; }
+  @container (max-width: 200px) {
+    #target::before { content: "PASS"; font-size: 10cqw; }
+    #target::after { font-size: 10cqw; }
+    #target::marker { font-size: 10cqw; }
+    #target::first-line { font-size: 10cqw; }
+    #target::first-letter { font-size: 10cqw; }
+  }
+  @container ((min-width: 300px) and (max-width: 350px)) {
+    #outer::first-line { font-size: 10cqw; }
+    #outer::first-letter { font-size: 10cqw; }
+  }
+  dialog::backdrop { font-size: 0px; }
+  @container (max-width: 100px) {
+    dialog::backdrop { font-size: 10cqw; }
+  }
+</style>
+<div style="width: 400px" class="container">
+  <div style="width: 300px" class="container">
+    <div id="target" class="container" style="width: 200px">First-line</div>
+    <dialog id="dialog" class="container" style="width: 100px"></dialog>
+  </div>
+  <div style="width: 400px" class="container">
+    <div id="outer" style="width: 300px" class="container">
+      <div class="container" style="width: 200px">First-line</div>
+  </div>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  test(() => {
+    assert_equals(getComputedStyle(target, "::before").fontSize, "20px");
+  }, "Originating element container for ::before");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::after").fontSize, "20px");
+  }, "Originating element container for ::after");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::marker").fontSize, "20px");
+  }, "Originating element container for ::marker");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::first-line").fontSize, "20px");
+  }, "Originating element container for ::first-line");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::first-letter").fontSize, "20px");
+  }, "Originating element container for ::first-letter");
+  test(() => {
+    assert_equals(getComputedStyle(outer, "::first-line").fontSize, "30px");
+  }, "Originating element container for outer ::first-line");
+  test(() => {
+    assert_equals(getComputedStyle(outer, "::first-letter").fontSize, "30px");
+  }, "Originating element container for outer ::first-letter");
+  test((t) => {
+    t.add_cleanup(() => dialog.close());
+    assert_equals(getComputedStyle(dialog, "::backdrop").fontSize, "0px", "::backdrop not rendered");
+    dialog.showModal();
+    assert_equals(getComputedStyle(dialog, "::backdrop").fontSize, "10px", "::backdrop rendered");
+  }, "Originating element container for ::backdrop");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Initial font-size for ::before
+PASS Initial font-size for ::after
+PASS Initial font-size for ::marker
+PASS Initial font-size for ::first-line
+PASS Initial font-size for ::first-letter
+PASS Initial font-size for ::backdrop
+FAIL font-size for ::before depending on container assert_equals: expected "30px" but got "80px"
+FAIL font-size for ::after depending on container assert_equals: expected "30px" but got "80px"
+FAIL font-size for ::marker depending on container assert_equals: expected "30px" but got "80px"
+FAIL font-size for ::first-line depending on container assert_equals: expected "30px" but got "80px"
+FAIL font-size for ::first-letter depending on container assert_equals: expected "30px" but got "80px"
+FAIL font-size for ::backdrop depending on container assert_equals: expected "30px" but got "80px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<title>@container: originating element container for pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-queries">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  #target { container-type: inline-size; }
+  #target::before,
+  #target::after,
+  #target::marker,
+  #target::first-line,
+  #target::first-letter,
+  #target::backdrop {
+    font-size: 0px;
+  }
+  @container (width >= 300px) {
+    #target::before,
+    #target::after,
+    #target::marker,
+    #target::first-line,
+    #target::first-letter,
+    #target::backdrop {
+      font-size: 10cqw;
+    }
+  }
+</style>
+<div id="outer" style="width: 200px">
+  <div id="target"></div>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  const pseudo_elements = ["::before", "::after", "::marker", "::first-line", "::first-letter", "::backdrop"];
+
+  pseudo_elements.forEach((pseudo_element) => {
+    test(() => {
+      assert_equals(getComputedStyle(target, pseudo_element).fontSize, "0px");
+    }, `Initial font-size for ${pseudo_element}`);
+  });
+
+  outer.style.width = "300px";
+
+  pseudo_elements.forEach((pseudo_element) => {
+    test(() => {
+      assert_equals(getComputedStyle(target, pseudo_element).fontSize, "30px");
+    }, `font-size for ${pseudo_element} depending on container`);
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt
@@ -1,0 +1,12 @@
+First-line
+First-line
+
+FAIL Originating element container for ::before assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::after assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::marker assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::first-line assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for ::first-letter assert_equals: expected "20px" but got "30px"
+FAIL Originating element container for outer ::first-line assert_equals: expected "30px" but got "40px"
+FAIL Originating element container for outer ::first-letter assert_equals: expected "30px" but got "40px"
+FAIL Originating element container for ::backdrop assert_equals: ::backdrop rendered expected "10px" but got "30px"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<title>@container: originating element container for pseudo elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-queries">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  .container { container-type: inline-size; }
+  #target { display: list-item; }
+  #target::before { content: "PASS"; font-size: 10cqw; }
+  #target::after { font-size: 10cqw; }
+  #target::marker { font-size: 10cqw; }
+  #target::first-line { font-size: 10cqw; }
+  #target::first-letter { font-size: 10cqw; }
+  #outer::first-line { font-size: 10cqw; }
+  #outer::first-letter { font-size: 10cqw; }
+  dialog::backdrop { font-size: 10cqw; }
+</style>
+<div style="width: 400px" class="container">
+  <div style="width: 300px" class="container">
+    <div id="target" class="container" style="width: 200px">First-line</div>
+    <dialog id="dialog" class="container" style="width: 100px"></dialog>
+  </div>
+  <div style="width: 400px" class="container">
+    <div id="outer" style="width: 300px" class="container">
+      <div class="container" style="width: 200px">First-line</div>
+  </div>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  test(() => {
+    assert_equals(getComputedStyle(target, "::before").fontSize, "20px");
+  }, "Originating element container for ::before");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::after").fontSize, "20px");
+  }, "Originating element container for ::after");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::marker").fontSize, "20px");
+  }, "Originating element container for ::marker");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::first-line").fontSize, "20px");
+  }, "Originating element container for ::first-line");
+  test(() => {
+    assert_equals(getComputedStyle(target, "::first-letter").fontSize, "20px");
+  }, "Originating element container for ::first-letter");
+  test(() => {
+    assert_equals(getComputedStyle(outer, "::first-line").fontSize, "30px");
+  }, "Originating element container for outer ::first-line");
+  test(() => {
+    assert_equals(getComputedStyle(outer, "::first-letter").fontSize, "30px");
+  }, "Originating element container for outer ::first-letter");
+  test((t) => {
+    t.add_cleanup(() => dialog.close());
+    assert_equals(getComputedStyle(dialog, "::backdrop").fontSize, "30px", "::backdrop not rendered");
+    dialog.showModal();
+    assert_equals(getComputedStyle(dialog, "::backdrop").fontSize, "10px", "::backdrop rendered");
+  }, "Originating element container for ::backdrop");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style-expected.txt
@@ -1,0 +1,33 @@
+
+FAIL style((--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style((--baz: qux))
+PASS style((unknown))
+PASS unknown((--foo: bar))
+PASS style(not (--foo: bar))
+FAIL style(not (--baz: qux)) assert_equals: expected "true" but got "false"
+PASS style(not (unknown))
+FAIL style((--foo: bar) and (--foo: bar)) assert_equals: expected "true" but got "false"
+FAIL style((--foo: bar) and (--foo: bar) and (--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style((--baz: qux) and (--baz: qux))
+PASS style((--baz: qux) and (--foo: bar) and (--foo: bar))
+PASS style((--foo: bar) and (--baz: qux) and (--foo: bar))
+PASS style((--foo: bar) and (--foo: bar) and (--baz: qux))
+PASS style((unknown) and (--foo: bar) and (--foo: bar))
+PASS style((--foo: bar) and (unknown) and (--foo: bar))
+PASS style((--foo: bar) and (--foo: bar) and (unknown))
+FAIL style((--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
+FAIL style((--foo: bar) or (--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style((--baz: qux) or (--baz: qux))
+FAIL style((--baz: qux) or (--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
+FAIL style((--foo: bar) or (--baz: qux) or (--foo: bar)) assert_equals: expected "true" but got "false"
+FAIL style((--foo: bar) or (--foo: bar) or (--baz: qux)) assert_equals: expected "true" but got "false"
+FAIL style((unknown) or (--foo: bar) or (--foo: bar)) assert_equals: expected "true" but got "false"
+FAIL style((--foo: bar) or (unknown) or (--foo: bar)) assert_equals: expected "true" but got "false"
+FAIL style((--foo: bar) or (--foo: bar) or (unknown)) assert_equals: expected "true" but got "false"
+FAIL style((unknown) or (--baz: qux) or (--foo: bar)) assert_equals: expected "true" but got "false"
+PASS style(not ((--foo: bar) and (--foo: bar)))
+FAIL style(not ((--foo: bar) and (--baz: qux))) assert_equals: expected "true" but got "false"
+PASS style((--foo: bar) and (not ((--baz: qux) or (--foo: bar))))
+FAIL style((--baz: qux) or (not ((--baz: qux) and (--foo: bar)))) assert_equals: expected "true" but got "false"
+PASS style((--baz: qux) or ((--baz: qux) and (--foo: bar)))
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<title>Evaluation of style queries</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-rule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  #container {
+    --applied: false;
+    --foo: bar;
+  }
+</style>
+<div id=container>
+  <div id=inner></div>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  function test_query(query, expected) {
+    test((t) => {
+      let style = document.createElement('style');
+      t.add_cleanup(() => { style.remove(); });
+      style.innerText = `@container ${query} { #inner { --applied:true; } }`;
+      let cs = getComputedStyle(inner);
+      assert_equals(cs.getPropertyValue('--applied'), 'false');
+      document.head.append(style);
+      assert_equals(cs.getPropertyValue('--applied'), expected.toString());
+    }, query);
+  };
+
+  // Note that the following assumes that elements are style containers by
+  // default [1], and that:
+  //
+  // - style(--foo: bar) is a query that returns 'true', and
+  // - style(--baz: qux) is a query that returns 'false'.
+  //
+  // [1] https://github.com/w3c/csswg-drafts/issues/7066
+
+  // Nesting in <style-query>:
+  test_query('style((--foo: bar))', true);
+  test_query('style((--baz: qux))', false);
+  test_query('style((unknown))', false);
+  test_query('unknown((--foo: bar))', false);
+
+  // "not" in <style-query>:
+  test_query('style(not (--foo: bar))', false);
+  test_query('style(not (--baz: qux))', true);
+  test_query('style(not (unknown))', false);
+
+  // "and" in <style-query>:
+  test_query('style((--foo: bar) and (--foo: bar))', true);
+  test_query('style((--foo: bar) and (--foo: bar) and (--foo: bar))', true);
+  test_query('style((--baz: qux) and (--baz: qux))', false);
+  test_query('style((--baz: qux) and (--foo: bar) and (--foo: bar))', false);
+  test_query('style((--foo: bar) and (--baz: qux) and (--foo: bar))', false);
+  test_query('style((--foo: bar) and (--foo: bar) and (--baz: qux))', false);
+  test_query('style((unknown) and (--foo: bar) and (--foo: bar))', false);
+  test_query('style((--foo: bar) and (unknown) and (--foo: bar))', false);
+  test_query('style((--foo: bar) and (--foo: bar) and (unknown))', false);
+
+  // "or" in <style-query>:
+  test_query('style((--foo: bar) or (--foo: bar))', true);
+  test_query('style((--foo: bar) or (--foo: bar) or (--foo: bar))', true);
+  test_query('style((--baz: qux) or (--baz: qux))', false);
+  test_query('style((--baz: qux) or (--foo: bar) or (--foo: bar))', true);
+  test_query('style((--foo: bar) or (--baz: qux) or (--foo: bar))', true);
+  test_query('style((--foo: bar) or (--foo: bar) or (--baz: qux))', true);
+  test_query('style((unknown) or (--foo: bar) or (--foo: bar))', true);
+  test_query('style((--foo: bar) or (unknown) or (--foo: bar))', true);
+  test_query('style((--foo: bar) or (--foo: bar) or (unknown))', true);
+  test_query('style((unknown) or (--baz: qux) or (--foo: bar))', true);
+
+  // Combinations, <style-query>:
+  test_query('style(not ((--foo: bar) and (--foo: bar)))', false);
+  test_query('style(not ((--foo: bar) and (--baz: qux)))', true);
+  test_query('style((--foo: bar) and (not ((--baz: qux) or (--foo: bar))))', false);
+  test_query('style((--baz: qux) or (not ((--baz: qux) and (--foo: bar))))', true);
+  test_query('style((--baz: qux) or ((--baz: qux) and (--foo: bar)))', false);
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-not-sharing-float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-not-sharing-float-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Check that style is not sharing in the case of Container Queries
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-not-sharing-float.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-not-sharing-float.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<title>CSS Container Queries Test: Check style is not sharing between cousins in the case of Container Queries</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#size-container">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  .float {
+    float: left;
+    width: 25px;
+    height: 25px;
+  }
+  .item {
+    container-type: inline-size;
+    height: 25px;
+  }
+  @container (width >= 50px) {
+    .item div { color: lime; }
+  }
+  @container (width >= 150px) {
+    .item div { color: green; }
+  }
+</style>
+<div style="width: 150px">
+  <div class="float"></div>
+  <div class="item">
+    <div id="target1"></div>
+  </div>
+  <div class="item">
+    <div id="target2"></div>
+  </div>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  test(() => {
+    assert_equals(getComputedStyle(target1).color, "rgb(0, 255, 0)", "Second item container should be 100px wide");
+    assert_equals(getComputedStyle(target2).color, "rgb(0, 128, 0)", "First item container should be 200px wide");
+  }, "Check that style is not sharing in the case of Container Queries");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/w3c-import.log
@@ -129,6 +129,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/iframe-in-container-invalidation.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/iframe-invalidation.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/ineligible-containment.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inheritance-from-container.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inline-size-and-min-width.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inline-size-bfc-floats-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inline-size-bfc-floats-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075-expected.html
@@ -9,10 +9,10 @@
 
 <style>
 .small_child {
-  height: 1000px;
+  height: 10000px;
 }
 .large_child {
-  height: 20000px;
+  height: 40000px;
   position: relative;
 }
 #target {
@@ -21,11 +21,11 @@
 }
 </style>
 
-<div class=auto><div class=small_child></div></div>
-<div class=auto><div class=small_child></div></div>
-<div class=auto><div class=large_child><div id=target>PASS</div></div></div>
-<div class=auto><div class=large_child></div></div>
-<div class=auto><div class=small_child></div></div>
+<div id=e1 class=auto><div class=large_child></div></div>
+<div id=e2 class=auto><div class=large_child></div></div>
+<div id=e3 class=auto><div class=large_child><div id=target>PASS</div></div></div>
+<div id=e4 class=auto><div class=large_child></div></div>
+<div id=e5 class=auto><div class=small_child></div></div>
 
 <script>
 function runReference() {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075-ref.html
@@ -9,10 +9,10 @@
 
 <style>
 .small_child {
-  height: 1000px;
+  height: 10000px;
 }
 .large_child {
-  height: 20000px;
+  height: 40000px;
   position: relative;
 }
 #target {
@@ -21,11 +21,11 @@
 }
 </style>
 
-<div class=auto><div class=small_child></div></div>
-<div class=auto><div class=small_child></div></div>
-<div class=auto><div class=large_child><div id=target>PASS</div></div></div>
-<div class=auto><div class=large_child></div></div>
-<div class=auto><div class=small_child></div></div>
+<div id=e1 class=auto><div class=large_child></div></div>
+<div id=e2 class=auto><div class=large_child></div></div>
+<div id=e3 class=auto><div class=large_child><div id=target>PASS</div></div></div>
+<div id=e4 class=auto><div class=large_child></div></div>
+<div id=e5 class=auto><div class=small_child></div></div>
 
 <script>
 function runReference() {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075.html
@@ -12,23 +12,26 @@
 <style>
 .auto {
   content-visibility: auto;
-  contain-intrinsic-size: 1px 1000px;
+  contain-intrinsic-size: 1px 10000px;
 }
 .child {
-  height: 20000px;
+  height: 40000px;
   position: relative;
 }
 #target {
   position: absolute;
   bottom: 0;
 }
+.before_target {
+  height: 40000px;
+}
 </style>
 
-<div class=auto><div class=child></div></div>
-<div class=auto><div class=child></div></div>
-<div class=auto><div class=child><div id=target>PASS</div></div></div>
-<div class=auto><div class=child></div></div>
-<div class=auto><div class=child></div></div>
+<div id=e1 class="auto before_target"></div>
+<div id=e2 class="auto before_target"></div>
+<div id=e3 class=auto><div class=child><div id=target>PASS</div></div></div>
+<div id=e4 class=auto><div class=child></div></div>
+<div id=e5 class=auto><div class=child></div></div>
 
 <script>
 function runTest() {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076-expected.html
@@ -9,10 +9,10 @@
 
 <style>
 .small_child {
-  height: 1000px;
+  height: 10000px;
 }
 .large_child {
-  height: 20000px;
+  height: 40000px;
   position: relative;
 }
 #target {
@@ -21,11 +21,11 @@
 }
 </style>
 
-<div class=auto><div class=small_child></div></div>
-<div class=auto><div class=small_child></div></div>
-<div class=auto><div class=large_child><div id=target>PASS</div></div></div>
-<div class=auto><div class=large_child></div></div>
-<div class=auto><div class=small_child></div></div>
+<div id=e1 class=auto><div class=large_child></div></div>
+<div id=e2 class=auto><div class=large_child></div></div>
+<div id=e3 class=auto><div class=large_child><div id=target>PASS</div></div></div>
+<div id=e4 class=auto><div class=large_child></div></div>
+<div id=e5 class=auto><div class=small_child></div></div>
 
 <script>
 function runReference() {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076.html
@@ -12,20 +12,23 @@
 <style>
 .auto {
   content-visibility: auto;
-  contain-intrinsic-size: 1px 1000px;
+  contain-intrinsic-size: 1px 10000px;
 }
 .child {
-  height: 20000px;
+  height: 40000px;
   position: relative;
 }
 #target {
   position: absolute;
   bottom: 0;
 }
+.before_target {
+  height: 40000px;
+}
 </style>
 
-<div class=auto><div class=child></div></div>
-<div class=auto><div class=child></div></div>
+<div class="auto before_target"></div>
+<div class="auto before_target"></div>
 <div class=auto><div class=child><div id=target>PASS</div></div></div>
 <div class=auto><div class=child></div></div>
 <div class=auto><div class=child></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085.html
@@ -1,0 +1,35 @@
+<!doctype HTML>
+<meta charset="utf8">
+<title>CSS Content Visibility: auto with content changes</title>
+<link rel="author" title="Cathie Chen" href="mailto:cathiechen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="content-visibility auto element should be resized when content changes">
+
+<style>
+.auto {
+  content-visibility: auto;
+  width: fit-content;
+}
+.hidden { height: 0; }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="auto">
+  <div id ="target" class="hidden">
+    <div style="width: 100px; height: 100px; background-color: green;"></div>
+  </div>
+</div>
+
+<script>
+function changeContent() {
+  requestAnimationFrame(() => {
+    target.classList.toggle("hidden");
+  });
+}
+function runTest() {
+  requestAnimationFrame(changeContent);
+}
+
+window.onload = () => { requestAnimationFrame(runTest); };
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Target is sized and laid out before resize observer promise_test: Unhandled rejection with value: "unexpected size 10"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate.html
@@ -1,0 +1,53 @@
+<!doctype HTML>
+<html>
+<meta charset="utf8">
+<title>Content Visibility: first visibility determination happens before resize observer.</title>
+<link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<meta name="assert" content="first visibility determination happens before resize observer">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#target {
+  content-visibility: auto;
+  contain-intrinsic-size: 10px;
+}
+#child {
+  height: 100px;
+}
+</style>
+
+<div id=container></div>
+
+<script>
+promise_test(t => new Promise(async (resolve, reject) => {
+  requestAnimationFrame(() => {
+    let target = document.createElement("div");
+    target.id = "target";
+
+    let child = document.createElement("div");
+    child.id = "child";
+    target.appendChild(child);
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentBoxSize) {
+          if (entry.contentBoxSize[0].blockSize == 100) {
+            resolve();
+            return;
+          } else {
+            reject(`unexpected size ${entry.contentBoxSize[0].blockSize}`);
+            return;
+          }
+        }
+      }
+      reject("no content boxes or no entries");
+    });
+
+    container.appendChild(target);
+    resizeObserver.observe(target);
+  });
+}), "Target is sized and laid out before resize observer");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt
@@ -5,10 +5,10 @@ FAIL CSS Transitions: property <content-visibility> from [visible] to [hidden] a
 FAIL CSS Transitions: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible] assert_equals: expected "visible " but got "hidden "
 PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden]
 PASS CSS Transitions: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden]
-PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (-1) should be [hidden]
-PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0) should be [hidden]
-PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.1) should be [hidden]
-PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.9) should be [hidden]
+FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible] assert_equals: expected "visible " but got "hidden "
+FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0) should be [visible] assert_equals: expected "visible " but got "hidden "
+FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.1) should be [visible] assert_equals: expected "visible " but got "hidden "
+FAIL CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (0.9) should be [visible] assert_equals: expected "visible " but got "hidden "
 PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (1) should be [hidden]
 PASS CSS Transitions with transition: all: property <content-visibility> from [visible] to [hidden] at (1.5) should be [hidden]
 PASS CSS Animations: property <content-visibility> from [visible] to [hidden] at (-1) should be [visible]
@@ -29,8 +29,8 @@ PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] a
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [hidden] to [visible] at (1.5) should be [visible]
-PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (-1) should be [visible]
-PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0) should be [visible]
+FAIL CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (-1) should be [hidden] assert_equals: expected "hidden " but got "visible "
+FAIL CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0) should be [hidden] assert_equals: expected "hidden " but got "visible "
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0.1) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation.html
@@ -26,10 +26,9 @@ const alwaysHidden = [
 
 test_interpolation({
   property: 'content-visibility',
+  behavior: 'allow-discrete',
   from: 'visible',
   to: 'hidden',
-  // transition:all is not supposed to allow content-visibility to be transitioned.
-  'CSS Transitions with transition: all': alwaysHidden,
 }, [
   {at: -1, expect: 'visible'},
   {at: 0, expect: 'visible'},
@@ -41,10 +40,9 @@ test_interpolation({
 
 test_interpolation({
   property: 'content-visibility',
+  behavior: 'allow-discrete',
   from: 'hidden',
   to: 'visible',
-  // transition:all is not supposed to allow content-visibility to be transitioned.
-  'CSS Transitions with transition: all': alwaysVisible,
 }, [
   {at: -1, expect: 'hidden'},
   {at: 0, expect: 'hidden'},

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-float-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-float-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        * {
+            content-visibility: hidden;
+            float: inline-start;
+        }
+    </style>
+</head>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/content-visibility-transition-finished-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/content-visibility-transition-finished-001.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1822907">
+<style>
+  #inner {
+    /* Extremely short so that we can just do a double-rAF and
+     * expect that this transition will have completed: */
+    transition: opacity 0.01s;
+  }
+</style>
+<script>
+  function setup() {
+    // Flush style, in case the document hasn't been styled yet:
+    let origOpacity = getComputedStyle(inner).opacity;
+
+    // Trigger the (extremely short) transition, and proceed to next step
+    // when it finishes.
+    inner.addEventListener("transitionend", handleTransitionEnd);
+    inner.style.opacity = "0.8";
+  }
+  function handleTransitionEnd(e) {
+    // Hide & unhide the subtree that contained the transition:
+    foo.style.contentVisibility = "hidden";
+    document.documentElement.offsetHeight; // flush layout
+    foo.style.contentVisibility = "";
+
+    // Double-rAF to see if we crash when animations are resampled.
+    requestAnimationFrame(() => { requestAnimationFrame(finish) });
+  }
+  function finish() {
+    // If we get here, we've succeeded; hooray!
+    document.documentElement.removeAttribute("class");
+  }
+</script>
+<body onload="setup()">
+  <div id="foo">
+    Hello
+    <div id="inner">Inner</div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/first-line-and-inline-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/first-line-and-inline-block.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+div, span {
+  content-visibility: auto;
+  contain-intrinsic-width: auto 100vw;
+}
+div::first-line {
+  color: blue;
+}
+</style>
+<div>
+  <span style="display: inline-block">foo</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/w3c-import.log
@@ -14,8 +14,5 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-crash-001.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-crash-002.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-crash-003.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-crash-004.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-relayout-boundary.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/content-visibility-transition-finished-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/first-line-and-inline-block.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/w3c-import.log
@@ -180,7 +180,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-083.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-084-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-084.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-applied-to-th-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-in-iframe-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-in-iframe-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-in-iframe.html
@@ -219,6 +222,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-float-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-000-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-000.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-popover-top-layer-001-expected.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004-expected.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="UTF-8">
+<title>CSS Test Reference</title>
+<style>
+  .list-item {
+    margin-left: 40px;
+  }
+</style>
+<div class="list-item">
+  [1] A1
+  <div class="list-item">[1] B1</div>
+  <div class="list-item">[2] B2</div>
+</div>
+<div class="list-item">[2] A2</div>
+<div class="list-item">[3] A3</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="UTF-8">
+<title>CSS-contain test: style containment and subtree root</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/#property-scoped-to-a-sub-tree">
+<link rel="match" href="reference/counter-scoping-004-ref.html">
+<style>
+  .list-item {
+    contain: style;
+    counter-increment: my-list-counter;
+    margin-left: 40px;
+  }
+  .list-item::before {
+    content: '[' counter(my-list-counter, decimal) '] ';
+  }
+</style>
+<div class="list-item">
+  A1
+  <div class="list-item">B1</div>
+  <div class="list-item">B2</div>
+</div>
+<div class="list-item">A2</div>
+<div class="list-item">A3</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-relayout-boundary.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-relayout-boundary.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<div style="position: relative; width: 100px; height: 100px; overflow: hidden;">
+  <div id="target" style="contain: size layout;">
+    <canvas id="inner" width="0"></canvas>
+  </div>
+</div>
+<script>
+document.body.offsetTop;
+document.getElementById('inner').width = '100';
+document.getElementById('target').style.contain = 'initial';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/w3c-import.log
@@ -655,6 +655,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-003-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/inheritance.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html


### PR DESCRIPTION
#### 55c3d001d951ff272c2d1c57230faa3f7d5af591
<pre>
Re-import css/css-contain WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=260057">https://bugs.webkit.org/show_bug.cgi?id=260057</a>
rdar://113731301

Reviewed by Aditya Keerthi.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/121c65a3646de571aa82a88de382623c5893e168">https://github.com/web-platform-tests/wpt/commit/121c65a3646de571aa82a88de382623c5893e168</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-parsing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-ineligible-container-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-ineligible-container.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/chrome-bug-1429955-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/dialog-backdrop-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/dirty-rowgroup-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/iframe-init-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/reversed-ol-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/crashtests/size-change-during-transition-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-create.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-remove-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/dialog-backdrop-remove.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/inheritance-from-container.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-query-containers-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/nested-query-containers.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-not-sharing-float-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/style-not-sharing-float.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-075.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-076.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-085.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-float-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/content-visibility-transition-finished-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/first-line-and-inline-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/counter-scoping-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/contain-nested-relayout-boundary.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/266811@main">https://commits.webkit.org/266811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/313334cb98c8c74d1fb9e974af7932c65b5ca2c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13957 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15234 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17310 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12773 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11909 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13237 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3577 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->