### PR TITLE
Make SpeechSynthesisUtterance an ActiveDOMObject

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -78,8 +78,9 @@ void SpeechSynthesis::setPlatformSynthesizer(Ref<PlatformSpeechSynthesizer>&& sy
 {
     m_platformSpeechSynthesizer = synthesizer.ptr();
     m_voiceList.clear();
-    m_currentSpeechUtterance = nullptr;
-    m_utteranceQueue.clear();
+    clearUtteranceQueue();
+    // Finish current utterance.
+    speakingErrorOccurred();
     m_isPaused = false;
     m_speechSynthesisClient = nullptr;
 }
@@ -162,7 +163,7 @@ void SpeechSynthesis::cancel()
     // Remove all the items from the utterance queue.
     // Hold on to the current utterance so the platform synthesizer can have a chance to clean up.
     RefPtr<SpeechSynthesisUtterance> current = m_currentSpeechUtterance;
-    m_utteranceQueue.clear();
+    clearUtteranceQueue();
     if (m_speechSynthesisClient) {
         m_speechSynthesisClient->cancel();
         // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
@@ -314,6 +315,14 @@ void SpeechSynthesis::speakingErrorOccurred(PlatformSpeechSynthesisUtterance& ut
 {
     if (utterance.client())
         handleSpeakingCompleted(static_cast<SpeechSynthesisUtterance&>(*utterance.client()), true);
+}
+
+void SpeechSynthesis::clearUtteranceQueue()
+{
+    while (!m_utteranceQueue.isEmpty()) {
+        auto utterance = m_utteranceQueue.takeFirst();
+        utterance->setIsActiveForEventDispatch(false);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -77,6 +77,7 @@ public:
 
 private:
     SpeechSynthesis(ScriptExecutionContext&);
+    void clearUtteranceQueue();
 
     // PlatformSpeechSynthesizerClient override methods.
     void voicesDidChange() override;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl
@@ -25,6 +25,7 @@
 
 // https://wicg.github.io/speech-api/#speechsynthesisutterance
 [
+    ActiveDOMObject,
     EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     ExportMacro=WEBCORE_EXPORT,


### PR DESCRIPTION
#### 42ffbe195e69ce41e7c37707231efc7ed5e9b460
<pre>
Make SpeechSynthesisUtterance an ActiveDOMObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=260214">https://bugs.webkit.org/show_bug.cgi?id=260214</a>
rdar://113921763

Reviewed by Ryosuke Niwa.

Currently dispatching event to SpeechSynthesisUtterance can lead to crash due to GC. To fix that, we now keep wrapper
of SpeechSynthesisUtterance alive until there is no more event to be dispatched. This can happen in two cases:
1. SpeechSynthesisUtterance is not processed yet, and is removed from SpeechSynthesis&apos;s queue (i.e. the utterance will
not be processed).
2. SpeechSynthesisUtterance is being processed, and it finishes dispatching end or error event -- these two events are
the last events to be fired on an untterance according to spec: <a href="https://wicg.github.io/speech-api/#utterance-events.">https://wicg.github.io/speech-api/#utterance-events.</a>

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::setPlatformSynthesizer):
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::clearUtteranceQueue):
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::SpeechSynthesisUtterance):
(WebCore::SpeechSynthesisUtterance::eventOccurred):
(WebCore::SpeechSynthesisUtterance::errorEventOccurred):
(WebCore::SpeechSynthesisUtterance::dispatchEventAndUpdateState):
(WebCore::SpeechSynthesisUtterance::setIsActiveForEventDispatch):
(WebCore::SpeechSynthesisUtterance::activeDOMObjectName const):
(WebCore::SpeechSynthesisUtterance::virtualHasPendingActivity const):
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl:

Canonical link: <a href="https://commits.webkit.org/266959@main">https://commits.webkit.org/266959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48f207c85a73f471a470e3a293d0ebafdea60a06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15232 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16988 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16920 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17721 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20703 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14477 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13752 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3660 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->