### PR TITLE
Reuse InteractionRegion layers when an element is resized

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -110,38 +110,228 @@
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
-          (layer position [x: 792.9200000000001 y: 792.9200000000001])
+          (layer bounds [x: 0 y: 0 width: 800 height: 32])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
-              (layer position [x: 4.08 y: 4.08])
-              (layer zPosition 1000)
+              (layer bounds [x: 0 y: 0 width: 96 height: 32])
+              (layer position [x: 400 y: 400]))
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
-                  (layer position [x: 4.08 y: 4.08])
-                  (layer cornerRadius 4.760000000000001))))
-            (
-              (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
-              (layer position [x: 4.08 y: 4.08])
-              (layer opacity 0.005))))
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48])
+                      (layer opacity 0)
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                          (layer opacity 0.15)
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))))))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48])
+                      (layer opacity 0.15)
+                      (layer cornerRadius 3))))))))
         (
-          (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
-          (layer position [x: 395.84000000000003 y: 395.84000000000003])
+          (layer bounds [x: 0 y: 0 width: 32 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
-              (layer position [x: 393 y: 393])
-              (layer zPosition 1000)
+              (layer bounds [x: 0 y: 0 width: 32 height: 96])
+              (layer position [x: 16 y: 16]))
+            (
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 16 y: 16])
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
-                  (layer position [x: 393 y: 393])
-                  (layer cornerRadius 4.760000000000001))))
-            (
-              (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
-              (layer position [x: 393 y: 393])
-              (layer opacity 0.005))))))))
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6])
+                      (layer opacity 0)
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                          (layer position [x: 3 y: 3])
+                          (layer opacity 0.15)
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))))))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6])
+                      (layer opacity 0.15)
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -76,6 +76,10 @@
                                       (layer position [x: 152 y: 152])
                                       (layer cornerRadius 8))
                                     (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 200 height: 100])
+                                      (layer position [x: 100 y: 100]))
+                                    (
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (sublayers
                                         (
@@ -118,38 +122,228 @@
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
+          (layer bounds [x: 0 y: 0 width: 800 height: 32])
           (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-              (layer position [x: 397 y: 397])
-              (layer zPosition 1000)
+              (layer bounds [x: 0 y: 0 width: 96 height: 32])
+              (layer position [x: 400 y: 400]))
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-                  (layer position [x: 397 y: 397])
-                  (layer cornerRadius 4.760000000000001))))
-            (
-              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-              (layer position [x: 397 y: 397])
-              (layer opacity 0.005))))
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48])
+                      (layer opacity 0)
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                          (layer opacity 0.15)
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                              (layer cornerRadius 1))))))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48])
+                      (layer opacity 0.15)
+                      (layer cornerRadius 3))))))))
         (
-          (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
-          (layer position [x: 792.9200000000001 y: 792.9200000000001])
+          (layer bounds [x: 0 y: 0 width: 32 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
-              (layer position [x: 4.08 y: 4.08])
-              (layer zPosition 1000)
+              (layer bounds [x: 0 y: 0 width: 32 height: 96])
+              (layer position [x: 16 y: 16]))
+            (
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 16 y: 16])
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
-                  (layer position [x: 4.08 y: 4.08])
-                  (layer cornerRadius 4.760000000000001))))
-            (
-              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
-              (layer position [x: 4.08 y: 4.08])
-              (layer opacity 0.005))))))))
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6])
+                      (layer opacity 0)
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                          (layer position [x: 3 y: 3])
+                          (layer opacity 0.15)
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))
+                            (
+                              (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                              (layer position [x: 3 y: 3])
+                              (layer cornerRadius 1))))))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6])
+                      (layer opacity 0.15)
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/interaction-region/layer-tree.html
+++ b/LayoutTests/interaction-region/layer-tree.html
@@ -29,6 +29,12 @@
         will-change: opacity;
         opacity: 0;
     }
+    #resized {
+        background-color: lightblue;
+        width: 100px;
+        height: 100px;
+        cursor: pointer;
+    }
 
 </style>
 <script src="../resources/ui-helper.js"></script>
@@ -44,6 +50,9 @@
     </div>
     <div id="faded">
         <a href="#">Faded link</a>
+    </div>
+    <div id="resized" onclick="click()">
+        will be resized
     </div>
 </div>
 
@@ -62,6 +71,10 @@ window.onload = async function () {
 
     await UIHelper.animationFrame();
     document.querySelector("iframe").srcdoc = "<div style='cursor:pointer;width:100%;height:200px'; onclick='click()'>tappable</div>";
+    document.getElementById("resized").style.backgroundColor = "blue";
+
+    await UIHelper.animationFrame();
+    document.getElementById("resized").style.width = "200px";
 
     await UIHelper.ensureStablePresentationUpdate();
     results.textContent = await UIHelper.getCALayerTree();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -41,6 +41,8 @@ SOFT_LINK_CONSTANT_MAY_FAIL(RealitySystemSupport, RCPAllowedInputTypesUserInfoKe
 
 #endif
 
+#import <WebCore/WebActionDisablingCALayerDelegate.h>
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -107,6 +109,65 @@ static void configureLayerForInteractionRegion(CALayer *, NSString *) { }
 static void configureLayerAsGuard(CALayer *, NSString *) { }
 #endif // !PLATFORM(VISION)
 
+static NSString *interactionRegionGroupNameForRegion(const WebCore::PlatformLayerIdentifier& layerID, const WebCore::InteractionRegion& interactionRegion)
+{
+    return makeString("WKInteractionRegion-"_s, layerID.toString(), interactionRegion.elementIdentifier.toUInt64());
+}
+
+static void configureRemoteEffect(CALayer *layer, WebCore::InteractionRegion::Type type, NSString *groupName)
+{
+    switch (type) {
+    case InteractionRegion::Type::Interaction:
+        configureLayerForInteractionRegion(layer, groupName);
+        break;
+    case InteractionRegion::Type::Guard:
+        configureLayerAsGuard(layer, groupName);
+        break;
+    case InteractionRegion::Type::Occlusion:
+        break;
+    }
+}
+
+static void applyBackgroundColorForDebuggingToLayer(CALayer *layer, WebCore::InteractionRegion::Type type)
+{
+    switch (type) {
+    case InteractionRegion::Type::Interaction:
+        [layer setBackgroundColor:cachedCGColor({ WebCore::SRGBA<float>(0, 1, 0, .2) }).get()];
+        [layer setName:@"Interaction"];
+        break;
+    case InteractionRegion::Type::Guard:
+        [layer setBorderColor:cachedCGColor({ WebCore::SRGBA<float>(0, 0, 1, .2) }).get()];
+        [layer setBorderWidth:6];
+        [layer setName:@"Guard"];
+        break;
+    case InteractionRegion::Type::Occlusion:
+        [layer setBorderColor:cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .2) }).get()];
+        [layer setBorderWidth:6];
+        [layer setName:@"Occlusion"];
+        break;
+    }
+}
+
+static CALayer *createInteractionRegionLayer(WebCore::InteractionRegion::Type type, NSString *groupName, bool applyBackgroundColorForDebugging)
+{
+    CALayer *layer = type == InteractionRegion::Type::Interaction
+        ? [[interactionRegionLayerClass() alloc] init]
+        : [[CALayer alloc] init];
+
+    [layer setHitTestsAsOpaque:YES];
+    [layer setDelegate:[WebActionDisablingCALayerDelegate shared]];
+
+    [layer setValue:@(static_cast<uint8_t>(type)) forKey:interactionRegionTypeKey];
+    [layer setValue:groupName forKey:interactionRegionGroupNameKey];
+
+    configureRemoteEffect(layer, type, groupName);
+
+    if (applyBackgroundColorForDebugging)
+        applyBackgroundColorForDebuggingToLayer(layer, type);
+
+    return layer;
+}
+
 static std::optional<WebCore::InteractionRegion::Type> interactionRegionTypeForLayer(CALayer *layer)
 {
     id value = [layer valueForKey:interactionRegionTypeKey];
@@ -115,36 +176,14 @@ static std::optional<WebCore::InteractionRegion::Type> interactionRegionTypeForL
     return std::nullopt;
 }
 
-static NSString * interactionRegionGroupNameForLayer(CALayer *layer)
+static NSString *interactionRegionGroupNameForLayer(CALayer *layer)
 {
     return [layer valueForKey:interactionRegionGroupNameKey];
-}
-
-static NSString* interactionRegionGroupNameForRegion(const WebCore::PlatformLayerIdentifier& layerID, const WebCore::InteractionRegion& interactionRegion)
-{
-    return makeString("WKInteractionRegion-"_s, layerID.toString(), interactionRegion.elementIdentifier.toUInt64());
 }
 
 static bool isAnyInteractionRegionLayer(CALayer *layer)
 {
     return !!interactionRegionTypeForLayer(layer);
-}
-
-static void setInteractionRegion(CALayer *layer, NSString *groupName)
-{
-    [layer setValue:@(static_cast<uint8_t>(InteractionRegion::Type::Interaction)) forKey:interactionRegionTypeKey];
-    [layer setValue:groupName forKey:interactionRegionGroupNameKey];
-}
-
-static void setInteractionRegionOcclusion(CALayer *layer)
-{
-    [layer setValue:@(static_cast<uint8_t>(InteractionRegion::Type::Occlusion)) forKey:interactionRegionTypeKey];
-}
-
-static void setInteractionRegionGuard(CALayer *layer, NSString *groupName)
-{
-    [layer setValue:@(static_cast<uint8_t>(InteractionRegion::Type::Guard)) forKey:interactionRegionTypeKey];
-    [layer setValue:groupName forKey:interactionRegionGroupNameKey];
 }
 
 static CACornerMask convertToCACornerMask(OptionSet<InteractionRegion::CornerMask> mask)
@@ -180,10 +219,19 @@ void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node)
     CALayer *layer = node.interactionRegionsLayer();
 
     HashMap<std::pair<IntRect, InteractionRegion::Type>, CALayer *>existingLayers;
+    HashMap<std::pair<String, InteractionRegion::Type>, CALayer *>reusableLayers;
     for (CALayer *sublayer in layer.sublayers) {
         if (auto type = interactionRegionTypeForLayer(sublayer)) {
             auto result = existingLayers.add(std::make_pair(enclosingIntRect(sublayer.frame), *type), sublayer);
             ASSERT_UNUSED(result, result.isNewEntry);
+
+            auto reuseKey = std::make_pair(interactionRegionGroupNameForLayer(sublayer), *type);
+            if (reusableLayers.contains(reuseKey))
+                reusableLayers.remove(reuseKey);
+            else {
+                auto result = reusableLayers.add(reuseKey, sublayer);
+                ASSERT_UNUSED(result, result.isNewEntry);
+            }
         }
     }
 
@@ -192,75 +240,58 @@ void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node)
     NSUInteger insertionPoint = 0;
     for (const WebCore::InteractionRegion& region : node.eventRegion().interactionRegions()) {
         IntRect rect = region.rectInLayerCoordinates;
-
         if (!node.visibleRect() || !node.visibleRect()->intersects(rect))
             continue;
 
-        bool foundInPosition = false;
-        RetainPtr<CALayer> regionLayer;
-        auto key = std::make_pair(rect, region.type);
         auto interactionRegionGroupName = interactionRegionGroupNameForRegion(node.layerID(), region);
+        auto key = std::make_pair(rect, region.type);
+        auto reuseKey = std::make_pair(interactionRegionGroupName, region.type);
 
-        auto layerIterator = existingLayers.find(key);
-        if (layerIterator != existingLayers.end()) {
-            regionLayer = layerIterator->value;
-            existingLayers.remove(key);
-            if ([layer.sublayers objectAtIndex:insertionPoint] == regionLayer)
-                foundInPosition = true;
-            else
-                [regionLayer removeFromSuperlayer];
-        } else {
-            if (region.type == InteractionRegion::Type::Interaction)
-                regionLayer = adoptNS([[interactionRegionLayerClass() alloc] init]);
-            else
-                regionLayer = adoptNS([[CALayer alloc] init]);
+        RetainPtr<CALayer> regionLayer;
+        bool didReuseLayer = true;
+        bool didReuseLayerBasedOnRect = false;
 
-            [regionLayer setFrame:rect];
-            [regionLayer setHitTestsAsOpaque:YES];
-
-            switch (region.type) {
-            case InteractionRegion::Type::Occlusion:
-                setInteractionRegionOcclusion(regionLayer.get());
-                if (applyBackgroundColorForDebugging) {
-                    [regionLayer setBorderColor:cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .2) }).get()];
-                    [regionLayer setBorderWidth:6];
-                    [regionLayer setName:@"Occlusion"];
-                }
-                break;
-            case InteractionRegion::Type::Guard:
-                setInteractionRegionGuard(regionLayer.get(), interactionRegionGroupName);
-                configureLayerAsGuard(regionLayer.get(), interactionRegionGroupName);
-                if (applyBackgroundColorForDebugging) {
-                    [regionLayer setBorderColor:cachedCGColor({ WebCore::SRGBA<float>(0, 0, 1, .2) }).get()];
-                    [regionLayer setBorderWidth:6];
-                    [regionLayer setName:@"Guard"];
-                }
-                break;
-            case InteractionRegion::Type::Interaction:
-                setInteractionRegion(regionLayer.get(), interactionRegionGroupName);
-                configureLayerForInteractionRegion(regionLayer.get(), interactionRegionGroupName);
-                if (applyBackgroundColorForDebugging) {
-                    [regionLayer setBackgroundColor:cachedCGColor({ WebCore::SRGBA<float>(0, 1, 0, .2) }).get()];
-                    [regionLayer setName:@"Interaction"];
-                }
-                break;
+        auto findOrCreateLayer = [&]() {
+            auto layerIterator = existingLayers.find(key);
+            if (layerIterator != existingLayers.end()) {
+                didReuseLayerBasedOnRect = true;
+                regionLayer = layerIterator->value;
+                return;
             }
+
+            auto layerReuseIterator = reusableLayers.find(reuseKey);
+            if (layerReuseIterator != reusableLayers.end()) {
+                regionLayer = layerReuseIterator->value;
+                return;
+            }
+
+            didReuseLayer = false;
+            regionLayer = adoptNS(createInteractionRegionLayer(region.type, interactionRegionGroupName, applyBackgroundColorForDebugging));
+        };
+        findOrCreateLayer();
+
+        if (didReuseLayer) {
+            auto layerKey = std::make_pair(enclosingIntRect([regionLayer frame]), region.type);
+            existingLayers.remove(layerKey);
+            reusableLayers.remove(reuseKey);
+
+            bool shouldReconfigureRemoteEffect = didReuseLayerBasedOnRect && ![interactionRegionGroupName isEqualToString:interactionRegionGroupNameForLayer(regionLayer.get())];
+            if (shouldReconfigureRemoteEffect)
+                configureRemoteEffect(regionLayer.get(), region.type, interactionRegionGroupName);
         }
 
-        if (!foundInPosition)
-            [layer insertSublayer:regionLayer.get() atIndex:insertionPoint];
-
-        if (![interactionRegionGroupName isEqualToString:interactionRegionGroupNameForLayer(regionLayer.get())]) {
-            if (region.type == InteractionRegion::Type::Guard)
-                configureLayerAsGuard(regionLayer.get(), interactionRegionGroupName);
-            if (region.type == InteractionRegion::Type::Interaction)
-                configureLayerForInteractionRegion(regionLayer.get(), interactionRegionGroupName);
-        }
+        if (!didReuseLayerBasedOnRect)
+            [regionLayer setFrame:rect];
 
         if (region.type == InteractionRegion::Type::Interaction) {
             [regionLayer setCornerRadius:region.borderRadius];
             if (!region.maskedCorners.isEmpty())
                 [regionLayer setMaskedCorners:convertToCACornerMask(region.maskedCorners)];
+        }
+
+        if ([layer.sublayers objectAtIndex:insertionPoint] != regionLayer) {
+            [regionLayer removeFromSuperlayer];
+            [layer insertSublayer:regionLayer.get() atIndex:insertionPoint];
         }
 
         insertionPoint++;


### PR DESCRIPTION
#### 3f543a9ea04e09fdfe995130a78dbbd7a86b4450
<pre>
Reuse InteractionRegion layers when an element is resized
<a href="https://bugs.webkit.org/show_bug.cgi?id=260078">https://bugs.webkit.org/show_bug.cgi?id=260078</a>
&lt;rdar://112930285&gt;

Reviewed by Tim Horton and Mike Wyrzykowski.

We currently only reuse InteractionRegions layers based on their frame.
This patch adds the ability to reuse layers when an element is resized
or moved.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::setInteractionRegion): Deleted.
(WebKit::setInteractionRegionOcclusion): Deleted.
(WebKit::setInteractionRegionGuard): Deleted.
(WebKit::createInteractionRegionLayer):
Extract the layer creation code in a single function for readability.
(WebKit::configureRemoteEffect):
Extract the remote effect configuration in a function for readibility.
(WebKit::applyBackgroundColorForDebuggingToLayer):
Extract the debug layer configuration to a function for readability.
(WebKit::interactionRegionTypeForLayer):
(WebKit::interactionRegionGroupNameForRegion):
(WebKit::interactionRegionGroupNameForLayer):
(WebKit::isAnyInteractionRegionLayer):
Style fix. Re-order functions.

(WebKit::updateLayersForInteractionRegions):
Keep track of existing layers that are not part of a multi-layer
group effect for reuse.
Move the layer reuse / creation code to a lambda to use early returns
and improve readability. Add the new `groupName` based reuse code path.
Clarify the conditions under which we update properties on the
InteractionRegion layer.

* LayoutTests/interaction-region/layer-tree.html:
Make sure all branches of the `updateLayersForInteractionRegions()` get
exercised during the test.
* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
Reset and update test expectations (something changed below us).

Canonical link: <a href="https://commits.webkit.org/266945@main">https://commits.webkit.org/266945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0986ff053ccf75a8def22cc7c814d10eac37cdc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14282 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16896 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17694 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20679 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17140 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->