### PR TITLE
[visionOS] WKContentView doesn't relinquish first responder after tapping Safari unified field

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4204,9 +4204,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_keyboardDidRequestDismissal:(NSNotification *)notification
 {
-    if (![self isFirstResponder])
-        return;
-    _keyboardDidRequestDismissal = YES;
+    if (_isEditable && [self isFirstResponder])
+        _keyboardDidRequestDismissal = YES;
 }
 
 - (void)copyForWebView:(id)sender


### PR DESCRIPTION
#### 8222cb10b1d003da26267b6132e73e1a1df636fd
<pre>
[visionOS] WKContentView doesn&apos;t relinquish first responder after tapping Safari unified field
<a href="https://bugs.webkit.org/show_bug.cgi?id=260060">https://bugs.webkit.org/show_bug.cgi?id=260060</a>
rdar://113732040

Reviewed by Wenson Hsieh.

The keyboard request dismissal can happen *after* the firstResponder chain
is affected by the dismissal and in fact this does happen on visionOS. By
also checking _isEditable we ensure that even if the firstResponder is the
content view but was not before the dismissal, we don&apos;t incorrectly set the
keyboard lock to true (blocking the next attempted resignation), as
_isEditable is not yet true in this case.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _keyboardDidRequestDismissal:]):
Require the content view is firstResponder AND editable to block the next
firstResponder resignation attempt.

Canonical link: <a href="https://commits.webkit.org/266863@main">https://commits.webkit.org/266863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a0dc3646cdcd09c09a247048c8883ca72f92e23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15085 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15592 "Exiting early after 60 failures. 2865 tests run. 60 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17386 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12871 "9 flakes 10 failures") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20413 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13950 "16 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16849 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11972 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13449 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3612 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17781 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->