### PR TITLE
REGRESSION(2.41.90): Cannot scroll certain pages opened in new tabs

### DIFF
--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.cpp
@@ -52,10 +52,11 @@ void DisplayRefreshMonitorClient::fireDisplayRefreshIfNeeded(const DisplayUpdate
     if (!m_scheduled)
         return;
 
+    m_scheduled = false;
+
     if (!displayUpdate.relevantForUpdateFrequency(m_preferredFramesPerSecond))
         return;
 
-    m_scheduled = false;
     displayRefreshFired();
 }
 


### PR DESCRIPTION
#### 9fdeffb5d0d56e7322490d611136c1575f2a76ae
<pre>
REGRESSION(2.41.90): Cannot scroll certain pages opened in new tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=260073">https://bugs.webkit.org/show_bug.cgi?id=260073</a>

Reviewed by NOBODY (OOPS!).

This only happens in GTK4 because the views opened in new tabs stay
unrealized until they are shown. With the DMA-BUF rendered enabled we
keep processing frames while the view is unrealized, just pretending
they have been rendered on screen. This causes the page to be throttled,
because it&apos;s visually idle, which changes the preferred frame rate from
60 to 30. This new condition makes DisplayUpdate::relevantForUpdateFrequency()
always return false, leaving the last frame scheduled forever, because
DisplayRefreshMonitorClient::fireDisplayRefreshIfNeeded() doesn&apos;t update
the m_scheduled in that particular case.

* Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.cpp:
(WebCore::DisplayRefreshMonitorClient::fireDisplayRefreshIfNeeded): Set
m_scheduled to false when relevantForUpdateFrequency() returns false.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fdeffb5d0d56e7322490d611136c1575f2a76ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16743 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17484 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12935 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13532 "7 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20495 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12063 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->