### PR TITLE
[JHBuild][GTK][WPE] Update libjxl version

### DIFF
--- a/Tools/gtk/jhbuild.modules
+++ b/Tools/gtk/jhbuild.modules
@@ -598,11 +598,10 @@
                     -DJPEGXL_STATIC=OFF
                     -DJPEGXL_WARNINGS_AS_ERRORS=OFF
                     -DJPEGXL_ENABLE_SKCMS=ON">
-    <pkg-config>libjxl.pc</pkg-config>
     <branch module="libjxl/libjxl.git"
-            version="0.6.1"
-            tag="v0.6.1"
-            checkoutdir="libjxl-0.6.1"
+            version="0.8.2"
+            tag="v0.8.2"
+            checkoutdir="libjxl-0.8.2"
             repo="github.com">
       <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
     </branch>

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -247,9 +247,9 @@
                     -DJPEGXL_ENABLE_SKCMS=ON">
     <pkg-config>libjxl.pc</pkg-config>
     <branch module="libjxl/libjxl.git"
-            version="0.6.1"
-            tag="v0.6.1"
-            checkoutdir="libjxl-0.6.1"
+            version="0.7.0"
+            tag="v0.7.0"
+            checkoutdir="libjxl-0.7.0"
             repo="github.com">
       <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
     </branch>

--- a/Tools/wpe/jhbuild.modules
+++ b/Tools/wpe/jhbuild.modules
@@ -346,11 +346,10 @@
                     -DJPEGXL_STATIC=OFF
                     -DJPEGXL_WARNINGS_AS_ERRORS=OFF
                     -DJPEGXL_ENABLE_SKCMS=ON">
-    <pkg-config>libjxl.pc</pkg-config>
     <branch module="libjxl/libjxl.git"
-            version="0.6.1"
-            tag="v0.6.1"
-            checkoutdir="libjxl-0.6.1"
+            version="0.8.2"
+            tag="v0.8.2"
+            checkoutdir="libjxl-0.8.2"
             repo="github.com">
       <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
     </branch>


### PR DESCRIPTION
#### bb423bffda5c6dcfdd7620d76b10906f492d323a
<pre>
[JHBuild][GTK][WPE] Update libjxl version
<a href="https://bugs.webkit.org/show_bug.cgi?id=260197">https://bugs.webkit.org/show_bug.cgi?id=260197</a>

Reviewed by Carlos Garcia Campos.

For the minimal jhbuild update it to the minium version supported (0.7.0)
and for the other modulests to the last stable version as of today (0.8.2)

* Tools/gtk/jhbuild.modules:
* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/wpe/jhbuild.modules:

Canonical link: <a href="https://commits.webkit.org/266902@main">https://commits.webkit.org/266902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9470da915b3c679999e62b5b255ca022106ace27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15278 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17580 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13619 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17031 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13629 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17966 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1819 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->