### PR TITLE
Could round rather than truncate in compileClampDoubleToByte?

### DIFF
--- a/JSTests/stress/uint8clamped-rounding-mode.js
+++ b/JSTests/stress/uint8clamped-rounding-mode.js
@@ -1,0 +1,15 @@
+let array = new Uint8ClampedArray(1);
+function foo(value) {
+    array[0] = value;
+}
+noInline(foo);
+
+for (let i = 0; i < 1e6; ++i) {
+    foo(2.5);
+    if (array[0] != 2)
+        throw new Error(i);
+
+    foo(3.5);
+    if (array[0] != 4)
+        throw new Error(i);
+}

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -20019,6 +20019,15 @@ IGNORE_CLANG_WARNINGS_END
                     unsure(continuation), unsure(withinRange));
                             
                 m_out.appendTo(withinRange, continuation);
+                if (isClamped) {
+                    PatchpointValue* patchpoint = m_out.patchpoint(Double);
+                    patchpoint->append(ConstrainedValue(doubleValue, B3::ValueRep::SomeRegister));
+                    patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+                        jit.roundTowardNearestIntDouble(params[1].fpr(), params[0].fpr());
+                    });
+                    patchpoint->effects = Effects::none();
+                    doubleValue = patchpoint;
+                }
                 intValues.append(m_out.anchor(m_out.doubleToInt(doubleValue)));
                 m_out.jump(continuation);
                             


### PR DESCRIPTION
#### c55d0673236c1b2367cc0f820298c06d4967346d
<pre>
Could round rather than truncate in compileClampDoubleToByte?
<a href="https://bugs.webkit.org/show_bug.cgi?id=72054">https://bugs.webkit.org/show_bug.cgi?id=72054</a>
rdar://113734964

Reviewed by Yusuke Suzuki.

Right now there&apos;s a difference between our non-optimizing code and our C++ code for ClampedUint8Arrays.
In the C++ code we correctly do a round to nearest (ties to even) but in the optimizing JITs we do a round to inifinity.
This patch fixes our optimizing code to round to nearest too.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::clampDoubleToByte):
(JSC::DFG::compileClampDoubleToByte):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/267100@main">https://commits.webkit.org/267100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee94e3c3aa3bc4462150a874067fdf567abbd373

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13995 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16672 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17350 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20391 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12727 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16845 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14137 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11945 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15068 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13422 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3845 "Found 1 jsc stress test failure: stress/watchdog-fire-while-in-forEachInIterable.js.default") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3746 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17755 "Built successfully") | | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15298 "Failed to compile JSC") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13976 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/15298 "Failed to compile JSC") | 
<!--EWS-Status-Bubble-End-->