### PR TITLE
Remove RenderTheme support for setting a custom focus ring color

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -95,12 +95,6 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static Color& customFocusRingColor()
-{
-    static NeverDestroyed<Color> color;
-    return color;
-}
-
 RenderTheme::RenderTheme()
 {
 }
@@ -2086,16 +2080,8 @@ Color RenderTheme::documentMarkerLineColor(const RenderText& renderer, DocumentM
     return Color::transparentBlack;
 }
 
-void RenderTheme::setCustomFocusRingColor(const Color& color)
-{
-    customFocusRingColor() = color;
-}
-
 Color RenderTheme::focusRingColor(OptionSet<StyleColorOptions> options) const
 {
-    if (customFocusRingColor().isValid())
-        return customFocusRingColor();
-
     auto& cache = colorCache(options);
     if (!cache.systemFocusRingColor.isValid())
         cache.systemFocusRingColor = platformFocusRingColor(options);

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -190,7 +190,6 @@ public:
 
     WEBCORE_EXPORT Color focusRingColor(OptionSet<StyleColorOptions>) const;
     virtual Color platformFocusRingColor(OptionSet<StyleColorOptions>) const { return Color::black; }
-    static void setCustomFocusRingColor(const Color&);
     static float platformFocusRingWidth() { return 3; }
     static float platformFocusRingOffset(float outlineWidth) { return std::max<float>(outlineWidth - platformFocusRingWidth(), 0); }
 #if ENABLE(TOUCH_EVENTS)


### PR DESCRIPTION
#### 6198453ada5cf2262b3c38e5ee1db5669f251122
<pre>
Remove RenderTheme support for setting a custom focus ring color
<a href="https://bugs.webkit.org/show_bug.cgi?id=260075">https://bugs.webkit.org/show_bug.cgi?id=260075</a>

Reviewed by Aditya Keerthi and Tim Nguyen.

Remove some unused codepaths for overriding the focus ring color with a `customFocusRingColor` in
RenderTheme. This was first introduced for the Windows port in 37230@main, and is no longer used on
any platform.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::focusRingColor const):
(WebCore::customFocusRingColor): Deleted.
(WebCore::RenderTheme::setCustomFocusRingColor): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::platformFocusRingColor const):

Canonical link: <a href="https://commits.webkit.org/266827@main">https://commits.webkit.org/266827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f70eea9c4622c7ddd5d13a503b43b36f3ad1b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15270 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17346 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20382 "Passed tests") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13887 "An unexpected error occured. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16813 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11940 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13418 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3586 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->