### PR TITLE
REGRESSION (Sonoma): Media elements can trigger extra compositing updates, increasing power usage

### DIFF
--- a/LayoutTests/media/media-source/media-source-rendering-update-count-expected.txt
+++ b/LayoutTests/media/media-source/media-source-rendering-update-count-expected.txt
@@ -1,0 +1,28 @@
+
+RUN(internals.setSpeculativeTilingDelayDisabledForTesting(true))
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+
+Wait for the rendering count to settle down
+
+Append first media segment
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+EVENT(progress)
+EXPECTED (internals.renderingUpdateCount() > '0') OK
+
+Append second media segment
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
+EVENT(update)
+EVENT(progress)
+EXPECTED (Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout == 'true') OK
+
+Append third media segment
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
+EVENT(update)
+EVENT(progress)
+EXPECTED (Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout == 'true') OK
+

--- a/LayoutTests/media/media-source/media-source-rendering-update-count.html
+++ b/LayoutTests/media/media-source/media-source-rendering-update-count.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-rendering-update-count</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var collectedLog = '';
+
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+    
+    // override consoleWrite() to collect logs rather than create DOM nodes.
+    function consoleWrite(text) { collectedLog += text + '<br/>'; }
+
+    async function waitForRenderingUpdateCountToSettle()
+    {
+        let renderingUpdateCount = 0;
+        do {
+            renderingUpdateCount = internals.renderingUpdateCount();
+            await sleepFor(32);
+        } while(internals.renderingUpdateCount() != renderingUpdateCount)
+
+        // Zero the count.
+        internals.startTrackingRenderingUpdates();
+    }
+
+    const maxUpdatesCausedByMediaSizeChangeLayout = 2;
+    let initialRenderingUpdateCount = 0;
+
+    async function runTest() {
+        findMediaElement();
+
+        run('internals.setSpeculativeTilingDelayDisabledForTesting(true)');
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(loader);
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('<br>Wait for the rendering count to settle down');
+        await waitForRenderingUpdateCountToSettle();
+        initialRenderingUpdateCount = internals.renderingUpdateCount();
+
+        consoleWrite('<br>Append first media segment')
+        run(`sourceBuffer.appendBuffer(loader.mediaSegment(0))`);
+
+        await Promise.all([
+            waitFor(video, 'progress'),
+            waitFor(sourceBuffer, 'update')
+            ]);
+
+        await testExpectedEventually('internals.renderingUpdateCount()', initialRenderingUpdateCount, '>');
+        initialRenderingUpdateCount = internals.renderingUpdateCount();
+
+        consoleWrite('<br>Append second media segment')
+        run(`sourceBuffer.appendBuffer(loader.mediaSegment(1))`);
+
+        await Promise.all([
+            waitFor(video, 'progress'),
+            waitFor(sourceBuffer, 'update')
+            ]);
+
+        testExpected('Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout', true,);
+
+        consoleWrite('<br>Append third media segment')
+        run(`sourceBuffer.appendBuffer(loader.mediaSegment(2))`);
+
+        await Promise.all([
+            waitFor(video, 'progress'),
+            waitFor(sourceBuffer, 'update')
+            ]);
+
+        testExpected('Math.abs(internals.renderingUpdateCount() - initialRenderingUpdateCount) <= maxUpdatesCausedByMediaSizeChangeLayout', true);
+    }
+    
+    window.addEventListener('load', event => {
+        runTest().then(() => {
+            logConsole().innerHTML = collectedLog;
+            endTest();
+        }).catch((e) => {
+            consoleWrite('Exception: ' + e);
+            logConsole().innerHTML = collectedLog;
+            failTest();
+        });
+    });
+    
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2464,6 +2464,7 @@ webkit.org/b/256768 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 webkit.org/b/249477 media/audioSession/audioSessionType.html [ Skip ]
 webkit.org/b/253832 media/media-source/media-source-webm-configuration-change.html [ Failure ]
 webkit.org/b/253832 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]
+media/media-source/media-source-rendering-update-count.html [ Skip ]
 
 # Tests failing while still having the right values in expected related to the import in webkit.org/b/252516
 imported/w3c/web-platform-tests/css/css-tables/table-model-fixup-2.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1517,6 +1517,7 @@ webkit.org/b/236926 webrtc/vp8-then-h264-gpu-process-crash.html [ Timeout Pass ]
 
 webkit.org/b/256543 media/media-source/media-source-webm-configuration-change.html [ Failure ]
 webkit.org/b/256543 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]
+media/media-source/media-source-rendering-update-count.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # UNSORTED Expectations. When in doubt, put it here.

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1319,10 +1319,14 @@ void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, 
 {
 #if HAVE(AVKIT)
     if (auto hostingContextID = videoElement.layerHostingContextID()) {
-        if (hostingContextID != m_layerHostingContextID) {
-            m_contentsLayer = createPlatformVideoLayer(videoElement, this);
-            m_layerHostingContextID = hostingContextID;
+        if (m_contentsLayer && !m_contentsDisplayDelegate
+            && m_layerHostingContextID == hostingContextID
+            && m_contentsLayerPurpose == purpose) {
+                return;
         }
+
+        m_contentsLayer = createPlatformVideoLayer(videoElement, this);
+        m_layerHostingContextID = hostingContextID;
         m_contentsLayerPurpose = purpose;
         m_contentsDisplayDelegate = nullptr;
         updateVideoGravity();


### PR DESCRIPTION
#### 050470812f66ff2f80f31700b9c959fa42b855ea
<pre>
REGRESSION (Sonoma): Media elements can trigger extra compositing updates, increasing power usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=260095">https://bugs.webkit.org/show_bug.cgi?id=260095</a>
rdar://113643405

Reviewed by Jer Noble.

After media layer double-hosting (260575@main) and subsequent fixes (261455@main, 264812@main)
every call to GraphicsLayerCA::setContentsToVideoElement() triggered layer tree mutations via
updateVideoGravity() and noteSublayersChanged(), which schedule rendering updates. These in
turn result in CA commits in the UI process, causing a meassurable power regression.

Fix by early returning from GraphicsLayerCA::setContentsToVideoElement() when nothing has changed.

* LayoutTests/media/media-source/media-source-rendering-update-count-expected.txt: Added.
* LayoutTests/media/media-source/media-source-rendering-update-count.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setContentsToVideoElement):

Canonical link: <a href="https://commits.webkit.org/266855@main">https://commits.webkit.org/266855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d99972ec7e110409fac5dd3a3791010586b1d9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16681 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17413 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20435 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16876 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12000 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13327 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3605 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->