### PR TITLE
Cap the duration of EventLoop::run in the main thread

### DIFF
--- a/LayoutTests/fast/eventloop/queue-task-event-loop-starvation-expected.txt
+++ b/LayoutTests/fast/eventloop/queue-task-event-loop-starvation-expected.txt
@@ -1,0 +1,10 @@
+This tests repeated queueing of event loop tasks. Event loop should eventually yield to the run loop.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS executedTaskCount < 100 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/eventloop/queue-task-event-loop-starvation.html
+++ b/LayoutTests/fast/eventloop/queue-task-event-loop-starvation.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests repeated queueing of event loop tasks. Event loop should eventually yield to the run loop.');
+
+if (!window.internals)
+    testFailed('This test relies on window.internals');
+else {
+    jsTestIsAsync = true;
+    logs = [];
+}
+
+function slowFunction(duration)
+{
+    const startTime = performance.now();
+    while (performance.now() < startTime + duration);
+}
+
+let executedTaskCount = 0;
+function scheduleSlowTask()
+{
+    internals.queueTask("DOMManipulation", () => {
+        slowFunction(10);
+        ++executedTaskCount;
+    });
+}
+
+function runTest()
+{
+    setTimeout(() => {
+        shouldBeTrue('executedTaskCount < 100');
+        finishJSTest();
+    }, 100);
+    for (let i = 0; i < 100; ++i)
+        scheduleSlowTask();
+}
+
+onload = runTest;
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "TaskSource.h"
+#include <optional>
+#include <wtf/ApproximateTime.h>
 #include <wtf/Function.h>
 #include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
@@ -128,7 +130,7 @@ public:
 protected:
     EventLoop();
     void scheduleToRunIfNeeded();
-    void run();
+    void run(std::optional<ApproximateTime> deadline = std::nullopt);
     void clearAllTasks();
 
     // FIXME: Account for fully-activeness of each document.

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -36,6 +36,7 @@
 #include "Page.h"
 #include "SecurityOrigin.h"
 #include "ThreadGlobalData.h"
+#include "ThreadTimers.h"
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RunLoop.h>
 
@@ -179,7 +180,8 @@ MonotonicTime WindowEventLoop::computeIdleDeadline()
 void WindowEventLoop::didReachTimeToRun()
 {
     Ref protectedThis { *this }; // Executing tasks may remove the last reference to this WindowEventLoop.
-    run();
+    auto deadline = ApproximateTime::now() + ThreadTimers::maxDurationOfFiringTimers;
+    run(deadline);
 
     if (hasTasksForFullyActiveDocument() || !microtaskQueue().isEmpty())
         return;

--- a/Source/WebCore/platform/ThreadTimers.cpp
+++ b/Source/WebCore/platform/ThreadTimers.cpp
@@ -39,9 +39,6 @@
 
 namespace WebCore {
 
-// Fire timers for this length of time, and then quit to let the run loop process user input events.
-static constexpr auto maxDurationOfFiringTimers { 16_ms };
-
 // Timers are created, started and fired on the same thread, and each thread has its own ThreadTimers
 // copy to keep the heap and a set of currently firing timers.
 

--- a/Source/WebCore/platform/ThreadTimers.h
+++ b/Source/WebCore/platform/ThreadTimers.h
@@ -48,6 +48,9 @@ class ThreadTimers {
 public:
     ThreadTimers();
 
+    // Fire timers for this length of time, and then quit to let the run loop process user input events.
+    static constexpr auto maxDurationOfFiringTimers { 16_ms };
+
     // On a thread different then main, we should set the thread's instance of the SharedTimer.
     void setSharedTimer(SharedTimer*);
 


### PR DESCRIPTION
#### 9c588230925217e6bd22cb40faaba28dac210e1a
<pre>
Cap the duration of EventLoop::run in the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=260112">https://bugs.webkit.org/show_bug.cgi?id=260112</a>

Reviewed by Yusuke Suzuki.

Cap the duration of EventLoop::run in the main thread using the same time limit
ThreadTimers::sharedTimerFiredInternal() uses.

* LayoutTests/fast/eventloop/queue-task-event-loop-starvation-expected.txt: Added.
* LayoutTests/fast/eventloop/queue-task-event-loop-starvation.html: Added.
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::run):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::didReachTimeToRun):
* Source/WebCore/platform/ThreadTimers.cpp:
* Source/WebCore/platform/ThreadTimers.h:

Canonical link: <a href="https://commits.webkit.org/266896@main">https://commits.webkit.org/266896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6500039caf2c92698d332f944cee511fff280536

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16782 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17536 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20541 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16985 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14305 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12106 "11 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13431 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17923 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1817 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->