### PR TITLE
Allow window.open to open in a new process when using TiledCoreAnimationDrawingArea

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5201,9 +5201,12 @@ ProcessSwapOnCrossSiteWindowOpenEnabled:
    category: networking
    humanReadableName: "Swap Processes on Cross-Site Window Open"
    humanReadableDescription: "Swap WebContent Processes on cross-site window.open"
-   webcoreBinding: none
    exposed: [ WebKit ]
    defaultValue:
+     WebCore:
+       default: false
+     WebKitLegacy:
+       default: false
      WebKit:
        default: false
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1173,10 +1173,6 @@ WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWeb
         if (m_page->preferences().siteIsolationEnabled())
             result = true;
 
-        // FIXME: Either make this work with TiledCoreAnimationDrawingArea or only enable it where remote layer trees are used.
-        if (m_page->preferences().processSwapOnCrossSiteWindowOpenEnabled())
-            result = true;
-
         if (isInRecoveryOS()) {
             // Temporarily disable UI side compositing in Recovery OS <rdar://107964149>.
             WTFLogAlways("Disabling UI side compositing in Recovery OS");

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4802,6 +4802,16 @@ void WebPage::updateRendering()
 #endif
 }
 
+bool WebPage::hasRootFrames()
+{
+    bool result = m_page && !m_page->rootFrames().isEmptyIgnoringNullReferences();
+    if (!result) {
+        ASSERT(m_page->settings().processSwapOnCrossSiteWindowOpenEnabled());
+        ASSERT(!m_page->settings().siteIsolationEnabled());
+    }
+    return result;
+}
+
 void WebPage::didUpdateRendering()
 {
     didPaintLayers();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -459,6 +459,7 @@ public:
 
     void layoutIfNeeded();
     void updateRendering();
+    bool hasRootFrames();
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const;
     void finalizeRenderingUpdate(OptionSet<WebCore::FinalizeRenderingUpdateFlags>);
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -349,6 +349,9 @@ void TiledCoreAnimationDrawingArea::updateRendering(UpdateRenderingType flushTyp
     if (layerTreeStateIsFrozen())
         return;
 
+    if (UNLIKELY(!m_webPage.hasRootFrames()))
+        return;
+
     @autoreleasepool {
         scaleViewToFitDocumentIfNeeded();
 
@@ -365,8 +368,10 @@ void TiledCoreAnimationDrawingArea::updateRendering(UpdateRenderingType flushTyp
         }
 
         FloatRect visibleRect = [m_hostingLayer frame];
-        if (auto exposedRect = m_webPage.localMainFrameView()->viewExposedRect())
-            visibleRect.intersect(*exposedRect);
+        if (auto* localMainFrameView = m_webPage.localMainFrameView()) {
+            if (auto exposedRect = localMainFrameView->viewExposedRect())
+                visibleRect.intersect(*exposedRect);
+        }
 
         // Because our view-relative overlay root layer is not attached to the main GraphicsLayer tree, we need to flush it manually.
         if (m_viewOverlayRootLayer)


### PR DESCRIPTION
#### 93d1a99132f08e29d098f0180aa1dab2bf286c98
<pre>
Allow window.open to open in a new process when using TiledCoreAnimationDrawingArea
<a href="https://bugs.webkit.org/show_bug.cgi?id=260059">https://bugs.webkit.org/show_bug.cgi?id=260059</a>
rdar://111064288

Reviewed by J Pascoe.

When using TiledCoreAnimationDrawingArea and after a cross-site window.open, we have a WebPage
that has only RemoteFrames, which would use RemoteLayerTreeDrawingArea in most cases except
pre-Sonoma macOS and 2-core CPUs.  This WebPage only exists to hold RemoteFrames to proxy messages
back and forth, so it doesn&apos;t need to draw.  We just want it to not crash.

Add a null check and an early return in updateRendering like we do when layerTreeStateIsFrozen returns true.
Covered by the API test SiteIsolation.BasicPostMessageWindowOpen on pre-Sonoma macOS.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hasRootFrames):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/266823@main">https://commits.webkit.org/266823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df633d7dbf452be92007a05f358dec7bb8eaf8a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17313 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20357 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12691 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16787 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14100 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11913 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15031 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13387 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3834 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17719 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15261 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1779 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13940 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3644 "Passed tests") | 
<!--EWS-Status-Bubble-End-->