### PR TITLE
WebGL extensions access the context root in racy way during GC

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5222,10 +5222,6 @@ sub GenerateImplementation
                 $rootString  = "    ${implType}* owner = &js${interfaceName}->wrapped();\n";
                 $rootString .= "    if (UNLIKELY(reason))\n";
                 $rootString .= "        *reason = \"Reachable from ${interfaceName}\";\n";
-            } elsif (GetGenerateIsReachable($interface) eq "ImplWebGLRenderingContext") {
-                $rootString  = "    WebGLRenderingContextBase* owner = WTF::getPtr(js${interfaceName}->wrapped().context());\n";
-                $rootString .= "    if (UNLIKELY(reason))\n";
-                $rootString .= "        *reason = \"Reachable from ${interfaceName}\";\n";
             } elsif (GetGenerateIsReachable($interface) eq "ReachableFromDOMWindow") {
                 $rootString  = "    auto* owner = WTF::getPtr(js${interfaceName}->wrapped().window());\n";
                 $rootString .= "    if (!owner)\n";

--- a/Source/WebCore/html/canvas/ANGLEInstancedArrays.idl
+++ b/Source/WebCore/html/canvas/ANGLEInstancedArrays.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface ANGLEInstancedArrays {
     const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
 

--- a/Source/WebCore/html/canvas/EXTBlendMinMax.idl
+++ b/Source/WebCore/html/canvas/EXTBlendMinMax.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTBlendMinMax {
     const unsigned long MIN_EXT = 0x8007;

--- a/Source/WebCore/html/canvas/EXTClipControl.idl
+++ b/Source/WebCore/html/canvas/EXTClipControl.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface EXTClipControl {
     const unsigned long LOWER_LEFT_EXT = 0x8CA1;
     const unsigned long UPPER_LEFT_EXT = 0x8CA2;

--- a/Source/WebCore/html/canvas/EXTColorBufferFloat.idl
+++ b/Source/WebCore/html/canvas/EXTColorBufferFloat.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface EXTColorBufferFloat {
 };

--- a/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.idl
+++ b/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface EXTColorBufferHalfFloat {
     const unsigned long RGBA16F_EXT = 0x881A;
     const unsigned long RGB16F_EXT = 0x881B;

--- a/Source/WebCore/html/canvas/EXTConservativeDepth.idl
+++ b/Source/WebCore/html/canvas/EXTConservativeDepth.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface EXTConservativeDepth {
 };

--- a/Source/WebCore/html/canvas/EXTDepthClamp.idl
+++ b/Source/WebCore/html/canvas/EXTDepthClamp.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface EXTDepthClamp {
     const unsigned long DEPTH_CLAMP_EXT = 0x864F;
 };

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface EXTDisjointTimerQuery {
   const unsigned long QUERY_COUNTER_BITS_EXT      = 0x8864;
   const unsigned long CURRENT_QUERY_EXT           = 0x8865;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface EXTDisjointTimerQueryWebGL2 {
   const unsigned long QUERY_COUNTER_BITS_EXT = 0x8864;
   const unsigned long TIME_ELAPSED_EXT       = 0x88BF;

--- a/Source/WebCore/html/canvas/EXTFloatBlend.idl
+++ b/Source/WebCore/html/canvas/EXTFloatBlend.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTFloatBlend {
 };

--- a/Source/WebCore/html/canvas/EXTFragDepth.idl
+++ b/Source/WebCore/html/canvas/EXTFragDepth.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface EXTFragDepth {
 };

--- a/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.idl
+++ b/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.idl
@@ -28,7 +28,7 @@ typedef unrestricted float GLfloat;
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface EXTPolygonOffsetClamp {
     const unsigned long POLYGON_OFFSET_CLAMP_EXT = 0x8E1B;
 

--- a/Source/WebCore/html/canvas/EXTRenderSnorm.idl
+++ b/Source/WebCore/html/canvas/EXTRenderSnorm.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTRenderSnorm {
 };

--- a/Source/WebCore/html/canvas/EXTShaderTextureLOD.idl
+++ b/Source/WebCore/html/canvas/EXTShaderTextureLOD.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface EXTShaderTextureLOD {
 };

--- a/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.idl
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTTextureCompressionBPTC {
     const unsigned long COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8E8C;

--- a/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.idl
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTTextureCompressionRGTC {
     const unsigned long COMPRESSED_RED_RGTC1_EXT = 0x8DBB;

--- a/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.idl
+++ b/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTTextureFilterAnisotropic {
     const unsigned long TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE;

--- a/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.idl
+++ b/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface EXTTextureMirrorClampToEdge {
     const unsigned long MIRROR_CLAMP_TO_EDGE_EXT = 0x8743;
 };

--- a/Source/WebCore/html/canvas/EXTTextureNorm16.idl
+++ b/Source/WebCore/html/canvas/EXTTextureNorm16.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTTextureNorm16 {
     const unsigned long R16_EXT = 0x822A;

--- a/Source/WebCore/html/canvas/EXTsRGB.idl
+++ b/Source/WebCore/html/canvas/EXTsRGB.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface EXTsRGB {
     const unsigned long SRGB_EXT = 0x8C40;

--- a/Source/WebCore/html/canvas/KHRParallelShaderCompile.idl
+++ b/Source/WebCore/html/canvas/KHRParallelShaderCompile.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface KHRParallelShaderCompile {
     const unsigned long COMPLETION_STATUS_KHR = 0x91B1;
 };

--- a/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.idl
+++ b/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface NVShaderNoperspectiveInterpolation {
 };

--- a/Source/WebCore/html/canvas/OESDrawBuffersIndexed.idl
+++ b/Source/WebCore/html/canvas/OESDrawBuffersIndexed.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESDrawBuffersIndexed {
     undefined enableiOES(unsigned long target, unsigned long index);
     undefined disableiOES(unsigned long target, unsigned long index);

--- a/Source/WebCore/html/canvas/OESElementIndexUint.idl
+++ b/Source/WebCore/html/canvas/OESElementIndexUint.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESElementIndexUint {
 };

--- a/Source/WebCore/html/canvas/OESFBORenderMipmap.idl
+++ b/Source/WebCore/html/canvas/OESFBORenderMipmap.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESFBORenderMipmap {
 };

--- a/Source/WebCore/html/canvas/OESSampleVariables.idl
+++ b/Source/WebCore/html/canvas/OESSampleVariables.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESSampleVariables {
 };

--- a/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.idl
+++ b/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESShaderMultisampleInterpolation {
     const unsigned long MIN_FRAGMENT_INTERPOLATION_OFFSET_OES  = 0x8E5B;
     const unsigned long MAX_FRAGMENT_INTERPOLATION_OFFSET_OES  = 0x8E5C;

--- a/Source/WebCore/html/canvas/OESStandardDerivatives.idl
+++ b/Source/WebCore/html/canvas/OESStandardDerivatives.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface OESStandardDerivatives {
     const unsigned long FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B;

--- a/Source/WebCore/html/canvas/OESTextureFloat.idl
+++ b/Source/WebCore/html/canvas/OESTextureFloat.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESTextureFloat {
 };

--- a/Source/WebCore/html/canvas/OESTextureFloatLinear.idl
+++ b/Source/WebCore/html/canvas/OESTextureFloatLinear.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESTextureFloatLinear {
 };

--- a/Source/WebCore/html/canvas/OESTextureHalfFloat.idl
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloat.idl
@@ -27,7 +27,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESTextureHalfFloat {
     const GLenum HALF_FLOAT_OES = 0x8D61;
 };

--- a/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.idl
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.idl
@@ -26,6 +26,6 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface OESTextureHalfFloatLinear {
 };

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.idl
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL, 
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface OESVertexArrayObject {
     const unsigned long VERTEX_ARRAY_BINDING_OES = 0x85B5;

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.idl
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLClipCullDistance {
     const unsigned long MAX_CLIP_DISTANCES_WEBGL = 0x0D32;
     const unsigned long MAX_CULL_DISTANCES_WEBGL = 0x82F9;

--- a/Source/WebCore/html/canvas/WebGLColorBufferFloat.idl
+++ b/Source/WebCore/html/canvas/WebGLColorBufferFloat.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface WebGLColorBufferFloat {
     const unsigned long RGBA32F_EXT = 0x8814;
     const unsigned long FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureASTC {
     /* Compressed Texture Format */

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC.idl
@@ -27,7 +27,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureETC {
     /* Compressed Texture Format */

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.idl
@@ -27,7 +27,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureETC1 {
     /* Compressed Texture Formats */

--- a/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTexturePVRTC {
     const unsigned long COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8C00;

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureS3TC {
     const unsigned long COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83F0;

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.idl
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLCompressedTextureS3TCsRGB {
     const unsigned long COMPRESSED_SRGB_S3TC_DXT1_EXT = 0x8C4C;

--- a/Source/WebCore/html/canvas/WebGLDebugRendererInfo.idl
+++ b/Source/WebCore/html/canvas/WebGLDebugRendererInfo.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLDebugRendererInfo {
     const unsigned long UNMASKED_VENDOR_WEBGL = 0x9245;

--- a/Source/WebCore/html/canvas/WebGLDebugShaders.idl
+++ b/Source/WebCore/html/canvas/WebGLDebugShaders.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLDebugShaders {
     DOMString getTranslatedShaderSource(WebGLShader shader);

--- a/Source/WebCore/html/canvas/WebGLDepthTexture.idl
+++ b/Source/WebCore/html/canvas/WebGLDepthTexture.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLDepthTexture {
     const unsigned long UNSIGNED_INT_24_8_WEBGL = 0x84FA;

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.idl
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.idl
@@ -28,7 +28,7 @@ typedef unsigned long GLenum;
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLDrawBuffers {
     const GLenum COLOR_ATTACHMENT0_WEBGL = 0x8CE0;
     const GLenum COLOR_ATTACHMENT1_WEBGL = 0x8CE1;

--- a/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.idl
+++ b/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLDrawInstancedBaseVertexBaseInstance {
   undefined drawArraysInstancedBaseInstanceWEBGL(unsigned long mode, long first, long count, long instanceCount, unsigned long baseInstance);
   undefined drawElementsInstancedBaseVertexBaseInstanceWEBGL(unsigned long mode, long count, unsigned long type, long long offset, long instanceCount, long baseVertex, unsigned long baseInstance);

--- a/Source/WebCore/html/canvas/WebGLLoseContext.idl
+++ b/Source/WebCore/html/canvas/WebGLLoseContext.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLLoseContext {
     undefined loseContext();
     undefined restoreContext();

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.idl
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.idl
@@ -32,7 +32,7 @@ typedef (Int32Array or sequence<GLint>) Int32List;
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext
+    GenerateIsReachable
 ] interface WebGLMultiDraw {
     undefined multiDrawArraysWEBGL(
         GLenum mode,

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.idl
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.idl
@@ -33,7 +33,7 @@ typedef (Uint32Array or sequence<GLuint>) Uint32List;
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLMultiDrawInstancedBaseVertexBaseInstance {
   undefined multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,

--- a/Source/WebCore/html/canvas/WebGLPolygonMode.idl
+++ b/Source/WebCore/html/canvas/WebGLPolygonMode.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLPolygonMode {
     const unsigned long POLYGON_MODE_WEBGL = 0x0B40;
 

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.idl
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLProvokingVertex {
     const unsigned long FIRST_VERTEX_CONVENTION_WEBGL = 0x8E4D;
     const unsigned long LAST_VERTEX_CONVENTION_WEBGL  = 0x8E4E;

--- a/Source/WebCore/html/canvas/WebGLRenderSharedExponent.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderSharedExponent.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
     LegacyNoInterfaceObject,
 ] interface WebGLRenderSharedExponent {
 };

--- a/Source/WebCore/html/canvas/WebGLStencilTexturing.idl
+++ b/Source/WebCore/html/canvas/WebGLStencilTexturing.idl
@@ -26,7 +26,7 @@
 [
     LegacyNoInterfaceObject,
     Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
+    GenerateIsReachable,
 ] interface WebGLStencilTexturing {
     const unsigned long DEPTH_STENCIL_TEXTURE_MODE_WEBGL = 0x90EA;
     const unsigned long STENCIL_INDEX_WEBGL              = 0x1901;


### PR DESCRIPTION
#### 99dc8dc84d403a8322e9d6ec448667877427d2ee
<pre>
WebGL extensions access the context root in racy way during GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=260137">https://bugs.webkit.org/show_bug.cgi?id=260137</a>
rdar://113846683

Reviewed by Dan Glastonbury.

The bindings would load WebGLExtension::m_context in GC thread
to navigate to the rendering context that is the opaque root
of the extension.

The WebGL would store WebGLExtension::m_context = nullptr during
context lost in JS thread.

These loads and stores are theoretically racy.
Instead, use std::atomic for m_context, and load in relaxed way
in the store thread, i.e. the JS thread.

Instead of using GenerateIsReachable=ImplWebGLRenderingContext that
hides the issue, use just normal GenerateIsReachable and implement
`WebCoreOpaqueRoot root(const WebGLExtension*)` for obtaining the root.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateImplementation):
* Source/WebCore/html/canvas/ANGLEInstancedArrays.idl:
* Source/WebCore/html/canvas/EXTBlendMinMax.idl:
* Source/WebCore/html/canvas/EXTClipControl.idl:
* Source/WebCore/html/canvas/EXTColorBufferFloat.idl:
* Source/WebCore/html/canvas/EXTColorBufferHalfFloat.idl:
* Source/WebCore/html/canvas/EXTConservativeDepth.idl:
* Source/WebCore/html/canvas/EXTDepthClamp.idl:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.idl:
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.idl:
* Source/WebCore/html/canvas/EXTFloatBlend.idl:
* Source/WebCore/html/canvas/EXTFragDepth.idl:
* Source/WebCore/html/canvas/EXTPolygonOffsetClamp.idl:
* Source/WebCore/html/canvas/EXTRenderSnorm.idl:
* Source/WebCore/html/canvas/EXTShaderTextureLOD.idl:
* Source/WebCore/html/canvas/EXTTextureCompressionBPTC.idl:
* Source/WebCore/html/canvas/EXTTextureCompressionRGTC.idl:
* Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.idl:
* Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.idl:
* Source/WebCore/html/canvas/EXTTextureNorm16.idl:
* Source/WebCore/html/canvas/EXTsRGB.idl:
* Source/WebCore/html/canvas/KHRParallelShaderCompile.idl:
* Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.idl:
* Source/WebCore/html/canvas/OESDrawBuffersIndexed.idl:
* Source/WebCore/html/canvas/OESElementIndexUint.idl:
* Source/WebCore/html/canvas/OESFBORenderMipmap.idl:
* Source/WebCore/html/canvas/OESSampleVariables.idl:
* Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.idl:
* Source/WebCore/html/canvas/OESStandardDerivatives.idl:
* Source/WebCore/html/canvas/OESTextureFloat.idl:
* Source/WebCore/html/canvas/OESTextureFloatLinear.idl:
* Source/WebCore/html/canvas/OESTextureHalfFloat.idl:
* Source/WebCore/html/canvas/OESTextureHalfFloatLinear.idl:
* Source/WebCore/html/canvas/OESVertexArrayObject.idl:
* Source/WebCore/html/canvas/WebGLClipCullDistance.idl:
* Source/WebCore/html/canvas/WebGLColorBufferFloat.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureASTC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureETC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureETC1.idl:
* Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.idl:
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.idl:
* Source/WebCore/html/canvas/WebGLDebugRendererInfo.idl:
* Source/WebCore/html/canvas/WebGLDebugShaders.idl:
* Source/WebCore/html/canvas/WebGLDepthTexture.idl:
* Source/WebCore/html/canvas/WebGLDrawBuffers.idl:
* Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.idl:
* Source/WebCore/html/canvas/WebGLExtension.h:
(WebCore::WebGLExtension::context):
(WebCore::WebGLExtension::isLostContext):
(WebCore::root):
* Source/WebCore/html/canvas/WebGLLoseContext.idl:
* Source/WebCore/html/canvas/WebGLMultiDraw.idl:
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.idl:
* Source/WebCore/html/canvas/WebGLPolygonMode.idl:
* Source/WebCore/html/canvas/WebGLProvokingVertex.idl:
* Source/WebCore/html/canvas/WebGLRenderSharedExponent.idl:
* Source/WebCore/html/canvas/WebGLStencilTexturing.idl:

Canonical link: <a href="https://commits.webkit.org/266991@main">https://commits.webkit.org/266991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83fe42be9b606b9eefebe261feaf463b9332b091

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17690 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20676 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17136 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12241 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13721 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3678 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->