### PR TITLE
Use 'FrozenArray' for 'thresholds' in IntersectionObserver.idl

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/idlharness.window-expected.txt
@@ -22,7 +22,7 @@ PASS IntersectionObserver must be primary interface of observer
 PASS Stringification of observer
 PASS IntersectionObserver interface: observer must inherit property "root" with the proper type
 PASS IntersectionObserver interface: observer must inherit property "rootMargin" with the proper type
-FAIL IntersectionObserver interface: observer must inherit property "thresholds" with the proper type assert_true: Value should be frozen expected true got false
+PASS IntersectionObserver interface: observer must inherit property "thresholds" with the proper type
 PASS IntersectionObserver interface: observer must inherit property "observe(Element)" with the proper type
 PASS IntersectionObserver interface: calling observe(Element) on observer with too few arguments must throw TypeError
 PASS IntersectionObserver interface: observer must inherit property "unobserve(Element)" with the proper type

--- a/Source/WebCore/page/IntersectionObserver.idl
+++ b/Source/WebCore/page/IntersectionObserver.idl
@@ -35,7 +35,7 @@
 
     readonly attribute Node? root;
     readonly attribute DOMString rootMargin;
-    readonly attribute sequence<double> thresholds;
+    readonly attribute FrozenArray<double> thresholds;
 
     undefined observe(Element target);
     undefined unobserve(Element target);


### PR DESCRIPTION
#### 37667adc938e3ebe885b1cbffbfb32116ea419de
<pre>
Use &apos;FrozenArray&apos; for &apos;thresholds&apos; in IntersectionObserver.idl

<a href="https://bugs.webkit.org/show_bug.cgi?id=260129">https://bugs.webkit.org/show_bug.cgi?id=260129</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Web-Spec [1] and Blink / Chromium.

[1] <a href="https://www.w3.org/TR/intersection-observer/#intersection-observer-interface">https://www.w3.org/TR/intersection-observer/#intersection-observer-interface</a>

GitHub Issue: <a href="https://github.com/w3c/IntersectionObserver/issues/114">https://github.com/w3c/IntersectionObserver/issues/114</a>

* Source/WebCore/page/IntersectionObserver.idl: Update
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/idlharness.window-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/266857@main">https://commits.webkit.org/266857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9298eb6a859a486438cbc15cf0fe1e6ebb6131ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16712 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16704 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17442 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20458 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12024 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13502 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3607 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->