### PR TITLE
WebVTT vertical multiline captions are cut off

### DIFF
--- a/LayoutTests/http/tests/media/resources/hls/subtitles/verticalrl.vtt
+++ b/LayoutTests/http/tests/media/resources/hls/subtitles/verticalrl.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000 vertical:rl
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line-expected.txt
+++ b/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line-expected.txt
@@ -1,0 +1,11 @@
+
+EVENT(canplay)
+EVENT(addtrack)
+EXPECTED (video.textTracks.length == '1') OK
+RUN(video.textTracks[0].mode = 'showing')
+RUN(video.currentTime = 1)
+EVENT(seeked)
+EXPECTED (window.internals.shadowRoot(video).querySelector('span[pseudo=cue]') != 'null') OK
+EXPECTED (video.offsetHeight >= window.internals.shadowRoot(video).querySelector('span[pseudo=cue]').offsetHeight == 'true') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line.html
+++ b/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+    <head>
+        <title>WebVTT multiline cues with vertical writing direction should wrap</title>
+        <script src="../../../../resources/js-test-pre.js"></script>
+        <script src="../../media-resources/video-test.js"></script>
+        <script src="../../media-resources/media-file.js"></script>
+        <script>
+            async function runTest()
+            {
+                video = document.getElementById('video');
+                video.src = findMediaFile('video', '../resources/test');
+                await waitFor(video, 'canplay');
+                let track = document.createElement('track');
+                track.src = '../resources/hls/subtitles/verticalrl.vtt';
+                video.appendChild(track)
+
+                await waitFor(video.textTracks, 'addtrack');
+                testExpected("video.textTracks.length", 1);
+                run("video.textTracks[0].mode = 'showing'");
+
+                run("video.currentTime = 1");
+                await waitFor(video, 'seeked');
+
+                window.internals.ensureUserAgentShadowRoot(video);
+                await testExpectedEventually("window.internals.shadowRoot(video).querySelector('span[pseudo=cue]')", null, "!=", 1000);
+                await testExpected("video.offsetHeight >= window.internals.shadowRoot(video).querySelector('span[pseudo=cue]').offsetHeight", true);
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video id="video" muted></video>
+    </body>
+</html>

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -215,7 +215,7 @@ void VTTCueBox::applyCSSProperties()
 
     // the 'height' property must be set to height
     std::visit(WTF::makeVisitor([&] (double height) {
-        setInlineStyleProperty(CSSPropertyHeight, height, CSSUnitType::CSS_CQW);
+        setInlineStyleProperty(CSSPropertyHeight, height, CSSUnitType::CSS_CQH);
     }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);
     }), cue->height());


### PR DESCRIPTION
#### b3d9884a0a1634cb1ff3d24748264f759173d35f
<pre>
WebVTT vertical multiline captions are cut off
<a href="https://bugs.webkit.org/show_bug.cgi?id=260148">https://bugs.webkit.org/show_bug.cgi?id=260148</a>
rdar://112951878

Reviewed by Eric Carlson.

Currently, vertical webvtt captions (such as Japanese) are not
Displayed correctly on Safari: long cues will get cut off, rather
Than wrapping and displaying multiple lines. This is because the height
Of the div with pseudo-class webkit-media-text-track-display was
Not being calculated with the correct unit. To fix this, I changed
The unit from CQW to CQH.

Added one layout test.

* LayoutTests/http/tests/media/resources/hls/subtitles/verticalrl.vtt: Added.
* LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line-expected.txt: Added.
* LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line.html: Added.

* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSProperties)

Canonical link: <a href="https://commits.webkit.org/267162@main">https://commits.webkit.org/267162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1733986af30e9bee66095fbf8ccd234b7b5d1763

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16240 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18343 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21187 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17715 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12765 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3782 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->