### PR TITLE
Regression(266049@main) Crash in MIMETypeRegistry::preferredExtensionForMIMEType

### DIFF
--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -153,6 +153,9 @@ String MIMETypeRegistry::mimeTypeForExtension(StringView extension)
 
 Vector<String> MIMETypeRegistry::extensionsForMIMEType(const String& type)
 {
+    if (type.isNull())
+        return { };
+
     if (type.endsWith('*'))
         return extensionsForWildcardMIMEType(type);
 
@@ -169,6 +172,9 @@ Vector<String> MIMETypeRegistry::extensionsForMIMEType(const String& type)
 
 String MIMETypeRegistry::preferredExtensionForMIMEType(const String& type)
 {
+    if (type.isNull())
+        return nullString();
+
     // We accept some non-standard USD MIMETypes, so we can't rely on
     // the file type mappings.
     if (isUSDMIMEType(type))

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp
@@ -80,4 +80,14 @@ TEST(MIMETypeRegistry, CanShowMIMEType)
     ASSERT_FALSE(MIMETypeRegistry::canShowMIMEType("text/vcard"_s));
 }
 
+TEST(MIMETypeRegistry, PreferredExtensionForMIMEType)
+{
+    EXPECT_TRUE(MIMETypeRegistry::preferredExtensionForMIMEType({ }).isEmpty());
+}
+
+TEST(MIMETypeRegistry, ExtensionsForMIMEType)
+{
+    EXPECT_EQ(MIMETypeRegistry::extensionsForMIMEType({ }).size(), 0U);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 97c1b7fd0b15d5a116620016f3714d271ed42a83
<pre>
Regression(266049@main) Crash in MIMETypeRegistry::preferredExtensionForMIMEType
<a href="https://bugs.webkit.org/show_bug.cgi?id=260098">https://bugs.webkit.org/show_bug.cgi?id=260098</a>
rdar://113774128

Reviewed by Aditya Keerthi.

Make sure we early return if `type` is a null string to avoid doing a HashMap
lookup with it later on, which would cause crashes.

* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::MIMETypeRegistry::preferredExtensionForMIMEType):
* Tools/TestWebKitAPI/Tests/WebCore/MIMETypeRegistry.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/266837@main">https://commits.webkit.org/266837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9635c76dabca639e4367d70542b904ca02a7a94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16649 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15306 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17382 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13442 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16844 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14160 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->