### PR TITLE
[visionOS] Add menu button to control scene dimming in fullscreen

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2784,11 +2784,11 @@ FullscreenSceneDimmingEnabled:
   condition: PLATFORM(VISION)
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 GStreamerEnabled:
   type: bool

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -235,6 +235,9 @@
 /* Menu item label for automatic track selection behavior. */
 "Auto (Recommended) (text track)" = "Auto (Recommended)";
 
+/* Menu item label to toggle automatic scene dimming in fullscreen (visionOS only). */
+"Auto Dimming" = "Auto Dimming";
+
 /* Automatically Resize context menu item */
 "Automatically Resize" = "Automatically Resize";
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -364,7 +364,10 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails&)
 
 #if ENABLE(FULLSCREEN_API) && PLATFORM(IOS_FAMILY)
 @interface WKWebView (FullScreenAPI_Internal)
--(WKFullScreenWindowController *)fullScreenWindowController;
+- (WKFullScreenWindowController *)fullScreenWindowController;
+#if PLATFORM(VISION)
+- (UIMenu *)fullScreenWindowSceneDimmingAction;
+#endif
 @end
 #endif
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4219,6 +4219,34 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _fullScreenWindowController.get();
 }
 
+#if PLATFORM(VISION)
+
+- (UIMenu *)fullScreenWindowSceneDimmingAction
+{
+    UIDeferredMenuElement *deferredMenu = [UIDeferredMenuElement elementWithUncachedProvider:[weakSelf = WeakObjCPtr<WKWebView>(self)] (void (^completion)(NSArray<UIMenuElement *> *)) {
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completion(@[ ]);
+            return;
+        }
+
+        UIAction *dimmingAction = [UIAction actionWithTitle:WEB_UI_STRING("Auto Dimming", "Menu item label to toggle automatic scene dimming in fullscreen") image:[UIImage _systemImageNamed:@"circle.lefthalf.dotted.inset.half.filled"] identifier:nil handler:[weakSelf] (UIAction *) {
+            auto strongSelf = weakSelf.get();
+            if (!strongSelf)
+                return;
+
+            [strongSelf->_fullScreenWindowController toggleSceneDimming];
+        }];
+        dimmingAction.state = [strongSelf->_fullScreenWindowController prefersSceneDimming] ? UIMenuElementStateOn : UIMenuElementStateOff;
+
+        completion(@[ dimmingAction ]);
+    }];
+
+    return [UIMenu menuWithTitle:@"" image:nil identifier:nil options:UIMenuOptionsDisplayInline children:@[ deferredMenu ]];
+}
+
+#endif // PLATFORM(VISION)
+
 @end
 
 #endif // ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h
@@ -93,6 +93,7 @@ typedef NS_ENUM(NSInteger, _WKElementActionType);
 - (BOOL)_allowAnimationControls;
 - (void)_actionSheetAssistant:(WKActionSheetAssistant *)assistant performAction:(WebKit::SheetAction)action onElements:(Vector<WebCore::ElementContext>&&)elements;
 #endif
+- (NSArray<UIMenuElement *> *)additionalMediaControlsContextMenuItemsForActionSheetAssistant:(WKActionSheetAssistant *)assistant;
 @end
 
 #if USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -869,12 +869,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     } else
         itemsToPresent = WTFMove(items);
 
-    if (![_view window] || itemsToPresent.isEmpty()) {
+    NSArray<UIMenuElement *> *additionalItems = nil;
+    if ([_delegate respondsToSelector:@selector(additionalMediaControlsContextMenuItemsForActionSheetAssistant:)])
+        additionalItems = [_delegate additionalMediaControlsContextMenuItemsForActionSheetAssistant:self];
+
+    if (![_view window] || (itemsToPresent.isEmpty() && !additionalItems.count)) {
         completionHandler(WebCore::MediaControlsContextMenuItem::invalidID);
         return;
     }
 
-    _mediaControlsContextMenu = [UIMenu menuWithTitle:WTFMove(menuTitle) children:[self _uiMenuElementsForMediaControlContextMenuItems:WTFMove(itemsToPresent)]];
+    NSArray<UIMenuElement *> *menuItems = [self _uiMenuElementsForMediaControlContextMenuItems:WTFMove(itemsToPresent)];
+    menuItems = [menuItems arrayByAddingObjectsFromArray:additionalItems];
+
+    _mediaControlsContextMenu = [UIMenu menuWithTitle:WTFMove(menuTitle) children:menuItems];
     _mediaControlsContextMenuTargetFrame = WTFMove(targetFrame);
     _mediaControlsContextMenuCallback = WTFMove(completionHandler);
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8548,6 +8548,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         completion(nil, nil);
 }
 
+- (NSArray<UIMenuElement *> *)additionalMediaControlsContextMenuItemsForActionSheetAssistant:(WKActionSheetAssistant *)assistant
+{
+#if PLATFORM(VISION)
+    if (self.webView.fullscreenState == WKFullscreenStateInFullscreen)
+        return @[ [self.webView fullScreenWindowSceneDimmingAction] ];
+#endif
+    return @[ ];
+}
+
 #if USE(UICONTEXTMENU)
 
 - (UITargetedPreview *)createTargetedContextMenuHintForActionSheetAssistant:(WKActionSheetAssistant *)assistant

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -35,9 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)requestExitFullScreen;
 - (void)showUI;
 - (void)hideUI;
-#if PLATFORM(VISION)
-- (void)toggleDimming;
-#endif
 @end
 
 @interface WKFullScreenViewController : UIViewController
@@ -60,7 +57,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations;
 - (void)resetSupportedOrientations;
 #if PLATFORM(VISION)
-- (void)setSceneDimmed:(BOOL)dimmed;
 - (void)hideCustomControls:(BOOL)hidden;
 #endif
 @end

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -32,6 +32,9 @@
 @interface WKFullScreenWindowController : NSObject <UIViewControllerTransitioningDelegate>
 @property (readonly, retain, nonatomic) UIView *webViewPlaceholder;
 @property (readonly, assign, nonatomic) BOOL isFullScreen;
+#if PLATFORM(VISION)
+@property (readonly, assign, nonatomic) BOOL prefersSceneDimming;
+#endif
 
 - (id)initWithWebView:(WKWebView *)webView;
 - (void)enterFullScreen:(CGSize)videoDimensions;
@@ -45,6 +48,10 @@
 - (void)close;
 - (void)webViewDidRemoveFromSuperviewWhileInFullscreen;
 - (void)videoControlsManagerDidChange;
+
+#if PLATFORM(VISION)
+- (void)toggleSceneDimming;
+#endif
 
 @end
 


### PR DESCRIPTION
#### c007fbf1d5da3f2a2420cc40fe7689edcf9f2cd9
<pre>
[visionOS] Add menu button to control scene dimming in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=260164">https://bugs.webkit.org/show_bug.cgi?id=260164</a>
rdar://110675100

Reviewed by Wenson Hsieh.

In &lt;video&gt; fullscreen, &quot;Auto Dimming&quot; will be offered as an option alongside
the rest of the overflow controls menu. In element fullscreen, a new menu is
added to the top left to hold the new action.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Enable fullscreen scene dimming by default.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView fullScreenWindowSceneDimmingAction]):

Expose the action as a method on `WKWebView` so that the logic may be shared
between &lt;video&gt; and element fullscreen.

Use a `UIDeferredMenuElement` so that the action is initialized each time its
menu is presented, and the selected state is accurately reflected.

Use `UIMenuOptionsDisplayInline` in order to display a separator.

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.h:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant showMediaControlsContextMenu:items:completionHandler:]):

Augment media controls context menu logic to add support for actions that are
completely handled on the UI process side.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView additionalMediaControlsContextMenuItemsForActionSheetAssistant:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:

Add `_WKExtrinsicButtonDelegate` in order to know if/when a button is presenting
a menu. If a menu is visible, the auto-hide logic needs to be prevented.

(-[_WKExtrinsicButton contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[_WKExtrinsicButton contextMenuInteraction:willEndForConfiguration:animator:]):
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController hideUI]):
(-[WKFullScreenViewController videoControlsManagerDidChange]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _createButtonWithExtrinsicContentSize:]):
(-[WKFullScreenViewController _wkExtrinsicButtonWillDisplayMenu:]):

Cancel auto-hide when a menu is presented.

(-[WKFullScreenViewController _wkExtrinsicButtonWillDismissMenu:]):

Auto-hide UI when the menu is dismissed, and playback is active.

(-[WKFullScreenViewController setSceneDimmed:]): Deleted.
(-[WKFullScreenViewController _toggleDimmingAction:]): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController prefersSceneDimming]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Update logic to ensure dimming state is restored when exiting fullscreen, if the
preference is toggled while in fullscreen.

(-[WKFullScreenWindowController toggleSceneDimming]):
(-[WKFullScreenWindowController _prefersSceneDimming]): Deleted.
(-[WKFullScreenWindowController toggleDimming]): Deleted.

Canonical link: <a href="https://commits.webkit.org/266892@main">https://commits.webkit.org/266892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/954b48c43821ac7b7b7c2dd51958a7fb1993710d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15451 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17531 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20533 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12884 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16976 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14303 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12102 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15243 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13582 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3627 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17919 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15475 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14142 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3699 "Passed tests") | 
<!--EWS-Status-Bubble-End-->