### PR TITLE
Remove Quirk shouldAutoplayWebAudioForArbitraryUserGesture for bing.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -157,7 +157,6 @@ bool Quirks::needsPerDocumentAutoplayBehavior() const
 #endif
 }
 
-// bing.com https://bugs.webkit.org/show_bug.cgi?id=213118
 // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
 bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
 {
@@ -165,7 +164,7 @@ bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
         return false;
 
     auto host = m_document->topDocument().url().host();
-    return equalLettersIgnoringASCIICase(host, "www.bing.com"_s) || host.endsWithIgnoringASCIICase(".zoom.us"_s);
+    return host.endsWithIgnoringASCIICase(".zoom.us"_s);
 }
 
 // hulu.com starz.com https://bugs.webkit.org/show_bug.cgi?id=190051


### PR DESCRIPTION
#### 56861d23fba2a841a37efe79cd4fdf4627e604e3
<pre>
Remove Quirk shouldAutoplayWebAudioForArbitraryUserGesture for bing.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=260134">https://bugs.webkit.org/show_bug.cgi?id=260134</a>
rdar://107430929

Reviewed by Jer Noble.

This quirk is not necessary anymore for bing.com.
The bing voice search is now working while the Site Specific Hacks is
disabled. Removing the quirk which was added with
<a href="https://bugs.webkit.org/show_bug.cgi?id=213118">https://bugs.webkit.org/show_bug.cgi?id=213118</a>

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldAutoplayWebAudioForArbitraryUserGesture const):

Canonical link: <a href="https://commits.webkit.org/266928@main">https://commits.webkit.org/266928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f391286b377088af0a3e4136adfac01f85c65757

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17466 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20479 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12046 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13524 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->