### PR TITLE
Match caret height with font size instead of line height

### DIFF
--- a/LayoutTests/editing/caret/ios/caret-in-overflow-area-expected.txt
+++ b/LayoutTests/editing/caret/ios/caret-in-overflow-area-expected.txt
@@ -24,4 +24,4 @@ line
 line
 line
 line
-Caret rect: (left = 39, top = 386, width = 2, height = 19)
+Caret rect: (left = 39, top = 391, width = 2, height = 14)

--- a/LayoutTests/editing/selection/ios/hide-selection-after-hiding-contenteditable-expected.txt
+++ b/LayoutTests/editing/selection/ios/hide-selection-after-hiding-contenteditable-expected.txt
@@ -1,6 +1,6 @@
 Here's to the crazy ones, the misfits, the rebels, the troublemakers, the round pegs in the square holes. The ones who see things differently. They're not fond of rules. You can quote them, disagree with them, glorify or vilify them, but the only thing you can't do is ignore them because they change things.
 Verifies that selection UI is hidden after the editable area becomes hidden, following a selection change. This test requires WebKitTestRunner.
 
-Caret rect after focus: (left = 173, top = 151, width = 2, height = 30)
+Caret rect after focus: (left = 173, top = 153, width = 2, height = 28)
 Selection rects after select all:
-Caret rect after collapsing: (left = 269, top = 271, width = 2, height = 30)
+Caret rect after collapsing: (left = 269, top = 273, width = 2, height = 28)

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -126,13 +126,13 @@ static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& re
     return currentStyle.isHorizontalWritingMode() ? rect : rect.transposedRect();
 }
 
-static LayoutRect computeCaretRectForLinePosition(const InlineIterator::LineBoxIterator& lineBox, float logicalLeftPosition, CaretRectMode caretRectMode)
+static LayoutRect computeCaretRectForLinePosition(const InlineIterator::LeafBoxIterator& leafBox, float logicalLeftPosition, CaretRectMode caretRectMode)
 {
-    auto& root = lineBox->formattingContextRoot();
-    auto lineSelectionRect = LineSelection::logicalRect(*lineBox);
+    auto& root = leafBox->lineBox()->formattingContextRoot();
+    auto lineSelectionRect = LineSelection::logicalRect(*(leafBox->lineBox()));
 
-    int height = lineSelectionRect.height();
-    int top = lineSelectionRect.y();
+    int height = leafBox->style().metricsOfPrimaryFont().height();
+    int top = leafBox->logicalTop();
 
     // Distribute the caret's width to either side of the offset.
     float left = logicalLeftPosition;
@@ -209,7 +209,7 @@ static LayoutRect computeCaretRectForText(const InlineBoxAndOffset& boxAndOffset
         return snapRectToDevicePixelsWithWritingDirection(selectionRect, textBox->renderer().document().deviceScaleFactor(), textRun.ltr()).maxX();
     };
 
-    return computeCaretRectForLinePosition(textBox->lineBox(), positionForOffset(boxAndOffset.offset), caretRectMode);
+    return computeCaretRectForLinePosition(textBox, positionForOffset(boxAndOffset.offset), caretRectMode);
 }
 
 static LayoutRect computeCaretRectForLineBreak(const InlineBoxAndOffset& boxAndOffset, CaretRectMode caretRectMode)
@@ -219,8 +219,7 @@ static LayoutRect computeCaretRectForLineBreak(const InlineBoxAndOffset& boxAndO
     if (!boxAndOffset.box)
         return { };
 
-    auto lineBox = boxAndOffset.box->lineBox();
-    return computeCaretRectForLinePosition(lineBox, lineBox->contentLogicalLeft(), caretRectMode);
+    return computeCaretRectForLinePosition(boxAndOffset.box, boxAndOffset.box->lineBox()->contentLogicalLeft(), caretRectMode);
 }
 
 static LayoutRect computeCaretRectForSVGInlineText(const InlineBoxAndOffset& boxAndOffset, CaretRectMode)


### PR DESCRIPTION
#### da007cd7236a23326122478db0b092ffdec7aaf4
<pre>
Match caret height with font size instead of line height
<a href="https://bugs.webkit.org/show_bug.cgi?id=249621">https://bugs.webkit.org/show_bug.cgi?id=249621</a>
<a href="https://rdar.apple.com/problem/103716521">rdar://problem/103716521</a>

Reviewed by NOBODY (OOPS!).

This commit resolves a problem where the caret height
didn&apos;t correctly correspond to the font size, leading to
visual inconsistencies.

* LayoutTests/editing/caret/ios/caret-in-overflow-area-expected.txt: rebaseline
* LayoutTests/editing/selection/ios/hide-selection-after-hiding-contenteditable-expected.txt: rebaseline
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForLinePosition): update as above
(WebCore::computeCaretRectForText):
(WebCore::computeCaretRectForLineBreak):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da007cd7236a23326122478db0b092ffdec7aaf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/28167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/4191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25980 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 27 flakes 200 failures; Uploaded test results; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/24237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/25233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25664 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/31282 "Found 1 new test failure: editing/input/reveal-caret-of-multiline-input.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29038 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->