### PR TITLE
[webkitbugspy] Set keywords on issues

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.13.3',
+    version='0.14.0',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 13, 3)
+version = Version(0, 14, 0)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -341,7 +341,7 @@ class Tracker(GenericTracker):
 
         return issue
 
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, **properties):
         update_dict = dict()
 
         if properties:
@@ -400,6 +400,9 @@ class Tracker(GenericTracker):
             update_dict['component'] = component
             update_dict['version'] = version
 
+        if keywords is not None:
+            update_dict['keywords'] = dict(set=keywords)
+
         if update_dict:
             update_dict['ids'] = [issue.id]
             response = None
@@ -420,10 +423,13 @@ class Tracker(GenericTracker):
                     issue._opened = None
                 sys.stderr.write("Failed to modify '{}'\n".format(issue))
                 return None
-            elif project and component and version:
+
+            if project and component and version:
                 issue._project = project
                 issue._component = component
                 issue._version = version
+            if keywords is not None:
+                issue._keywords = keywords
 
         return issue
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -211,6 +211,9 @@ class Issue(object):
             self.tracker.populate(self, 'keywords')
         return self._keywords
 
+    def set_keywords(self, keywords):
+        return self.tracker.set(self, keywords=keywords)
+
     @property
     def classification(self):
         if self._classification is None:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -159,6 +159,14 @@ class Bugzilla(Base, mocks.Requests):
             if data.get('version'):
                 issue['version'] = data['version']
 
+            keywords = data.get('keywords', {})
+            if keywords:
+                assert len(keywords) == 1
+                if keywords.get('set'):
+                    issue['keywords'] = keywords.get('set')
+                elif keywords.get('add'):
+                    issue['keywords'] = issue.get('keywords', []) + keywords.get('add')
+
             if not issue.get('watchers', None):
                 issue['watchers'] = []
             for candidate in data.get('cc', {}).get('add', []):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -572,3 +572,21 @@ What component in 'WebKit' should the bug be associated with?:
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = bugzilla.Tracker(self.URL)
             self.assertEqual(tracker.issue(1).classification, '')
+
+    def test_set_keywords(self):
+        with OutputCapture(level=logging.INFO), mocks.Bugzilla(
+            self.URL.split('://')[1],
+            projects=mocks.PROJECTS,
+            environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ), users=mocks.USERS, issues=mocks.ISSUES,
+        ):
+
+            tracker = bugzilla.Tracker(self.URL)
+            issue = tracker.issue(1)
+
+            self.assertEqual(issue.keywords, ['Keyword A'])
+            issue.set_keywords(['REGRESSION'])
+            self.assertEqual(issue.keywords, ['REGRESSION'])
+            self.assertEqual(tracker.issue(1).keywords, ['REGRESSION'])

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -448,3 +448,13 @@ What version of 'WebKit Text' should the bug be associated with?:
                 '<original text - begin>\n\n'
                 'An example issue for testing',
             )
+
+    def test_set_keywords(self):
+        with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            tracker = radar.Tracker()
+            issue = tracker.issue(1)
+
+            self.assertEqual(issue.keywords, ['Keyword A'])
+            issue.set_keywords(['Keyword B'])
+            self.assertEqual(issue.keywords, ['Keyword B'])
+            self.assertEqual(tracker.issue(1).keywords, ['Keyword B'])


### PR DESCRIPTION
#### 9c049cef55a9dd9b034e7fbc5213ff3117b59fe0
<pre>
[webkitbugspy] Set keywords on issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=260184">https://bugs.webkit.org/show_bug.cgi?id=260184</a>
<a href="https://rdar.apple.com/113880142">rdar://113880142</a>

Reviewed by Dewei Zhu.

Tools and services should be able to add and remove keywords from
radars and bugzillas.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.set): Add ability to set keywords.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.set_keywords): Set keywords in tracker implementation.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue): Mock adding and setting keywords.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.keywords): Pull from pre-constructed Keyword objects.
(RadarModel.remove_keyword): Remove a keyword from the issue.
(RadarModel.add_keyword): Add a keyword to the issue.
(RadarClient.keywords_for_name): List all keywords starting with a given string.
(Radar.__init__): Construct set of available keywords.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.__init__): Keep track of previously queries keywords.
(Tracker.set): Add and remove keywords from a radar.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:

Canonical link: <a href="https://commits.webkit.org/270193@main">https://commits.webkit.org/270193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05ae006d2f9c6cd816ac5b61dbddda09baf0fd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26941 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25091 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/5050 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25067 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/5050 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/21429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27524 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24987 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/5050 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/22360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/5050 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/22706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/26338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2055 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2505 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3164 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/2406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->