### PR TITLE
merge-queue is marking builds as FAILURE when it successfully lands PR after retry

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5121,6 +5121,8 @@ class SetBuildSummary(buildstep.BuildStep):
         previous_build_summary = self.getProperty('build_summary', '')
         if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary:
             self.build.results = FAILURE
+        elif 'Committed ' in previous_build_summary and '@' in previous_build_summary:
+            self.build.results = SUCCESS
         self.build.buildFinished([build_summary], self.build.results)
         return defer.succeed(None)
 


### PR DESCRIPTION
#### afae26e9504066af8d4d928962ad762d596c4fc4
<pre>
merge-queue is marking builds as FAILURE when it successfully lands PR after retry
<a href="https://bugs.webkit.org/show_bug.cgi?id=234644">https://bugs.webkit.org/show_bug.cgi?id=234644</a>

Reviewed by Jonathan Bedard.

Set overall build status as SUCCESS (green) if the commit was successful.

* Tools/CISupport/ews-build/steps.py:
(SetBuildSummary.start):

Canonical link: <a href="https://commits.webkit.org/266880@main">https://commits.webkit.org/266880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f9a8254c2c0721726dbc95ca54403b241b9db64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15037 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/15342 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/15696 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/16793 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15176 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/17861 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/15442 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/16793 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15218 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/17861 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/15696 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/17522 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/17861 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/15696 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/17522 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/17861 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/15696 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/17522 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/14293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/15442 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14934 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/13573 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/15696 "Build was cancelled. Recent messages:OS: Monterey (12.6.7), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17910 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1812 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/14134 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->