### PR TITLE
Idle time should take timers into account

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1232,6 +1232,7 @@ http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Skip ]
 # Only supported on CF (Apple) WebKit2 ports for now.
 requestidlecallback [ Skip ]
 imported/w3c/web-platform-tests/requestidlecallback [ Skip ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Skip ]
 
 # Only supported in WebKit2.
 http/wpt/cross-origin-resource-policy/ [ Skip ]

--- a/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin-expected.txt
@@ -1,0 +1,10 @@
+This tests requestIdleCallback is not affected by timers scheduled in other origins.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didRunIdleCallback is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html
+++ b/LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test-pre.js"></script>
+<script>
+
+description('This tests requestIdleCallback is not affected by timers scheduled in other origins.');
+
+jsTestIsAsync = true;
+logs = [];
+
+didRunIdleCallback = false;
+function runTest() {
+    frame.contentWindow.postMessage({'timeouts': [10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
+        110, 120, 130, 140, 150, 160, 170, 180, 190, 200]}, '*');
+}
+
+let retryCount = 0;
+let shouldRetry = false;
+onmessage = (event) => {
+    if (event.data.step == 'scheduledTimers') {
+        requestIdleCallback(() => {
+            didRunIdleCallback = true;
+            if (shouldRetry) {
+                shouldRetry = false;
+                didRunIdleCallback = false;
+                setTimeout(runTest, 0);
+            }
+        });        
+    } else if (event.data.step == 'timerFired' && event.data.timeout == 200) {
+        if (didRunIdleCallback) {
+            shouldRetry = false;
+            shouldBeTrue('didRunIdleCallback');
+            finishJSTest();
+        } else {
+            ++retryCount;
+            if (retryCount < 10)
+                shouldRetry = true;
+            else {
+                shouldBeTrue('didRunIdleCallback');
+                finishJSTest();
+            }
+        }
+    }
+}
+
+window.frame = document.createElement('iframe');
+frame.src = 'http://localhost:8000/eventloop/resources/idle-callback-timer-helper.html';
+frame.addEventListener('load', runTest);
+document.body.appendChild(frame);
+
+successfullyParsed = true;
+
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/eventloop/resources/idle-callback-timer-helper.html
+++ b/LayoutTests/http/tests/eventloop/resources/idle-callback-timer-helper.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+onmessage = (event) => {
+    for (let timeout of event.data.timeouts) {
+        setTimeout(() => {
+            let now = performance.now();
+            while (performance.now() < now + 10);
+            top.postMessage({'step': 'timerFired', 'timeout': timeout}, '*');
+        }, timeout);
+    }
+    top.postMessage({'step': 'scheduledTimers'}, '*');
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-expected.txt
@@ -5,5 +5,5 @@ This test validates that deadlines returned for requestIdleCallback are less tha
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is less than 50ms. assert_less_than_equal: expected a number less than or equal to 50 but got 93
+PASS Check that the deadline is less than 50ms.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic-expected.txt
@@ -3,5 +3,5 @@ Test of requestIdleCallback deadline behavior
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is changed if there is a new requestAnimationFrame from within requestIdleCallback. assert_less_than_equal: expected a number less than or equal to 16.666666666666668 but got 101
+PASS Check that the deadline is changed if there is a new requestAnimationFrame from within requestIdleCallback.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic-expected.txt
@@ -3,5 +3,5 @@ Test of requestIdleCallback deadline behavior
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is changed if there is a new timeout from within requestIdleCallback. assert_less_than_equal: expected a number less than or equal to 10 but got 95
+PASS Check that the deadline is changed if there is a new timeout from within requestIdleCallback.
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -166,10 +166,8 @@ storage/filesystemaccess/ [ Pass ]
 
 requestidlecallback [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max.html [ Pass Failure ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -152,10 +152,8 @@ storage/filesystemaccess/ [ Pass ]
 
 requestidlecallback [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic.html [ Pass Failure ]
-imported/w3c/web-platform-tests/requestidlecallback/deadline-max.html [ Pass Failure ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -46,6 +46,7 @@ public:
     void removeIdleCallback(int);
 
     void startIdlePeriod();
+    bool isEmpty() { return m_idleRequestCallbacks.isEmpty() && m_runnableIdleCallbacks.isEmpty(); }
 
 private:
     void queueTaskToStartIdlePeriod();

--- a/Source/WebCore/dom/IdleDeadline.cpp
+++ b/Source/WebCore/dom/IdleDeadline.cpp
@@ -38,9 +38,9 @@ DOMHighResTimeStamp IdleDeadline::timeRemaining(Document& document) const
     RefPtr window { document.domWindow() };
     if (!window || m_didTimeout == DidTimeout::Yes)
         return 0;
-    auto deadline = document.windowEventLoop().computeIdleDeadline();
-    auto remainingTime = window->performance().relativeTimeFromTimeOriginInReducedResolution(deadline) - window->performance().now();
-    return remainingTime < 0 ? 0 : remainingTime;
+    auto duration = document.windowEventLoop().computeIdleDeadline() - MonotonicTime::now();
+    auto remainingTime = window->performance().reduceTimeResolution(duration);
+    return remainingTime < 0_s ? 0 : remainingTime.milliseconds();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1690,7 +1690,11 @@ void Page::scheduleRenderingUpdateInternal()
         renderingUpdateScheduler().scheduleRenderingUpdate();
 
     forEachWindowEventLoop([&](WindowEventLoop& windowEventLoop) {
-        windowEventLoop.didScheduleRenderingUpdate(*this, m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval());
+        auto nextRenderingUpdateTime = m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval();
+        auto now = MonotonicTime::now();
+        if (nextRenderingUpdateTime < now)
+            nextRenderingUpdateTime = now;
+        windowEventLoop.didScheduleRenderingUpdate(*this, nextRenderingUpdateTime);
     });
 }
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -66,6 +66,7 @@ public:
     WEBCORE_EXPORT void stop();
     bool isActive() const;
 
+    MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
     WEBCORE_EXPORT Seconds nextFireInterval() const;
     Seconds nextUnalignedFireInterval() const;
     Seconds repeatInterval() const { return m_repeatInterval; }
@@ -104,8 +105,6 @@ private:
     void heapPop();
     void heapPopMin();
     static void heapDeleteNullMin(ThreadTimerHeap&);
-
-    MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
 
     WeakPtr<TimerAlignment> m_alignment;
     MonotonicTime m_unalignedNextFireTime; // m_nextFireTime not considering alignment interval


### PR DESCRIPTION
#### da129e5c86c3db117d73f083d88ae5872f831ba7
<pre>
Idle time should take timers into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=260131">https://bugs.webkit.org/show_bug.cgi?id=260131</a>

Reviewed by NOBODY (OOPS!).

This PR updates WindowEventLoop::computeIdleDeadline() to take into account the next time a timer associated
with this event loop fires. This is computed &amp; cached by EventLoop::nextTimerFiringTime.

It also makes WindowEventLoop::didReachTimeToRun to run the idle callbacks whenever appropriate.

In addition, it fixes IdleDeadline::timeRemaining to subtract the current time before reducing the resolution
as it turns out that reducing the resolution before subtraction can generate the remaining time that is
slightly longer than the actual time remaining. e.g. 50.000000002ms as opposed to 50ms.

Finally, this PR fixes a bug in Page::scheduleRenderingUpdateInternal() that it was sometimes calling
WindowEventLoop::didScheduleRenderingUpdate with a rendering update time in the past.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin-expected.txt: Added.
* LayoutTests/http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html: Added.
* LayoutTests/http/tests/eventloop/resources/idle-callback-timer-helper.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-timeout-dynamic-expected.txt:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::removeScheduledTimer):
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoop::removeRepeatingTimer):
(WebCore::EventLoop::nextTimerFiringTime const): Added.
(WebCore::EventLoopTaskGroup::suspend):
(WebCore::EventLoopTaskGroup::resume):
(WebCore::EventLoopTaskGroup::setTimerAlignment):
(WebCore::EventLoopTaskGroup::didChangeTimerAlignmentInterval):
(WebCore::EventLoopTaskGroup::setTimerHasReachedMaxNestingLevel):
(WebCore::EventLoopTaskGroup::adjustTimerNextFireTime):
(WebCore::EventLoopTaskGroup::adjustTimerRepeatInterval):

* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoop::invalidateNextTimerFiringTimeCache): Added.

* Source/WebCore/dom/IdleCallbackController.h:
(WebCore::IdleCallbackController::isEmpty): Added.

* Source/WebCore/dom/IdleDeadline.cpp:
(WebCore::IdleDeadline::timeRemaining const): Fixed the bug that this function would sometimes return
a remaining time slightly greater than the time remaining due to the loss of precision.

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::computeIdleDeadline):
(WebCore::WindowEventLoop::didReachTimeToRun):

* Source/WebCore/page/Page.cpp:
(WebCore::Page::scheduleRenderingUpdateInternal): Fixed a bug that we would sometimes call
didScheduleRenderingUpdate with a time in the past. Use preferredRenderingUpdateInterval if there was no
recent rendering update.

* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::nextFireTime const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da129e5c86c3db117d73f083d88ae5872f831ba7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17469 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20481 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16922 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12049 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13375 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->