### PR TITLE
Convert WebCore/CSS WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCounterStyleRegistry);
 
 void CSSCounterStyleRegistry::resolveUserAgentReferences()
 {

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCounterStyleRegistry);
+
 struct ListStyleType;
 class StyleRuleCounterStyle;
 enum CSSValueID : uint16_t;
@@ -39,7 +41,7 @@ enum CSSValueID : uint16_t;
 using CounterStyleMap = HashMap<AtomString, RefPtr<CSSCounterStyle>>;
 
 class CSSCounterStyleRegistry {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSCounterStyleRegistry);
 public:
     CSSCounterStyleRegistry() = default;
     RefPtr<CSSCounterStyle> resolvedCounterStyle(const ListStyleType&);

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -47,6 +47,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFaceSource);
+
 inline void CSSFontFaceSource::setStatus(Status newStatus)
 {
     switch (newStatus) {

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFaceSource);
+
 class CSSFontFace;
 class CSSFontSelector;
 class SharedBuffer;
@@ -45,7 +47,7 @@ class WeakPtrImplWithEventTargetData;
 struct FontCustomPlatformData;
 
 class CSSFontFaceSource final : public FontLoadRequestClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSFontFaceSource);
 public:
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName);
     CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName, SVGFontFaceElement&);

--- a/Source/WebCore/css/CSSRuleList.cpp
+++ b/Source/WebCore/css/CSSRuleList.cpp
@@ -26,6 +26,8 @@
 
 namespace WebCore {
 
+DDEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSRuleList);
+
 CSSRuleList::CSSRuleList() = default;
 
 CSSRuleList::~CSSRuleList() = default;

--- a/Source/WebCore/css/CSSRuleList.h
+++ b/Source/WebCore/css/CSSRuleList.h
@@ -69,10 +69,12 @@ private:
     Vector<RefPtr<CSSRule>> m_rules;
 };
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(LiveCSSRuleList);
+
 // The rule owns the live list.
 template <class Rule>
 class LiveCSSRuleList final : public CSSRuleList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LiveCSSRuleList);
 public:
     LiveCSSRuleList(Rule& rule)
         : m_rule(rule)

--- a/Source/WebCore/css/CSSSegmentedFontFace.cpp
+++ b/Source/WebCore/css/CSSSegmentedFontFace.cpp
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSegmentedFontFace);
+
 CSSSegmentedFontFace::CSSSegmentedFontFace()
 {
 }

--- a/Source/WebCore/css/CSSSegmentedFontFace.h
+++ b/Source/WebCore/css/CSSSegmentedFontFace.h
@@ -33,6 +33,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSegmentedFontFace);
+
 class CSSFontSelector;
 class FontCreationContext;
 class FontDescription;
@@ -40,7 +42,7 @@ class FontPaletteValues;
 class FontRanges;
 
 class CSSSegmentedFontFace final : public RefCounted<CSSSegmentedFontFace>, public CSSFontFace::Client {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSegmentedFontFace);
 public:
     static Ref<CSSSegmentedFontFace> create()
     {

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -54,6 +54,7 @@ struct SameSizeAsCSSSelector {
 static_assert(CSSSelector::RelationType::Subselector == static_cast<CSSSelector::RelationType>(0u), "Subselector must be 0 for consumeCombinator.");
 static_assert(sizeof(CSSSelector) == sizeof(SameSizeAsCSSSelector), "CSSSelector should remain small.");
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelector);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelectorRareData);
 
 CSSSelector::CSSSelector(const QualifiedName& tagQName, bool tagIsForNamespaceRule)

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelector);
+
 class CSSSelectorList;
 
 struct PossiblyQuotedIdentifier {
@@ -46,7 +48,7 @@ struct PossiblyQuotedIdentifier {
     // Selector for a StyleRule.
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelectorRareData);
     class CSSSelector {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSelector);
     public:
         CSSSelector() = default;
         CSSSelector(const CSSSelector&);

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -33,6 +33,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSSelectorList);
+
 CSSSelectorList::CSSSelectorList(const CSSSelectorList& other)
 {
     unsigned otherComponentCount = other.componentCount();

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -31,10 +31,12 @@
 
 namespace WebCore {
 
+WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSelectorList)
+
 class CSSParserSelector;
 
 class CSSSelectorList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSSelectorList);
 public:
     CSSSelectorList() = default;
     CSSSelectorList(const CSSSelectorList&);

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -49,6 +49,9 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSStyleSheet);
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSStyleSheet);
+
 static Style::Scope& styleScopeFor(ContainerNode& treeScope)
 {
     ASSERT(is<Document>(treeScope) || is<ShadowRoot>(treeScope));
@@ -58,7 +61,7 @@ static Style::Scope& styleScopeFor(ContainerNode& treeScope)
 }
 
 class StyleSheetCSSRuleList final : public CSSRuleList {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleSheetCSSRuleList);
 public:
     StyleSheetCSSRuleList(CSSStyleSheet* sheet) : m_styleSheet(sheet) { }
     

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValuePool);
+
 LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
 
 StaticCSSValuePool::StaticCSSValuePool()

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -33,6 +33,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValuePool);
+
 class CSSValueList;
 class CSSValuePool;
 
@@ -64,7 +66,7 @@ private:
 WEBCORE_EXPORT extern LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
 
 class CSSValuePool {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSValuePool);
     WTF_MAKE_NONCOPYABLE(CSSValuePool);
 public:
     CSSValuePool();

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -40,6 +40,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSVariableData);
+
 template<typename CharacterType> void CSSVariableData::updateTokens(const CSSParserTokenRange& range)
 {
     const CharacterType* currentOffset = m_backingString.characters<CharacterType>();

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -34,9 +34,11 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSVariableData);
+
 class CSSVariableData : public RefCounted<CSSVariableData> {
     WTF_MAKE_NONCOPYABLE(CSSVariableData);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSVariableData);
 public:
     static Ref<CSSVariableData> create(const CSSParserTokenRange& range)
     {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -83,6 +83,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleExtractor);
+
 template<typename ConvertibleType> Ref<CSSPrimitiveValue> createConvertingToCSSValueID(const ConvertibleType& value)
 {
     return CSSPrimitiveValue::create(toCSSValueID(value));

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -25,6 +25,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleExtractor);
+
 class Animation;
 class CSSFunctionValue;
 class CSSPrimitiveValue;
@@ -52,7 +54,7 @@ enum class SVGPaintType : uint8_t;
 using CSSValueListBuilder = Vector<Ref<CSSValue>, 4>;
 
 class ComputedStyleExtractor {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ComputedStyleExtractor);
 public:
     ComputedStyleExtractor(Node*, bool allowVisitedStyle = false);
     ComputedStyleExtractor(Node*, bool allowVisitedStyle, PseudoId);

--- a/Source/WebCore/css/DOMCSSPaintWorklet.cpp
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.cpp
@@ -37,6 +37,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMCSSPaintWorklet);
+
 PaintWorklet& DOMCSSPaintWorklet::ensurePaintWorklet(Document& document)
 {
     return document.ensurePaintWorklet();

--- a/Source/WebCore/css/DOMCSSPaintWorklet.h
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.h
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMCSSPaintWorklet);
+
 class Document;
 class Worklet;
 class DOMCSSNamespace;
@@ -59,7 +61,7 @@ private:
 };
 
 class DOMCSSPaintWorklet final : public Supplement<DOMCSSNamespace> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DOMCSSPaintWorklet);
 public:
     explicit DOMCSSPaintWorklet(DOMCSSNamespace&) { }
 

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -42,6 +42,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMCSSRegisterCustomProperty);
+
 ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& document, const DOMCSSCustomPropertyDescriptor& descriptor)
 {
     if (!isCustomPropertyName(descriptor.name))

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.h
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.h
@@ -31,11 +31,13 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMCSSRegisterCustomProperty);
+
 class Document;
 class DOMCSSNamespace;
 
 class DOMCSSRegisterCustomProperty final : public Supplement<DOMCSSNamespace> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DOMCSSRegisterCustomProperty);
 public:
     explicit DOMCSSRegisterCustomProperty(DOMCSSNamespace&) { }
 

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -37,6 +37,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleImport);
+
 Ref<StyleRuleImport> StyleRuleImport::create(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName)
 {
     return adoptRef(*new StyleRuleImport(href, WTFMove(mediaQueries), WTFMove(cascadeLayerName)));

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -29,11 +29,13 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleImport);
+
 class CachedCSSStyleSheet;
 class StyleSheetContents;
 
 class StyleRuleImport final : public StyleRuleBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleImport);
 public:
     static Ref<StyleRuleImport> create(const String& href, MQ::MediaQueryList&&, std::optional<CascadeLayerName>&&);
     ~StyleRuleImport();

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -41,6 +41,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCalcOperationNode);
+
 // This is the result of the "To add two types type1 and type2, perform the following steps:" rules.
 
 static const CalculationCategory addSubtractResult[static_cast<unsigned>(CalculationCategory::Angle)][static_cast<unsigned>(CalculationCategory::Angle)] = {

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -31,8 +31,10 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCalcOperationNode);
+
 class CSSCalcOperationNode final : public CSSCalcExpressionNode {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSCalcOperationNode);
 public:
     enum class IsRoot : bool { No, Yes };
     

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -37,6 +37,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCalcPrimitiveValueNode);
+
 Ref<CSSCalcPrimitiveValueNode> CSSCalcPrimitiveValueNode::create(Ref<CSSPrimitiveValue>&& value)
 {
     return adoptRef(*new CSSCalcPrimitiveValueNode(WTFMove(value)));

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -29,13 +29,15 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSCalcPrimitiveValueNode);
+
 class CSSPrimitiveValue;
 class CSSToLengthConversionData;
 
 enum CSSPropertyID : uint16_t;
 
 class CSSCalcPrimitiveValueNode final : public CSSCalcExpressionNode {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSCalcPrimitiveValueNode);
 public:
     static Ref<CSSCalcPrimitiveValueNode> create(Ref<CSSPrimitiveValue>&&);
     static RefPtr<CSSCalcPrimitiveValueNode> create(double value, CSSUnitType);

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserSelector);
+
 std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePagePseudoSelector(StringView pseudoTypeString)
 {
     CSSSelector::PagePseudoClassType pseudoType;

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -25,6 +25,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserSelector);
+
 enum class CSSParserSelectorCombinator {
     Child,
     DescendantSpace,
@@ -33,7 +35,7 @@ enum class CSSParserSelectorCombinator {
 };
 
 class CSSParserSelector {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSParserSelector);
 public:
     static std::unique_ptr<CSSParserSelector> parsePseudoClassSelector(StringView);
     static std::unique_ptr<CSSParserSelector> parsePseudoElementSelector(StringView);

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -40,6 +40,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserToken);
+
 template<typename CharacterType>
 CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned length)
 {

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserToken);
+
 enum CSSParserTokenType {
     IdentToken = 0,
     FunctionToken,
@@ -89,7 +91,7 @@ enum HashTokenType {
 };
 
 class CSSParserToken {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSParserToken);
 public:
     enum BlockType {
         NotBlock,

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -41,6 +41,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizer);
+
 // https://drafts.csswg.org/css-syntax/#input-preprocessing
 String CSSTokenizer::preprocessString(const String& string)
 {

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -37,13 +37,15 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizer);
+
 class CSSTokenizerInputStream;
 class CSSParserObserverWrapper;
 class CSSParserTokenRange;
 
 class CSSTokenizer {
     WTF_MAKE_NONCOPYABLE(CSSTokenizer);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSTokenizer);
 public:
     static std::unique_ptr<CSSTokenizer> tryCreate(const String&);
     static std::unique_ptr<CSSTokenizer> tryCreate(const String&, CSSParserObserverWrapper&); // For the inspector

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizerInputStream);
+
 CSSTokenizerInputStream::CSSTokenizerInputStream(const String& input)
     : m_offset(0)
     , m_stringLength(input.length())

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.h
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.h
@@ -33,11 +33,13 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizerInputStream);
+
 constexpr LChar kEndOfFileMarker = 0;
 
 class CSSTokenizerInputStream {
     WTF_MAKE_NONCOPYABLE(CSSTokenizerInputStream);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSTokenizerInputStream);
 public:
     explicit CSSTokenizerInputStream(const String& input);
 

--- a/Source/WebCore/css/typedom/CSSNumericFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.cpp
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSNumericFactory);
+
 CSSNumericFactory* CSSNumericFactory::from(DOMCSSNamespace& css)
 {
     auto* supplement = static_cast<CSSNumericFactory*>(Supplement<DOMCSSNamespace>::from(&css, supplementName()));

--- a/Source/WebCore/css/typedom/CSSNumericFactory.h
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.h
@@ -34,11 +34,13 @@
 
 namespace WebCore {
 
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSNumericFactory);
+
 class Document;
 class DOMCSSNamespace;
 
 class CSSNumericFactory final : public Supplement<DOMCSSNamespace> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSNumericFactory);
 public:
     explicit CSSNumericFactory(DOMCSSNamespace&) { }
 


### PR DESCRIPTION
#### 430b2899b5291b5fbaaec7b12d61329511cb2ed0
<pre>
Convert WebCore/CSS WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER
<a href="https://bugs.webkit.org/show_bug.cgi?id=260085">https://bugs.webkit.org/show_bug.cgi?id=260085</a>

Reviewed by NOBODY (OOPS!).

To get more debug info from MALLOC_HEAP_BREAKDOWN build we are converting
WTF_MAKE_FAST_ALLOCATED to WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER.

 * Source/WebCore/css/CSSCounterStyleRegistry.cpp:
 * Source/WebCore/css/CSSCounterStyleRegistry.h:
 * Source/WebCore/css/CSSFontFaceSource.cpp:
 * Source/WebCore/css/CSSFontFaceSource.h:
 * Source/WebCore/css/CSSRuleList.cpp:
 * Source/WebCore/css/CSSRuleList.h:
 * Source/WebCore/css/CSSSegmentedFontFace.cpp:
 * Source/WebCore/css/CSSSegmentedFontFace.h:
 * Source/WebCore/css/CSSSelector.cpp:
 * Source/WebCore/css/CSSSelector.h:
 * Source/WebCore/css/CSSSelectorList.cpp:
 * Source/WebCore/css/CSSSelectorList.h:
 * Source/WebCore/css/CSSStyleSheet.cpp:
 * Source/WebCore/css/CSSValuePool.cpp:
 * Source/WebCore/css/CSSValuePool.h:
 * Source/WebCore/css/CSSVariableData.cpp:
 * Source/WebCore/css/CSSVariableData.h:
 * Source/WebCore/css/ComputedStyleExtractor.cpp:
 * Source/WebCore/css/ComputedStyleExtractor.h:
 * Source/WebCore/css/DOMCSSPaintWorklet.cpp:
 * Source/WebCore/css/DOMCSSPaintWorklet.h:
 * Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
 * Source/WebCore/css/DOMCSSRegisterCustomProperty.h:
 * Source/WebCore/css/StyleRuleImport.cpp:
 * Source/WebCore/css/StyleRuleImport.h:
 * Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
 * Source/WebCore/css/calc/CSSCalcOperationNode.h:
 * Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
 * Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
 * Source/WebCore/css/parser/CSSParserSelector.cpp:
 * Source/WebCore/css/parser/CSSParserSelector.h:
 * Source/WebCore/css/parser/CSSParserToken.cpp:
 * Source/WebCore/css/parser/CSSParserToken.h:
 * Source/WebCore/css/parser/CSSTokenizer.cpp:
 * Source/WebCore/css/parser/CSSTokenizer.h:
 * Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
 * Source/WebCore/css/parser/CSSTokenizerInputStream.h:
 * Source/WebCore/css/typedom/CSSNumericFactory.cpp:
 * Source/WebCore/css/typedom/CSSNumericFactory.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/430b2899b5291b5fbaaec7b12d61329511cb2ed0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14884 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15188 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15542 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16632 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14009 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15021 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17709 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15289 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/16632 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15064 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/17709 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/15542 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17366 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/17709 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/15542 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/17366 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/17709 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/15542 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/17366 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14148 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/15289 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13436 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/15542 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17768 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13990 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->