### PR TITLE
Implement in-place interpreter prologue and loop OSR

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-hot-12.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-hot-12.js
@@ -1,0 +1,55 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $add (export "add") (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.add)
+        (local.get 2)
+        (i32.add)
+        (local.get 3)
+        (i32.add)
+        (local.get 4)
+        (i32.add)
+        (local.get 5)
+        (i32.add)
+        (local.get 6)
+        (i32.add)
+        (local.get 7)
+        (i32.add)
+        (local.get 8)
+        (i32.add)
+        (local.get 9)
+        (i32.add)
+        (local.get 10)
+        (i32.add)
+        (local.get 11)
+        (i32.add)
+        (return)
+    )
+)
+`
+
+let seed = 89666917;
+function prng() {
+    // xorshift
+    let v = seed;
+    seed ^= (seed << 13);
+    seed ^= (seed >> 17);
+    seed ^= (seed << 5);
+    return v % 256;
+}
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test, add } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        let values = new Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).map((_) => prng());
+        assert.eq(add(...values), values.reduce((p, c) => p + c, 0));
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-hot-loop.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-hot-loop.js
@@ -1,0 +1,55 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "isPrime") (param i32) (result i32)
+        (local i32 i32)
+        (local.get 0)
+        (i32.const 2)
+        (local.tee 1)
+        (i32.lt_s)
+        (if
+            (then
+                (i32.const 0)
+                (return)
+            )
+        )
+        (loop
+            (local.get 0)
+            (local.get 1)
+            (i32.rem_s)
+            (if
+                (then
+                    (local.get 1)
+                    (i32.const 1)
+                    (i32.add)
+                    (local.set 1)
+                )
+                (else
+                    (i32.const 0)
+                    (return)
+                )
+            )
+            (local.get 1)
+            (local.get 0)
+            (i32.lt_s)
+            (br_if 0)
+        )
+        (local.get 0)
+        (local.get 1)
+        (i32.eq)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { isPrime } = instance.exports
+    assert.eq(isPrime(101), 1);
+    assert.eq(isPrime(65537), 1);
+    assert.eq(isPrime(1048577), 0);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-hot.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-hot.js
@@ -1,0 +1,44 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "fib") (param i32) (result i32)
+        (local i32 i32)
+        (i32.const 1)
+        (local.set 1)
+        (loop
+            (local.get 2)
+            (local.get 1)
+            (local.get 2)
+            (i32.add)
+            (local.set 2)
+            (local.set 1)
+            (local.get 0)
+            (i32.const 1)
+            (i32.sub)
+            (local.tee 0)
+            (i32.const 0)
+            (i32.gt_s)
+            (br_if 0)
+        )
+        (local.get 2)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { fib } = instance.exports
+    for (let c = 0; c < 10000; ++c) {
+        let a = 0;
+        let b = 1;
+        for (let i = 1; i < 47; ++i) {
+            assert.eq(fib(i), b);
+            [a, b] = [b, a+b];
+        }
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -296,7 +296,7 @@ public:
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
         // The LLInt discovers this value.
-        ASSERT(Options::useWasmLLInt());
+        ASSERT(Options::useWasmLLInt() || Options::useWasmIPInt());
         return m_usesSIMD;
     }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -603,6 +603,8 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 #define OFFLINE_ASM_OPCODE_DEBUG_LABEL(label)
 #endif
 
+#include "WasmCallee.h"
+
 // This works around a bug in GDB where, if the compilation unit
 // doesn't have any address range information, its line table won't
 // even be consulted. Emit {before,after}_llint_asm so that the code

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -664,7 +664,7 @@ void Options::notifyOptionsChanged()
         if (Options::forceAllFunctionsToUseSIMD() && !Options::useWebAssemblySIMD())
             Options::forceAllFunctionsToUseSIMD() = false;
 
-        if (Options::useWebAssemblySIMD() && !Options::useWasmLLInt()) {
+        if (Options::useWebAssemblySIMD() && !(Options::useWasmLLInt() || Options::useWasmIPInt())) {
             // The LLInt is responsible for discovering if functions use SIMD.
             // If we can't run using it, then we should be conservative.
             Options::forceAllFunctionsToUseSIMD() = true;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -587,6 +587,10 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec.") \
     v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec.") \
     v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt.") \
+    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
+    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
+    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
+    v(Bool, wasmIPIntTiersUpToOMG, false, Normal, "Allow IPInt to tier up to OMG")
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -237,10 +237,17 @@ void BBQPlan::work(CompilationEffort effort)
         m_calleeGroup->callsiteCollection().updateCallsitesToCallUs(locker, *m_calleeGroup, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex, functionIndexSpace);
 
         {
-            LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
-            Locker locker { llintCallee.tierUpCounter().m_lock };
-            llintCallee.setReplacement(callee.copyRef(), mode());
-            llintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+            if (Options::useWasmIPInt()) {
+                IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
+                Locker locker { ipintCallee.tierUpCounter().m_lock };
+                ipintCallee.setReplacement(callee.copyRef(), mode());
+                ipintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+            } else {
+                LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
+                Locker locker { llintCallee.tierUpCounter().m_lock };
+                llintCallee.setReplacement(callee.copyRef(), mode());
+                llintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+            }
         }
     }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -166,6 +166,7 @@ WasmToJSCallee::WasmToJSCallee()
 
 IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index, std::pair<const Name*, RefPtr<NameSection>>&& name)
     : Callee(Wasm::CompilationMode::IPIntMode, index, WTFMove(name))
+    , m_functionIndex(generator.m_functionIndex)
     , m_signatures(WTFMove(generator.m_signatures))
     , m_bytecode(generator.m_bytecode + generator.m_bytecodeOffset)
     , m_bytecodeLength(generator.m_bytecodeLength - generator.m_bytecodeOffset)
@@ -177,6 +178,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index
     , m_localSizeToAlloc(roundUpToMultipleOf(2, generator.m_numLocals))
     , m_numLocals(generator.m_numLocals)
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
+    , m_tierUpCounter(WTFMove(generator.m_tierUpCounter))
 {
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -102,6 +102,8 @@ public:
         if (!m_bbqCallees.isEmpty() && m_bbqCallees[calleeIndex])
             return *m_bbqCallees[calleeIndex].get();
 #endif
+        if (Options::useWasmIPInt())
+            return m_ipintCallees->at(calleeIndex).get();
         return m_llintCallees->at(calleeIndex).get();
     }
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -79,6 +79,8 @@ public:
     const uint8_t* getBytecode() const { return m_bytecode; }
     const uint8_t* getMetadata() const { return m_metadata.data(); }
 
+    HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData>& tierUpCounter() { return m_tierUpCounter; }
+
     unsigned addSignature(const TypeDefinition&);
 
 private:
@@ -107,6 +109,7 @@ private:
     Vector<uint8_t, 16> m_argumINTBytecode { };
 
     Vector<const TypeDefinition*> m_signatures;
+    HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData> m_tierUpCounter;
 
     // Optimization to skip large numbers of blocks
 

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -140,7 +140,7 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
         // The LLInt discovers this value.
-        ASSERT(Options::useWasmLLInt());
+        ASSERT(Options::useWasmLLInt() || Options::useWasmIPInt());
 
         return functions[index].usesSIMD;
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -179,7 +179,13 @@ void OMGPlan::work(CompilationEffort)
                 bbqCallee->setReplacement(callee.copyRef());
                 bbqCallee->tierUpCount()->m_compilationStatusForOMG = TierUpCount::CompilationStatus::Compiled;
             }
-            if (m_calleeGroup->m_llintCallees) {
+            if (Options::useWasmIPInt() && m_calleeGroup->m_ipintCallees) {
+                IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
+                Locker locker { ipintCallee.tierUpCounter().m_lock };
+                ipintCallee.setReplacement(callee.copyRef(), mode());
+                ipintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+            }
+            if (!Options::useWasmIPInt() && m_calleeGroup->m_llintCallees) {
                 LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
                 Locker locker { llintCallee.tierUpCounter().m_lock };
                 llintCallee.setReplacement(callee.copyRef(), mode());

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -161,6 +161,13 @@ void OSREntryPlan::work(CompilationEffort)
                 llintCallee->tierUpCounter().m_loopCompilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
                 break;
             }
+            case CompilationMode::IPIntMode: {
+                IPIntCallee* ipintCallee = static_cast<IPIntCallee*>(m_callee.ptr());
+                Locker locker { ipintCallee->tierUpCounter().m_lock };
+                ipintCallee->setOSREntryCallee(callee.copyRef(), mode());
+                ipintCallee->tierUpCounter().m_loopCompilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
+                break;
+            }
             case CompilationMode::BBQMode: {
                 BBQCallee* bbqCallee = static_cast<BBQCallee*>(m_callee.ptr());
                 Locker locker { bbqCallee->tierUpCount()->getLock() };

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -66,7 +66,9 @@ namespace LLInt {
 
 #if ENABLE(WEBASSEMBLY_B3JIT)
 WASM_SLOW_PATH_HIDDEN_DECL(prologue_osr);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prologue_osr, CallFrame* callFrame);
 WASM_SLOW_PATH_HIDDEN_DECL(loop_osr);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t* pl);
 WASM_SLOW_PATH_HIDDEN_DECL(epilogue_osr);
 WASM_SLOW_PATH_HIDDEN_DECL(simd_go_straight_to_bbq_osr);
 #endif


### PR DESCRIPTION
#### 5f18ff5fc08d864caa2315af403ec63f535362fa
<pre>
Implement in-place interpreter prologue and loop OSR
<a href="https://bugs.webkit.org/show_bug.cgi?id=260083">https://bugs.webkit.org/show_bug.cgi?id=260083</a>
rdar://113768807

Reviewed by Justin Michaud.

Add on stack replacement (OSR) functionality to the in-place interpreter, allowing tiering up to both BBQ and OMG JIT tiers. JS2 performance is comparable to LLInt, with local scores both at around 330.

* JSTests/wasm/ipint-tests/ipint-test-hot-12.js: Added.
(prng):
(async test):
* JSTests/wasm/ipint-tests/ipint-test-hot-loop.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.i32.result.i32.local.i32.i32.local.0.i32.const.2.local.tee.1.i32.lt_s.then.i32.const.0.return.loop.local.0.local.1.i32.rem_s.then.local.1.i32.const.1.i32.add.local.1.else.i32.const.0.return.local.1.local.0.i32.lt_s.br_if.0.local.0.local.1.i32.eq.return.async test):
* JSTests/wasm/ipint-tests/ipint-test-hot.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.i32.result.i32.local.i32.i32.i32.const.1.local.1.loop.local.2.local.1.local.2.i32.add.local.2.local.1.local.0.i32.const.1.i32.sub.local.tee.0.i32.const.0.i32.gt_s.br_if.0.local.2.return.async test):
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::usesSIMD const):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
(ipint_probe_precall):
(ipint_probe_calling):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
(JSC::Wasm::FunctionIPIntMetadataGenerator::tierUpCounter):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::notifyFunctionUsesSIMD):
(JSC::Wasm::IPIntGenerator::condenseControlFlowInstructions):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::endTopLevel):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
(JSC::Wasm::ModuleInformation::usesSIMD const):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::shouldJIT):
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/266887@main">https://commits.webkit.org/266887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af4340a0691987da2f976dd13f806e4b95520778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16667 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17399 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20423 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12766 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16862 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11986 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15116 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13461 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3624 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17793 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15347 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14019 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3662 "Passed tests") | 
<!--EWS-Status-Bubble-End-->