### PR TITLE
Remove tracker-related member variables in ResourceError

### DIFF
--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -55,8 +55,10 @@ public:
     WEBCORE_EXPORT NSError *nsError() const;
     WEBCORE_EXPORT operator NSError *() const;
 
-    bool blockedKnownTracker() const { return !m_blockedTrackerHostName.isEmpty(); }
-    const String& blockedTrackerHostName() const { return m_blockedTrackerHostName; }
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    WEBCORE_EXPORT bool blockedKnownTracker() const;
+    WEBCORE_EXPORT String blockedTrackerHostName() const;
+#endif
 
     WEBCORE_EXPORT ErrorRecoveryMethod errorRecoveryMethod() const;
 
@@ -76,7 +78,6 @@ private:
 
     mutable RetainPtr<NSError> m_platformError;
     bool m_dataIsUpToDate { true };
-    String m_blockedTrackerHostName;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1119,7 +1119,8 @@ void NetworkResourceLoader::didFailLoading(const ResourceError& error)
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     if (error.blockedKnownTracker()) {
         auto effectiveBlockedURL = error.failingURL();
-        effectiveBlockedURL.setHost(error.blockedTrackerHostName());
+        if (auto hostName = error.blockedTrackerHostName(); !hostName.isEmpty())
+            effectiveBlockedURL.setHost(hostName);
         m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::DidBlockLoadToKnownTracker(m_parameters.webPageProxyID, WTFMove(effectiveBlockedURL)), 0);
     }
 #endif


### PR DESCRIPTION
#### bf96dcdc21fe6ce8a1c19d747b616fdd75ce32f3
<pre>
Remove tracker-related member variables in ResourceError
<a href="https://bugs.webkit.org/show_bug.cgi?id=260084">https://bugs.webkit.org/show_bug.cgi?id=260084</a>

Reviewed by Alex Christensen.

Remove `ResourceError::m_blockedTrackerHostName`, and replace it with a couple of getter methods
instead to retrieve (1) whether or not the networking stack blocked a tracker, and (2) the resolved
host name of a blocked known tracker from the underlying `NSError`.

* Source/WebCore/platform/network/cf/ResourceError.h:
(WebCore::ResourceError::blockedKnownTracker const): Deleted.
(WebCore::ResourceError::blockedTrackerHostName const): Deleted.
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::platformLazyInit):
(WebCore::ResourceError::blockedKnownTracker const):
(WebCore::ResourceError::blockedTrackerHostName const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFailLoading):

Canonical link: <a href="https://commits.webkit.org/266840@main">https://commits.webkit.org/266840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4cb4de6623a920839e67f7de8b9910a171839aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15298 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17374 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20406 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16838 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13442 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3599 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->