### PR TITLE
bankofamerica.com - Loading icon still present when navigating back after failing log in

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -877,6 +877,7 @@ bool Quirks::shouldBypassBackForwardCache() const
 
     auto topURL = m_document->topDocument().url();
     auto host = topURL.host();
+    RegistrableDomain registrableDomain { topURL };
 
     // Vimeo.com used to bypass the back/forward cache by serving "Cache-Control: no-store" over HTTPS.
     // We started caching such content in r250437 but the vimeo.com content unfortunately is not currently compatible
@@ -885,6 +886,18 @@ bool Quirks::shouldBypassBackForwardCache() const
     if (topURL.protocolIs("https"_s) && equalLettersIgnoringASCIICase(host, "vimeo.com"_s)) {
         if (auto* documentLoader = m_document->frame() ? m_document->frame()->loader().documentLoader() : nullptr)
             return documentLoader->response().cacheControlContainsNoStore();
+    }
+
+    // Login issue on bankofamerica.com (rdar://104938789).
+    if (registrableDomain == "bankofamerica.com"_s) {
+        if (auto* window = m_document->domWindow()) {
+            if (window->hasEventListeners(eventNames().unloadEvent)) {
+                static MainThreadNeverDestroyed<const AtomString> signInId("signIn"_s);
+                static MainThreadNeverDestroyed<const AtomString> loadingClass("loading"_s);
+                RefPtr signinButton = m_document->getElementById(signInId.get());
+                return signinButton && signinButton->classNames().contains(loadingClass.get());
+            }
+        }
     }
 
     // Google Docs used to bypass the back/forward cache by serving "Cache-Control: no-store" over HTTPS.


### PR DESCRIPTION
#### c6859d32429f4a49a12a23def78015821824b05d
<pre>
bankofamerica.com - Loading icon still present when navigating back after failing log in
<a href="https://bugs.webkit.org/show_bug.cgi?id=260082">https://bugs.webkit.org/show_bug.cgi?id=260082</a>
rdar://104938789

Reviewed by Brent Fulgham.

On bankofamerica.com, if you attempt to log in with invalid credential and then
navigate back, the &quot;log in&quot; will still be shown as &quot;Loading ...&quot;.

The reason this happens is that the page changes the &quot;Log in&quot; button text to
&quot;Loading ...&quot; right before the navigation but fails to reset it on &quot;pagehide&quot;
or &quot;pageshow&quot; event. Safari successfully caches the page in the back/forward
cache and thus the page still shows &quot;Loading ...&quot; after the back navigation.

The issue doesn&apos;t reproduce in Chrome because they do not cache pages as
aggressively as we do. In particular, they do not cache pages that have an
&quot;unload&quot; event handler, like this page. Safari has been caching such pages
for years.

Since this is a content issue that could easily be addressed by the site
developers, I am addressing this with a quirk. If we detect this particular
&quot;sign in&quot; button with the &quot;loading&quot; class on bankofamerica.com, and if the
page has an &quot;unload&quot; event handler, we now prevent the page from going into
the cache.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldBypassBackForwardCache const):

Canonical link: <a href="https://commits.webkit.org/266898@main">https://commits.webkit.org/266898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58bd9c5fed1668b434dc05312e7de8d522aa72e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16639 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17357 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20402 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16834 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11952 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13428 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3630 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->