### PR TITLE
[JSC] Remove distinct tail bucket in JSMap / JSSet

### DIFF
--- a/Source/JavaScriptCore/runtime/HashMapImpl.h
+++ b/Source/JavaScriptCore/runtime/HashMapImpl.h
@@ -54,16 +54,12 @@ template <typename Data>
 class HashMapBucket final : public JSCell {
     using Base = JSCell;
 
-    template <typename T = Data>
-    static typename std::enable_if<std::is_same<T, HashMapBucketDataKey>::value, Structure*>::type selectStructure(VM& vm)
+    static Structure* selectStructure(VM& vm)
     {
-        return vm.hashMapBucketSetStructure.get();
-    }
-
-    template <typename T = Data>
-    static typename std::enable_if<std::is_same<T, HashMapBucketDataKeyValue>::value, Structure*>::type selectStructure(VM& vm)
-    {
-        return vm.hashMapBucketMapStructure.get();
+        if constexpr (std::is_same_v<Data, HashMapBucketDataKeyValue>)
+            return vm.hashMapBucketMapStructure.get();
+        else
+            return vm.hashMapBucketSetStructure.get();
     }
 
 public:
@@ -124,19 +120,25 @@ public:
     {
         m_prev.set(vm, this, bucket);
     }
+    ALWAYS_INLINE void clearNext()
+    {
+        m_next.clear();
+    }
 
     ALWAYS_INLINE void setKey(VM& vm, JSValue key)
     {
         m_data.key.set(vm, this, key);
     }
 
-    template <typename T = Data>
-    ALWAYS_INLINE typename std::enable_if<std::is_same<T, HashMapBucketDataKeyValue>::value>::type setValue(VM& vm, JSValue value)
+    ALWAYS_INLINE void setValue(VM& vm, JSValue value)
     {
-        m_data.value.set(vm, this, value);
+        if constexpr (std::is_same_v<Data, HashMapBucketDataKeyValue>)
+            m_data.value.set(vm, this, value);
+        else {
+            UNUSED_PARAM(vm);
+            UNUSED_PARAM(value);
+        }
     }
-    template <typename T = Data>
-    ALWAYS_INLINE typename std::enable_if<std::is_same<T, HashMapBucketDataKey>::value>::type setValue(VM&, JSValue) { }
 
     ALWAYS_INLINE JSValue key() const { return m_data.key.get(); }
 
@@ -152,10 +154,11 @@ public:
     ALWAYS_INLINE HashMapBucket* prev() const { return m_prev.get(); }
 
     ALWAYS_INLINE bool deleted() const { return !key(); }
-    ALWAYS_INLINE void makeDeleted(VM& vm)
+    ALWAYS_INLINE void makeDeleted()
     {
-        setKey(vm, JSValue());
-        setValue(vm, JSValue());
+        m_data.key.clear();
+        if constexpr (std::is_same_v<Data, HashMapBucketDataKeyValue>)
+            m_data.value.clear();
     }
 
     static ptrdiff_t offsetOfKey()
@@ -174,16 +177,14 @@ public:
         return OBJECT_OFFSETOF(HashMapBucket, m_next);
     }
 
-    template <typename T = Data>
-    ALWAYS_INLINE static typename std::enable_if<std::is_same<T, HashMapBucketDataKeyValue>::value, JSValue>::type extractValue(const HashMapBucket& bucket)
+    ALWAYS_INLINE static JSValue extractValue(const HashMapBucket& bucket)
     {
-        return bucket.value();
-    }
-
-    template <typename T = Data>
-    ALWAYS_INLINE static typename std::enable_if<std::is_same<T, HashMapBucketDataKey>::value, JSValue>::type extractValue(const HashMapBucket&)
-    {
-        return JSValue();
+        if constexpr (std::is_same_v<Data, HashMapBucketDataKeyValue>)
+            return bucket.value();
+        else {
+            UNUSED_PARAM(bucket);
+            return JSValue();
+        }
     }
 
 private:

--- a/Source/JavaScriptCore/runtime/HashMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/HashMapImplInlines.h
@@ -287,9 +287,14 @@ ALWAYS_INLINE bool HashMapImpl<HashMapBucketType>::removeNormalized(JSGlobalObje
 
     VM& vm = getVM(globalObject);
     HashMapBucketType* impl = *bucket;
-    impl->next()->setPrev(vm, impl->prev());
-    impl->prev()->setNext(vm, impl->next());
-    impl->makeDeleted(vm);
+    HashMapBucketType* prev = impl->prev();
+    // If this bucket is the last one in the chain, then we just mark it as deleted.
+    // It is even possible that this one is in m_tail, but it is OK: we handle it when inserting a new entry.
+    if (impl->next()) {
+        impl->next()->setPrev(vm, prev);
+        prev->setNext(vm, impl->next());
+    }
+    impl->makeDeleted();
 
     *bucket = deletedValue();
 
@@ -310,16 +315,15 @@ ALWAYS_INLINE void HashMapImpl<HashMapBucketType>::clear(VM& vm)
     m_deleteCount = 0;
     HashMapBucketType* head = m_head.get();
     HashMapBucketType* bucket = m_head->next();
-    HashMapBucketType* tail = m_tail.get();
-    while (bucket != tail) {
+    while (bucket) {
         HashMapBucketType* next = bucket->next();
         // We restart each iterator by pointing it to the head of the list.
         bucket->setNext(vm, head);
-        bucket->makeDeleted(vm);
+        bucket->makeDeleted();
         bucket = next;
     }
-    m_head->setNext(vm, m_tail.get());
-    m_tail->setPrev(vm, m_head.get());
+    head->clearNext();
+    m_tail.set(vm, this, head);
     m_buffer.clear();
     m_capacity = 0;
     checkConsistency();
@@ -328,13 +332,12 @@ ALWAYS_INLINE void HashMapImpl<HashMapBucketType>::clear(VM& vm)
 template <typename HashMapBucketType>
 ALWAYS_INLINE void HashMapImpl<HashMapBucketType>::setUpHeadAndTail(VM& vm)
 {
-    m_head.set(vm, this, HashMapBucketType::create(vm));
-    m_tail.set(vm, this, HashMapBucketType::create(vm));
-
-    m_head->setNext(vm, m_tail.get());
-    m_tail->setPrev(vm, m_head.get());
+    auto* head = HashMapBucketType::create(vm);
+    m_head.set(vm, this, head);
+    m_tail.set(vm, this, head);
+    ASSERT(!m_head->prev());
+    ASSERT(!m_head->next());
     ASSERT(m_head->deleted());
-    ASSERT(m_tail->deleted());
 }
 
 template <typename HashMapBucketType>
@@ -413,19 +416,27 @@ ALWAYS_INLINE HashMapBucketType* HashMapImpl<HashMapBucketType>::addNormalizedIn
             index = (index + 1) & mask;
     }
 
-    HashMapBucketType* newEntry = m_tail.get();
-    buffer[index] = newEntry;
-    newEntry->setKey(vm, key);
-    newEntry->setValue(vm, value);
-    ASSERT(!newEntry->deleted());
+    auto* oldTail = m_tail.get();
     HashMapBucketType* newTail = HashMapBucketType::create(vm);
+    newTail->setKey(vm, key);
+    newTail->setValue(vm, value);
+    ASSERT(!newTail->deleted());
+    buffer[index] = newTail;
+    oldTail->setNext(vm, newTail);
+
+    if (!oldTail->deleted() || oldTail == m_head.get())
+        newTail->setPrev(vm, oldTail);
+    else {
+        auto* prev = oldTail->prev();
+        ASSERT(prev);
+        newTail->setPrev(vm, prev);
+        prev->setNext(vm, newTail);
+    }
     m_tail.set(vm, this, newTail);
-    newTail->setPrev(vm, newEntry);
-    ASSERT(newTail->deleted());
-    newEntry->setNext(vm, newTail);
+    ASSERT(!newTail->next());
 
     ++m_keyCount;
-    return newEntry;
+    return newTail;
 }
 
 template <typename HashMapBucketType>
@@ -471,21 +482,22 @@ void HashMapImpl<HashMapBucketType>::rehash(JSGlobalObject* globalObject, Rehash
     }
 
     HashMapBucketType* iter = m_head->next();
-    HashMapBucketType* end = m_tail.get();
     const uint32_t mask = m_capacity - 1;
     RELEASE_ASSERT(!(m_capacity & (m_capacity - 1)));
     HashMapBucketType** buffer = this->buffer();
-    while (iter != end) {
-        uint32_t index = jsMapHashForAlreadyHashedValue(globalObject, vm, iter->key()) & mask;
-        EXCEPTION_ASSERT_WITH_MESSAGE(!scope.exception(), "All keys should already be hashed before, so this should not throw because it won't resolve ropes.");
-        {
-            HashMapBucketType* bucket = buffer[index];
-            while (!isEmpty(bucket)) {
-                index = (index + 1) & mask;
-                bucket = buffer[index];
+    while (iter) {
+        if (!iter->deleted()) {
+            uint32_t index = jsMapHashForAlreadyHashedValue(globalObject, vm, iter->key()) & mask;
+            EXCEPTION_ASSERT_WITH_MESSAGE(!scope.exception(), "All keys should already be hashed before, so this should not throw because it won't resolve ropes.");
+            {
+                HashMapBucketType* bucket = buffer[index];
+                while (!isEmpty(bucket)) {
+                    index = (index + 1) & mask;
+                    bucket = buffer[index];
+                }
             }
+            buffer[index] = iter;
         }
-        buffer[index] = iter;
         iter = iter->next();
     }
 
@@ -499,10 +511,10 @@ ALWAYS_INLINE void HashMapImpl<HashMapBucketType>::checkConsistency() const
 {
     if (ASSERT_ENABLED) {
         HashMapBucketType* iter = m_head->next();
-        HashMapBucketType* end = m_tail.get();
         uint32_t size = 0;
-        while (iter != end) {
-            ++size;
+        while (iter) {
+            if (!iter->deleted())
+                ++size;
             iter = iter->next();
         }
         ASSERT_UNUSED(size, size == m_keyCount);


### PR DESCRIPTION
#### 76449f2142c4ac0525718c83016c7e4c122dea0e
<pre>
[JSC] Remove distinct tail bucket in JSMap / JSSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=260117">https://bugs.webkit.org/show_bug.cgi?id=260117</a>
rdar://113791351

Reviewed by Michael Saboff.

JSMap / JSSet&apos;s m_tail can just point to the same entry to the head initially.
And we can keep this head&apos;s next() as nullptr.
So,

1. Iterating entries is just doing it until we hit nullptr.
2. Adding a entry is chaining a new entry after m_tail and replace m_tail with this new entry.
3. Removing a entry is unchaining from this linked-list. But we must correctly update m_tail when removing a entry which is pointed by m_tail too.

Then, we do not need to have distinct tail entry for JSMap and JSSet.

* Source/JavaScriptCore/runtime/HashMapImplInlines.h:
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::removeNormalized):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::clear):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::setUpHeadAndTail):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::addNormalizedInternal):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::rehash):
(JSC::HashMapImpl&lt;HashMapBucketType&gt;::checkConsistency const):

Canonical link: <a href="https://commits.webkit.org/266869@main">https://commits.webkit.org/266869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4d460b33ae781a3d36ebe1486e72ffd7f54af3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14092 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16720 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17460 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20473 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12824 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16914 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14240 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12040 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15175 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13519 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3871 "Found 1 jsc stress test failure: stress/watchdog-fire-while-in-forEachInIterable.js.default") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17853 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15407 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1801 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14079 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3681 "Passed tests") | 
<!--EWS-Status-Bubble-End-->