### PR TITLE
Roots should be packaged in the system cryptex on macOS and iOS

### DIFF
--- a/Tools/Scripts/package-root
+++ b/Tools/Scripts/package-root
@@ -42,13 +42,15 @@ sub usage()
 {
     my $usage = <<EOF;
     Bundles up products created with build-webkit into a zip suitable for sharing as a root.
-    The archive is created in the top level webkit directory.
+    The archive is created in the build directory for the chosen platform and SDK.
 
     Usage: $programName [configuration options]
       --help                            Show this help message
       --sdk                             Specifies SDK for which the roots are staged
                                         (Default: currently installed Base SDK)
       --ios-device                      Use "iphoneos.internal" SDK if installed, else "iphoneos" SDK (iOS only)
+      --tvos-device                     Use "appletvos.internal" SDK if installed, else "appletvos" SDK (tvOS only)
+      --watchos-device                  Use "watchos.internal" SDK if installed, else "watchos" SDK (watchOS only)
       --device                          DEPRECATED alias of --ios-device
       --ios-simulator                   Use "iphonesimulator.internal" SDK if installed, else "iphonesimulator" SDK (iOS only)
       --simulator                       DEPRECATED alias of --ios-simulator
@@ -74,8 +76,10 @@ setConfiguration();
 
 my @privateFrameworks = qw(WebCore WebGPU WebKitLegacy);
 my @publicFrameworks = qw(JavaScriptCore WebKit);
-my $privateInstallPath = "/System/Library/PrivateFrameworks";
-my $publicInstallPath = "/System/Library/Frameworks";
+my $packagedRootBasePath = usesCryptexPath() ? "/System/Cryptexes/OS/" : "/";
+$packagedRootBasePath = "$packagedRootBasePath" . "System/iOSSupport/" if isMacCatalystWebKit();
+my $privateInstallPath = "$packagedRootBasePath" . "System/Library/PrivateFrameworks";
+my $publicInstallPath = "$packagedRootBasePath" . "System/Library/Frameworks";
 
 my $configuration = configuration();
 my $platform = xcodeSDKPlatformName();
@@ -102,7 +106,7 @@ foreach my $framework (@publicFrameworks) {
     die "Check to see that you have built $framework for $configuration-$platform" if $?;
 }
 
-system 'ditto', "$productDir/usr", "$stagingRoot/usr";
+system 'ditto', "$productDir/usr", "$stagingRoot" . "$packagedRootBasePath" . "usr";
 
 chdir $stagingRoot;
 print "Creating compressed archive ...\n";

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -131,6 +131,7 @@ BEGIN {
        &isInspectorFrontend
        &isJSCOnly
        &isLinux
+       &isMacCatalystWebKit
        &isPlayStation
        &isWPE
        &isWinCairo
@@ -193,6 +194,7 @@ BEGIN {
        &splitVersionString
        &tsanIsEnabled
        &ubsanIsEnabled
+       &usesCryptexPath
        &willUseAppleTVDeviceSDK
        &willUseAppleTVSimulatorSDK
        &willUseIOSDeviceSDK
@@ -1865,6 +1867,11 @@ sub isMacCatalystWebKit()
 sub isAppleCocoaWebKit()
 {
     return isAppleMacWebKit() || isEmbeddedWebKit() || isMacCatalystWebKit();
+}
+
+sub usesCryptexPath
+{
+    return isAppleMacWebKit() || isMacCatalystWebKit() || isIOSWebKit();
 }
 
 sub simulatorDeviceFromJSON


### PR DESCRIPTION
#### 62a835176599d85aa783850d0e9150fd0c00bd19
<pre>
Roots should be packaged in the system cryptex on macOS and iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=260153">https://bugs.webkit.org/show_bug.cgi?id=260153</a>
rdar://113862633

Reviewed by Andy Estes.

This will package a root into /System/Cryptexes/OS instead of / on
macOS, Mac Catalyst, and iOS.

* Tools/Scripts/package-root:
(usage):
* Tools/Scripts/webkitdirs.pm:
(usesCryptexPath):

Canonical link: <a href="https://commits.webkit.org/267157@main">https://commits.webkit.org/267157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81066f9cc153040710fd1b32c5f38b2f627fc935

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16855 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17631 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20623 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12981 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17074 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12196 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15342 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13672 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3912 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18012 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15576 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1940 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14233 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3722 "Passed tests") | 
<!--EWS-Status-Bubble-End-->