### PR TITLE
[iOS] Avoid leaving the data owner `Undefined` when writing to the pasteboard

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1370,7 +1370,7 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (void)translate:(NSString *)text fromRect:(CGRect)presentationRect;
 @end
 
- @interface UIColor (IPI)
+@interface UIColor (IPI)
 + (UIColor *)insertionPointColor;
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -26,9 +26,11 @@
 #import "WKWebViewInternal.h"
 #import "_WKTapHandlingResult.h"
 
-@class UIScrollEvent;
-
 #if PLATFORM(IOS_FAMILY)
+
+#import "UIKitSPI.h"
+
+@class UIScrollEvent;
 
 namespace WebKit {
 enum class TapHandlingResult : uint8_t;
@@ -156,6 +158,8 @@ enum class TapHandlingResult : uint8_t;
 
 - (BOOL)_effectiveAppearanceIsDark;
 - (BOOL)_effectiveUserInterfaceLevelIsElevated;
+
+- (_UIDataOwner)_effectiveDataOwner:(_UIDataOwner)clientSuppliedDataOwner;
 
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
 - (void)_beginLiveResize;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -38,7 +38,6 @@
 #import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "ScrollingTreeScrollingNodeDelegateIOS.h"
 #import "TapHandlingResult.h"
-#import "UIKitSPI.h"
 #import "UIKitUtilities.h"
 #import "VideoFullscreenManagerProxy.h"
 #import "ViewGestureController.h"
@@ -67,6 +66,7 @@
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/UserInterfaceLayoutDirection.h>
+#import <pal/ios/ManagedConfigurationSoftLink.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <wtf/BlockPtr.h>
@@ -3212,6 +3212,28 @@ static bool isLockdownModeWarningNeeded()
 {
 }
 #endif
+
+- (_UIDataOwner)_effectiveDataOwner:(_UIDataOwner)clientSuppliedDataOwner
+{
+    auto isCurrentURLManaged = [&] {
+#if PLATFORM(MACCATALYST)
+        return NO;
+#else
+        return [[PAL::getMCProfileConnectionClass() sharedConnection] isURLManaged:self.URL];
+#endif
+    };
+
+    switch (clientSuppliedDataOwner) {
+    case _UIDataOwnerUndefined:
+        return isCurrentURLManaged() ? _UIDataOwnerEnterprise : _UIDataOwnerUser;
+    case _UIDataOwnerUser:
+    case _UIDataOwnerEnterprise:
+    case _UIDataOwnerShared:
+        return clientSuppliedDataOwner;
+    }
+    ASSERT_NOT_REACHED();
+    return _UIDataOwnerUndefined;
+}
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8654,26 +8654,8 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
 
 - (WebCore::DataOwnerType)_dataOwnerForPasteboard:(WebKit::PasteboardAccessIntent)intent
 {
-    auto specifiedType = [&] {
-        if (intent == WebKit::PasteboardAccessIntent::Read)
-            return coreDataOwnerType(self._dataOwnerForPaste);
-
-        if (intent == WebKit::PasteboardAccessIntent::Write)
-            return coreDataOwnerType(self._dataOwnerForCopy);
-
-        ASSERT_NOT_REACHED();
-        return WebCore::DataOwnerType::Undefined;
-    }();
-
-    if (specifiedType != WebCore::DataOwnerType::Undefined)
-        return specifiedType;
-
-#if !PLATFORM(MACCATALYST)
-    if ([[PAL::getMCProfileConnectionClass() sharedConnection] isURLManaged:[_webView URL]])
-        return WebCore::DataOwnerType::Enterprise;
-#endif
-
-    return WebCore::DataOwnerType::Undefined;
+    auto clientSuppliedDataOwner = intent == WebKit::PasteboardAccessIntent::Read ? self._dataOwnerForPaste : self._dataOwnerForCopy;
+    return coreDataOwnerType([_webView _effectiveDataOwner:clientSuppliedDataOwner]);
 }
 
 - (RetainPtr<WKTargetedPreviewContainer>)_createPreviewContainerWithLayerName:(NSString *)layerName
@@ -10732,8 +10714,13 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 - (void)_writePromisedAttachmentToPasteboard:(WebCore::PromisedAttachmentInfo&&)info
 {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-    if (auto item = createItemProvider(*_page, WTFMove(info)))
+    auto item = createItemProvider(*_page, WTFMove(info));
+    if (!item)
+        return;
+
+    [UIPasteboard _performAsDataOwner:[_webView _effectiveDataOwner:self._dataOwnerForCopy] block:^{
         UIPasteboard.generalPasteboard.itemProviders = @[ item.get() ];
+    }];
 #else
     UNUSED_PARAM(info);
 #endif

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -651,7 +651,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     };
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    [UIPasteboard generalPasteboard].items = @[ representations ];
+    [UIPasteboard _performAsDataOwner:[_webView _effectiveDataOwner:self._dataOwnerForCopy] block:^{
+        UIPasteboard.generalPasteboard.items = @[ representations ];
+    }];
 }
 
 - (void)actionSheetAssistant:(WKActionSheetAssistant *)assistant openElementAtLocation:(CGPoint)location

--- a/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
@@ -471,6 +471,20 @@ TEST(UIPasteboardTests, PerformAsDataOwnerWithManagedURL)
         [destination waitForNextPresentationUpdate];
         EXPECT_EQ(gLastKnownDataOwner, _UIDataOwnerUser);
     }
+    {
+        auto destination = setUpWebViewForPasteboardTests(@"simple2");
+        [destination _setDataOwnerForPaste:_UIDataOwnerUndefined];
+        [destination paste:nil];
+        [destination waitForNextPresentationUpdate];
+        EXPECT_EQ(gLastKnownDataOwner, _UIDataOwnerUser);
+    }
+    {
+        auto destination = setUpWebViewForPasteboardTests(@"simple");
+        [destination _setDataOwnerForPaste:_UIDataOwnerShared];
+        [destination paste:nil];
+        [destination waitForNextPresentationUpdate];
+        EXPECT_EQ(gLastKnownDataOwner, _UIDataOwnerShared);
+    }
 }
 
 #endif // PLATFORM(IOS) || PLATFORM(VISION)


### PR DESCRIPTION
#### 92e85e0ddd90ada507c1fd80541785adae91dd46
<pre>
[iOS] Avoid leaving the data owner `Undefined` when writing to the pasteboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=260171">https://bugs.webkit.org/show_bug.cgi?id=260171</a>
rdar://113107334

Reviewed by Aditya Keerthi.

Instead of passing in `_UIDataOwnerUndefined` when copying or pasting web content, explicitly use
`_UIDataOwnerUser` when the current domain is not managed (unless the client has already set one of
the other data owner flags on the web view). This makes it explicit that the copied/pasted data is
unmanaged, and also avoids a fault message in pasteboard code, which would otherwise have security
implications.

Added new API test cases: UIPasteboardTests.PerformAsDataOwnerWithManagedURL

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _effectiveDataOwner:]):

Add a helper method to take a client supplied data owner value, and either return it (if defined) or
fall back to checking against `-[MCProfileConnection isManagedURL:]`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _dataOwnerForPasteboard:]):
(-[WKContentView _writePromisedAttachmentToPasteboard:]):
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView actionSheetAssistant:performAction:]):

Patch a couple of places where we currently write to the pasteboard outside of the context of any
data owner in WebKit.

* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:
(TestWebKitAPI::TEST):

Add a couple of API tests to verify that:
1.  An unmanaged domain results in `_UIDataOwnerUser` by default.
2.  In a managed domain, if the client explicitly sets a `_UIDataOwner` type that&apos;s not undefined,
    we&apos;ll use that instead of `_UIDataOwnerEnterprise`.

Canonical link: <a href="https://commits.webkit.org/266894@main">https://commits.webkit.org/266894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2f8727ac92fd47ab78de8b177851c6c01a5d3c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16822 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15712 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17551 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16995 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13600 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3629 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->