### PR TITLE
[WGSL] Only visit functions and structures once

### DIFF
--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -93,7 +93,6 @@ private:
     MangledName makeMangledName(const String&, MangledName::Kind);
 
     void visitVariableDeclaration(AST::Variable&, MangledName::Kind);
-    void visitFunctionBody(AST::Function&);
 
     const CallGraph& m_callGraph;
     PrepareResult& m_result;
@@ -104,30 +103,23 @@ private:
 void NameManglerVisitor::run()
 {
     auto& module = m_callGraph.ast();
-    for (auto& function : module.functions()) {
-        String originalName = function.name();
-        introduceVariable(function.name(), MangledName::Function);
-        auto it = m_result.entryPoints.find(originalName);
-        if (it != m_result.entryPoints.end())
-            it->value.mangledName = function.name();
-    }
-
     for (auto& structure : module.structures())
         visit(structure);
 
     for (auto& variable : module.variables())
         visit(variable);
 
-    for (auto& function : module.functions())
-        visitFunctionBody(function);
+    for (auto& function : module.functions()) {
+        String originalName = function.name();
+        introduceVariable(function.name(), MangledName::Function);
+        auto it = m_result.entryPoints.find(originalName);
+        if (it != m_result.entryPoints.end())
+            it->value.mangledName = function.name();
+        visit(function);
+    }
 }
 
 void NameManglerVisitor::visit(AST::Function& function)
-{
-    introduceVariable(function.name(), MangledName::Function);
-}
-
-void NameManglerVisitor::visitFunctionBody(AST::Function& function)
 {
     ContextScope functionScope(this);
 

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -154,9 +154,9 @@ TypeStore::TypeStore()
     allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureStorage3d, Texture::Kind::TextureStorage3d);
 }
 
-const Type* TypeStore::structType(AST::Structure& structure)
+const Type* TypeStore::structType(AST::Structure& structure, HashMap<String, const Type*>&& fields)
 {
-    return allocateType<Struct>(structure);
+    return allocateType<Struct>(structure, fields);
 }
 
 const Type* TypeStore::constructType(AST::ParameterizedTypeName::Base base, const Type* elementType)

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -30,6 +30,7 @@
 #include <wtf/FixedVector.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
+#include <wtf/text/StringHash.h>
 
 namespace WGSL {
 
@@ -56,7 +57,7 @@ public:
     const Type* samplerType() const { return m_sampler; }
     const Type* textureExternalType() const { return m_textureExternal; }
 
-    const Type* structType(AST::Structure&);
+    const Type* structType(AST::Structure&, HashMap<String, const Type*>&& = { });
     const Type* arrayType(const Type*, std::optional<unsigned>);
     const Type* vectorType(const Type*, uint8_t);
     const Type* matrixType(const Type*, uint8_t columns, uint8_t rows);


### PR DESCRIPTION
#### c9507058e6995c9f173d0552bc12e7749a2ada3f
<pre>
[WGSL] Only visit functions and structures once
<a href="https://bugs.webkit.org/show_bug.cgi?id=260144">https://bugs.webkit.org/show_bug.cgi?id=260144</a>
rdar://113854125

Reviewed by Dan Glastonbury.

Originally, the type checker and name mangling pass did two passes over global
declarations. That was necessary since declarations can refer to other declarations
that only appear later in the program. However, in 266862@main we introduced a new
pass that sorts all declarations, guaranteeing that by the time we visit a given
declaration, any other declaration it depends on will have already been visited.
This allows simplifying the code, and doing a single pass over all declarations.

* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
(WGSL::NameManglerVisitor::visit):
(WGSL::NameManglerVisitor::visitFunctionBody): Deleted.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitStructMembers): Deleted.
(WGSL::TypeChecker::visitFunctionBody): Deleted.
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::structType):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::structType):

Canonical link: <a href="https://commits.webkit.org/266900@main">https://commits.webkit.org/266900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e9a422bbe27de25615cfc635799fb731d77fca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14112 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16740 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17481 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12932 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20492 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16933 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13539 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3632 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->