### PR TITLE
[GPU Process] Allow replaying back a whole DisplayList in GPU Process

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -28,6 +28,7 @@
 
 #include "BidiResolver.h"
 #include "DecomposedGlyphs.h"
+#include "DisplayListReplayer.h"
 #include "Filter.h"
 #include "FilterImage.h"
 #include "FloatRoundedRect.h"
@@ -197,6 +198,13 @@ void GraphicsContext::drawBidiText(const FontCascade& font, const TextRun& run, 
     }
 
     bidiRuns.clear();
+}
+
+void GraphicsContext::drawDisplayListItems(const Vector<DisplayList::Item>& items, const DisplayList::ResourceHeap& resourceHeap, const FloatPoint& destination)
+{
+    translate(destination);
+    DisplayList::Replayer(*this, items, resourceHeap).replay();
+    translate(-destination);
 }
 
 static IntSize scaledImageBufferSize(const FloatSize& size, const FloatSize& scale)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -29,6 +29,7 @@
 #include "ControlPart.h"
 #include "DashArray.h"
 #include "DestinationColorSpace.h"
+#include "DisplayListItem.h"
 #include "FloatRect.h"
 #include "FontCascade.h"
 #include "GraphicsContextState.h"
@@ -62,6 +63,7 @@ class VideoFrame;
 
 namespace DisplayList {
 class DrawNativeImage;
+class ResourceHeap;
 }
 
 class GraphicsContext {
@@ -312,6 +314,9 @@ public:
     WEBCORE_EXPORT void drawLineForText(const FloatRect&, bool printing, bool doubleLines = false, StrokeStyle = StrokeStyle::SolidStroke);
     virtual void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines = false, StrokeStyle = StrokeStyle::SolidStroke) = 0;
     virtual void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) = 0;
+
+    // DisplayList
+    WEBCORE_EXPORT virtual void drawDisplayListItems(const Vector<DisplayList::Item>&, const DisplayList::ResourceHeap&, const FloatPoint& destination);
 
     // Transparency Layers
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -152,6 +152,9 @@ ApplyItemResult applyItem(GraphicsContext& context, const ResourceHeap& resource
             if (auto missingCachedResourceIdentifier = applyDrawDecomposedGlyphs(context, resourceHeap, item))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };
             return { };
+        }, [&](const DrawDisplayListItems& item) -> ApplyItemResult {
+            item.apply(context, resourceHeap);
+            return { };
         }, [&](const DrawImageBuffer& item) -> ApplyItemResult {
             if (auto missingCachedResourceIdentifier = applyImageBufferItem(context, resourceHeap, item))
                 return { StopReplayReason::MissingCachedResource, WTFMove(missingCachedResourceIdentifier) };

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -61,6 +61,7 @@ class DrawFocusRingPath;
 class DrawFocusRingRects;
 class DrawGlyphs;
 class DrawDecomposedGlyphs;
+class DrawDisplayListItems;
 class DrawImageBuffer;
 class DrawLine;
 class DrawLinesForText;
@@ -136,6 +137,7 @@ using Item = std::variant
     , DrawFocusRingRects
     , DrawGlyphs
     , DrawDecomposedGlyphs
+    , DrawDisplayListItems
     , DrawImageBuffer
     , DrawLine
     , DrawLinesForText

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -327,6 +327,34 @@ void DrawDecomposedGlyphs::dump(TextStream& ts, OptionSet<AsTextFlag> flags) con
     }
 }
 
+DrawDisplayListItems::DrawDisplayListItems(const Vector<Item>& items, const FloatPoint& destination)
+    : m_items(items)
+    , m_destination(destination)
+{
+}
+
+DrawDisplayListItems::DrawDisplayListItems(Vector<Item>&& items, const FloatPoint& destination)
+    : m_items(WTFMove(items))
+    , m_destination(destination)
+{
+}
+
+void DrawDisplayListItems::apply(GraphicsContext& context, const ResourceHeap& resourceHeap) const
+{
+    context.drawDisplayListItems(m_items, resourceHeap, m_destination);
+}
+
+NO_RETURN_DUE_TO_ASSERT void DrawDisplayListItems::apply(GraphicsContext&) const
+{
+    ASSERT_NOT_REACHED();
+}
+
+void DrawDisplayListItems::dump(TextStream& ts, OptionSet<AsTextFlag>) const
+{
+    ts << items();
+    ts.dumpProperty("destination", destination());
+}
+
 void DrawImageBuffer::apply(GraphicsContext& context, WebCore::ImageBuffer& imageBuffer) const
 {
     context.drawImageBuffer(imageBuffer, m_destinationRect, m_srcRect, m_options);
@@ -662,8 +690,8 @@ void FillEllipse::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 }
 
 #if ENABLE(VIDEO)
-PaintFrameForMedia::PaintFrameForMedia(MediaPlayer& player, const FloatRect& destination)
-    : m_identifier(player.identifier())
+PaintFrameForMedia::PaintFrameForMedia(MediaPlayerIdentifier identifier, const FloatRect& destination)
+    : m_identifier(identifier)
     , m_destination(destination)
 {
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -144,6 +144,8 @@ protected:
 
     virtual void recordDrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) = 0;
 
+    virtual void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) = 0;
+
 #if USE(CG)
     virtual void recordApplyStrokePattern() = 0;
     virtual void recordApplyFillPattern() = 0;
@@ -231,6 +233,8 @@ private:
     WEBCORE_EXPORT void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
     WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
+
+    WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, const FloatPoint& destination) final;
 
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "DisplayListRecorder.h"
+#include "DisplayListRecorderImpl.h"
 
 #include "DisplayList.h"
 #include "DisplayListDrawingContext.h"
@@ -187,6 +187,11 @@ void RecorderImpl::recordDrawDecomposedGlyphs(const Font& font, const Decomposed
     append(DrawDecomposedGlyphs(font.renderingResourceIdentifier(), decomposedGlyphs.renderingResourceIdentifier()));
 }
 
+void RecorderImpl::recordDrawDisplayListItems(const Vector<Item>& items, const FloatPoint& destination)
+{
+    append(DrawDisplayListItems(items, destination));
+}
+
 void RecorderImpl::recordDrawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     append(DrawImageBuffer(imageBuffer.renderingResourceIdentifier(), destRect, srcRect, options));
@@ -329,7 +334,7 @@ void RecorderImpl::recordFillEllipse(const FloatRect& rect)
 #if ENABLE(VIDEO)
 void RecorderImpl::recordPaintFrameForMedia(MediaPlayer& player, const FloatRect& destination)
 {
-    append(PaintFrameForMedia(player, destination));
+    append(PaintFrameForMedia(player.identifier(), destination));
 }
 
 void RecorderImpl::recordPaintVideoFrame(VideoFrame&, const FloatRect&, bool /* shouldDiscardAlpha */)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -113,6 +113,7 @@ private:
     void recordStrokeEllipse(const FloatRect&) final;
     void recordClearRect(const FloatRect&) final;
     void recordDrawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
+    void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) final;
 #if USE(CG)
     void recordApplyStrokePattern() final;
     void recordApplyFillPattern() final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h
@@ -25,7 +25,8 @@
 
 #pragma once
 
-#include "DisplayListItems.h"
+#include "DisplayList.h"
+#include "DisplayListItem.h"
 #include <wtf/Noncopyable.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -121,10 +121,7 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
         m_context.drawText(font, textRun, textOrigin, startOffset, endOffset);
     else {
         // Replaying back a whole cached glyph run to the GraphicsContext.
-        m_context.translate(textOrigin);
-        DisplayList::Replayer replayer(m_context, *m_glyphDisplayList);
-        replayer.replay();
-        m_context.translate(-textOrigin);
+        m_context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), textOrigin);
     }
     m_glyphDisplayList = nullptr;
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -324,6 +324,11 @@ void RemoteDisplayListRecorder::drawDecomposedGlyphs(RenderingResourceIdentifier
     handleItem(DisplayList::DrawDecomposedGlyphs(fontIdentifier, decomposedGlyphsIdentifier), *font, *decomposedGlyphs);
 }
 
+void RemoteDisplayListRecorder::drawDisplayListItems(Vector<WebCore::DisplayList::Item>&& items, const FloatPoint& destination)
+{
+    handleItem(DisplayList::DrawDisplayListItems(WTFMove(items), destination), resourceCache().resourceHeap());
+}
+
 void RemoteDisplayListRecorder::drawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     RefPtr sourceImage = imageBuffer(imageBufferIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -80,6 +80,7 @@ public:
     void resetClip();
     void drawGlyphs(WebCore::DisplayList::DrawGlyphs&&);
     void drawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier);
+    void drawDisplayListItems(Vector<WebCore::DisplayList::Item>&&, const WebCore::FloatPoint& destination);
     void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, Ref<WebCore::Filter>);
     void drawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);
     void drawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatSize& imageSize, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -48,6 +48,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     ResetClip()
     DrawGlyphs(WebCore::DisplayList::DrawGlyphs item)
     DrawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier)
+    DrawDisplayListItems(Vector<WebCore::DisplayList::Item> items, WebCore::FloatPoint destination)
     DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter)
     DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
     DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatSize imageSize, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -48,6 +48,8 @@ public:
     void cacheFilter(Ref<WebCore::Filter>&&);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
 
+    const WebCore::DisplayList::ResourceHeap& resourceHeap() const { return m_resourceHeap; }
+
     RefPtr<WebCore::NativeImage> cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
     RefPtr<WebCore::Font> cachedFont(WebCore::RenderingResourceIdentifier) const;
     RefPtr<WebCore::DecomposedGlyphs> cachedDecomposedGlyphs(WebCore::RenderingResourceIdentifier) const;

--- a/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
@@ -20,15 +20,88 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+headers: <WebCore/DisplayListItem.h>
 headers: <WebCore/DisplayListItems.h>
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::Save {
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::Restore {
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::Translate {
+    float x();
+    float y();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::Rotate {
+    float angle();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::Scale {
+    WebCore::FloatSize amount();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetCTM {
+    WebCore::AffineTransform transform();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ConcatenateCTM {
+    WebCore::AffineTransform transform();
+};
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetState {
     WebCore::GraphicsContextState state();
 };
 
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineFillColor {
+    WebCore::PackedColor::RGBA colorData()
+}
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetInlineStroke {
+    std::optional<WebCore::PackedColor::RGBA> colorData();
+    std::optional<float> thickness();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetLineCap {
+    WebCore::LineCap lineCap();
+};
+
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetLineDash {
     WebCore::DashArray dashArray();
     float dashOffset();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetLineJoin {
+    WebCore::LineJoin lineJoin();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::SetMiterLimit {
+    float miterLimit();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClearDropShadow {
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::Clip {
+    WebCore::FloatRect rect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipRoundedRect {
+    WebCore::FloatRoundedRect rect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipOut {
+    WebCore::FloatRect rect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipOutRoundedRect {
+    WebCore::FloatRoundedRect rect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipToImageBuffer {
+    WebCore::RenderingResourceIdentifier imageBufferIdentifier();
+    WebCore::FloatRect destinationRect();
 };
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClipOutToPath {
@@ -40,14 +113,75 @@ headers: <WebCore/DisplayListItems.h>
     WebCore::WindRule windRule();
 };
 
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ResetClip {
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawFilteredImageBuffer {
+    std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier();
+    WebCore::FloatRect sourceImageRect();
+    Ref<WebCore::Filter> filter();
+};
+
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawGlyphs {
     WebCore::RenderingResourceIdentifier fontIdentifier();
     WebCore::PositionedGlyphs positionedGlyphs();
 };
 
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawDecomposedGlyphs {
+    WebCore::RenderingResourceIdentifier fontIdentifier();
+    WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawDisplayListItems {
+    Vector<WebCore::DisplayList::Item> items();
+    WebCore::FloatPoint destination();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawImageBuffer {
+    WebCore::RenderingResourceIdentifier imageBufferIdentifier();
+    WebCore::FloatRect destinationRect();
+    WebCore::FloatRect source();
+    WebCore::ImagePaintingOptions options();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawNativeImage {
+    WebCore::RenderingResourceIdentifier imageIdentifier();
+    WebCore::FloatSize imageSize();
+    WebCore::FloatRect destinationRect();
+    WebCore::FloatRect source();
+    WebCore::ImagePaintingOptions options();
+};
+
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawSystemImage {
     Ref<WebCore::SystemImage> systemImage();
     WebCore::FloatRect destinationRect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawLine {
+    WebCore::FloatPoint point1();
+    WebCore::FloatPoint point2();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawPattern {
+    WebCore::RenderingResourceIdentifier imageIdentifier();
+    WebCore::FloatRect destRect();
+    WebCore::FloatRect tileRect();
+    WebCore::AffineTransform patternTransform();
+    WebCore::FloatPoint phase();
+    WebCore::FloatSize spacing();
+    WebCore::ImagePaintingOptions options();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::BeginTransparencyLayer {
+    float opacity();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::EndTransparencyLayer {
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawRect {
+    WebCore::FloatRect rect();
+    float borderThickness();
 };
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawLinesForText {
@@ -58,6 +192,10 @@ headers: <WebCore/DisplayListItems.h>
     bool isPrinting();
     bool doubleLines();
     WebCore::StrokeStyle style();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawEllipse {
+    WebCore::FloatRect rect();
 };
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawPath {
@@ -77,6 +215,10 @@ headers: <WebCore/DisplayListItems.h>
     WebCore::Color color();
 };
 
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRect {
+    WebCore::FloatRect rect();
+};
+
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRectWithColor {
     WebCore::FloatRect rect();
     WebCore::Color color();
@@ -94,22 +236,118 @@ headers: <WebCore/DisplayListItems.h>
     WebCore::BlendMode blendMode();
 };
 
-[CustomHeader] class WebCore::DisplayList::FillRoundedRect {
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRoundedRect {
     WebCore::FloatRoundedRect roundedRect();
     WebCore::Color color();
     WebCore::BlendMode blendMode();
 };
 
-[CustomHeader] class WebCore::DisplayList::FillRectWithRoundedHole {
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRectWithRoundedHole {
     WebCore::FloatRect rect();
     WebCore::FloatRoundedRect roundedHoleRect();
     WebCore::Color color();
 };
 
-[CustomHeader] class WebCore::DisplayList::FillPath {
+#if ENABLE(INLINE_PATH_DATA)
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillLine {
+    WebCore::PathDataLine line();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillArc {
+    WebCore::PathArc arc();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillQuadCurve {
+    WebCore::PathDataQuadCurve quadCurve();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillBezierCurve {
+    WebCore::PathDataBezierCurve bezierCurve();
+};
+
+#endif // ENABLE(INLINE_PATH_DATA)
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillPathSegment {
+    WebCore::PathSegment segment();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillPath {
     WebCore::Path path();
 };
 
-[CustomHeader] class WebCore::DisplayList::StrokePath {
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillEllipse {
+    WebCore::FloatRect rect();
+};
+
+#if ENABLE(VIDEO)
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::PaintFrameForMedia {
+    WebCore::MediaPlayerIdentifier identifier();
+    WebCore::FloatRect destination();
+};
+
+#endif
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokeRect {
+    WebCore::FloatRect rect();
+    float lineWidth();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokeLine {
+    WebCore::FloatPoint start();
+    WebCore::FloatPoint end();
+};
+
+#if ENABLE(INLINE_PATH_DATA)
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokeArc {
+    WebCore::PathArc arc();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokeQuadCurve {
+    WebCore::PathDataQuadCurve quadCurve();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokeBezierCurve {
+    WebCore::PathDataBezierCurve bezierCurve();
+};
+
+#endif // ENABLE(INLINE_PATH_DATA)
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokePathSegment {
+    WebCore::PathSegment segment();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokePath {
     WebCore::Path path();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::StrokeEllipse {
+    WebCore::FloatRect rect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ClearRect {
+    WebCore::FloatRect rect();
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawControlPart {
+    Ref<WebCore::ControlPart> part();
+    WebCore::FloatRoundedRect borderRect();
+    float deviceScaleFactor();
+    WebCore::ControlStyle style();
+};
+
+#if USE(CG)
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ApplyStrokePattern {
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ApplyFillPattern {
+};
+
+#endif
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::ApplyDeviceScaleFactor {
+    float scaleFactor();
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1821,16 +1821,6 @@ struct WebCore::ViewportArguments {
 };
 #endif // ENABLE(META_VIEWPORT)
 
-header: <WebCore/DisplayListItems.h>
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineFillColor {
-    WebCore::PackedColor::RGBA colorData()
-}
-
-[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineStroke {
-    std::optional<WebCore::PackedColor::RGBA> colorData()
-    std::optional<float> thickness()
-}
-
 header: <WebCore/HTTPHeaderMap.h>
 [Nested, CustomHeader] struct WebCore::HTTPHeaderMap::CommonHeader {
     WebCore::HTTPHeaderName key;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -221,6 +221,11 @@ void RemoteDisplayListRecorderProxy::recordDrawDecomposedGlyphs(const Font& font
     send(Messages::RemoteDisplayListRecorder::DrawDecomposedGlyphs(font.renderingResourceIdentifier(), decomposedGlyphs.renderingResourceIdentifier()));
 }
 
+void RemoteDisplayListRecorderProxy::recordDrawDisplayListItems(const Vector<DisplayList::Item>& items, const FloatPoint& destination)
+{
+    send(Messages::RemoteDisplayListRecorder::DrawDisplayListItems(items, destination));
+}
+
 void RemoteDisplayListRecorderProxy::recordDrawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     send(Messages::RemoteDisplayListRecorder::DrawImageBuffer(imageBuffer.renderingResourceIdentifier(), destRect, srcRect, options));

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -84,6 +84,7 @@ private:
     void recordDrawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
     void recordDrawGlyphs(const WebCore::Font&, const WebCore::GlyphBufferGlyph*, const WebCore::GlyphBufferAdvance*, unsigned count, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) final;
+    void recordDrawDisplayListItems(const Vector<WebCore::DisplayList::Item>&, const WebCore::FloatPoint& destination);
     void recordDrawImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatSize& imageSize, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawSystemImage(WebCore::SystemImage&, const WebCore::FloatRect&);


### PR DESCRIPTION
#### c708ae60f9fa9abf1d383d35fccb149786f50a54
<pre>
[GPU Process] Allow replaying back a whole DisplayList in GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=260181">https://bugs.webkit.org/show_bug.cgi?id=260181</a>
<a href="https://rdar.apple.com/113878782">rdar://113878782</a>

Reviewed by Cameron McCormack.

Add a new DisplayList item called DrawDisplayListItems. Add the needed functions
for recording it and replaying it back. The ResourceHeap will not be stored in
this item. Instead it will be passed as an extra argument to its apply() method.

Add the new method GraphicsContext::drawDisplayListItems() which draws a DisplayList
given ResourceHeap and a destination point.

In Recorder::drawDisplayListItems() record the use all the ResourceHeap resources
and then call recordDrawDisplayListItems().

In RecorderImpl::recordDrawDisplayListItems(), add the item DrawDisplayListItems
to the recording DisplayList.

In RemoteDisplayListRecorderProxy::recordDrawDisplayListItems(), send the message
RemoteDisplayListRecorder.DrawDisplayListItem to GPUProcess.

In RemoteDisplayListRecorder::drawDisplayListItems(), create a DrawDisplayListItems
item given the received DisplayList. Then call its apply() method given the
ResourceHeap of the RemoteResourceCache.

TextPainter will call GraphicsContext::drawDisplayListItems() instead of replaying
the cached DisplayList back.

All DisplayList items have to have ArgumentCoders because DrawDisplayListItems
includes a Vector of DisplayListItem which is a std::variant of all the items.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawDisplayListItems):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawDisplayListItems::DrawDisplayListItems):
(WebCore::DisplayList::DrawDisplayListItems::apply const):
(WebCore::DisplayList::DrawDisplayListItems::dump const):
(WebCore::DisplayList::PaintFrameForMedia::PaintFrameForMedia):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::DrawFilteredImageBuffer::filter const):
(WebCore::DisplayList::DrawDisplayListItems::items const):
(WebCore::DisplayList::DrawDisplayListItems::destination const):
(WebCore::DisplayList::DrawNativeImage::imageSize const):
(WebCore::DisplayList::DrawNativeImage::source const):
(WebCore::DisplayList::DrawNativeImage::options const):
(WebCore::DisplayList::DrawPattern::options const):
(WebCore::DisplayList::FillLine::line const):
(WebCore::DisplayList::FillArc::arc const):
(WebCore::DisplayList::FillQuadCurve::quadCurve const):
(WebCore::DisplayList::FillBezierCurve::bezierCurve const):
(WebCore::DisplayList::FillPathSegment::segment const):
(WebCore::DisplayList::PaintFrameForMedia::destination const):
(WebCore::DisplayList::StrokeArc::arc const):
(WebCore::DisplayList::StrokeQuadCurve::quadCurve const):
(WebCore::DisplayList::StrokeBezierCurve::bezierCurve const):
(WebCore::DisplayList::StrokePathSegment::segment const):
(WebCore::DisplayList::DrawControlPart::part const):
(WebCore::DisplayList::DrawControlPart::type const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawDisplayListItems):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordDrawDisplayListItems):
(WebCore::DisplayList::RecorderImpl::recordPaintFrameForMedia):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.h:
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextOrEmphasisMarks):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawDisplayListItems):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
(WebKit::RemoteResourceCache::resourceHeap const):
* Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordDrawDisplayListItems):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Canonical link: <a href="https://commits.webkit.org/270688@main">https://commits.webkit.org/270688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69bc3ea8195e63c562d7a9b95d2bc6757c6ffaf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28753 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29464 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27348 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4605 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6283 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->