### PR TITLE
Make SpeechSynthesis an ActiveDOMObject

### DIFF
--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-voiceschanged-gc-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-voiceschanged-gc-expected.txt
@@ -1,0 +1,11 @@
+This tests SpeechSynthesis can fire voiceschanged event without crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS speechSynthesis.testProperty !== undefined is true
+PASS speechSynthesis.testProperty is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-voiceschanged-gc.html
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-voiceschanged-gc.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    description("This tests SpeechSynthesis can fire voiceschanged event without crash.");
+
+    if (window.internals)
+        window.internals.enableMockSpeechSynthesizer();
+
+    window.jsTestIsAsync = true;
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    speechSynthesis.testProperty = 1;
+    const voices = speechSynthesis.getVoices();
+    speechSynthesis.onvoiceschanged = () => {
+        shouldBeTrue("speechSynthesis.testProperty !== undefined");
+        shouldBe("speechSynthesis.testProperty", '1');
+        finishJSTest(); 
+    };
+    gc();
+
+    if (window.internals) {
+        setTimeout(() => {
+            if (window.internals)
+                window.internals.simulateSpeechSynthesizerVoiceListChange();
+        }, 0);
+    } else {
+        debug("Test requires window.internals to run.");
+        finishJSTest();
+    }
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -42,7 +42,7 @@ class Document;
 class PlatformSpeechSynthesizerClient;
 class SpeechSynthesisVoice;
 
-class SpeechSynthesis : public PlatformSpeechSynthesizerClient, public SpeechSynthesisClientObserver, public RefCounted<SpeechSynthesis>, public ContextDestructionObserver, public EventTarget {
+class SpeechSynthesis : public PlatformSpeechSynthesizerClient, public SpeechSynthesisClientObserver, public RefCounted<SpeechSynthesis>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(SpeechSynthesis);
 public:
     static Ref<SpeechSynthesis> create(ScriptExecutionContext&);
@@ -58,7 +58,7 @@ public:
     void speak(SpeechSynthesisUtterance&);
     void cancel();
     void pause();
-    void resume();
+    void resumeSynthesis();
 
     const Vector<Ref<SpeechSynthesisVoice>>& getVoices();
 
@@ -74,12 +74,13 @@ public:
 
     bool userGestureRequiredForSpeechStart() const { return m_restrictions & RequireUserGestureForSpeechStartRestriction; }
     void removeBehaviorRestriction(BehaviorRestrictions restriction) { m_restrictions &= ~restriction; }
+    WEBCORE_EXPORT void simulateVoicesListChange();
 
 private:
     SpeechSynthesis(ScriptExecutionContext&);
     RefPtr<SpeechSynthesisUtterance> protectedCurrentSpeechUtterance();
 
-    // PlatformSpeechSynthesizerClient override methods.
+    // PlatformSpeechSynthesizerClient
     void voicesDidChange() override;
     void didStartSpeaking(PlatformSpeechSynthesisUtterance&) override;
     void didPauseSpeaking(PlatformSpeechSynthesisUtterance&) override;
@@ -88,7 +89,7 @@ private:
     void speakingErrorOccurred(PlatformSpeechSynthesisUtterance&) override;
     void boundaryEventOccurred(PlatformSpeechSynthesisUtterance&, SpeechBoundary, unsigned charIndex, unsigned charLength) override;
 
-    // SpeechSynthesisClient override methods
+    // SpeechSynthesisClientObserver
     void didStartSpeaking() override;
     void didFinishSpeaking() override;
     void didPauseSpeaking() override;
@@ -96,24 +97,31 @@ private:
     void speakingErrorOccurred() override;
     void boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength) override;
     void voicesChanged() override;
-    
+
+    // ActiveDOMObject
+    const char* activeDOMObjectName() const final;
+    bool virtualHasPendingActivity() const final;
+
     void startSpeakingImmediately(SpeechSynthesisUtterance&);
     void handleSpeakingCompleted(SpeechSynthesisUtterance&, bool errorOccurred);
 
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    // EventTarget
+    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
     EventTargetInterface eventTargetInterface() const final { return SpeechSynthesisEventTargetInterfaceType; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
+    void eventListenersDidChange() final;
     
     PlatformSpeechSynthesizer& ensurePlatformSpeechSynthesizer();
     
     RefPtr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
-    Vector<Ref<SpeechSynthesisVoice>> m_voiceList;
+    std::optional<Vector<Ref<SpeechSynthesisVoice>>> m_voiceList;
     std::unique_ptr<SpeechSynthesisUtteranceActivity> m_currentSpeechUtterance;
     Deque<Ref<SpeechSynthesisUtterance>> m_utteranceQueue;
     bool m_isPaused;
     BehaviorRestrictions m_restrictions;
     WeakPtr<SpeechSynthesisClient> m_speechSynthesisClient;
+    bool m_hasEventListener { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesis
 [
+    ActiveDOMObject,
     EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     Exposed=Window,
@@ -39,6 +40,6 @@
     undefined speak(SpeechSynthesisUtterance utterance);
     undefined cancel();
     undefined pause();
-    undefined resume();
+    [ImplementedAs=resumeSynthesis] undefined resume();
     sequence<SpeechSynthesisVoice> getVoices();
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1571,6 +1571,20 @@ ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vect
 }
 
 #if ENABLE(SPEECH_SYNTHESIS)
+void Internals::simulateSpeechSynthesizerVoiceListChange()
+{
+    if (m_platformSpeechSynthesizer) {
+        m_platformSpeechSynthesizer->client().voicesDidChange();
+        return;
+    }
+
+    RefPtr document = contextDocument();
+    if (!document || !document->domWindow())
+        return;
+
+    if (RefPtr synthesis = LocalDOMWindowSpeechSynthesis::speechSynthesis(*document->domWindow()))
+        synthesis->simulateVoicesListChange();
+}
 
 void Internals::enableMockSpeechSynthesizer()
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -687,6 +687,7 @@ public:
     void enableMockMediaCapabilities();
 
 #if ENABLE(SPEECH_SYNTHESIS)
+    void simulateSpeechSynthesizerVoiceListChange();
     void enableMockSpeechSynthesizer();
     void enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement&);
     ExceptionOr<void> setSpeechUtteranceDuration(double);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -818,6 +818,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined enableMockMediaCapabilities();
 
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizer();
+    [Conditional=SPEECH_SYNTHESIS] undefined simulateSpeechSynthesizerVoiceListChange();
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement element);
     [Conditional=SPEECH_SYNTHESIS] undefined setSpeechUtteranceDuration(double duration);
     [Conditional=SPEECH_SYNTHESIS] readonly attribute unsigned long minimumExpectedVoiceCount;


### PR DESCRIPTION
#### 5eb9dd27dc3df7998ca679a50fd2b4e27680378e
<pre>
Make SpeechSynthesis an ActiveDOMObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=260207">https://bugs.webkit.org/show_bug.cgi?id=260207</a>

Reviewed by Ryosuke Niwa.

Keep wrapper of SpeechSynthesis alive when voiceschanged event might be fired and it has event handler.

Test: fast/speechsynthesis/speech-synthesis-voiceschanged-gc.html.

* LayoutTests/fast/speechsynthesis/speech-synthesis-voiceschanged-gc-expected.txt: Added.
* LayoutTests/fast/speechsynthesis/speech-synthesis-voiceschanged-gc.html: Added.
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::Ref&lt;SpeechSynthesis&gt;SpeechSynthesis::create):
(WebCore::SpeechSynthesis::SpeechSynthesis):
(WebCore::SpeechSynthesis::setPlatformSynthesizer):
(WebCore::SpeechSynthesis::voicesDidChange):
(WebCore::SpeechSynthesis::getVoices):
(WebCore::SpeechSynthesis::resumeSynthesis):
(WebCore::SpeechSynthesis::simulateVoicesListChange):
(WebCore::SpeechSynthesis::activeDOMObjectName const):
(WebCore::SpeechSynthesis::virtualHasPendingActivity const):
(WebCore::SpeechSynthesis::eventListenersDidChange):
(WebCore::SpeechSynthesis::resume): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesis.idl:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::simulateSpeechSynthesizerVoiceListChange):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/267385@main">https://commits.webkit.org/267385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce2e99b547e429f8b3563c468b9547b5128023eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17737 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18920 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21646 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19321 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15591 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13247 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->