### PR TITLE
MotionMark: improve drag and drop feedback on developer page

### DIFF
--- a/PerformanceTests/MotionMark/resources/debug-runner/motionmark.css
+++ b/PerformanceTests/MotionMark/resources/debug-runner/motionmark.css
@@ -287,9 +287,8 @@ label.tree-label {
     color: rgb(235, 235, 235);
 }
 
-#drop-target:hover {
+#drop-target.drag-over {
     background-color: rgba(255, 255, 255, .1);
-    cursor: pointer;
 }
 
 #options ul {

--- a/PerformanceTests/MotionMark/resources/debug-runner/motionmark.js
+++ b/PerformanceTests/MotionMark/resources/debug-runner/motionmark.js
@@ -560,15 +560,27 @@ Utilities.extendObject(window.benchmarkController, {
             e.stopPropagation();
             e.preventDefault();
         }
-        dropTarget.addEventListener("dragenter", stopEvent, false);
-        dropTarget.addEventListener("dragover", stopEvent, false);
-        dropTarget.addEventListener("dragleave", stopEvent, false);
-        dropTarget.addEventListener("drop", function (e) {
-            e.stopPropagation();
-            e.preventDefault();
+        dropTarget.addEventListener("dragenter", (e) => {
+            dropTarget.classList.add('drag-over');
+            stopEvent(e);
+        }, false);
 
-            if (!e.dataTransfer.files.length)
+        dropTarget.addEventListener("dragover", stopEvent, false);
+
+        dropTarget.addEventListener("dragleave", (e) => {
+            dropTarget.classList.remove('drag-over');
+            stopEvent(e);
+        }, false);
+
+        dropTarget.addEventListener("drop", function (e) {
+            stopEvent(e);
+
+            if (!e.dataTransfer.files.length) {
+                dropTarget.classList.remove('drag-over');
                 return;
+            }
+
+            dropTarget.textContent = 'Processing…';
 
             var file = e.dataTransfer.files[0];
 


### PR DESCRIPTION
#### 11b9c2c66cbdf32a5c42cff3ce95e13f1791afb9
<pre>
MotionMark: improve drag and drop feedback on developer page
<a href="https://bugs.webkit.org/show_bug.cgi?id=260099">https://bugs.webkit.org/show_bug.cgi?id=260099</a>
rdar://113772977

Reviewed by NOBODY (OOPS!).

The MotionMark developer.html page allows you to drag and drop a JSON file, but
the drop target didn&apos;t highlight on drag-over, and there was no feedback after dropping,
even though things can be processing for a few seconds. So fix both issues.

* PerformanceTests/MotionMark/resources/debug-runner/motionmark.css:
(#drop-target.drag-over):
(#drop-target:hover): Deleted.
* PerformanceTests/MotionMark/resources/debug-runner/motionmark.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11b9c2c66cbdf32a5c42cff3ce95e13f1791afb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14013 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16647 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17371 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12830 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16836 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11965 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->