### PR TITLE
[motion-path] Check if we are mid layout when setting containing block rect for ray

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5278,12 +5278,6 @@ webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-tra
 webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-transform-box-fill-box-002.html [ ImageOnlyFailure ]
 webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-transform-box-fill-box-003.html [ ImageOnlyFailure ]
 
-# CSS motion path ray test failing due to getting wrong size from containing block.
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-007.html [ ImageOnlyFailure ]
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-009.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-ray-012.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-ray-013.html [ ImageOnlyFailure ]
-
 # CSS motion path URL support.
 imported/w3c/web-platform-tests/css/motion/offset-path-url-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-url-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-020-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-020-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray paths</title>
+    <style>
+      #container {
+        width: 400px;
+        height: 300px;
+      }
+      #target {
+        position: relative;
+        left: 200px;
+        top: 100px;
+        width: 100px;
+        height: 50px;
+        background-color: lime;
+        transform-origin: 0px 0px;
+        transform: rotate(90deg) translate(200px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div id="target"></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-020.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-020.html
@@ -3,36 +3,31 @@
   <head>
     <title>CSS Motion Path: ray paths</title>
     <link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
-    <link rel="match" href="offset-path-ray-019-ref.html">
-    <meta name="assert" content="Tests ray() when sharing style with different sized containing blocks.">
+    <link rel="match" href="offset-path-ray-020-ref.html">
+    <meta name="assert" content="This tests ray() in a flex box.">
     <style>
-      #container1 {
-        width: 100px;
-        height: 100px;
-      }
-      #container2 {
-        width: 200px;
-        height: 200px;
+      #container {
+        display: flex;
+        width: 400px;
+        height: 300px;
       }
       #target {
         position: relative;
-        width: 50px;
+        left: 200px;
+        top: 100px;
+        width: 100px;
         height: 50px;
         background-color: lime;
         transform-origin: 0px 0px;
-        offset-path: ray(90deg sides);
+        offset-path: ray(180deg sides);
         offset-distance: 100%;
         offset-position: auto;
       }
     </style>
   </head>
   <body>
-    <div id="container1">
+    <div id="container">
       <div id="target"></div>
     </div>
-    <div id="container2">
-      <div id="target"></div>
-    </div>
-    
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-021-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-021-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray paths</title>
+    <style>
+      #container {
+        width: 400px;
+        height: 300px;
+      }
+      #target {
+        position: relative;
+        left: 200px;
+        top: 100px;
+        width: 100px;
+        height: 50px;
+        background-color: lime;
+        transform-origin: 0px 0px;
+        transform: rotate(90deg) translate(200px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div id="target"></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-021.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-021.html
@@ -3,36 +3,31 @@
   <head>
     <title>CSS Motion Path: ray paths</title>
     <link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
-    <link rel="match" href="offset-path-ray-019-ref.html">
-    <meta name="assert" content="Tests ray() when sharing style with different sized containing blocks.">
+    <link rel="match" href="offset-path-ray-021-ref.html">
+    <meta name="assert" content="This tests ray() in a flex box.">
     <style>
-      #container1 {
-        width: 100px;
-        height: 100px;
-      }
-      #container2 {
-        width: 200px;
-        height: 200px;
+      #container {
+        display: grid;
+        width: 400px;
+        height: 300px;
       }
       #target {
         position: relative;
-        width: 50px;
+        left: 200px;
+        top: 100px;
+        width: 100px;
         height: 50px;
         background-color: lime;
         transform-origin: 0px 0px;
-        offset-path: ray(90deg sides);
+        offset-path: ray(180deg sides);
         offset-distance: 100%;
         offset-position: auto;
       }
     </style>
   </head>
   <body>
-    <div id="container1">
+    <div id="container">
       <div id="target"></div>
     </div>
-    <div id="container2">
-      <div id="target"></div>
-    </div>
-    
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-022-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-022-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray paths</title>
+    <style>
+      #container {
+        width: 400px;
+        height: 300px;
+        overflow: scroll;
+      }
+      #target {
+        position: relative;
+        left: 200px;
+        top: 100px;
+        width: 100px;
+        height: 50px;
+        background-color: lime;
+        transform-origin: 0px 0px;
+        transform: rotate(90deg) translate(200px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div id="target"></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-022.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-022.html
@@ -3,36 +3,32 @@
   <head>
     <title>CSS Motion Path: ray paths</title>
     <link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
-    <link rel="match" href="offset-path-ray-019-ref.html">
-    <meta name="assert" content="Tests ray() when sharing style with different sized containing blocks.">
+    <link rel="match" href="offset-path-ray-022-ref.html">
+    <meta name="assert" content="This tests that ray() affects overflow .">
     <style>
-      #container1 {
-        width: 100px;
-        height: 100px;
+      #container {
+        width: 400px;
+        height: 300px;
+        overflow: scroll;
       }
-      #container2 {
-        width: 200px;
-        height: 200px;
-      }
+
       #target {
         position: relative;
-        width: 50px;
+        left: 200px;
+        top: 100px;
+        width: 100px;
         height: 50px;
         background-color: lime;
         transform-origin: 0px 0px;
-        offset-path: ray(90deg sides);
+        offset-path: ray(180deg sides);
         offset-distance: 100%;
         offset-position: auto;
       }
     </style>
   </head>
   <body>
-    <div id="container1">
+    <div id="container">
       <div id="target"></div>
     </div>
-    <div id="container2">
-      <div id="target"></div>
-    </div>
-    
   </body>
 </html>

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -627,6 +627,17 @@ void LocalFrameViewLayoutContext::popLayoutState()
     }
 }
 
+void LocalFrameViewLayoutContext::setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox& box, RenderBlock& container)
+{
+    auto it = m_containersWithDescendantsNeedingTransformUpdate.ensure(container, [] { return Vector<WeakPtr<RenderBox>>({ }); });
+    it.iterator->value.append(WeakPtr { box });
+}
+
+Vector<WeakPtr<RenderBox>> LocalFrameViewLayoutContext::takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock& container)
+{
+    return m_containersWithDescendantsNeedingTransformUpdate.take(container);
+}
+
 #ifndef NDEBUG
 void LocalFrameViewLayoutContext::checkLayoutState()
 {

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LayoutUnit.h"
+#include "RenderLayerModelObject.h"
 #include "Timer.h"
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -127,6 +128,8 @@ public:
 
     UpdateScrollInfoAfterLayoutTransaction& updateScrollInfoAfterLayoutTransaction();
     UpdateScrollInfoAfterLayoutTransaction* updateScrollInfoAfterLayoutTransactionIfExists() { return m_updateScrollInfoAfterLayoutTransaction.get(); }
+    void setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox&, RenderBlock& container);
+    Vector<WeakPtr<RenderBox>> takeBoxesNeedingTransformUpdateAfterContainerLayout(RenderBlock&);
 
 private:
     friend class LayoutScope;
@@ -191,6 +194,7 @@ private:
     std::unique_ptr<Layout::LayoutTree> m_layoutTree;
     std::unique_ptr<Layout::LayoutState> m_layoutState;
     std::unique_ptr<UpdateScrollInfoAfterLayoutTransaction> m_updateScrollInfoAfterLayoutTransaction;
+    WeakHashMap<RenderBlock, Vector<WeakPtr<RenderBox>>> m_containersWithDescendantsNeedingTransformUpdate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3548,4 +3548,13 @@ LayoutUnit RenderBlock::layoutOverflowLogicalBottom(const RenderBlock& renderer)
     return std::max(renderer.clientLogicalBottom(), maxChildLogicalBottom + renderer.paddingAfter());
 }
 
+void RenderBlock::updateDescendantTransformsAfterLayout()
+{
+    auto boxes = view().frameView().layoutContext().takeBoxesNeedingTransformUpdateAfterContainerLayout(*this);
+    for (auto& box : boxes) {
+        if (box && box->hasLayer())
+            box->layer()->updateTransform();
+    }
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -294,6 +294,8 @@ public:
 
     virtual bool hasLineIfEmpty() const;
 
+    void updateDescendantTransformsAfterLayout();
+
 protected:
     RenderFragmentedFlow* locateEnclosingFragmentedFlow() const override;
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -593,6 +593,9 @@ void RenderBlockFlow::layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalH
             relayoutChildren = true;
         layoutPositionedObjects(relayoutChildren || isDocumentElementRenderer());
     }
+
+    updateDescendantTransformsAfterLayout();
+
     // Add overflow from children (unless we're multi-column, since in that case all our child overflow is clipped anyway).
     computeOverflow(oldClientAfterEdge);
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -356,6 +356,8 @@ void RenderDeprecatedFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
 
         layoutPositionedObjects(relayoutChildren || isDocumentElementRenderer());
 
+        updateDescendantTransformsAfterLayout();
+
         computeOverflow(oldClientAfterEdge);
     }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -455,6 +455,8 @@ void RenderFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
         repaintChildrenDuringLayoutIfMoved(oldChildRects);
         // FIXME: css3/flexbox/repaint-rtl-column.html seems to repaint more overflow than it needs to.
         computeOverflow(layoutOverflowLogicalBottom(*this));
+
+        updateDescendantTransformsAfterLayout();
     }
     updateLayerTransform();
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -382,6 +382,8 @@ void RenderGrid::layoutGrid(bool relayoutChildren)
         m_trackSizingAlgorithm.reset();
 
         computeOverflow(layoutOverflowLogicalBottom(*this));
+
+        updateDescendantTransformsAfterLayout();
     }
 
     updateLayerTransform();
@@ -513,6 +515,8 @@ void RenderGrid::layoutMasonry(bool relayoutChildren)
         m_trackSizingAlgorithm.reset();
 
         computeOverflow(layoutOverflowLogicalBottom(*this));
+
+        updateDescendantTransformsAfterLayout();
     }
 
     updateLayerTransform();

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -287,6 +287,12 @@ TransformationMatrix* RenderLayerModelObject::layerTransform() const
 
 void RenderLayerModelObject::updateLayerTransform()
 {
+    if (is<RenderBox>(this) && style().offsetPath() && MotionPath::needsUpdateAfterContainingBlockLayout(*style().offsetPath())) {
+        if (auto* containingBlock = this->containingBlock()) {
+            view().frameView().layoutContext().setBoxNeedsTransformUpdateAfterContainerLayout(*downcast<RenderBox>(this), *containingBlock);
+            return;
+        }
+    }
     // Transform-origin depends on box size, so we need to update the layer transform after layout.
     if (hasLayer())
         layer()->updateTransform();


### PR DESCRIPTION
#### acfa97d238a39af164eaf24a0abd4eec0cf096b4
<pre>
[motion-path] Check if we are mid layout when setting containing block rect for ray
<a href="https://bugs.webkit.org/show_bug.cgi?id=260110">https://bugs.webkit.org/show_bug.cgi?id=260110</a>
rdar://113780201

Reviewed by Simon Fraser.

On the first RenderLayer::updateTransform call the parent is mid layout, so it is
inorrect to query it about its rect size. If we have a motion path transform, set
that this RenderObject needs a transform update on the parent through the FrameView&apos;s
layout context, and have the parent call updateTransform after it has completed layout.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-020-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-020.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-021-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-021.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-022-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-022.html: Added.

Canonical link: <a href="https://commits.webkit.org/267479@main">https://commits.webkit.org/267479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/653d25c8b2ded9740a9d3d839ec5b92e4ba1a73e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15653 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17167 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19271 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15137 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14977 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19456 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2063 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->