### PR TITLE
[JSC] Increase minimumFractionDigits / maximumFractionDigits limit from 20 to 100

### DIFF
--- a/JSTests/stress/intl-numberformat.js
+++ b/JSTests/stress/intl-numberformat.js
@@ -168,13 +168,13 @@ shouldBe(testNumberFormat(Intl.NumberFormat('en', {minimumFractionDigits: 0}), [
 shouldBe(testNumberFormat(Intl.NumberFormat('en', {style: 'percent', minimumFractionDigits: 0}), [{locale: 'en', style: 'percent', minimumFractionDigits: 0, maximumFractionDigits: 0}]), true);
 shouldBe(testNumberFormat(Intl.NumberFormat('en', {minimumFractionDigits: 6}), [{locale: 'en', minimumFractionDigits: 6, maximumFractionDigits: 6}]), true);
 shouldThrow(() => Intl.NumberFormat('en', {minimumFractionDigits: -1}), RangeError);
-shouldThrow(() => Intl.NumberFormat('en', {minimumFractionDigits: 21}), RangeError);
+shouldThrow(() => Intl.NumberFormat('en', {minimumFractionDigits: 101}), RangeError);
 
 // The option maximumFractionDigits is processed correctly.
 shouldBe(testNumberFormat(Intl.NumberFormat('en', {maximumFractionDigits: 6}), [{locale: 'en', maximumFractionDigits: 6}]), true);
 shouldThrow(() => Intl.NumberFormat('en', {minimumFractionDigits: 7, maximumFractionDigits: 6}), RangeError);
 shouldThrow(() => Intl.NumberFormat('en', {maximumFractionDigits: -1}), RangeError);
-shouldThrow(() => Intl.NumberFormat('en', {maximumFractionDigits: 21}), RangeError);
+shouldThrow(() => Intl.NumberFormat('en', {maximumFractionDigits: 101}), RangeError);
 
 // The option minimumSignificantDigits is processed correctly.
 shouldBe(testNumberFormat(Intl.NumberFormat('en', {minimumSignificantDigits: 6}), [{locale: 'en', minimumFractionDigits: undefined, maximumFractionDigits: undefined, minimumSignificantDigits: 6, maximumSignificantDigits: 21}]), true);

--- a/JSTests/stress/intl-pluralrules.js
+++ b/JSTests/stress/intl-pluralrules.js
@@ -259,13 +259,13 @@ shouldBe(new Intl.PluralRules('en', {minimumFractionDigits: 0}).resolvedOptions(
 shouldBe(new Intl.PluralRules('en', {minimumFractionDigits: 6}).resolvedOptions().minimumFractionDigits, 6);
 shouldBe(new Intl.PluralRules('en', {minimumFractionDigits: 6}).resolvedOptions().maximumFractionDigits, 6);
 shouldThrow(() => new Intl.PluralRules('en', {minimumFractionDigits: -1}), RangeError);
-shouldThrow(() => new Intl.PluralRules('en', {minimumFractionDigits: 21}), RangeError);
+shouldThrow(() => new Intl.PluralRules('en', {minimumFractionDigits: 101}), RangeError);
 
 // The option maximumFractionDigits is processed correctly.
 shouldBe(new Intl.PluralRules('en', {maximumFractionDigits: 6}).resolvedOptions().maximumFractionDigits, 6);
 shouldThrow(() => new Intl.PluralRules('en', {minimumFractionDigits: 7, maximumFractionDigits: 6}), RangeError);
 shouldThrow(() => new Intl.PluralRules('en', {maximumFractionDigits: -1}), RangeError);
-shouldThrow(() => new Intl.PluralRules('en', {maximumFractionDigits: 21}), RangeError);
+shouldThrow(() => new Intl.PluralRules('en', {maximumFractionDigits: 101}), RangeError);
 
 // The option minimumSignificantDigits is processed correctly.
 shouldBe(new Intl.PluralRules('en', {minimumSignificantDigits: 6}).resolvedOptions().minimumSignificantDigits, 6);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1744,12 +1744,6 @@ test/intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js:
 test/intl402/NumberFormat/prototype/format/value-decimal-string.js:
   default: 'Test262Error: Expected SameValue(«1», «1.0000000000000001») to be true'
   strict mode: 'Test262Error: Expected SameValue(«1», «1.0000000000000001») to be true'
-test/intl402/NumberFormat/throws-for-maximumFractionDigits-over-limit.js:
-  default: 'RangeError: maximumFractionDigits is out of range'
-  strict mode: 'RangeError: maximumFractionDigits is out of range'
-test/intl402/NumberFormat/throws-for-minimumFractionDigits-over-limit.js:
-  default: 'RangeError: minimumFractionDigits is out of range'
-  strict mode: 'RangeError: minimumFractionDigits is out of range'
 test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js:
   default: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -94,9 +94,9 @@ void setNumberFormatDigitOptions(JSGlobalObject* globalObject, IntlType* intlIns
     if (needFd) {
         if (hasFd) {
             constexpr unsigned undefinedValue = UINT32_MAX;
-            unsigned minimumFractionDigits = intlDefaultNumberOption(globalObject, minimumFractionDigitsValue, vm.propertyNames->minimumFractionDigits, 0, 20, undefinedValue);
+            unsigned minimumFractionDigits = intlDefaultNumberOption(globalObject, minimumFractionDigitsValue, vm.propertyNames->minimumFractionDigits, 0, 100, undefinedValue);
             RETURN_IF_EXCEPTION(scope, void());
-            unsigned maximumFractionDigits = intlDefaultNumberOption(globalObject, maximumFractionDigitsValue, vm.propertyNames->maximumFractionDigits, 0, 20, undefinedValue);
+            unsigned maximumFractionDigits = intlDefaultNumberOption(globalObject, maximumFractionDigitsValue, vm.propertyNames->maximumFractionDigits, 0, 100, undefinedValue);
             RETURN_IF_EXCEPTION(scope, void());
 
             if (minimumFractionDigits == undefinedValue)


### PR DESCRIPTION
#### d4b49d3314c109f14fd981616cdb72c693cd2865
<pre>
[JSC] Increase minimumFractionDigits / maximumFractionDigits limit from 20 to 100
<a href="https://bugs.webkit.org/show_bug.cgi?id=260169">https://bugs.webkit.org/show_bug.cgi?id=260169</a>
rdar://113869343

Reviewed by Mark Lam.

This patch aligns the implementation to the latest spec change[1].
Just increasing minimumFractionDigits and maximumFractionDigits limit from 20 to 100.

[1]: <a href="https://github.com/tc39/ecma402/commit/f6d29456b85392840931bb962875c68351ad658c">https://github.com/tc39/ecma402/commit/f6d29456b85392840931bb962875c68351ad658c</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::setNumberFormatDigitOptions):

Canonical link: <a href="https://commits.webkit.org/266879@main">https://commits.webkit.org/266879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0cba640ee85cc73714b1446c2e87b0646154821

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16795 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15444 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15220 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17524 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/12881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/14047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/14299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/14295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15236 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15468 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1811 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/14136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/3697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->