### PR TITLE
visionOS Media Controls: Volume slider has wrong layout in small sizes

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -40,6 +40,11 @@
     --center-controls-bar-button-zoom: 2;
 }
 
+.media-controls.vision.fullscreen .controls-bar .slider.volume,
+.media-controls.vision.fullscreen .controls-bar .slider.volume * {
+    --slider-height: 10px;
+}
+
 /* Size class 2 */
 
 @container (min-width: 262px) {
@@ -309,22 +314,33 @@
 
 /* Make the slider grow taller when active */
 
+.media-controls.vision:not(.audio) .slider {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
 .media-controls.vision:not(.audio) > .bottom.controls-bar .slider:active,
 .media-controls.vision:not(.audio) > .bottom.controls-bar .slider:active * {
     --slider-height: 20px;
 }
 
-.media-controls.vision:not(.audio) > .bottom.controls-bar,
-.media-controls.vision:not(.audio) > .bottom.controls-bar * {
+.media-controls.vision:not(.audio) .slider,
+.media-controls.vision:not(.audio) .slider * {
     transition: all 350ms;
 }
 
-.media-controls.vision:not(.audio) > .bottom.controls-bar * {
+.media-controls.vision:not(.audio) > .controls-bar:is(.top-right, .bottom) * {
     transition-property: min-width, height, border-radius !important;
+}
+
+.media-controls.vision:not(.audio) > .top-right.controls-bar .fill:after {
+    --progress-bar-knob-margin: 1px;
 }
 
 .media-controls.vision:not(.audio) > .bottom.controls-bar .fill:after {
     --progress-bar-knob-margin: 3px;
+}
+
+.media-controls.vision:not(.audio) > .controls-bar:is(.bottom, .top-right) .fill:after {
     --progress-bar-knob-size: calc(var(--slider-height) - 2 * var(--progress-bar-knob-margin) - 2 * var(--slider-fill-recessed-margin));
 
     content: "";
@@ -341,7 +357,7 @@
     transition-duration: inherit;
 }
 
-.media-controls.vision:not(.audio) > .bottom.controls-bar .slider:active .fill:after {
+.media-controls.vision:not(.audio) > .controls-bar:is(.bottom, .top-right) .slider:active .fill:after {
     opacity: 1;
 }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
@@ -466,7 +466,6 @@ class VisionFullscreenMediaControls extends VisionMediaControls
         this.bottomControlsBar.width = Math.min(this._shouldUseAudioLayout ? this.width : (this.width - 2 * inlineInsideMargin), MaxWidthForBottomControlsBarInFullscreen);
 
         this.playPauseButton.style = Button.Styles.Bar;
-        this.muteButton.style = this._widthForSizeClassDetermination >= MaxWidthForBottomControlsBarInFullscreen ? Button.Styles.Bar : Button.Styles.Rounded;
         
         this._bottomBarLeftContainer.children = this._bottomBarLeftContainerButtons();
         this._bottomBarLeftContainer.layout();


### PR DESCRIPTION
#### 1d5fbefb714166eebf47d4b06477332bb39b3a32
<pre>
visionOS Media Controls: Volume slider has wrong layout in small sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=260130">https://bugs.webkit.org/show_bug.cgi?id=260130</a>
rdar://113722710

Reviewed by Tim Horton and Tim Nguyen.

The mute button should always be `Bar` when contained in a volume slider.

Drive-by fix: General media controls polish
- Fix bottom bar controls having a weird animation when changing fullscreen size by making the
  transition be constrained only to the slider.
- Increase the size of the volume slider a bit to better match the system, and to make it easier to use.
- Apply the same track thumb style to the volume slider that the time slider uses.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls.vision.fullscreen .controls-bar.simple-layout .slider.vision.volume,):
(.media-controls.vision:not(.audio) .slider,):
(.media-controls.vision:not(.audio) &gt; .controls-bar.top-right *,):
(.media-controls.vision:not(.audio) &gt; .controls-bar.simple-layout.top-right .fill:after):
(.media-controls.vision:not(.audio) &gt; .bottom.controls-bar .fill:after):
(.media-controls.vision:not(.audio) &gt; .controls-bar.simple-layout.top-right .fill:after,):
(.media-controls.vision:not(.audio) &gt; .controls-bar.simple-layout.top-right .slider:active .fill:after,):
(.media-controls.vision:not(.audio) &gt; .bottom.controls-bar,): Deleted.
(.media-controls.vision:not(.audio) &gt; .bottom.controls-bar *): Deleted.
(.media-controls.vision:not(.audio) &gt; .bottom.controls-bar .slider:active .fill:after): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js:
(VisionFullscreenMediaControls.prototype._performBottomBarLayout):
(VisionFullscreenMediaControls):

Canonical link: <a href="https://commits.webkit.org/266939@main">https://commits.webkit.org/266939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b29bc2944c06cd278d6e732eef9f413af7d9e39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14260 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15584 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15808 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17670 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13696 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17116 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12221 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13702 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3649 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->