### PR TITLE
Positive look-behind RegExp doesn't match in JSC but does match in V8

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -221,4 +221,7 @@ testRegExp(/(?<=a*\1aaaaaaaaaaaaaa)x/, "aaaaaaaaaaaaaax", null, null);
 
 // Test 91
 testRegExp(/(?<=a*\1aaaaaaaaaaaaaa)x/, "\x01aaaaaaaaaaaaaax", ["x"], null);
-
+testRegExp(/(?<=^v?)(?:(?:\d+)\.){2}(?:\d+)|(^v)(?:(?:\d+)\.){2}(?:\d+)/, "v1.0.123", ["v1.0.123", "v"]);
+testRegExp(/(?<=^v?|\sv?)(?:(?:\d+)\.){2}(?:\d+)/, "v1.0.123", ["1.0.123"]);
+testRegExp(/(?<=^v?|\sv?)(?:(?:\d+)\.){2}(?:\d+)/, "Rev v1.0.123", ["1.0.123"]);
+testRegExp(/(?<=(^v|\sv?|Rev)+)(?:(?:\d+)\.){2}(?:\d+)/, "Rev v v1.0.123", ["1.0.123", "Rev"]);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2623,16 +2623,17 @@ public:
 
             if (matchDirection == Forward)
                 countToCheck = minimumSize - parenthesesInputCountAlreadyChecked;
-            else if (minimumSize > parenthesesInputCountAlreadyChecked)
+            else if (minimumSize > parenthesesInputCountAlreadyChecked) {
                 countToCheck = minimumSize - parenthesesInputCountAlreadyChecked;
+                haveCheckedInput(minimumSize);
+            } else if (minimumSize > disjunction->m_minimumSize) {
+                countToCheck = minimumSize - disjunction->m_minimumSize;
+                haveCheckedInput(currentCountAlreadyChecked);
+            }
 
             if (countToCheck) {
                 if (matchDirection == Forward)
                     checkInput(countToCheck);
-                else {
-                    // Check that we have enough input for this alternative.
-                    haveCheckedInput(minimumSize);
-                }
 
                 currentCountAlreadyChecked += countToCheck;
                 if (currentCountAlreadyChecked.hasOverflowed())

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1068,12 +1068,15 @@ public:
 
     void assertionBOL()
     {
-        if (!m_alternative->m_terms.size() && !parenthesisInvert()) {
+        if (!m_alternative->m_terms.size() && !parenthesisInvert() && parenthesisMatchDirection() == Forward) {
             m_alternative->m_startsWithBOL = true;
             m_alternative->m_containsBOL = true;
             m_pattern.m_containsBOL = true;
         }
-        m_alternative->m_terms.append(PatternTerm::BOL());
+
+        auto bolTerm = PatternTerm::BOL();
+        bolTerm.setMatchDirection(parenthesisMatchDirection());
+        m_alternative->m_terms.append(bolTerm);
     }
     void assertionEOL()
     {
@@ -1475,7 +1478,7 @@ public:
         std::unique_ptr<PatternDisjunction> newDisjunction;
         for (unsigned alt = 0; alt < disjunction->m_alternatives.size(); ++alt) {
             PatternAlternative* alternative = disjunction->m_alternatives[alt].get();
-            if (!filterStartsWithBOL || !alternative->m_startsWithBOL) {
+            if (!filterStartsWithBOL || !alternative->m_startsWithBOL || alternative->m_direction == Backward) {
                 if (!newDisjunction) {
                     newDisjunction = makeUnique<PatternDisjunction>();
                     newDisjunction->m_parent = disjunction->m_parent;


### PR DESCRIPTION
#### caa31552bab4d322ec1ced2f059d93f2c2fd45b4
<pre>
Positive look-behind RegExp doesn&apos;t match in JSC but does match in V8
<a href="https://bugs.webkit.org/show_bug.cgi?id=259536">https://bugs.webkit.org/show_bug.cgi?id=259536</a>
rdar://112952197

Reviewed by Yusuke Suzuki.

The reported bug indicated one issue.  We were performing the beginning of line / end of line assertion optimization
on lookbehinds that contain BOL&apos;s / EOL&apos;s.  Given that we match backwards for lookbehinds while doing soft
&quot;do we have enough input&quot; checks, we won&apos;t properly match such an assertion as the BOL assertion optimization
assumes that the BOL is at position 0 and not some prior location in the lookbehind.

After fixing that bug and adding more tests, discovered that we don&apos;t properly handle lookbehinds with alternatives
of different minimum lengths.  We emit a single HaveCheckedInput for the minimum size of the alternation.  Added a
check to emit a HaveCheckedInput for any alternative that had a minimum size larger that the minimum for the whole
alternation.

Updated tests accordingly.

* JSTests/stress/regexp-lookbehind.js:
(testRegExp.v):
(d.v):
(testRegExp.v.sv):
(testRegExp.v.sv.Rev):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::ByteCompiler::emitDisjunction):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::assertionBOL):
(JSC::Yarr::YarrPatternConstructor::copyDisjunction):

Canonical link: <a href="https://commits.webkit.org/266912@main">https://commits.webkit.org/266912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ff639af71c4e1aac3aff51f7894a57d691e2cbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14165 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16791 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17549 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20548 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12899 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16993 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14320 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12118 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15261 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13598 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3893 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17935 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15494 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14158 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3703 "Passed tests") | 
<!--EWS-Status-Bubble-End-->