### PR TITLE
[WGSL] staticCheck should use CHECK_PASS

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -298,17 +298,17 @@ static AST::UnaryOperation toUnaryOperation(const Token& token)
 }
 
 template<typename Lexer>
-std::optional<Error> parse(ShaderModule& shaderModule)
+std::optional<FailedCheck> parse(ShaderModule& shaderModule)
 {
     Lexer lexer(shaderModule.source());
     Parser parser(shaderModule, lexer);
     auto result = parser.parseShader();
     if (!result.has_value())
-        return result.error();
+        return FailedCheck { { result.error() }, { /* warnings */ } };
     return std::nullopt;
 }
 
-std::optional<Error> parse(ShaderModule& shaderModule)
+std::optional<FailedCheck> parse(ShaderModule& shaderModule)
 {
     if (shaderModule.source().is8Bit())
         return parse<Lexer<LChar>>(shaderModule);

--- a/Source/WebGPU/WGSL/Parser.h
+++ b/Source/WebGPU/WGSL/Parser.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include "CompilationMessage.h"
+#include "WGSL.h"
 
 namespace WGSL {
 
 class ShaderModule;
 
-std::optional<Error> parse(ShaderModule&);
+std::optional<FailedCheck> parse(ShaderModule&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -40,18 +40,14 @@
 
 namespace WGSL {
 
-#define CHECK_PASS(name, pass, ...) \
-    dumpASTBetweenEachPassIfNeeded(ast, "AST before " # pass); \
-    auto name##Expected = [&]() { \
+#define CHECK_PASS(pass) \
+    dumpASTBetweenEachPassIfNeeded(shaderModule, "AST before " # pass); \
+    auto maybe##pass##Failure = [&]() { \
         PhaseTimer phaseTimer(#pass, phaseTimes); \
-        return pass(__VA_ARGS__); \
+        return pass(shaderModule); \
     }(); \
-    if (!name##Expected) { \
-        if (dumpPassFailure) \
-            dataLogLn("failed pass: " # pass, toString(name##Expected.error())); \
-        return makeUnexpected(name##Expected.error()); \
-    } \
-    auto& name = *name##Expected; \
+    if (maybe##pass##Failure) \
+        return *maybe##pass##Failure;
 
 #define RUN_PASS(pass, ...) \
     do { \
@@ -69,24 +65,14 @@ namespace WGSL {
 
 std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&, const Configuration& configuration)
 {
+    PhaseTimes phaseTimes;
     auto shaderModule = makeUniqueRef<ShaderModule>(wgsl, configuration);
-    std::optional<Error> error = parse(shaderModule);
-    if (error.has_value()) {
-        // FIXME: Add support for returning multiple errors from the parser.
-        return FailedCheck { { *error }, { /* warnings */ } };
-    }
 
     // FIXME: add more validation
-    dumpASTBetweenEachPassIfNeeded(shaderModule, "AST before reorderGlobals");
-    if (auto maybeFailure = reorderGlobals(shaderModule))
-        return *maybeFailure;
-
-    dumpASTBetweenEachPassIfNeeded(shaderModule, "AST before typeCheck");
-    if (auto maybeFailure = typeCheck(shaderModule))
-        return *maybeFailure;
-
-    if (auto maybeFailure = rewriteConstants(shaderModule))
-        return *maybeFailure;
+    CHECK_PASS(parse);
+    CHECK_PASS(reorderGlobals);
+    CHECK_PASS(typeCheck);
+    CHECK_PASS(rewriteConstants);
 
     Vector<Warning> warnings { };
     return std::variant<SuccessfulCheck, FailedCheck>(std::in_place_type<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -73,7 +73,7 @@ static void checkVec4F32Type(WGSL::AST::TypeName& type)
 
 namespace TestWGSLAPI {
 
-inline Expected<WGSL::ShaderModule, WGSL::Error> parse(const String& wgsl)
+inline Expected<WGSL::ShaderModule, WGSL::FailedCheck> parse(const String& wgsl)
 {
     WGSL::ShaderModule shaderModule(wgsl, { 8 });
     auto maybeError = WGSL::parse(shaderModule);
@@ -160,7 +160,7 @@ static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, c
 
 TEST(WGSLParserTests, SourceLifecycle)
 {
-    Expected<WGSL::ShaderModule, WGSL::Error> shader = ([&]() {
+    auto shader = ([&]() {
         auto source = makeString(
             "@group(0)"_s,
             " "_s,
@@ -1119,28 +1119,28 @@ TEST(WGSLParserTests, GlobalVarWithoutTypeOrInitializer)
 {
     auto shader = parse("var x;"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "var declaration requires a type or initializer"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "var declaration requires a type or initializer"_s);
 }
 
 TEST(WGSLParserTests, GlobalConstWithoutTypeOrInitializer)
 {
     auto shader = parse("const x;"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "Expected a =, but got a ;"_s);
 }
 
 TEST(WGSLParserTests, GlobalConstWithoutInitializer)
 {
     auto shader = parse("const x: i32;"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "Expected a =, but got a ;"_s);
 }
 
 TEST(WGSLParserTests, GlobalOverrideWithoutTypeOrInitializer)
 {
     auto shader = parse("override x;"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "override declaration requires a type or initializer"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "override declaration requires a type or initializer"_s);
 }
 
 TEST(WGSLParserTests, LocalVarWithoutTypeOrInitializer)
@@ -1150,7 +1150,7 @@ TEST(WGSLParserTests, LocalVarWithoutTypeOrInitializer)
         "   var x;\n"
         "}"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "var declaration requires a type or initializer"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "var declaration requires a type or initializer"_s);
 }
 
 TEST(WGSLParserTests, LocalLetWithoutTypeOrInitializer)
@@ -1160,7 +1160,7 @@ TEST(WGSLParserTests, LocalLetWithoutTypeOrInitializer)
         "   let x;\n"
         "}"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "Expected a =, but got a ;"_s);
 }
 
 TEST(WGSLParserTests, LocalLetWithoutInitializer)
@@ -1170,7 +1170,7 @@ TEST(WGSLParserTests, LocalLetWithoutInitializer)
         "   let x: i32;\n"
         "}"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "Expected a =, but got a ;"_s);
 }
 
 TEST(WGSLParserTests, LocalConstWithoutTypeOrInitializer)
@@ -1180,7 +1180,7 @@ TEST(WGSLParserTests, LocalConstWithoutTypeOrInitializer)
         "   const x;\n"
         "}"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "Expected a =, but got a ;"_s);
 }
 
 TEST(WGSLParserTests, LocalConstWithoutInitializer)
@@ -1190,7 +1190,7 @@ TEST(WGSLParserTests, LocalConstWithoutInitializer)
         "   const x: i32;\n"
         "}"_s);
     EXPECT_FALSE(shader.has_value());
-    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+    EXPECT_EQ(shader.error().errors.first().message(), "Expected a =, but got a ;"_s);
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp
@@ -28,12 +28,17 @@
 
 #include "WGSL.h"
 #include <wtf/Assertions.h>
+#include <wtf/StringPrintStream.h>
 
 namespace TestWGSLAPI {
 
-void logCompilationError(WGSL::CompilationMessage& error)
+void logCompilationError(WGSL::FailedCheck& failedCheck)
 {
-    WTFLogAlways("%u:%u length:%u %s", error.lineNumber(), error.lineOffset(), error.length(), error.message().utf8().data());
+    StringPrintStream message;
+    message.print(String::number(failedCheck.errors.size()), " error", failedCheck.errors.size() != 1 ? "s" : "", " generated while compiling the shader:"_s);
+    for (const auto& error : failedCheck.errors)
+        message.print("\n"_s, error);
+    WTFLogAlways("%s", message.toString().utf8().data());
     GTEST_FAIL();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -34,11 +34,11 @@
     } while (false)
 
 namespace WGSL {
-class CompilationMessage;
+struct FailedCheck;
 }
 
 namespace TestWGSLAPI {
 
-void logCompilationError(WGSL::CompilationMessage& error);
+void logCompilationError(WGSL::FailedCheck& error);
 
 } // namespace TestWGSLAPI


### PR DESCRIPTION
#### 6ea64bd9136a467a721e02935ff883864697f4b8
<pre>
[WGSL] staticCheck should use CHECK_PASS
<a href="https://bugs.webkit.org/show_bug.cgi?id=260138">https://bugs.webkit.org/show_bug.cgi?id=260138</a>
rdar://113847047

Reviewed by Dan Glastonbury.

Minor refactoring: clean up duplication, compute phase times and remove duplication.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::parse):
* Source/WebGPU/WGSL/Parser.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):

Canonical link: <a href="https://commits.webkit.org/266942@main">https://commits.webkit.org/266942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d2bb34a7636b1d4598351e3241117e9a68448a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16828 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17586 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20589 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17037 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12161 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13635 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3652 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->