### PR TITLE
Added color contrast ratio information within Color Picker.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
@@ -108,6 +108,49 @@
     color: var(--glyph-color-active);
 }
 
+.color-picker > .contrast-accessibility-container {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 6px;
+    padding-right: 5px;
+    align-items: center;
+}
+    
+.color-picker > .contrast-accessibility-container a {
+    margin: 0;
+    padding: 0;
+    height: min-content;
+}
+    
+.color-picker > .contrast-accessibility-container > .contrast-rating {
+    display: flex;
+    gap: 5px;
+    font-weight: bold;
+}
+
+.color-picker > .contrast-accessibility-container > .contrast-rating > p {
+    font-size: 10px;
+}
+
+.color-picker > .contrast-accessibility-container > .contrast-rating > .swatches-wrapper {
+    display: flex;
+}
+
+.color-picker > .contrast-accessibility-container > .contrast-rating > .swatches-wrapper > .inline-swatch {
+    --inline-swatch-margin-right-override: 0;
+    --inline-swatch-vertical-align-override: 0;
+}
+    
+.color-picker > .contrast-accessibility-container > .contrast-rating > .swatches-wrapper > .inline-swatch:first-child {
+    z-index: 1;
+    margin-right: -4px;
+}
+
+.color-picker > .contrast-accessibility-container > .contrast-rating > .swatches-wrapper > .inline-swatch:last-child {
+    z-index: 0;
+    margin-top: 4px;
+}
+
 .color-picker > .variable-color-swatches {
     padding: 8px 0 0;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
@@ -328,7 +328,7 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             break;
 
         case WI.InlineSwatch.Type.Color:
-            this._valueEditor = new WI.ColorPicker({preventChangingColorFormats: this._preventChangingColorFormats, colorVariables: this._delegate?.inlineSwatchGetColorVariables?.(this)});
+            this._valueEditor = new WI.ColorPicker({preventChangingColorFormats: this._preventChangingColorFormats, colorVariables: this._delegate?.inlineSwatchGetColorVariables?.(this), contrastObject: this._delegate?.inlineSwatchGetContrastObject?.(this)});
             this._valueEditor.addEventListener(WI.ColorPicker.Event.ColorChanged, this._valueEditorValueDidChange, this);
             break;
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -482,6 +482,22 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
         return this._property.ownerStyle.nodeStyles.computedStyle.variablesForType(WI.CSSStyleDeclaration.VariablesGroupType.Colors);
     }
 
+    inlineSwatchGetContrastObject(inline)
+    {
+        if (!(this.property.name === "color" || this.property.name === "background-color")) {
+            return null;
+        }
+
+        let enabledProperties = this.property.ownerStyle.nodeStyles.computedStyle.enabledProperties;
+        let propertyBackgroundColor = WI.Color.fromString(enabledProperties.find(property => property.name === "background-color")?.value);
+        let propertyForegroundColor = WI.Color.fromString(enabledProperties.find(property => property.name === "color")?.value)
+
+        if (!propertyBackgroundColor || !propertyForegroundColor)
+            return null;
+
+        return {propertyBackgroundColor, propertyForegroundColor, active: this.property.name};
+    }
+
     // Private
 
     _toggle()


### PR DESCRIPTION
#### 5c639fe94ba412de737e7d60bdc6b43a4539b766
<pre>
Added color contrast ratio information within Color Picker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260101">https://bugs.webkit.org/show_bug.cgi?id=260101</a>
rdar://113830664

Reviewed by NOBODY (OOPS!).

Include color contrast ratio based on WCAG 2.1 standards. Display foreground and background colors with swatches. Ratio as well as category are updated within Color Picker.

* Source/WebInspectorUI/UserInterface/Views/ColorPicker.css:
(.color-picker &gt; .contrast-accessibility-container):
(.color-picker &gt; .contrast-accessibility-container a):
(.color-picker &gt; .contrast-accessibility-container &gt; .contrast-rating):
(.color-picker &gt; .contrast-accessibility-container &gt; .contrast-rating &gt; p):
(.color-picker &gt; .contrast-accessibility-container &gt; .contrast-rating &gt; .swatches-wrapper):
(.color-picker &gt; .contrast-accessibility-container &gt; .contrast-rating &gt; .swatches-wrapper &gt; .inline-swatch):
(.color-picker &gt; .contrast-accessibility-container &gt; .contrast-rating &gt; .swatches-wrapper &gt; .inline-swatch:first-child):
(.color-picker &gt; .contrast-accessibility-container &gt; .contrast-rating &gt; .swatches-wrapper &gt; .inline-swatch:last-child):
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:
(WI.ColorPicker.prototype.async colorInputsWrapperElement):
(WI.ColorPicker.accessabilityContrast.getLuminance):
(WI.ColorPicker.accessabilityContrast):
(WI.ColorPicker.prototype.set color):
(WI.ColorPicker.prototype._updateColor):
(WI.ColorPicker.prototype._updateColorContrast):
(WI.ColorPicker):
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype.inlineSwatchGetContrastObject):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c639fe94ba412de737e7d60bdc6b43a4539b766

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14182 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16815 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17570 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20571 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14089 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17021 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12147 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13619 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->