### PR TITLE
Set PAGE_NO_ACCESS when calling OSAllocatorWin protect rw: false

### DIFF
--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -143,10 +143,11 @@ bool OSAllocator::protect(void* address, size_t bytes, bool readable, bool writa
             protection = PAGE_READWRITE;
         else
             protection = PAGE_READONLY;
-        return VirtualAlloc(address, bytes, MEM_COMMIT, protection);
+    } else {
+        ASSERT(!readable && !writable);
+        protection = PAGE_NOACCESS;
     }
-    ASSERT(!readable && !writable);
-    return VirtualFree(address, bytes, MEM_DECOMMIT);
+    return VirtualAlloc(address, bytes, MEM_COMMIT, protection);
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### 673b5ea5e903e2863a488e1b5c8a02f945d8c7dc
<pre>
Set PAGE_NO_ACCESS when calling OSAllocatorWin protect rw: false
<a href="https://bugs.webkit.org/show_bug.cgi?id=260069">https://bugs.webkit.org/show_bug.cgi?id=260069</a>

Reviewed by Don Olmstead and Yusuke Suzuki.

In OSAllocatorWin, if you call OSAllocator::protect with readable false
and writeable false, it’ll free the page + decommit. To the caller,
this looks like it does the right thing - attempting to access the
freed page will throw an access violation. However by freeing the page
there’s a risk that we re-allocate that page later.

For WasmMemory we want the pages to remain reserved in the virtual
address space, so if someone tries to access memory in a “red zone”
page it’ll throw an access violation. If that page is re-allocated, we
could overflow WasmMemory and read / write that page.

Switched OSAllocatorWin to set PAGE_NOACCESS instead of freeing the
page when protect is called with readable and writeable false.

* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::protect):

Canonical link: <a href="https://commits.webkit.org/266876@main">https://commits.webkit.org/266876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54b398c857040962f494f06504c8d16618c1194

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16779 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15428 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17508 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20516 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/12868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16957 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/14286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12081 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15220 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13561 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3882 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17897 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15452 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14122 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3692 "Passed tests") | 
<!--EWS-Status-Bubble-End-->