### PR TITLE
[results.webkit.org] Add error handling for unexpected data format on test request.

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -487,6 +487,12 @@ class TimelineFromEndpoint {
                         CommitBank.add(oldestUuid, newestUuid);
 
                     self.ref.setState(params.limit ? parseInt(params.limit[params.limit.length - 1]) : DEFAULT_LIMIT);
+                }).catch(error => {
+                    const bugsLink = '<a href="https://bugs.webkit.org/enter_bug.cgi?product=WebKit&component=Tools%20%2F%20Tests&version=Other">file a bug</a>';
+                    this.ref.setState({
+                        error: "Error: unexpected data format.",
+                        description: `This could be due to too large of a request or a server error.<br>If this error persists, please ${bugsLink}.`
+                    });
                 });
             }).catch(error => {
                 if (myDispatch === this.latestDispatch)


### PR DESCRIPTION
#### f92c0d78c636eb62a2c457283eb684623a927f1a
<pre>
[results.webkit.org] Add error handling for unexpected data format on test request.
rdar://113770542
<a href="https://bugs.webkit.org/show_bug.cgi?id=260089">https://bugs.webkit.org/show_bug.cgi?id=260089</a>

Reviewed by Jonathan Bedard.

This change fixes the infinite spinner bug when test data is returned in an unexpected format from the results server.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(TimelineFromEndpoint.prototype.reload):

Canonical link: <a href="https://commits.webkit.org/266831@main">https://commits.webkit.org/266831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f724027cb093c00bf7fb98cd3b8307f6ad880d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16631 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15288 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15063 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17365 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14986 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16831 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/14147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14779 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/3593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/1784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->