### PR TITLE
[GTK] Send screen properties from UI process to all web processes

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "PlatformScreen.h"
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK)
 
 #include "ScreenProperties.h"
 
@@ -71,4 +71,4 @@ const ScreenData* screenData(PlatformDisplayID screenDisplayID)
 
 } // namespace WebCore
 
-#endif // PLATFORM(COCOA)
+#endif // PLATFORM(COCOA) || PLATFORM(GTK)

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -74,7 +74,6 @@ bool screenHasInvertedColors();
 
 #if USE(GLIB)
 double screenDPI();
-void setScreenDPIObserverHandler(Function<void()>&&, void*);
 #endif
 
 FloatRect screenRect(Widget*);

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -50,6 +50,10 @@ struct ScreenData {
     PlatformGPUID gpuID { 0 };
     DynamicRangeMode preferredDynamicRangeMode { DynamicRangeMode::Standard };
 #endif
+#if PLATFORM(GTK)
+    IntSize screenSize; // In millimeters.
+    double dpi;
+#endif
 
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
     float scaleFactor { 1 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2050,6 +2050,10 @@ header: <WebCore/ScreenProperties.h>
     WebCore::PlatformGPUID gpuID;
     WebCore::DynamicRangeMode preferredDynamicRangeMode;
 #endif
+#if PLATFORM(GTK)
+    WebCore::IntSize screenSize;
+    double dpi;
+#endif
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)
     float scaleFactor;
 #endif

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -42,9 +42,12 @@
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
+#if PLATFORM(COCOA) || PLATFORM(GTK)
+#include <WebCore/ScreenProperties.h>
+#endif
+
 #if PLATFORM(COCOA)
 #include <WebCore/PlatformScreen.h>
-#include <WebCore/ScreenProperties.h>
 #include <wtf/MachSendRight.h>
 #endif
 
@@ -164,6 +167,9 @@ struct WebProcessCreationParameters {
 
 #if PLATFORM(COCOA)
     Vector<String> mediaMIMETypes;
+#endif
+
+#if PLATFORM(COCOA) || PLATFORM(GTK)
     WebCore::ScreenProperties screenProperties;
 #endif
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -116,6 +116,9 @@
 
 #if PLATFORM(COCOA)
     Vector<String> mediaMIMETypes;
+#endif
+
+#if PLATFORM(COCOA) || PLATFORM(GTK)
     WebCore::ScreenProperties screenProperties;
 #endif
 

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -280,6 +280,7 @@ UIProcess/gtk/KeyBindingTranslator.cpp
 UIProcess/gtk/PointerLockManager.cpp @no-unify
 UIProcess/gtk/PointerLockManagerWayland.cpp @no-unify
 UIProcess/gtk/PointerLockManagerX11.cpp @no-unify
+UIProcess/gtk/ScreenManager.cpp @no-unify
 UIProcess/gtk/TextCheckerGtk.cpp @no-unify
 UIProcess/gtk/ViewSnapshotStoreGtk3.cpp @no-unify
 UIProcess/gtk/ViewSnapshotStoreGtk4.cpp @no-unify

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -53,8 +53,9 @@
 #endif
 
 #if PLATFORM(GTK)
-#include "GtkSettingsManager.h"
 #include "AcceleratedBackingStoreDMABuf.h"
+#include "GtkSettingsManager.h"
+#include "ScreenManager.h"
 #endif
 
 
@@ -147,6 +148,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 
 #if PLATFORM(GTK)
     parameters.gtkSettings = GtkSettingsManager::singleton().settingsState();
+    parameters.screenProperties = ScreenManager::singleton().collectScreenProperties();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/gtk/ScreenManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/ScreenManager.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScreenManager.h"
+
+#include "GtkSettingsManager.h"
+#include "WebProcessMessages.h"
+#include "WebProcessPool.h"
+#include <WebCore/GtkUtilities.h>
+#include <WebCore/PlatformScreen.h>
+#include <cmath>
+
+namespace WebKit {
+using namespace WebCore;
+
+ScreenManager& ScreenManager::singleton()
+{
+    static NeverDestroyed<ScreenManager> manager;
+    return manager;
+}
+
+static PlatformDisplayID generatePlatformDisplayID()
+{
+    static PlatformDisplayID id;
+    return ++id;
+}
+
+ScreenManager::ScreenManager()
+{
+    auto* display = gdk_display_get_default();
+#if USE(GTK4)
+    auto* monitors = gdk_display_get_monitors(display);
+    auto monitorsCount = g_list_model_get_n_items(monitors);
+    for (unsigned i = 0; i < monitorsCount; ++i) {
+        auto monitor = adoptGRef(GDK_MONITOR(g_list_model_get_item(monitors, i)));
+        addMonitor(monitor.get());
+    }
+    g_signal_connect(monitors, "items-changed", G_CALLBACK(+[](GListModel* monitors, guint index, guint removedCount, guint addedCount, ScreenManager* manager) {
+        for (unsigned i = 0; i < removedCount; ++i)
+            manager->removeMonitor(manager->m_monitors[index].get());
+        for (unsigned i = 0; i < addedCount; ++i) {
+            auto monitor = adoptGRef(GDK_MONITOR(g_list_model_get_item(monitors, index + i)));
+            manager->addMonitor(monitor.get());
+        }
+        manager->propertiesDidChange();
+    }), this);
+#else
+    auto monitorsCount = gdk_display_get_n_monitors(display);
+    for (int i = 0; i < monitorsCount; ++i) {
+        if (auto* monitor = gdk_display_get_monitor(display, i))
+            addMonitor(monitor);
+    }
+    g_signal_connect(display, "monitor-added", G_CALLBACK(+[](GdkDisplay*, GdkMonitor* monitor, ScreenManager* manager) {
+        manager->addMonitor(monitor);
+        manager->propertiesDidChange();
+    }), this);
+    g_signal_connect(display, "monitor-removed", G_CALLBACK(+[](GdkDisplay*, GdkMonitor* monitor, ScreenManager* manager) {
+        manager->removeMonitor(monitor);
+        manager->propertiesDidChange();
+    }), this);
+#endif
+}
+
+void ScreenManager::addMonitor(GdkMonitor* monitor)
+{
+    m_monitors.append(monitor);
+    m_monitorToDisplayIDMap.add(monitor, generatePlatformDisplayID());
+}
+
+void ScreenManager::removeMonitor(GdkMonitor* monitor)
+{
+    m_monitorToDisplayIDMap.remove(monitor);
+    m_monitors.removeFirstMatching([monitor](const auto& item) {
+        return item.get() == monitor;
+    });
+}
+
+void ScreenManager::propertiesDidChange() const
+{
+    auto properties = collectScreenProperties();
+    for (auto& pool : WebProcessPool::allProcessPools())
+        pool->sendToAllProcesses(Messages::WebProcess::SetScreenProperties(properties));
+}
+
+ScreenProperties ScreenManager::collectScreenProperties() const
+{
+#if USE(GTK4)
+    GdkMonitor* primaryMonitor = nullptr;
+#else
+    auto systemVisual = [](GdkDisplay* display) -> GdkVisual* {
+        if (auto* screen = gdk_display_get_default_screen(display))
+            return gdk_screen_get_system_visual(screen);
+
+        return nullptr;
+    };
+
+    auto* display = gdk_display_get_default();
+    auto* primaryMonitor = gdk_display_get_primary_monitor(display);
+#endif
+
+    ScreenProperties properties;
+    for (const auto& iter : m_monitorToDisplayIDMap) {
+        GdkMonitor* monitor = iter.key;
+        if (!properties.primaryDisplayID && (!primaryMonitor || primaryMonitor == monitor))
+            properties.primaryDisplayID = iter.value;
+
+        ScreenData data;
+        GdkRectangle workArea;
+        monitorWorkArea(monitor, &workArea);
+        data.screenAvailableRect = FloatRect(workArea.x, workArea.y, workArea.width, workArea.height);
+        GdkRectangle geometry;
+        gdk_monitor_get_geometry(monitor, &geometry);
+        data.screenRect = FloatRect(geometry.x, geometry.y, geometry.width, geometry.height);
+#if USE(GTK4)
+        data.screenDepth = 24;
+        data.screenDepthPerComponent = 8;
+#else
+        auto* visual = systemVisual(display);
+        data.screenDepth = visual ? gdk_visual_get_depth(visual) : 24;
+        if (visual) {
+            int redDepth;
+            gdk_visual_get_red_pixel_details(visual, nullptr, nullptr, &redDepth);
+            data.screenDepthPerComponent = redDepth;
+        } else
+            data.screenDepthPerComponent = 8;
+#endif
+        data.screenSize = { gdk_monitor_get_width_mm(monitor), gdk_monitor_get_height_mm(monitor) };
+        static const double millimetresPerInch = 25.4;
+        double diagonalInPixels = std::hypot(geometry.width, geometry.height);
+        double diagonalInInches = std::hypot(data.screenSize.width(), data.screenSize.height()) / millimetresPerInch;
+        data.dpi = diagonalInPixels / diagonalInInches;
+        properties.screenDataMap.add(iter.value, WTFMove(data));
+    }
+
+    // FIXME: don't use PlatformScreen from the UI process, better use ScreenManager directly.
+    WebCore::setScreenProperties(properties);
+
+    return properties;
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/ScreenManager.h
+++ b/Source/WebKit/UIProcess/gtk/ScreenManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Purism SPC
+ * Copyright (C) 2023 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,45 +25,35 @@
 
 #pragma once
 
-#include "GtkSettingsState.h"
-#include <gtk/gtk.h>
-#include <wtf/Function.h>
+#include <WebCore/ScreenProperties.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Vector.h>
+#include <wtf/glib/GRefPtr.h>
+
+typedef struct _GdkMonitor GdkMonitor;
 
 namespace WebKit {
 
-class GtkSettingsManager {
-    WTF_MAKE_NONCOPYABLE(GtkSettingsManager);
-    friend NeverDestroyed<GtkSettingsManager>;
+using PlatformDisplayID = uint32_t;
+
+class ScreenManager {
+    WTF_MAKE_NONCOPYABLE(ScreenManager);
+    friend NeverDestroyed<ScreenManager>;
 public:
-    static GtkSettingsManager& singleton();
+    static ScreenManager& singleton();
 
-    const GtkSettingsState& settingsState() const { return m_settingsState; }
+    WebCore::ScreenProperties collectScreenProperties() const;
 
-    void addObserver(Function<void(const GtkSettingsState&)>&&, void* context);
-    void removeObserver(void* context);
 private:
-    GtkSettingsManager();
+    ScreenManager();
 
-    void settingsDidChange();
+    void addMonitor(GdkMonitor*);
+    void removeMonitor(GdkMonitor*);
+    void propertiesDidChange() const;
 
-    String themeName() const;
-    String fontName() const;
-    int xftAntialias() const;
-    int xftHinting() const;
-    String xftHintStyle() const;
-    String xftRGBA() const;
-    int xftDPI() const;
-    bool cursorBlink() const;
-    int cursorBlinkTime() const;
-    bool primaryButtonWarpsSlider() const;
-    bool overlayScrolling() const;
-    bool enableAnimations() const;
-
-    GtkSettings* m_settings;
-    GtkSettingsState m_settingsState;
-    HashMap<void*, Function<void(const GtkSettingsState&)>> m_observers;
+    Vector<GRefPtr<GdkMonitor>, 1> m_monitors;
+    HashMap<GdkMonitor*, PlatformDisplayID> m_monitorToDisplayIDMap;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -585,9 +585,11 @@ private:
     void displayConfigurationChanged(CGDirectDisplayID, CGDisplayChangeSummaryFlags);
 #endif
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK)
     void setScreenProperties(const WebCore::ScreenProperties&);
+#endif
 
+#if PLATFORM(COCOA)
     enum class IsInProcessInitialization : bool { No, Yes };
     void updateProcessName(IsInProcessInitialization);
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -108,7 +108,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     MarkIsNoLongerPrewarmed()
     GetActivePagesOriginsForTesting() -> (Vector<String> activeOrigins)
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK)
     SetScreenProperties(struct WebCore::ScreenProperties screenProperties)
 #endif
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -201,6 +201,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
 #if PLATFORM(GTK)
     GtkSettingsManagerProxy::singleton().applySettings(WTFMove(parameters.gtkSettings));
+    WebCore::setScreenProperties(parameters.screenProperties);
 #endif
 }
 
@@ -252,6 +253,15 @@ void WebProcess::releaseSystemMallocMemory()
 #endif
 #endif
 }
+
+#if PLATFORM(GTK)
+void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties)
+{
+    WebCore::setScreenProperties(properties);
+    for (auto& page : m_pageMap.values())
+        page->screenPropertiesDidChange();
+}
+#endif
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 9fd2ac8b277e317e38359e922e9c7b7db7bebf9d
<pre>
[GTK] Send screen properties from UI process to all web processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=260203">https://bugs.webkit.org/show_bug.cgi?id=260203</a>

Reviewed by Michael Catanzaro.

Instead of web processes getting the properties from the default screen.
Add ScreenManager singleton to handle monitors in the default display,
used to collect properties of all screens. The web process will still
use the default or primary monitor always, because there&apos;s a mismatch
between the platform display ID assigned to monitors by ScreenManager
and the display ID set to the Page by the drawing area. This is because
of the way ThreadedCompositor works, which we plan to change soon, so it
will be automatically fixed and the right display ID will be used by
PlatformScreen functions receiving a Widget parameter.
This patch also removes screen DPI observer from PlatformScreen and it&apos;s
now implemented by GtkSettingsManager since what we are monitoring is
the GTK setting in the end.

* Source/WebCore/platform/PlatformScreen.cpp:
* Source/WebCore/platform/PlatformScreen.h: Remove setScreenDPIObserverHandler().
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::widgetDisplayID): Get the PlatformDisplayID of the given Widget.
(WebCore::screenDepth): Use ScreenData.
(WebCore::screenDepthPerComponent): Ditto.
(WebCore::screenDPI): Check the GTK setting falling back to ScreenData.
(WebCore::screenRect): Use ScreenData.
(WebCore::screenAvailableRect): Ditto.
(WebCore::systemVisual): Deleted.
(WebCore::screenDPIObserverHandlersMap): Deleted.
(WebCore::gtkXftDPIChangedCallback): Deleted.
(WebCore::setScreenDPIObserverHandler): Deleted.
(WebCore::currentScreenMonitor): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed): Use GtkSettingsManager to monitor dpi changes.
(webkitWebViewDispose): Ditto.
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess): Collect screen properties and set the parameter.
* Source/WebKit/UIProcess/gtk/GtkSettingsManager.cpp:
(WebKit::GtkSettingsManager::settingsDidChange): Notify observers.
(WebKit::GtkSettingsManager::addObserver):
(WebKit::GtkSettingsManager::removeObserver):
* Source/WebKit/UIProcess/gtk/GtkSettingsManager.h:
* Source/WebKit/UIProcess/gtk/ScreenManager.cpp: Added.
(WebKit::ScreenManager::singleton):
(WebKit::generatePlatformDisplayID):
(WebKit::ScreenManager::ScreenManager):
(WebKit::ScreenManager::addMonitor):
(WebKit::ScreenManager::removeMonitor):
(WebKit::ScreenManager::propertiesDidChange const):
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/UIProcess/gtk/ScreenManager.h: Copied from Source/WebKit/UIProcess/gtk/GtkSettingsManager.h.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess): Initialize screen porperties.
(WebKit::WebProcess::setScreenProperties): Update screen properties.

Canonical link: <a href="https://commits.webkit.org/267031@main">https://commits.webkit.org/267031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333c47fb9c45c826ff5d5ce294c9453decee4e4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16831 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17590 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20595 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17049 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14358 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12166 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17976 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1879 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->