### PR TITLE
deadline-max-rAF.html fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-expected.txt
@@ -3,5 +3,5 @@ Test of requestIdleCallback deadline behavior
 The test can pass accidentally as idle deadlines have a maximum but they can always be shorter. It runs multiple times to expose potential failures.
 
 
-FAIL Check that the deadline is less than 16ms when there is a pending animation frame. assert_less_than_equal: expected a number less than or equal to 16.666666666666668 but got 115
+PASS Check that the deadline is less than 16ms when there is a pending animation frame.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html
@@ -7,12 +7,16 @@
 <script src="resources/ric-utils.js"></script>
 <script>
 
+function runRAFLoop()
+{
+  requestAnimationFrame(runRAFLoop);
+}
+
 promise_test(async done => {
+  runRAFLoop();
   for (let i = 0; i < getRICRetryCount(); ++i) {
-    requestAnimationFrame(() => {})
     assert_less_than_equal(await getDeadlineForNextIdleCallback(), getPendingRenderDeadlineCap())
   }
-
 }, 'Check that the deadline is less than 16ms when there is a pending animation frame.');
 </script>
 <h1>Test of requestIdleCallback deadline behavior</h1>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -167,7 +167,7 @@ storage/filesystemaccess/ [ Pass ]
 requestidlecallback [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback [ Pass ]
 imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html [ Pass Failure ]
-http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Skip ]
+http/tests/eventloop/idle-callback-not-affected-by-timers-in-cross-origin.html [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update-expected.txt
@@ -1,0 +1,11 @@
+This tests that the deadline can be reached.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS idleDeadline.timeRemaining() <= preferredRenderingUpdateInterval is true
+PASS didRunIdleCallback is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+
+description('This tests that the deadline can be reached.');
+
+jsTestIsAsync = true;
+
+let didRunIdleCallback = false;
+onload = () => {
+    function runRAFLoop() {
+        requestAnimationFrame(runRAFLoop);
+    }
+    runRAFLoop();
+    requestIdleCallback((idleDeadline) => {
+        didRunIdleCallback = true;
+        window.idleDeadline = idleDeadline;
+        window.preferredRenderingUpdateInterval = internals.preferredRenderingUpdateInterval();
+        shouldBeTrue('idleDeadline.timeRemaining() <= preferredRenderingUpdateInterval');
+        if (idleDeadline.timeRemaining() > preferredRenderingUpdateInterval)
+            console.log(idleDeadline.timeRemaining() + ' >'  + preferredRenderingUpdateInterval);
+    });
+    setTimeout(() => {
+        shouldBeTrue('didRunIdleCallback');
+        finishJSTest();
+    }, 200);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/IdleDeadline.cpp
+++ b/Source/WebCore/dom/IdleDeadline.cpp
@@ -38,9 +38,10 @@ DOMHighResTimeStamp IdleDeadline::timeRemaining(Document& document) const
     RefPtr window { document.domWindow() };
     if (!window || m_didTimeout == DidTimeout::Yes)
         return 0;
-    auto duration = document.windowEventLoop().computeIdleDeadline() - MonotonicTime::now();
-    auto remainingTime = window->performance().reduceTimeResolution(duration);
-    return remainingTime < 0_s ? 0 : remainingTime.milliseconds();
+    auto& performance = window->performance();
+    auto now = performance.now();
+    auto deadline = performance.relativeTimeFromTimeOriginInReducedResolution(document.windowEventLoop().computeIdleDeadline() - performance.timeResolution());
+    return deadline < now ? 0 : deadline - now;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -56,9 +56,9 @@ public:
     CustomElementQueue& backupElementQueue();
 
     void didScheduleRenderingUpdate(Page&, MonotonicTime);
-    void didFinishRenderingUpdate(Page&);
+    void didStartRenderingUpdate(Page&);
     void opportunisticallyRunIdleCallbacks();
-    bool shouldEndIdlePeriod();
+    bool shouldEndIdlePeriod(MonotonicTime);
     MonotonicTime computeIdleDeadline();
 
     WEBCORE_EXPORT static void breakToAllowRenderingUpdate();
@@ -71,6 +71,7 @@ private:
     bool isContextThread() const final;
     MicrotaskQueue& microtaskQueue() final;
 
+    std::optional<MonotonicTime> nextRenderingTime() const;
     void didReachTimeToRun();
 
     String m_agentClusterKey;

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -104,6 +104,11 @@ void Performance::allowHighPrecisionTime()
     timePrecision = highTimePrecision;
 }
 
+Seconds Performance::timeResolution()
+{
+    return timePrecision;
+}
+
 DOMHighResTimeStamp Performance::relativeTimeFromTimeOriginInReducedResolution(MonotonicTime timestamp) const
 {
     Seconds seconds = timestamp - m_timeOrigin;

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -107,6 +107,7 @@ public:
     void unregisterPerformanceObserver(PerformanceObserver&);
 
     static void allowHighPrecisionTime();
+    static Seconds timeResolution();
     static Seconds reduceTimeResolution(Seconds);
 
     DOMHighResTimeStamp relativeTimeFromTimeOriginInReducedResolution(MonotonicTime) const;


### PR DESCRIPTION
#### 7090728677dd90e4c86e2fe9764e4c0008e049c2
<pre>
deadline-max-rAF.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=260183">https://bugs.webkit.org/show_bug.cgi?id=260183</a>

Reviewed by Antti Koivisto.

This PR fixes a number of issues to make requestidlecallback/deadline-max-rAF.html pass.

1. Due to rounding errors / loss of precision, IdleDeadline::timeRemaining could return a time
that is off by 1ms or 20us, which ever is currently used for the time precision. We now ensure
this off-by-one-time-unit issue does not affect idle callbacks by always subtracting the same
amount from the remaining time. Since timeRemaining is defined to be an upper cap, this is fine.

2. didFinishRenderingUpdate was erroneously removing Page from m_pagesWithRenderingOpportunity
when the next rendering update has been scheduled within the current rendering update. Moved
the removal of the entry to at the beginning of Page::updateRendering so that subsequent
scheduling of rendering update within this rendering update does not end up getting cleared.

3. shouldEndIdlePeriod would return true whenever m_pagesWithRenderingOpportunity contains any
entry, which would effectively disable idle callbacks when there is any pending rendering update.
We now return true only if the next rendering update is happening within the next 4ms.

Unfortunately, this PR doesn&apos;t remove PASS FAIL expectation from deadline-max-rAF.html because
the test fails intermittently on the stress bots, and adding any logging to help debug the issue
will make the test no longer flaky, not providing means to debug it. Instead, this PR introduces
a new layout test to test the same scenario.

* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF.html:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update-expected.txt: Added.
* LayoutTests/requestidlecallback/requestidlecallback-deadline-cap-by-rendering-update.html: Added.

* Source/WebCore/dom/IdleDeadline.cpp:
(WebCore::IdleDeadline::timeRemaining const): Fixed off-by-one error (1).

* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::didStartRenderingUpdate): Renamed from didFinishRenderingUpdate.
(WebCore::WindowEventLoop::opportunisticallyRunIdleCallbacks):
(WebCore::WindowEventLoop::shouldEndIdlePeriod): Now takes the current timestamp and only returns
true if the next rendering update is happening within the next 4ms instead of whenever (3).
(WebCore::WindowEventLoop::computeIdleDeadline):
(WebCore::WindowEventLoop::nextRenderingTime const): Added.

* Source/WebCore/dom/WindowEventLoop.h:

* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering): Moved the call to didStartRenderingUpdate (previously named
didFinishRenderingUpdate) here so that rendering update scheduled within this rendering update
doesn&apos;t get cleared at the end of the current rendering update (2).
(WebCore::Page::renderingUpdateCompleted):

* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::timeResolution): Added.

* Source/WebCore/page/Performance.h:

Canonical link: <a href="https://commits.webkit.org/267008@main">https://commits.webkit.org/267008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d374ebad028c63c206b24077133397bfae6c9d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17788 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20748 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17223 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12316 "7 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13645 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18156 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1866 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->