### PR TITLE
[GTK] Test fast/picture/viewport-resize.html only fails under Xvfb

### DIFF
--- a/LayoutTests/fast/picture/resources/resize-test.js
+++ b/LayoutTests/fast/picture/resources/resize-test.js
@@ -54,5 +54,5 @@ function resizeTest(sizes, testFunction)
 
 function standardResizeTest(testFunction)
 {
-    resizeTest([[800, 600], [1200, 600]], testFunction);
+    resizeTest([[800, 600], [900, 600]], testFunction);
 }

--- a/LayoutTests/fast/picture/viewport-resize-expected.txt
+++ b/LayoutTests/fast/picture/viewport-resize-expected.txt
@@ -30,7 +30,7 @@ PASS document.getElementById("empty_srcset").clientWidth is 1600
 PASS currentSrcFileName("empty_srcset") is "image-set-4x.png?3"
 PASS document.getElementById("no_srcset").clientWidth is 1600
 PASS currentSrcFileName("no_srcset") is "image-set-4x.png?3"
-PASS innerWidth is 1200
+PASS innerWidth is 900
 PASS innerHeight is 600
 PASS document.getElementById("simple").clientWidth is 1600
 PASS currentSrcFileName("simple") is "image-set-4x.png?3"

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2167,8 +2167,6 @@ webkit.org/b/163829 svg/W3C-SVG-1.1/fonts-desc-02-t.svg [ Failure ]
 
 webkit.org/b/168188 fast/events/ime-compositionend-on-selection-change.html [ Failure ]
 
-webkit.org/b/168164 fast/picture/viewport-resize.html [ Failure ]
-
 webkit.org/b/168427 fast/scrolling/rtl-scrollbars-listbox.html [ ImageOnlyFailure ]
 webkit.org/b/168427 fast/scrolling/rtl-scrollbars-overflow-contents.html [ ImageOnlyFailure ]
 


### PR DESCRIPTION
#### cdf29532d625c5ffad58e4874dc2bc74919b92ea
<pre>
[GTK] Test fast/picture/viewport-resize.html only fails under Xvfb
<a href="https://bugs.webkit.org/show_bug.cgi?id=168164">https://bugs.webkit.org/show_bug.cgi?id=168164</a>

Unreviewed test gardening.

Previously, this test tried to resize the window to 1200x600 but
the biggest resulution we support when running under Xvfb is 1024x768.

The exact window width is not so important for this test.
It just needs to be wider than 800 pixels.

* LayoutTests/fast/picture/resources/resize-test.js:
(standardResizeTest):
* LayoutTests/fast/picture/viewport-resize-expected.txt:
* LayoutTests/platform/gtk/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/266906@main">https://commits.webkit.org/266906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f63f0ebac1ce0b66001e93f67314e63b4b1ef8c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14187 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17575 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13614 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14343 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12150 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17961 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1823 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->