### PR TITLE
visionOS Media Controls: Controls briefly flash to a different size when you release a resize

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
@@ -83,6 +83,10 @@ public:
     virtual void didCleanupFullscreen() { };
     virtual void fullscreenMayReturnToInline() { };
 
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+    virtual void didResolvePlayerLayerBounds() { };
+#endif
+
     virtual void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&& completionHandler) { completionHandler(RouteSharingPolicy::Default, emptyString()); }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -300,6 +300,11 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
     [_videoSublayer setFrame:_targetVideoFrame];
 
     [CATransaction commit];
+
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+    if (auto model = _fullscreenModel.get())
+        model->didResolvePlayerLayerBounds();
+#endif
 }
 
 - (void)setVideoGravity:(NSString *)videoGravity

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3056,6 +3056,16 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [self _ensureResizeAnimationView];
 }
 
+- (void)_doAfterVideoFullscreenPlayerLayerBoundsHaveChanged:(void (^)(void))updateBlock
+{
+    _page->callAfterVideoFullscreenPlayerLayerBoundsHaveChanged([updateBlockCopy = makeBlockPtr(updateBlock)] {
+        if (!updateBlockCopy)
+            return;
+
+        updateBlockCopy();
+    });
+}
+
 - (void)_endLiveResize
 {
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endLiveResize]", self, _page->identifier().toUInt64());
@@ -3074,8 +3084,10 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [self _didStopDeferringGeometryUpdates];
 
     [self _doAfterNextPresentationUpdate:^{
-        [liveResizeSnapshotView removeFromSuperview];
-    }];    
+        [self _doAfterVideoFullscreenPlayerLayerBoundsHaveChanged:^{
+            [liveResizeSnapshotView removeFromSuperview];
+        }];
+    }];
 }
 
 #endif // HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -82,6 +82,12 @@ public:
 
     void requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&&);
 
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+    void callAfterPlayerLayerBoundsHaveChanged(CompletionHandler<void()>&&);
+
+    void didResolvePlayerLayerBounds() final;
+#endif
+
 private:
     friend class VideoFullscreenManagerProxy;
     VideoFullscreenModelContext(VideoFullscreenManagerProxy&, PlaybackSessionModelContext&, PlaybackSessionContextIdentifier);
@@ -184,6 +190,12 @@ public:
 
     void willRemoveLayerForID(PlaybackSessionContextIdentifier);
 
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+    void callAfterPlayerLayerBoundsHaveChanged(CompletionHandler<void()>&&);
+
+    void didResolvePlayerLayerBounds();
+#endif
+
 private:
     friend class VideoFullscreenModelContext;
 
@@ -257,6 +269,10 @@ private:
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
     WeakHashSet<VideoInPictureInPictureDidChangeObserver> m_pipChangeObservers;
+
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+    Vector<CompletionHandler<void()>> m_playerLayerBoundsHaveChangedCallbacks;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -357,6 +357,15 @@ void VideoFullscreenModelContext::fullscreenMayReturnToInline()
         m_manager->fullscreenMayReturnToInline(m_contextId);
 }
 
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+void VideoFullscreenModelContext::didResolvePlayerLayerBounds()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+    if (m_manager)
+        m_manager->didResolvePlayerLayerBounds();
+}
+#endif
+
 void VideoFullscreenModelContext::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&& completionHandler)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
@@ -1136,6 +1145,21 @@ void VideoFullscreenManagerProxy::fullscreenMayReturnToInline(PlaybackSessionCon
 {
     m_page->send(Messages::VideoFullscreenManager::FullscreenMayReturnToInline(contextId, m_page->isViewVisible()));
 }
+
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+
+void VideoFullscreenManagerProxy::callAfterPlayerLayerBoundsHaveChanged(CompletionHandler<void()>&& callback)
+{
+    m_playerLayerBoundsHaveChangedCallbacks.append(WTFMove(callback));
+}
+
+void VideoFullscreenManagerProxy::didResolvePlayerLayerBounds()
+{
+    for (auto& callback : std::exchange(m_playerLayerBoundsHaveChangedCallbacks, { }))
+        callback();
+}
+
+#endif
 
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -976,6 +976,15 @@ bool WebPageProxy::shouldForceForegroundPriorityForClientNavigation() const
     return canTakeForegroundAssertions;
 }
 
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+
+void WebPageProxy::callAfterVideoFullscreenPlayerLayerBoundsHaveChanged(CompletionHandler<void()>&& callback)
+{
+    m_videoFullscreenManager->callAfterPlayerLayerBoundsHaveChanged(WTFMove(callback));
+}
+
+#endif
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK_COMPLETION

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1771,6 +1771,10 @@ public:
     void clearWheelEventTestMonitor();
     void callAfterNextPresentationUpdate(CompletionHandler<void()>&&);
 
+#if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
+    void callAfterVideoFullscreenPlayerLayerBoundsHaveChanged(CompletionHandler<void()>&&);
+#endif
+
     void didReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone>);
 
     void didRestoreScrollPosition();


### PR DESCRIPTION
#### 4a65f53b3024d3989acc3e189e178ac92e5e4ac4
<pre>
visionOS Media Controls: Controls briefly flash to a different size when you release a resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=260097">https://bugs.webkit.org/show_bug.cgi?id=260097</a>
rdar://113771996

Reviewed by NOBODY (OOPS!).

The media controls flashing is just a symptom of the actual bug, which is that when releasing a
resize, the snapshot gets removed too early. This makes it so that after releasing the resize
handle, the video content goes back to its original size briefly before getting back to the final size.

When releasing the resize handle, the live resize ends (`_endLiveResize`). A snapshot view is then
created and shown, to give the web content time to update. Then, theoretically, in the `doAfterNextPresentationUpdate`
completion block, the web content will have been fully laid out and resized from the transaction commit,
and then the snapshot view can be removed.

Howevever, it turns out that `doAfterNextPresentationUpdate` doesn&apos;t necessarily guarantee that
everything is laid out. The presentation update causes a transaction commit to happen, and the commit
sets the bounds of the video, which ends up calling `-[CALayer setNeedsLayout]`. This invalidates the
current layout, but does not actually force a layout. Instead, the layout happens at the next
CoreAnimation commit.

What ends up happening is that the presentation update does call `setNeedsLayout` before the completion
block is invoked, but the actual layout of the video, which happens in `-[WebAVPlayerLayer layoutSublayers]`,
does not happen until some time afterwards.

Now, even if `-[WebAVPlayerLayer layoutSublayers]` were too happen before the completion block is invoked,
the bug would still happen. This is because `layoutSublayers` ends up calling `-[WebAVPlayerLayer resolveBounds]`
after a delay, and `resolveBounds` is the method that does the actual resizing.

To illustrate the sequence, this is what is currently happening:
1. The resize ends, which triggers `endLiveResize`
2. A snapshot view is created and placed on top of the web content
3. A presentation update is triggered
4. The presentation update forces a transaction commit to occur
5. The transaction commit updates the bounds of the web content
6. This causes `-[CALayer setNeedsLayout]` to be called
7. After the transaction commit, the presentation update&apos;s completion block is invoked
8. The snapshot gets removed. At this point, the video layer&apos;s size still has yet to update
9. After some time, `-[WebAVPlayerLayer layoutSublayers]` gets called
10. After even more time, `-[WebAVPlayerLayer resolveBounds]`
11. The video layer&apos;s size is finally updated

The solution to this is to ensure steps 9, 10, 11 have to happen strictly before step 8.

To fix, create a completion handler that only gets invoked once the video layer&apos;s size has actually been
updated in `-[WebAVPlayerLayer resolveBounds]`, and then don&apos;t remove the snapshot until the completion
handler is invoked.

* Source/WebCore/platform/cocoa/VideoFullscreenModel.h:
(WebCore::VideoFullscreenModel::didResolvePlayerLayerBounds):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer resolveBounds]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _doAfterVideoFullscreenPlayerLayerBoundsHaveChanged:]):
(-[WKWebView _endLiveResize]):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::didResolvePlayerLayerBounds):
(WebKit::VideoFullscreenManagerProxy::callAfterPlayerLayerBoundsHaveChanged):
(WebKit::VideoFullscreenManagerProxy::didResolvePlayerLayerBounds):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::callAfterVideoFullscreenPlayerLayerBoundsHaveChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a65f53b3024d3989acc3e189e178ac92e5e4ac4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16646 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15303 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17379 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20408 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16842 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14158 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14000 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->