### PR TITLE
math-style property should be marked inherited

### DIFF
--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
@@ -2,7 +2,7 @@
 PASS mathvariant on the math element is not mapped to CSS text-transform
 FAIL scriptlevel on the math element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the math element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
-FAIL displaystyle on the math element is mapped to CSS math-style assert_equals: no attribute expected "compact" but got "normal"
+PASS displaystyle on the math element is mapped to CSS math-style
 PASS mathvariant on the annotation element is not mapped to CSS text-transform
 FAIL scriptlevel on the annotation element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the annotation element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
@@ -2,7 +2,7 @@
 PASS mathvariant on the math element is not mapped to CSS text-transform
 FAIL scriptlevel on the math element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the math element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
-FAIL displaystyle on the math element is mapped to CSS math-style assert_equals: no attribute expected "compact" but got "normal"
+PASS displaystyle on the math element is mapped to CSS math-style
 PASS mathvariant on the annotation element is not mapped to CSS text-transform
 FAIL scriptlevel on the annotation element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the annotation element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
@@ -2,7 +2,7 @@
 PASS mathvariant on the math element is not mapped to CSS text-transform
 FAIL scriptlevel on the math element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the math element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
-FAIL displaystyle on the math element is mapped to CSS math-style assert_equals: no attribute expected "compact" but got "normal"
+PASS displaystyle on the math element is mapped to CSS math-style
 PASS mathvariant on the annotation element is not mapped to CSS text-transform
 FAIL scriptlevel on the annotation element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the annotation element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""

--- a/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
+++ b/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
@@ -2,7 +2,7 @@
 PASS mathvariant on the math element is not mapped to CSS text-transform
 FAIL scriptlevel on the math element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the math element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
-FAIL displaystyle on the math element is mapped to CSS math-style assert_equals: no attribute expected "compact" but got "normal"
+PASS displaystyle on the math element is mapped to CSS math-style
 PASS mathvariant on the annotation element is not mapped to CSS text-transform
 FAIL scriptlevel on the annotation element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the annotation element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt
@@ -2,7 +2,7 @@
 PASS mathvariant on the math element is not mapped to CSS text-transform
 FAIL scriptlevel on the math element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the math element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
-FAIL displaystyle on the math element is mapped to CSS math-style assert_equals: no attribute expected "compact" but got "normal"
+PASS displaystyle on the math element is mapped to CSS math-style
 PASS mathvariant on the annotation element is not mapped to CSS text-transform
 FAIL scriptlevel on the annotation element is mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""
 FAIL invalid scriptlevel values on the annotation element are not mapped to math-depth(...) assert_equals: no attribute expected "0" but got ""

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4461,6 +4461,7 @@
             "status": "experimental"
         },
         "math-style": {
+            "inherited": true,
             "values": [
                 "normal",
                 "compact"


### PR DESCRIPTION
#### 59fc68749e0e7c5cfaac0903e54ad875146e1670
<pre>
math-style property should be marked inherited
<a href="https://bugs.webkit.org/show_bug.cgi?id=260143">https://bugs.webkit.org/show_bug.cgi?id=260143</a>
rdar://problem/113853280

Reviewed by Tim Nguyen.

It is correctly treated as inherited in RenderStyle but not marked as such in CSSProperties.json.

* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt:
* LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/mathml/relations/css-styling/attribute-mapping-002-expected.txt:
* Source/WebCore/css/CSSProperties.json:

Canonical link: <a href="https://commits.webkit.org/266871@main">https://commits.webkit.org/266871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9183e261148ba436b5b0b5268e3aa6e089859277

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17483 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20493 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14260 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12061 "1 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13541 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3617 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->