### PR TITLE
[iOS] Adopt ThreadSafeWeakPtr in WebMediaSessionHelper

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,10 +44,10 @@
 #import <pal/cocoa/AVFoundationSoftLink.h>
 #import <pal/ios/UIKitSoftLink.h>
 
-WEBCORE_EXPORT NSString* WebUIApplicationWillResignActiveNotification = @"WebUIApplicationWillResignActiveNotification";
-WEBCORE_EXPORT NSString* WebUIApplicationWillEnterForegroundNotification = @"WebUIApplicationWillEnterForegroundNotification";
-WEBCORE_EXPORT NSString* WebUIApplicationDidBecomeActiveNotification = @"WebUIApplicationDidBecomeActiveNotification";
-WEBCORE_EXPORT NSString* WebUIApplicationDidEnterBackgroundNotification = @"WebUIApplicationDidEnterBackgroundNotification";
+WEBCORE_EXPORT NSString *WebUIApplicationWillResignActiveNotification = @"WebUIApplicationWillResignActiveNotification";
+WEBCORE_EXPORT NSString *WebUIApplicationWillEnterForegroundNotification = @"WebUIApplicationWillEnterForegroundNotification";
+WEBCORE_EXPORT NSString *WebUIApplicationDidBecomeActiveNotification = @"WebUIApplicationDidBecomeActiveNotification";
+WEBCORE_EXPORT NSString *WebUIApplicationDidEnterBackgroundNotification = @"WebUIApplicationDidEnterBackgroundNotification";
 
 #if HAVE(CELESTIAL)
 SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(Celestial)
@@ -62,10 +62,10 @@ SOFT_LINK_CONSTANT_MAY_FAIL(Celestial, AVSystemController_SubscribeToNotificatio
 
 using namespace WebCore;
 
-class MediaSessionHelperiOS;
+class MediaSessionHelperIOS;
 
 @interface WebMediaSessionHelper : NSObject {
-    MediaSessionHelperiOS* _callback;
+    ThreadSafeWeakPtr<MediaSessionHelperIOS> _callback;
 
 #if !PLATFORM(WATCHOS)
     RetainPtr<AVRouteDetector> _routeDetector;
@@ -74,9 +74,8 @@ class MediaSessionHelperiOS;
     bool _startMonitoringAirPlayRoutesPending;
 }
 
-- (id)initWithCallback:(MediaSessionHelperiOS*)callback;
+- (id)initWithCallback:(MediaSessionHelperIOS&)callback;
 
-- (void)clearCallback;
 - (void)applicationWillEnterForeground:(NSNotification *)notification;
 - (void)applicationWillResignActive:(NSNotification *)notification;
 - (void)applicationDidEnterBackground:(NSNotification *)notification;
@@ -89,10 +88,9 @@ class MediaSessionHelperiOS;
 
 @end
 
-class MediaSessionHelperiOS final : public MediaSessionHelper {
+class MediaSessionHelperIOS final : public MediaSessionHelper {
 public:
-    MediaSessionHelperiOS();
-    ~MediaSessionHelperiOS();
+    MediaSessionHelperIOS();
 
     void externalOutputDeviceAvailableDidChange();
 #if HAVE(CELESTIAL)
@@ -135,7 +133,7 @@ MediaSessionHelper& MediaSessionHelper::sharedHelper()
 
 void MediaSessionHelper::resetSharedHelper()
 {
-    sharedHelperInstance() = adoptRef(*new MediaSessionHelperiOS());
+    sharedHelperInstance() = adoptRef(*new MediaSessionHelperIOS());
 }
 
 void MediaSessionHelper::setSharedHelper(Ref<MediaSessionHelper>&& helper)
@@ -230,10 +228,10 @@ void MediaSessionHelper::stopMonitoringWirelessRoutes()
     stopMonitoringWirelessRoutesInternal();
 }
 
-MediaSessionHelperiOS::MediaSessionHelperiOS()
+MediaSessionHelperIOS::MediaSessionHelperIOS()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    m_objcObserver = adoptNS([[WebMediaSessionHelper alloc] initWithCallback:this]);
+    m_objcObserver = adoptNS([[WebMediaSessionHelper alloc] initWithCallback:*this]);
     setIsExternalOutputDeviceAvailable([m_objcObserver hasWirelessTargetsAvailable]);
     END_BLOCK_OBJC_EXCEPTIONS
 
@@ -242,14 +240,7 @@ MediaSessionHelperiOS::MediaSessionHelperiOS()
 #endif
 }
 
-MediaSessionHelperiOS::~MediaSessionHelperiOS()
-{
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_objcObserver clearCallback];
-    END_BLOCK_OBJC_EXCEPTIONS
-}
-
-void MediaSessionHelperiOS::providePresentingApplicationPID(int pid, ShouldOverride shouldOverride)
+void MediaSessionHelperIOS::providePresentingApplicationPID(int pid, ShouldOverride shouldOverride)
 {
 #if HAVE(CELESTIAL)
     if (m_presentedApplicationPID && (*m_presentedApplicationPID == pid || shouldOverride == ShouldOverride::No))
@@ -270,7 +261,7 @@ void MediaSessionHelperiOS::providePresentingApplicationPID(int pid, ShouldOverr
 #endif
 }
 
-void MediaSessionHelperiOS::startMonitoringWirelessRoutesInternal()
+void MediaSessionHelperIOS::startMonitoringWirelessRoutesInternal()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 #if !PLATFORM(WATCHOS)
@@ -279,7 +270,7 @@ void MediaSessionHelperiOS::startMonitoringWirelessRoutesInternal()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void MediaSessionHelperiOS::stopMonitoringWirelessRoutesInternal()
+void MediaSessionHelperIOS::stopMonitoringWirelessRoutesInternal()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 #if !PLATFORM(WATCHOS)
@@ -289,7 +280,7 @@ void MediaSessionHelperiOS::stopMonitoringWirelessRoutesInternal()
 }
 
 #if HAVE(CELESTIAL)
-void MediaSessionHelperiOS::mediaServerConnectionDied()
+void MediaSessionHelperIOS::mediaServerConnectionDied()
 {
     updateCarPlayIsConnected(std::nullopt);
 
@@ -305,7 +296,7 @@ void MediaSessionHelperiOS::mediaServerConnectionDied()
     }
 }
 
-void MediaSessionHelperiOS::updateCarPlayIsConnected(std::optional<bool>&& carPlayIsConnected)
+void MediaSessionHelperIOS::updateCarPlayIsConnected(std::optional<bool>&& carPlayIsConnected)
 {
     if (carPlayIsConnected) {
         setIsPlayingToAutomotiveHeadUnit(carPlayIsConnected.value());
@@ -320,19 +311,19 @@ void MediaSessionHelperiOS::updateCarPlayIsConnected(std::optional<bool>&& carPl
     setIsPlayingToAutomotiveHeadUnit([[[getAVSystemControllerClass() sharedAVSystemController] attributeForKey:getAVSystemController_CarPlayIsConnectedAttribute()] boolValue]);
 }
 
-void MediaSessionHelperiOS::setIsPlayingToAutomotiveHeadUnit(bool isPlaying)
+void MediaSessionHelperIOS::setIsPlayingToAutomotiveHeadUnit(bool isPlaying)
 {
     isPlayingToAutomotiveHeadUnitDidChange(isPlaying ? PlayingToAutomotiveHeadUnit::Yes : PlayingToAutomotiveHeadUnit::No);
 }
 #endif // HAVE(CELESTIAL)
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST) && !PLATFORM(WATCHOS)
-void MediaSessionHelperiOS::activeAudioRouteDidChange(bool shouldPause)
+void MediaSessionHelperIOS::activeAudioRouteDidChange(bool shouldPause)
 {
     MediaSessionHelper::activeAudioRouteDidChange(shouldPause ? ShouldPause::Yes : ShouldPause::No);
 }
 
-void MediaSessionHelperiOS::activeVideoRouteDidChange()
+void MediaSessionHelperIOS::activeVideoRouteDidChange()
 {
     auto target = MediaPlaybackTargetCocoa::create();
     auto supportsRemoteVideoPlayback = target->supportsRemoteVideoPlayback() ? SupportsAirPlayVideo::Yes : SupportsAirPlayVideo::No;
@@ -340,7 +331,7 @@ void MediaSessionHelperiOS::activeVideoRouteDidChange()
 }
 #endif
 
-void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
+void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
 {
     HasAvailableTargets hasAvailableTargets;
     BEGIN_BLOCK_OBJC_EXCEPTIONS
@@ -352,7 +343,7 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 
 @implementation WebMediaSessionHelper
 
-- (id)initWithCallback:(MediaSessionHelperiOS*)callback
+- (id)initWithCallback:(MediaSessionHelperIOS&)callback
 {
     LOG(Media, "-[WebMediaSessionHelper initWithCallback]");
 
@@ -361,7 +352,7 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 
     _callback = callback;
 
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
     [center addObserver:self selector:@selector(applicationWillEnterForeground:) name:PAL::get_UIKit_UIApplicationWillEnterForegroundNotification() object:nil];
     [center addObserver:self selector:@selector(applicationWillEnterForeground:) name:WebUIApplicationWillEnterForegroundNotification object:nil];
     [center addObserver:self selector:@selector(applicationDidBecomeActive:) name:PAL::get_UIKit_UIApplicationDidBecomeActiveNotification() object:nil];
@@ -399,32 +390,25 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 
 #if !PLATFORM(WATCHOS)
     if (!pthread_main_np()) {
-        RunLoop::main().dispatch([routeDetector = WTFMove(_routeDetector)] () mutable {
+        RunLoop::main().dispatch([routeDetector = std::exchange(_routeDetector, nil)]() {
             LOG(Media, "safelyTearDown - dipatched to UI thread.");
             BEGIN_BLOCK_OBJC_EXCEPTIONS
-            routeDetector.get().routeDetectionEnabled = NO;
-            routeDetector.clear();
+            [routeDetector setRouteDetectionEnabled:NO];
             END_BLOCK_OBJC_EXCEPTIONS
         });
     } else
-        _routeDetector.get().routeDetectionEnabled = NO;
+        [_routeDetector setRouteDetectionEnabled:NO];
 #endif
 
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [NSNotificationCenter.defaultCenter removeObserver:self];
     [super dealloc];
-}
-
-- (void)clearCallback
-{
-    LOG(Media, "-[WebMediaSessionHelper clearCallback]");
-    _callback = nil;
 }
 
 - (BOOL)hasWirelessTargetsAvailable
 {
     LOG(Media, "-[WebMediaSessionHelper hasWirelessTargetsAvailable]");
 #if !PLATFORM(WATCHOS)
-    return _routeDetector.get().multipleRoutesDetected;
+    return [_routeDetector multipleRoutesDetected];
 #else
     return NO;
 #endif
@@ -433,6 +417,8 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 #if !PLATFORM(WATCHOS)
 - (void)startMonitoringAirPlayRoutes
 {
+    ASSERT(isMainThread());
+
     if (_monitoringAirPlayRoutes)
         return;
 
@@ -442,7 +428,7 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
         return;
 
     if (_routeDetector) {
-        _routeDetector.get().routeDetectionEnabled = YES;
+        [_routeDetector setRouteDetectionEnabled:YES];
         return;
     }
 
@@ -450,32 +436,34 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 
     LOG(Media, "-[WebMediaSessionHelper startMonitoringAirPlayRoutes]");
 
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
-        ASSERT(!protectedSelf->_routeDetector);
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
+        ASSERT(!_routeDetector);
 
-        if (protectedSelf->_callback) {
+        if (auto callback = _callback.get()) {
             BEGIN_BLOCK_OBJC_EXCEPTIONS
-            protectedSelf->_routeDetector = adoptNS([PAL::allocAVRouteDetectorInstance() init]);
-            protectedSelf->_routeDetector.get().routeDetectionEnabled = protectedSelf->_monitoringAirPlayRoutes;
-            [[NSNotificationCenter defaultCenter] addObserver:protectedSelf.get() selector:@selector(wirelessRoutesAvailableDidChange:) name:PAL::AVRouteDetectorMultipleRoutesDetectedDidChangeNotification object:protectedSelf->_routeDetector.get()];
+            _routeDetector = adoptNS([PAL::allocAVRouteDetectorInstance() init]);
+            [_routeDetector setRouteDetectionEnabled:_monitoringAirPlayRoutes];
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(wirelessRoutesAvailableDidChange:) name:PAL::AVRouteDetectorMultipleRoutesDetectedDidChangeNotification object:_routeDetector.get()];
 
-            protectedSelf->_callback->externalOutputDeviceAvailableDidChange();
+            callback->externalOutputDeviceAvailableDidChange();
             END_BLOCK_OBJC_EXCEPTIONS
         }
 
-        protectedSelf->_startMonitoringAirPlayRoutesPending = false;
+        _startMonitoringAirPlayRoutesPending = false;
     });
 }
 
 - (void)stopMonitoringAirPlayRoutes
 {
+    ASSERT(isMainThread());
+
     if (!_monitoringAirPlayRoutes)
         return;
 
     LOG(Media, "-[WebMediaSessionHelper stopMonitoringAirPlayRoutes]");
 
     _monitoringAirPlayRoutes = false;
-    _routeDetector.get().routeDetectionEnabled = NO;
+    [_routeDetector setRouteDetectionEnabled:NO];
 }
 #endif // !PLATFORM(WATCHOS)
 
@@ -483,14 +471,11 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 {
     using SuspendedUnderLock = MediaSessionHelperClient::SuspendedUnderLock;
 
-    if (!_callback)
-        return;
-
     LOG(Media, "-[WebMediaSessionHelper applicationWillEnterForeground]");
 
     auto isSuspendedUnderLock = [[[notification userInfo] objectForKey:@"isSuspendedUnderLock"] boolValue] ? SuspendedUnderLock::Yes : SuspendedUnderLock::No;
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self), isSuspendedUnderLock]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), isSuspendedUnderLock]() {
+        if (auto callback = _callback.get())
             callback->applicationWillEnterForeground(isSuspendedUnderLock);
     });
 }
@@ -499,13 +484,10 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 {
     UNUSED_PARAM(notification);
 
-    if (!_callback)
-        return;
-
     LOG(Media, "-[WebMediaSessionHelper applicationDidBecomeActive]");
 
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
+        if (auto callback = _callback.get())
             callback->applicationDidBecomeActive();
     });
 }
@@ -514,13 +496,10 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 {
     UNUSED_PARAM(notification);
 
-    if (!_callback)
-        return;
-
     LOG(Media, "-[WebMediaSessionHelper applicationWillResignActive]");
 
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
+        if (auto callback = _callback.get())
             callback->applicationWillBecomeInactive();
     });
 }
@@ -529,13 +508,11 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 {
     UNUSED_PARAM(notification);
 
-    if (!_callback || !_monitoringAirPlayRoutes)
-        return;
-
     LOG(Media, "-[WebMediaSessionHelper wirelessRoutesAvailableDidChange]");
 
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
+        auto callback = _callback.get();
+        if (callback && _monitoringAirPlayRoutes)
             callback->externalOutputDeviceAvailableDidChange();
     });
 }
@@ -544,14 +521,11 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 {
     using SuspendedUnderLock = MediaSessionHelperClient::SuspendedUnderLock;
 
-    if (!_callback)
-        return;
-
     LOG(Media, "-[WebMediaSessionHelper applicationDidEnterBackground]");
 
     auto isSuspendedUnderLock = [[[notification userInfo] objectForKey:@"isSuspendedUnderLock"] boolValue] ? SuspendedUnderLock::Yes : SuspendedUnderLock::No;
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self), isSuspendedUnderLock]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), isSuspendedUnderLock]() {
+        if (auto callback = _callback.get())
             callback->applicationDidEnterBackground(isSuspendedUnderLock);
     });
 }
@@ -559,22 +533,16 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 #if HAVE(CELESTIAL)
 - (void)mediaServerConnectionDied:(NSNotification *)notification
 {
-    if (!_callback)
-        return;
-
     LOG(Media, "-[WebMediaSessionHelper mediaServerConnectionDied:]");
     UNUSED_PARAM(notification);
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
+        if (auto callback = _callback.get())
             callback->mediaServerConnectionDied();
     });
 }
 
 - (void)carPlayIsConnectedDidChange:(NSNotification *)notification
 {
-    if (!_callback)
-        return;
-
     std::optional<bool> carPlayIsConnected;
     if (notification && canLoadAVSystemController_CarPlayIsConnectedNotificationParameter()) {
         NSNumber *nsCarPlayIsConnected = [[notification userInfo] valueForKey:getAVSystemController_CarPlayIsConnectedNotificationParameter()];
@@ -582,8 +550,8 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
             carPlayIsConnected = [nsCarPlayIsConnected boolValue];
     }
 
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self), carPlayIsConnected = WTFMove(carPlayIsConnected)]() mutable {
-        if (auto* callback = protectedSelf->_callback)
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), carPlayIsConnected = WTFMove(carPlayIsConnected)]() mutable {
+        if (auto callback = _callback.get())
             callback->updateCarPlayIsConnected(WTFMove(carPlayIsConnected));
     });
 }
@@ -592,20 +560,16 @@ void MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange()
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST) && !PLATFORM(WATCHOS)
 - (void)activeOutputDeviceDidChange:(NSNotification *)notification
 {
-    if (!_callback)
-        return;
-
     bool shouldPause = [[notification.userInfo objectForKey:PAL::get_AVFoundation_AVAudioSessionRouteChangeReasonKey()] unsignedIntegerValue] == AVAudioSessionRouteChangeReasonOldDeviceUnavailable;
-    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self), shouldPause]() mutable {
-        if (auto* callback = protectedSelf->_callback) {
+    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self), shouldPause]() {
+        if (auto callback = _callback.get()) {
             callback->activeAudioRouteDidChange(shouldPause);
             callback->activeVideoRouteDidChange();
         }
     });
-
 }
 #endif
 
 @end
 
-#endif
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,10 +35,10 @@
 OBJC_CLASS WebMediaSessionHelper;
 
 #if defined(__OBJC__) && __OBJC__
-extern NSString* WebUIApplicationWillResignActiveNotification;
-extern NSString* WebUIApplicationWillEnterForegroundNotification;
-extern NSString* WebUIApplicationDidBecomeActiveNotification;
-extern NSString* WebUIApplicationDidEnterBackgroundNotification;
+extern NSString *WebUIApplicationWillResignActiveNotification;
+extern NSString *WebUIApplicationWillEnterForegroundNotification;
+extern NSString *WebUIApplicationDidBecomeActiveNotification;
+extern NSString *WebUIApplicationDidEnterBackgroundNotification;
 #endif
 
 namespace WebCore {


### PR DESCRIPTION
#### 147e066f07349b960743d7d9f950b85c02bfec52
<pre>
[iOS] Adopt ThreadSafeWeakPtr in WebMediaSessionHelper
<a href="https://bugs.webkit.org/show_bug.cgi?id=260205">https://bugs.webkit.org/show_bug.cgi?id=260205</a>
rdar://113910990

Reviewed by Jean-Yves Avenard.

Adopted ThreadSafeWeakPtr for WebMediaSessionHelper&apos;s _callback ivar. Ensured
WebMediaSessionHelper&apos;s _monitoringAirPlayRoutes and _startMonitoringAirPlayRoutesPending ivars are
accessed exclusively on the main thread. Fixed some naming and formatting issues, notably renaming
MediaSessionHelperiOS to MediaSessionHelperIOS.

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::resetSharedHelper):
(MediaSessionHelperIOS::MediaSessionHelperIOS):
(MediaSessionHelperIOS::providePresentingApplicationPID):
(MediaSessionHelperIOS::startMonitoringWirelessRoutesInternal):
(MediaSessionHelperIOS::stopMonitoringWirelessRoutesInternal):
(MediaSessionHelperIOS::mediaServerConnectionDied):
(MediaSessionHelperIOS::setIsPlayingToAutomotiveHeadUnit):
(MediaSessionHelperIOS::activeAudioRouteDidChange):
(MediaSessionHelperIOS::activeVideoRouteDidChange):
(MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange):
(-[WebMediaSessionHelper initWithCallback:]):
(-[WebMediaSessionHelper hasWirelessTargetsAvailable]):
(-[WebMediaSessionHelper startMonitoringAirPlayRoutes]):
(-[WebMediaSessionHelper applicationWillEnterForeground:]):
(-[WebMediaSessionHelper applicationDidBecomeActive:]):
(-[WebMediaSessionHelper applicationWillResignActive:]):
(-[WebMediaSessionHelper wirelessRoutesAvailableDidChange:]):
(-[WebMediaSessionHelper applicationDidEnterBackground:]):
(-[WebMediaSessionHelper mediaServerConnectionDied:]):
(-[WebMediaSessionHelper carPlayIsConnectedDidChange:]):
(-[WebMediaSessionHelper activeOutputDeviceDidChange:]):
(MediaSessionHelperiOS::MediaSessionHelperiOS): Deleted.
(MediaSessionHelperiOS::~MediaSessionHelperiOS): Deleted.
(MediaSessionHelperiOS::providePresentingApplicationPID): Deleted.
(MediaSessionHelperiOS::startMonitoringWirelessRoutesInternal): Deleted.
(MediaSessionHelperiOS::stopMonitoringWirelessRoutesInternal): Deleted.
(MediaSessionHelperiOS::mediaServerConnectionDied): Deleted.
(MediaSessionHelperiOS::updateCarPlayIsConnected): Deleted.
(MediaSessionHelperiOS::setIsPlayingToAutomotiveHeadUnit): Deleted.
(MediaSessionHelperiOS::activeAudioRouteDidChange): Deleted.
(MediaSessionHelperiOS::activeVideoRouteDidChange): Deleted.
(MediaSessionHelperiOS::externalOutputDeviceAvailableDidChange): Deleted.
(-[WebMediaSessionHelper clearCallback]): Deleted.

Canonical link: <a href="https://commits.webkit.org/266985@main">https://commits.webkit.org/266985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd958ed4ec50cd6ac1d336718314e50784fb858

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15300 "Failed to checkout and rebase branch from PR 16709") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15703 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17790 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13801 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14541 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13811 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->