### PR TITLE
[JSC] Avoid Vector allocation if possible for Types etc. in Wasm parsers

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -7794,10 +7794,11 @@ public:
     void emitCCall(Func function, const Vector<Value, N>& arguments)
     {
         // Currently, we assume the Wasm calling convention is the same as the C calling convention
-        Vector<Type, 1> resultTypes;
-        Vector<Type> argumentTypes;
+        Vector<Type, 16> resultTypes;
+        Vector<Type, 16> argumentTypes;
+        argumentTypes.reserveInitialCapacity(arguments.size());
         for (const Value& value : arguments)
-            argumentTypes.append(Type { value.type(), 0u });
+            argumentTypes.uncheckedAppend(Type { value.type(), 0u });
         RefPtr<TypeDefinition> functionType = TypeInformation::typeDefinitionForFunction(resultTypes, argumentTypes);
         CallInformation callInfo = wasmCallingConvention().callInformationFor(*functionType, CallRole::Caller);
         Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), callInfo.headerAndArgumentStackSizeInBytes);
@@ -7822,10 +7823,11 @@ public:
         ASSERT(result.isTemp());
 
         // Currently, we assume the Wasm calling convention is the same as the C calling convention
-        Vector<Type, 1> resultTypes = { Type { result.type(), 0u } };
-        Vector<Type> argumentTypes;
+        Vector<Type, 16> resultTypes = { Type { result.type(), 0u } };
+        Vector<Type, 16> argumentTypes;
+        argumentTypes.reserveInitialCapacity(arguments.size());
         for (const Value& value : arguments)
-            argumentTypes.append(Type { value.type(), 0u });
+            argumentTypes.uncheckedAppend(Type { value.type(), 0u });
         RefPtr<TypeDefinition> functionType = TypeInformation::typeDefinitionForFunction(resultTypes, argumentTypes);
         CallInformation callInfo = wasmCallingConvention().callInformationFor(*functionType, CallRole::Caller);
         Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), callInfo.headerAndArgumentStackSizeInBytes);

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -93,7 +93,7 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
         ASSERT_NOT_IMPLEMENTED_YET();
 }
 
-void FunctionIPIntMetadataGenerator::addReturnData(const Vector<Type>& types)
+void FunctionIPIntMetadataGenerator::addReturnData(const Vector<Type, 16>& types)
 {
     size_t size = m_metadata.size();
     m_returnMetadata = size;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -87,7 +87,7 @@ private:
     void addRawValue(uint64_t value);
     void addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, uint32_t length);
-    void addReturnData(const Vector<Type>& types);
+    void addReturnData(const Vector<Type, 16>& types);
 
     uint32_t m_functionIndex;
     bool m_tailCallClobbersInstance { false };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -1160,7 +1160,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addEndToUnreachable(ControlEntr
 
         // Metadata = round up 8 bytes, one for each
         m_metadata->m_bytecodeLength = m_parser->offset();
-        Vector<Type> types(entry.controlData.branchTargetArity());
+        Vector<Type, 16> types(entry.controlData.branchTargetArity());
         for (size_t i = 0; i < entry.controlData.branchTargetArity(); ++i)
             types[i] = entry.controlData.branchTargetType(i);
         m_metadata->addReturnData(types);
@@ -1226,7 +1226,7 @@ void IPIntGenerator::addCallCommonData(const FunctionSignature& signature)
         WRITE_TO_METADATA(extraMetadata + 6 + i * 2, locations[i], uint16_t);
 
     // Returns
-    Vector<Type> returns(signature.returnCount());
+    Vector<Type, 16> returns(signature.returnCount());
     for (size_t i = 0; i < signature.returnCount(); ++i)
         returns[i] = signature.returnType(i);
     m_metadata->addReturnData(returns);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -779,25 +779,25 @@ auto SectionParser::parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&
     uint32_t argumentCount;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(argumentCount), "can't get Type's argument count at index ", position);
     WASM_PARSER_FAIL_IF(argumentCount > maxFunctionParams, "argument count of Type at index ", position, " is too big ", argumentCount, " maximum ", maxFunctionParams);
-    Vector<Type> argumentTypes;
+    Vector<Type, 16> argumentTypes;
     WASM_PARSER_FAIL_IF(!argumentTypes.tryReserveCapacity(argumentCount), "can't allocate enough memory for Type section's ", position, "th signature");
 
     for (unsigned i = 0; i < argumentCount; ++i) {
         Type argumentType;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, argumentType), "can't get ", i, "th argument Type");
-        argumentTypes.append(argumentType);
+        argumentTypes.uncheckedAppend(argumentType);
     }
 
     uint32_t returnCount;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(returnCount), "can't get Type's return count at index ", position);
     WASM_PARSER_FAIL_IF(returnCount > maxFunctionReturns, "return count of Type at index ", position, " is too big ", returnCount, " maximum ", maxFunctionReturns);
 
-    Vector<Type, 1> returnTypes;
+    Vector<Type, 16> returnTypes;
     WASM_PARSER_FAIL_IF(!returnTypes.tryReserveCapacity(returnCount), "can't allocate enough memory for Type section's ", position, "th signature");
     for (unsigned i = 0; i < returnCount; ++i) {
         Type value;
         WASM_PARSER_FAIL_IF(!parseValueType(m_info, value), "can't get ", i, "th Type's return value");
-        returnTypes.append(value);
+        returnTypes.uncheckedAppend(value);
     }
 
     functionSignature = TypeInformation::typeDefinitionForFunction(returnTypes, argumentTypes);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -423,10 +423,10 @@ const TypeDefinition& TypeDefinition::replacePlaceholders(TypeIndex projectee) c
 {
     if (is<FunctionSignature>()) {
         const FunctionSignature* func = as<FunctionSignature>();
-        Vector<Type> newArguments;
-        Vector<Type, 1> newReturns;
-        newArguments.tryReserveCapacity(func->argumentCount());
-        newReturns.tryReserveCapacity(func->returnCount());
+        Vector<Type, 16> newArguments;
+        Vector<Type, 16> newReturns;
+        newArguments.reserveInitialCapacity(func->argumentCount());
+        newReturns.reserveInitialCapacity(func->returnCount());
         for (unsigned i = 0; i < func->argumentCount(); ++i)
             newArguments.uncheckedAppend(substitute(func->argumentType(i), projectee));
         for (unsigned i = 0; i < func->returnCount(); ++i)
@@ -585,8 +585,8 @@ const TypeDefinition& TypeInformation::signatureForLLIntBuiltin(LLIntBuiltin bui
 }
 
 struct FunctionParameterTypes {
-    const Vector<Type, 1>& returnTypes;
-    const Vector<Type>& argumentTypes;
+    const Vector<Type, 16>& returnTypes;
+    const Vector<Type, 16>& argumentTypes;
 
     static unsigned hash(const FunctionParameterTypes& params)
     {
@@ -869,7 +869,7 @@ TypeInformation::TypeInformation()
     m_Anyref_Externref = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { anyrefType() }, { externrefType() } }).iterator->key;
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForFunction(const Vector<Type, 1>& results, const Vector<Type>& args)
+RefPtr<TypeDefinition> TypeInformation::typeDefinitionForFunction(const Vector<Type, 16>& results, const Vector<Type, 16>& args)
 {
     if constexpr (ASSERT_ENABLED) {
         ASSERT(!results.contains(Wasm::Types::Void));

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -865,7 +865,7 @@ public:
 
     static const TypeDefinition& signatureForLLIntBuiltin(LLIntBuiltin);
 
-    static RefPtr<TypeDefinition> typeDefinitionForFunction(const Vector<Type, 1>& returnTypes, const Vector<Type>& argumentTypes);
+    static RefPtr<TypeDefinition> typeDefinitionForFunction(const Vector<Type, 16>& returnTypes, const Vector<Type, 16>& argumentTypes);
     static RefPtr<TypeDefinition> typeDefinitionForStruct(const Vector<FieldType>& fields);
     static RefPtr<TypeDefinition> typeDefinitionForArray(FieldType);
     static RefPtr<TypeDefinition> typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
@@ -56,7 +56,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTag, (JSGlobalObject* globalObjec
     if (!signatureObject.isObject())
         return throwVMTypeError(globalObject, scope, "WebAssembly.Tag constructor expects a tag type with the 'parameters' property."_s);
 
-    Vector<Wasm::Type> parameters;
+    Vector<Wasm::Type, 16> parameters;
     forEachInIterable(globalObject, signatureObject, [&] (auto& vm, auto* globalObject, JSValue nextType) -> void {
         auto scope = DECLARE_THROW_SCOPE(vm);
 


### PR DESCRIPTION
#### 3dcbd27bc35924ca17a4d5c3211d2f99a7f4669c
<pre>
[JSC] Avoid Vector allocation if possible for Types etc. in Wasm parsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=260061">https://bugs.webkit.org/show_bug.cgi?id=260061</a>
rdar://113733001

Reviewed by Alex Christensen.

We should use Vector&lt;Type, 16&gt; to avoid frequent allocation and deallocation of memory.
And we also use uncheckedAppend for pre-allocated Vector.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitCCall):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseFunctionType):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::TypeInformation::typeDefinitionForFunction):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/266812@main">https://commits.webkit.org/266812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adc5545938e2481f8173a3257dcc6fed66e231a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13963 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17317 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20358 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12695 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16788 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14104 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11915 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15035 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13391 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3837 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17723 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15265 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1775 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13944 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3647 "Passed tests") | 
<!--EWS-Status-Bubble-End-->