### PR TITLE
Crashes under currentUserInterfaceIdiomIsVisionOrVisionLegacy() on iPad

### DIFF
--- a/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
+++ b/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
@@ -108,7 +108,7 @@ bool updateCurrentUserInterfaceIdiom()
         return UserInterfaceIdiom::Default;
     }();
 
-    if (oldIdiom == newIdiom)
+    if (s_currentUserInterfaceIdiom.load() && oldIdiom == newIdiom)
         return false;
 
     setCurrentUserInterfaceIdiom(newIdiom);


### PR DESCRIPTION
#### 81f1c237dc818ef3ca64e9174432a779644c2dd6
<pre>
Crashes under currentUserInterfaceIdiomIsVisionOrVisionLegacy() on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=260077">https://bugs.webkit.org/show_bug.cgi?id=260077</a>
rdar://113758512

Reviewed by Wenson Hsieh.

* Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm:
(PAL::updateCurrentUserInterfaceIdiom):
Ensure that we write `Default` to the optional so it is always engaged once updated.

Canonical link: <a href="https://commits.webkit.org/266825@main">https://commits.webkit.org/266825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61cfcf36c5d3c256735ed8b6ab29ee74c62e616d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15268 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15043 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15533 "Exiting early after 60 failures. 2865 tests run. 60 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17344 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12812 "4 flakes 9 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13409 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13577 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11939 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13417 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3583 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->