### PR TITLE
Allow explicit inherit in matched declarations cache

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -671,12 +671,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
             if (current.isInherited())
                 continue;
 
-            // If the property value is explicitly inherited, we need to apply further non-inherited properties
-            // as they might override the value inherited here. For this reason we don't allow declarations with
-            // explicitly inherited properties to be cached.
             auto& value = *current.value();
-            if (isValueID(value, CSSValueInherit))
-                return false;
 
             // The value currentColor has implicitely the same side effect. It depends on the value of color,
             // which is an inherited value, making the non-inherited property implicitly inherited.

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -221,27 +221,33 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
 
             if (m_includedProperties.containsAll(allProperties()))
                 return true;
-            if (m_includedProperties.contains(PropertyType::Inherited) && current.isInherited())
-                return true;
-            if (m_includedProperties.contains(PropertyType::NonInherited) && !current.isInherited())
-                return true;
 
             // If we have applied this property for some reason already we must apply anything that overrides it.
             if (hasProperty(propertyID, *current.value()))
                 return true;
 
-            if (m_includedProperties.contains(PropertyType::VariableReference)) {
-                if (current.value()->hasVariableReferences())
-                    return true;
-                // Apply all deferred properties if we have applied any. They may override the ones we already applied.
-                if (propertyID >= firstDeferredProperty && m_lastIndexForDeferred)
-                    return true;
-            }
             if (m_includedProperties.containsAny({ PropertyType::AfterAnimation, PropertyType::AfterTransition })) {
                 if (shouldApplyAfterAnimation(current)) {
                     m_animationLayer->overriddenProperties.add(propertyID);
                     return true;
                 }
+                return false;
+            }
+
+            if (m_includedProperties.contains(PropertyType::Inherited) && current.isInherited())
+                return true;
+            if (m_includedProperties.contains(PropertyType::ExplicitlyInherited) && isValueID(*current.value(), CSSValueInherit))
+                return true;
+            if (m_includedProperties.contains(PropertyType::NonInherited) && !current.isInherited())
+                return true;
+
+            // Apply all deferred properties if we have applied any. They may override the ones we already applied.
+            if (propertyID >= firstDeferredProperty && m_lastIndexForDeferred)
+                return true;
+
+            if (m_includedProperties.contains(PropertyType::VariableReference)) {
+                if (current.value()->hasVariableReferences())
+                    return true;
             }
 
             return false;

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -42,9 +42,10 @@ public:
     enum class PropertyType : uint8_t {
         NonInherited = 1 << 0,
         Inherited = 1 << 1,
-        VariableReference = 1 << 2,
-        AfterAnimation = 1 << 3,
-        AfterTransition = 1 << 4
+        ExplicitlyInherited = 1 << 2,
+        VariableReference = 1 << 3,
+        AfterAnimation = 1 << 4,
+        AfterTransition = 1 << 5
     };
     static constexpr OptionSet<PropertyType> allProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
 


### PR DESCRIPTION
#### b733d192e11b8379df67740799a87cecaa565a85
<pre>
Allow explicit inherit in matched declarations cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=260199">https://bugs.webkit.org/show_bug.cgi?id=260199</a>
rdar://113902520

Reviewed by Alan Baradlay.

If explicit inherit is involved we just need to apply it on top of the cached value.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):

Check for explicit inherit if needed.

* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::applyMatchedProperties):

Canonical link: <a href="https://commits.webkit.org/266986@main">https://commits.webkit.org/266986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d8d379e77b6d2dabce57cee0e54e093d0140442

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16824 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17583 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20586 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17034 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13632 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3675 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14192 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->