### PR TITLE
[IntersectionObserver] Fix some edge cases in parsing options

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/observer-attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/observer-attributes-expected.txt
@@ -1,6 +1,11 @@
 
-FAIL Observer attribute getters. Failed to construct 'IntersectionObserver': rootMargin must be specified in pixels or percent.
+PASS Observer attribute getters.
 PASS observer.root
 PASS observer.thresholds
 PASS observer.rootMargin
+PASS empty observer.thresholds
+PASS whitespace observer.rootMargin
+PASS set observer.root
+PASS set observer.thresholds
+PASS set observer.rootMargin
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2020 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +57,7 @@ static ExceptionOr<LengthBox> parseRootMargin(String& rootMargin)
 {
     CSSTokenizer tokenizer(rootMargin);
     auto tokenRange = tokenizer.tokenRange();
+    tokenRange.consumeWhitespace();
     Vector<Length, 4> margins;
     while (!tokenRange.atEnd()) {
         if (margins.size() == 4)
@@ -116,6 +118,9 @@ ExceptionOr<Ref<IntersectionObserver>> IntersectionObserver::create(Document& do
     }, [&thresholds] (Vector<double>& initThresholds) {
         thresholds = WTFMove(initThresholds);
     });
+
+    if (thresholds.isEmpty())
+        thresholds.append(0.f);
 
     for (auto threshold : thresholds) {
         if (!(threshold >= 0 && threshold <= 1))


### PR DESCRIPTION
#### 0fcecf40e3a1d5863c5161302409208958ef1821
<pre>
[IntersectionObserver] Fix some edge cases in parsing options

<a href="https://bugs.webkit.org/show_bug.cgi?id=260126">https://bugs.webkit.org/show_bug.cgi?id=260126</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/2388706">https://chromium-review.googlesource.com/c/chromium/src/+/2388706</a>

This patch fixes some edge cases in InterssectionObserver by doing two things:
- For &apos;rootMargine&apos;, make &apos;token&apos; to consume whitespace
- For &apos;thresholds&apos;, add new case in case &apos;empty&apos; to return &apos;0&apos;

* Source/WebCore/page/IntersectionObserver.cpp:
(parseRootMargin):
(IntersectionObserver::create):
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/observer-attributes-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/266856@main">https://commits.webkit.org/266856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7d0009253b2c5da47ca97bf3da9c889773ee961

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16696 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17431 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20449 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16890 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12015 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13492 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3606 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->