### PR TITLE
Event loop should attempt to run idle callbacks at the end of each task

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1232,6 +1232,7 @@ http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Skip ]
 # Only supported on CF (Apple) WebKit2 ports for now.
 requestidlecallback [ Skip ]
 imported/w3c/web-platform-tests/requestidlecallback [ Skip ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Skip ]
 
 # Only supported in WebKit2.
 http/wpt/cross-origin-resource-policy/ [ Skip ]

--- a/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin-expected.txt
@@ -1,0 +1,10 @@
+This tests requestIdleCallback is not affected by timers scheduled in other origins.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didRunIdleCallback is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html
+++ b/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test-pre.js"></script>
+<script>
+
+description('This tests requestIdleCallback is not affected by timers scheduled in other origins.');
+
+jsTestIsAsync = true;
+logs = [];
+
+didRunIdleCallback = false;
+function runTest() {
+    frame.contentWindow.postMessage({'timeouts': [10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
+        110, 120, 130, 140, 150, 160, 170, 180, 190, 200]}, '*');
+}
+
+let retryCount = 0;
+let shouldRetry = false;
+onmessage = (event) => {
+    if (event.data.step == 'scheduledTimers') {
+        requestIdleCallback(() => {
+            didRunIdleCallback = true;
+            if (shouldRetry) {
+                didRunIdleCallback = false;
+                setTimeout(runTest, 0);
+            }
+        });        
+    } else if (event.data.step == 'timerFired' && event.data.timeout == 200) {
+        if (didRunIdleCallback) {
+            shouldBeTrue('didRunIdleCallback');
+            finishJSTest();
+        } else {
+            ++retryCount;
+            if (retryCount < 5)
+                shouldRetry = true;
+            else {
+                shouldBeTrue('didRunIdleCallback');
+                finishJSTest();
+            }
+        }
+    }
+}
+
+window.frame = document.createElement('iframe');
+frame.src = 'http://localhost:8000/eventloop/resources/idle-callback-timer-helper.html';
+frame.addEventListener('load', runTest);
+document.body.appendChild(frame);
+
+successfullyParsed = true;
+
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/eventloop/resources/idle-callback-timer-helper.html
+++ b/LayoutTests/http/tests/eventloop/resources/idle-callback-timer-helper.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+onmessage = (event) => {
+    for (let timeout of event.data.timeouts) {
+        setTimeout(() => {
+            let now = performance.now();
+            while (performance.now() < now + 10);
+            top.postMessage({'step': 'timerFired', 'timeout': timeout}, '*');
+        }, timeout);
+    }
+    top.postMessage({'step': 'scheduledTimers'}, '*');
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-expected.txt
@@ -5,5 +5,5 @@ This test validates that deadlines returned for requestIdleCallback are less tha
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is less than 50ms. assert_less_than_equal: expected a number less than or equal to 50 but got 93
+PASS Check that the deadline is less than 50ms.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic-expected.txt
@@ -3,5 +3,5 @@ Test of requestIdleCallback deadline behavior
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is changed if there is a new requestAnimationFrame from within requestIdleCallback. assert_less_than_equal: expected a number less than or equal to 16.666666666666668 but got 101
+PASS Check that the deadline is changed if there is a new requestAnimationFrame from within requestIdleCallback.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic-expected.txt
@@ -3,5 +3,5 @@ Test of requestIdleCallback deadline behavior
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is changed if there is a new timeout from within requestIdleCallback. assert_less_than_equal: expected a number less than or equal to 10 but got 95
+PASS Check that the deadline is changed if there is a new timeout from within requestIdleCallback.
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -166,10 +166,8 @@ storage/filesystemaccess/ [ Pass ]
 
 requestidlecallback [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]
 imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max.html [ Pass Failure ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -150,10 +150,8 @@ storage/filesystemaccess/ [ Pass ]
 
 requestidlecallback [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]
 imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max.html [ Pass Failure ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html
@@ -30,13 +30,13 @@ window.addEventListener("pageshow", function(event) {
     shouldBe('logsB.length', '0');
     iframe.contentWindow.requestIdleCallback(() => logsB.push('B3'));
     requestIdleCallback(() => logsA.push('A4'));
-    requestIdleCallback(() => {
+    setTimeout(() => {
         shouldBe('logsA.length', '4');
         shouldBeEqualToString('logsA.join(", ")', 'A1, A2, A3, A4');
         shouldBe('logsB.length', '3');
         shouldBeEqualToString('logsB.join(", ")', 'B1, B2, B3');
         finishJSTest();
-    });
+    }, 100);
 });
 
 window.addEventListener("pagehide", function(event) {

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -46,6 +46,7 @@ public:
     void removeIdleCallback(int);
 
     void startIdlePeriod();
+    bool isEmpty() const { return m_idleRequestCallbacks.isEmpty() && m_runnableIdleCallbacks.isEmpty(); }
 
 private:
     void queueTaskToStartIdlePeriod();

--- a/Source/WebCore/dom/IdleDeadline.cpp
+++ b/Source/WebCore/dom/IdleDeadline.cpp
@@ -38,9 +38,9 @@ DOMHighResTimeStamp IdleDeadline::timeRemaining(Document& document) const
     RefPtr window { document.domWindow() };
     if (!window || m_didTimeout == DidTimeout::Yes)
         return 0;
-    auto deadline = document.windowEventLoop().computeIdleDeadline();
-    auto remainingTime = window->performance().relativeTimeFromTimeOriginInReducedResolution(deadline) - window->performance().now();
-    return remainingTime < 0 ? 0 : remainingTime;
+    auto duration = document.windowEventLoop().computeIdleDeadline() - MonotonicTime::now();
+    auto remainingTime = window->performance().reduceTimeResolution(duration);
+    return remainingTime < 0_s ? 0 : remainingTime.milliseconds();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -65,6 +65,8 @@ static String agentClusterKeyOrNullIfUnique(const SecurityOrigin& origin)
     return key;
 }
 
+static constexpr auto IdleCallbackDurationExpectation = 4_ms;
+
 Ref<WindowEventLoop> WindowEventLoop::eventLoopForSecurityOrigin(const SecurityOrigin& origin)
 {
     auto key = agentClusterKeyOrNullIfUnique(origin);
@@ -158,21 +160,51 @@ bool WindowEventLoop::shouldEndIdlePeriod()
 
 MonotonicTime WindowEventLoop::computeIdleDeadline()
 {
+    auto minTime = m_lastIdlePeriodStartTime + 50_ms;
+
+    auto timerTime = nextTimerFireTime();
+    if (timerTime && *timerTime < minTime)
+        minTime = *timerTime;
+
     if (!m_pagesWithRenderingOpportunity.isEmptyIgnoringNullReferences()) {
-        MonotonicTime minRenderingUpdateTime = MonotonicTime::infinity();
         for (auto it : m_pagesWithRenderingOpportunity) {
-            if (it.value < minRenderingUpdateTime)
-                minRenderingUpdateTime = it.value;
+            if (it.value < minTime)
+                minTime = it.value;
         }
-        return minRenderingUpdateTime;
     }
-    return m_lastIdlePeriodStartTime + 50_ms;
+
+    return minTime;
 }
 
 void WindowEventLoop::didReachTimeToRun()
 {
     Ref protectedThis { *this }; // Executing tasks may remove the last reference to this WindowEventLoop.
     run();
+
+    if (hasTasksForFullyActiveDocument() || !microtaskQueue().isEmpty())
+        return;
+
+    auto hasIdleCallbacks = findMatchingAssociatedContext([&](ScriptExecutionContext& context) {
+        RefPtr document = dynamicDowncast<Document>(context);
+        if (!document)
+            return false;
+        auto* idleCallbackController = document->idleCallbackController();
+        if (!idleCallbackController)
+            return false;
+        return !idleCallbackController->isEmpty();
+    });
+    if (!hasIdleCallbacks)
+        return;
+
+    auto now = MonotonicTime::now();
+
+    auto timerTime = nextTimerFireTime();
+    if (timerTime && *timerTime <= now + IdleCallbackDurationExpectation) {
+        scheduleToRunIfNeeded();
+        return;
+    }
+
+    opportunisticallyRunIdleCallbacks();
 }
 
 void WindowEventLoop::queueMutationObserverCompoundMicrotask()

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1689,8 +1689,12 @@ void Page::scheduleRenderingUpdateInternal()
     if (!chrome().client().scheduleRenderingUpdate())
         renderingUpdateScheduler().scheduleRenderingUpdate();
 
+    auto now = MonotonicTime::now();
     forEachWindowEventLoop([&](WindowEventLoop& windowEventLoop) {
-        windowEventLoop.didScheduleRenderingUpdate(*this, m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval());
+        auto nextRenderingUpdateTime = m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval();
+        if (nextRenderingUpdateTime < now)
+            nextRenderingUpdateTime = now + preferredRenderingUpdateInterval();
+        windowEventLoop.didScheduleRenderingUpdate(*this, nextRenderingUpdateTime);
     });
 }
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -66,6 +66,7 @@ public:
     WEBCORE_EXPORT void stop();
     bool isActive() const;
 
+    MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
     WEBCORE_EXPORT Seconds nextFireInterval() const;
     Seconds nextUnalignedFireInterval() const;
     Seconds repeatInterval() const { return m_repeatInterval; }
@@ -104,8 +105,6 @@ private:
     void heapPop();
     void heapPopMin();
     static void heapDeleteNullMin(ThreadTimerHeap&);
-
-    MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
 
     WeakPtr<TimerAlignment> m_alignment;
     MonotonicTime m_unalignedNextFireTime; // m_nextFireTime not considering alignment interval


### PR DESCRIPTION
#### 374b4feb0aeff3225da6e6f25579d7b460f1363e
<pre>
Event loop should attempt to run idle callbacks at the end of each task
<a href="https://bugs.webkit.org/show_bug.cgi?id=260115">https://bugs.webkit.org/show_bug.cgi?id=260115</a>

Reviewed by Wenson Hsieh.

This PR implements the step 8 in the HTML5 event loop processing model:
<a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model</a>

Specifically, after executing each task in WindowEventLoop, we check if there are any tasks or microtasks
scheduled in the event loop. If there are none, we attempt to run idle callbacks.

This PR also fixes IdleDeadline::timeRemaining to subtract the current time before reducing the resolution
as it turns out that reducing the resolution before subtraction can generate the remaining time that is
slightly longer than the actual time remaining. e.g. 50.000000002ms as opposed to 50ms.

In addition, this PR updates WindowEventLoop::computeIdleDeadline() to take into account the next time
a timer associated with this event loop fires. This is computed &amp; cached by EventLoop::nextTimerFiringTime.

Finally, this PR also fixes a bug in Page::scheduleRenderingUpdateInternal() that it was sometimes calling
WindowEventLoop::didScheduleRenderingUpdate with a rendering update time in the past.

* LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin-expected.txt: Added.
* LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html: Added.
* LayoutTests/http/tests/eventloop/resources/idle-callback-timer-helper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html: This test was relying on the idle
callback in the main frame to be invoked after idle callbacks in subframes. Since this is not guaranteed,
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::removeScheduledTimer):
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoop::removeRepeatingTimer):
(WebCore::EventLoop::findMatchingAssociatedContext): Added.
(WebCore::EventLoop::nextTimerFiringTime const): Added.
(WebCore::EventLoopTaskGroup::suspend):
(WebCore::EventLoopTaskGroup::resume):
(WebCore::EventLoopTaskGroup::setTimerAlignment):
(WebCore::EventLoopTaskGroup::didChangeTimerAlignmentInterval):
(WebCore::EventLoopTaskGroup::setTimerHasReachedMaxNestingLevel):
(WebCore::EventLoopTaskGroup::adjustTimerNextFireTime):
(WebCore::EventLoopTaskGroup::adjustTimerRepeatInterval):
* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoop::invalidateNextTimerFiringTimeCache): Added.
* Source/WebCore/dom/IdleCallbackController.h:
(WebCore::IdleCallbackController::isEmpty):
* Source/WebCore/dom/IdleDeadline.cpp:
(WebCore::IdleDeadline::timeRemaining const):
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::computeIdleDeadline):
(WebCore::WindowEventLoop::didReachTimeToRun):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::scheduleRenderingUpdateInternal):
* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::nextFireTime const):

Canonical link: <a href="https://commits.webkit.org/266877@main">https://commits.webkit.org/266877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/027ff49c718ed0f43b3c29a66660c9c3f5e5af08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16774 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15423 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17503 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13549 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16960 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13406 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17892 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1806 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->