### PR TITLE
[ews] mac-wk2 build marked as green even though it found failure in stress mode

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2243,7 +2243,7 @@ class TestRunWebKitTestsInStressMode(BuildStepMixinAdditions, unittest.TestCase)
         )
         self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
         rc = self.runStep()
-        self.assertEqual(self.getProperty('build_summary'), 'Found test failures')
+        self.assertEqual(self.getProperty('build_summary'), 'Found test failures in stress mode')
         return rc
 
     def test_success(self):
@@ -2346,7 +2346,7 @@ class TestRunWebKitTestsInStressGuardmallocMode(BuildStepMixinAdditions, unittes
         )
         self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
         rc = self.runStep()
-        self.assertEqual(self.getProperty('build_summary'), 'Found test failures')
+        self.assertEqual(self.getProperty('build_summary'), 'Found test failures in stress mode')
         return rc
 
 


### PR DESCRIPTION
#### ad0590629fe039f6c156050f08c73eceb23a1a45
<pre>
[ews] mac-wk2 build marked as green even though it found failure in stress mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=260020">https://bugs.webkit.org/show_bug.cgi?id=260020</a>

Reviewed by Jonathan Bedard.

Check if stress mode already set build_summary before updating it.
Also mark build as failure if stress mode detected failures.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests.evaluateCommand):
(RunWebKitTestsInStressMode): Updated the failure text to be more clear.
(ReRunWebKitTests.evaluateCommand):
(AnalyzeLayoutTestsResults.report_pre_existing_failures):
(SetBuildSummary.start):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/266824@main">https://commits.webkit.org/266824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/076f5b20b7a53d18e45f891429acf8b2fbe1b657

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15171 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/15524 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16616 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15272 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15047 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15534 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/15524 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17348 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12813 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/15524 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20385 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13892 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/15524 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16816 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14132 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11946 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14763 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13420 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/15524 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17753 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1780 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->