### PR TITLE
Add initial support for the browser.i18n Web Extension API.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -372,6 +372,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -52,6 +52,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIExtension.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPILocalization.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPILocalization.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -650,6 +650,7 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIAlarms \
     WebExtensionAPIEvent \
     WebExtensionAPIExtension \
+    WebExtensionAPILocalization \
     WebExtensionAPINamespace \
     WebExtensionAPIPermissions \
     WebExtensionAPIRuntime \

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2159,6 +2159,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionLocalization {
+      header "_WKWebExtensionLocalization.h"
+      export *
+  }
+
   explicit module _WKWebExtensionMatchPattern {
     header "_WKWebExtensionMatchPattern.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3061,6 +3061,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionLocalization {
+      header "_WKWebExtensionLocalization.h"
+      export *
+  }
+
   explicit module _WKWebExtensionMatchPattern {
     header "_WKWebExtensionMatchPattern.h"
     export *

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -32,6 +32,8 @@
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
+OBJC_CLASS NSError;
+OBJC_CLASS NSLocale;
 OBJC_CLASS NSSet;
 OBJC_CLASS NSString;
 OBJC_CLASS NSUUID;
@@ -79,6 +81,20 @@ T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returnin
     return objectForKey<T>(dictionary.get(), key, returningNilIfEmpty, containingObjectsOfClass);
 }
 
+// MARK: NSDictionary helper methods.
+
+NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *);
+NSDictionary *mergeDictionaries(NSDictionary *, NSDictionary *);
+NSDictionary *mergeDictionariesAndSetValues(NSDictionary *, NSDictionary *);
+
+// MARK: NSLocale helper methods.
+
+NSString *localeStringInWebExtensionFormat(NSLocale *);
+
+// MARK: NSError helper methods.
+
+NSString *privacyPreservingDescription(NSError *);
+
 NSString *escapeCharactersInString(NSString *, NSString *charactersToEscape);
 
 NSDate *toAPI(const WallTime&);
@@ -86,5 +102,7 @@ WallTime toImpl(NSDate *);
 
 NSSet *toAPI(HashSet<String>&);
 NSArray *toAPIArray(HashSet<String>&);
+Vector<String> toImpl(NSArray *);
+HashSet<String> toImplSet(NSArray *);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+WK_EXTERN NSString * const _WKLocalizationDictionaryMessageKey;
+WK_EXTERN NSString * const _WKLocalizationDictionaryDescriptionKey;
+WK_EXTERN NSString * const _WKLocalizationDictionaryPlaceholdersKey;
+
+WK_EXTERN
+@interface _WKWebExtensionLocalization : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@property (nonatomic, nullable, copy) NSString *uniqueIdentifier;
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL defaultLocale:(NSString *)defaultLocaleString uniqueIdentifier:(nullable NSString *)uniqueIdentifier;
+- (instancetype)initWithRegionalLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)regionalLocalization languageLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)languageLocalization defaultLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)defaultLocalization withBestLocale:(nullable NSString *)localeString uniqueIdentifier:(NSString *)uniqueIdentifier NS_DESIGNATED_INITIALIZER;
+
+- (NSDictionary<NSString *, id> *)localizedDictionaryForDictionary:(NSDictionary<NSString *, id> *)dictionary;
+- (nullable NSString *)localizedStringForKey:(NSString *)key withPlaceholders:(nullable NSArray<NSString *> *)placeholders;
+- (NSString *)localizedStringForString:(NSString *)string;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionLocalization.h"
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#endif
+
+NSString * const _WKLocalizationDictionaryMessageKey = @"message";
+NSString * const _WKLocalizationDictionaryDescriptionKey = @"description";
+NSString * const _WKLocalizationDictionaryPlaceholdersKey = @"placeholders";
+
+static NSString * const localizationDictionaryJSONPathFormat = @"_locales/%@/messages.json";
+static NSString * const predefinedMessageUILocale = @"@@ui_locale";
+static NSString * const predefinedMessageLanguageDirection = @"@@bidi_dir";
+static NSString * const predefinedMessageLanguageDirectionReversed = @"@@bidi_reversed_dir";
+static NSString * const predefinedMessageTextLeadingEdge = @"@@bidi_start_edge";
+static NSString * const predefinedMessageTextTrailingEdge = @"@@bidi_end_edge";
+static NSString * const predefinedMessageExtensionID = @"@@extension_id";
+
+static NSString * const predefinedMessageValueLeftToRight = @"ltr";
+static NSString * const predefinedMessageValueRightToLeft = @"rtl";
+static NSString * const predefinedMessageValueTextEdgeLeft = @"left";
+static NSString * const predefinedMessageValueTextEdgeRight = @"right";
+
+static NSString * const placeholderDictionaryContentKey = @"content";
+
+// NSCoding keys
+static NSString * const localizationDictionaryCodingKey = @"localizationDictionary";
+static NSString * const localeStringDictionaryCodingKey = @"localeString";
+static NSString * const localeCodingKey = @"locale";
+static NSString * const uniqueIdentifierCodingKey = @"uniqueIdentifier";
+
+using LocalizationDictionary = NSDictionary<NSString *, NSDictionary *>;
+using PlaceholderDictionary = NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *>;
+
+using namespace WebKit;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+static LocalizationDictionary *localizationDictionaryAtURL(NSURL *dictionaryFileURL)
+{
+    NSData *dictionaryData = [NSData dataWithContentsOfURL:dictionaryFileURL];
+    if (!dictionaryData)
+        return nil;
+
+    NSError *jsonParsingError;
+    LocalizationDictionary *localizationDictionary = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:dictionaryData options:0 error:&jsonParsingError]);
+
+    if (!localizationDictionary)
+        RELEASE_LOG_ERROR(Extensions , "Could not parse localization dictionary: %{public}@", privacyPreservingDescription(jsonParsingError));
+
+    return localizationDictionary;
+}
+
+@interface _WKWebExtensionLocalization ()
+{
+    LocalizationDictionary *_localizationDictionary;
+    NSString *_localeString;
+    NSLocale *_locale;
+    NSString *_uniqueIdentifier;
+}
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@implementation _WKWebExtensionLocalization
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL defaultLocale:(NSString *)defaultLocaleString uniqueIdentifier:(NSString *)uniqueIdentifier
+{
+    if (!defaultLocaleString.length) {
+        RELEASE_LOG(Extensions, "Not loading localization for extension bundle at URL %{private}@. No default locale provided.", bundleURL);
+        return [self initWithRegionalLocalization:nil languageLocalization:nil defaultLocalization:nil withBestLocale:nil uniqueIdentifier:uniqueIdentifier];
+    }
+
+    NSLocale *currentLocale = NSLocale.autoupdatingCurrentLocale;
+    NSString *languageCode = currentLocale.languageCode;
+    NSString *countryCode = currentLocale.countryCode;
+
+    NSString *regionalLocaleString = [NSString stringWithFormat:@"%@_%@", languageCode, countryCode];
+    NSURL *defaultLocaleDictionaryURL = [bundleURL URLByAppendingPathComponent:[NSString stringWithFormat:localizationDictionaryJSONPathFormat, defaultLocaleString]];
+    NSURL *languageDictionaryURL = [bundleURL URLByAppendingPathComponent:[NSString stringWithFormat:localizationDictionaryJSONPathFormat, languageCode]];
+    NSURL *regionalDictionaryURL = [bundleURL URLByAppendingPathComponent:[NSString stringWithFormat:localizationDictionaryJSONPathFormat, regionalLocaleString]];
+
+    NSString *bestLocaleString;
+
+    LocalizationDictionary *defaultLocaleDictionary = localizationDictionaryAtURL(defaultLocaleDictionaryURL);
+    if (defaultLocaleDictionary)
+        bestLocaleString = defaultLocaleString;
+    else
+        RELEASE_LOG_DEBUG(Extensions, "Could not find localization for %{public}@ for extension bundle at URL %{private}@", defaultLocaleString, bundleURL);
+
+    LocalizationDictionary *languageDictionary = localizationDictionaryAtURL(languageDictionaryURL);
+    if (languageDictionary)
+        bestLocaleString = languageCode;
+    else
+        RELEASE_LOG_DEBUG(Extensions, "Could not find localization for %{public}@ for extension bundle at URL %{private}@", languageCode, bundleURL);
+
+    LocalizationDictionary *regionalDictionary = localizationDictionaryAtURL(regionalDictionaryURL);
+    if (regionalDictionary)
+        bestLocaleString = defaultLocaleString;
+    else
+        RELEASE_LOG_DEBUG(Extensions, "Could not find localization for %{public}@ for extension bundle at URL %{private}@", regionalLocaleString, bundleURL);
+
+    return [self initWithRegionalLocalization:regionalDictionary languageLocalization:languageDictionary defaultLocalization:defaultLocaleDictionary withBestLocale:bestLocaleString uniqueIdentifier:uniqueIdentifier];
+}
+
+- (instancetype)initWithRegionalLocalization:(LocalizationDictionary *)regionalLocalization languageLocalization:(LocalizationDictionary *)languageLocalization defaultLocalization:(LocalizationDictionary *)defaultLocalization withBestLocale:(NSString *)localeString uniqueIdentifier:(NSString *)uniqueIdentifier
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _locale = [NSLocale localeWithLocaleIdentifier:localeString];
+    _localeString = localeString;
+    if (_uniqueIdentifier)
+        _uniqueIdentifier = uniqueIdentifier;
+
+    LocalizationDictionary *localizationDictionary = [self _predefinedMessagesForLocale:_locale];
+    localizationDictionary = dictionaryWithLowercaseKeys(localizationDictionary);
+    localizationDictionary = mergeDictionaries(languageLocalization, localizationDictionary);
+    localizationDictionary = mergeDictionaries(localizationDictionary, dictionaryWithLowercaseKeys(languageLocalization));
+    localizationDictionary = mergeDictionaries(localizationDictionary, dictionaryWithLowercaseKeys(defaultLocalization));
+
+    _localizationDictionary = localizationDictionary;
+
+    return self;
+}
+
+- (NSDictionary<NSString *, id> *)localizedDictionaryForDictionary:(NSDictionary<NSString *, id> *)dictionary
+{
+    if (!_localizationDictionary)
+        return dictionary;
+
+    NSMutableDictionary<NSString *, id> *localizedDictionary = [dictionary mutableCopy];
+
+    for (NSString *key in localizedDictionary.allKeys) {
+        id value = localizedDictionary[key];
+
+        if ([value isKindOfClass:NSString.class])
+            localizedDictionary[key] = [self localizedStringForString:(NSString *)value];
+        else if ([value isKindOfClass:NSArray.class])
+            localizedDictionary[key] = [self _localizedArrayForArray:(NSArray *)value];
+        else if ([value isKindOfClass:NSDictionary.class])
+            localizedDictionary[key] = [self localizedDictionaryForDictionary:(NSDictionary *)value];
+    }
+
+    return localizedDictionary;
+}
+
+- (NSString *)localizedStringForKey:(NSString *)key withPlaceholders:(NSArray<NSString *> *)placeholders
+{
+    if (placeholders.count > 9)
+        return nil;
+
+    LocalizationDictionary *stringDictionary = objectForKey<NSDictionary>(_localizationDictionary, key.lowercaseString);
+
+    NSString *localizedString = objectForKey<NSString>(stringDictionary, _WKLocalizationDictionaryMessageKey);
+    if (!localizedString.length)
+        return @"";
+
+    PlaceholderDictionary *namedPlaceholders = dictionaryWithLowercaseKeys(objectForKey<NSDictionary>(stringDictionary, _WKLocalizationDictionaryPlaceholdersKey));
+
+    localizedString = [self _stringByReplacingNamedPlaceholdersInString:localizedString withNamedPlaceholders:namedPlaceholders];
+    localizedString = [self _stringByReplacingPositionalPlaceholdersInString:localizedString withValues:placeholders];
+
+    // Replace escaped $'s.
+    localizedString = [localizedString stringByReplacingOccurrencesOfString:@"$$" withString:@"$"];
+
+    return localizedString;
+}
+
+- (NSArray *)_localizedArrayForArray:(NSArray *)array
+{
+    return mapObjects(array, ^id(id key, id value) {
+        if ([value isKindOfClass:NSString.class])
+            return [self localizedStringForString:value];
+        if ([value isKindOfClass:NSArray.class])
+            return [self _localizedArrayForArray:value];
+        if ([value isKindOfClass:NSDictionary.class])
+            return [self localizedDictionaryForDictionary:value];
+
+        return value;
+    });
+}
+
+- (NSString *)localizedStringForString:(NSString *)sourceString
+{
+    NSString *localizedString = sourceString;
+
+    NSRegularExpression *localizableStringRegularExpression = [NSRegularExpression regularExpressionWithPattern:@"__MSG_([A-Za-z0-9_@]+)__" options:0 error:nil];
+
+    NSTextCheckingResult *localizableStringResult = [localizableStringRegularExpression firstMatchInString:localizedString options:0 range:NSMakeRange(0, localizedString.length)];
+    while (localizableStringResult) {
+        NSString *key = [localizedString substringWithRange:[localizableStringResult rangeAtIndex:1]];
+        NSString *localizedReplacement = [self localizedStringForKey:key withPlaceholders:nil];
+
+        NSString *stringToReplace = [localizedString substringWithRange:localizableStringResult.range];
+        localizedString = [localizedString stringByReplacingOccurrencesOfString:stringToReplace withString:localizedReplacement];
+
+        localizableStringResult = [localizableStringRegularExpression firstMatchInString:localizedString options:0 range:NSMakeRange(0, localizedString.length)];
+    }
+
+    return localizedString;
+}
+
+- (LocalizationDictionary *)_predefinedMessagesForLocale:(NSLocale *)locale
+{
+    NSDictionary *predefindedMessage;
+    if ([NSParagraphStyle defaultWritingDirectionForLanguage:_locale.languageCode] == NSWritingDirectionLeftToRight) {
+        predefindedMessage = @{
+            predefinedMessageUILocale: @{ _WKLocalizationDictionaryMessageKey: _localeString ?: @"" },
+            predefinedMessageLanguageDirection: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueLeftToRight },
+            predefinedMessageLanguageDirectionReversed: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueRightToLeft },
+            predefinedMessageTextLeadingEdge: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueTextEdgeLeft },
+            predefinedMessageTextTrailingEdge: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueTextEdgeRight },
+        };
+    } else {
+        predefindedMessage = @{
+            predefinedMessageUILocale: @{ _WKLocalizationDictionaryMessageKey: _localeString ?: @"" },
+            predefinedMessageLanguageDirection: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueRightToLeft },
+            predefinedMessageLanguageDirectionReversed: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueLeftToRight },
+            predefinedMessageTextLeadingEdge: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueTextEdgeRight },
+            predefinedMessageTextTrailingEdge: @{ _WKLocalizationDictionaryMessageKey: predefinedMessageValueTextEdgeLeft },
+        };
+    }
+
+    if (_uniqueIdentifier)
+        return mergeDictionaries(predefindedMessage, @{ predefinedMessageExtensionID: @{ _WKLocalizationDictionaryMessageKey: _uniqueIdentifier } });
+    return predefindedMessage;
+}
+
+- (NSString *)_stringByReplacingNamedPlaceholdersInString:(NSString *)string withNamedPlaceholders:(PlaceholderDictionary *)namedPlaceholders
+{
+    NSRegularExpression *namedPlaceholderExpression = [NSRegularExpression regularExpressionWithPattern:@"(?:[^$]|^)(\\$([A-Za-z0-9_@]+)\\$)" options:0 error:nil];
+    NSTextCheckingResult *namedPlaceholderMatch = [namedPlaceholderExpression firstMatchInString:string options:0 range:NSMakeRange(0, string.length)];
+    while (namedPlaceholderMatch) {
+        NSString *placeholderKey = [string substringWithRange:[namedPlaceholderMatch rangeAtIndex:2]].lowercaseString;
+        NSString *replacement = objectForKey<NSString>(objectForKey<NSDictionary>(namedPlaceholders, placeholderKey), placeholderDictionaryContentKey) ?: @"";
+
+        NSString *stringToReplace = [string substringWithRange:[namedPlaceholderMatch rangeAtIndex:1]];
+
+        string = [string stringByReplacingOccurrencesOfString:stringToReplace withString:replacement options:NSCaseInsensitiveSearch range:NSMakeRange(0, string.length)];
+
+        namedPlaceholderMatch = [namedPlaceholderExpression firstMatchInString:string options:0 range:NSMakeRange(0, string.length)];
+    }
+
+    return string;
+}
+
+- (NSString *)_stringByReplacingPositionalPlaceholdersInString:(NSString *)string withValues:(NSArray<NSString *> *)placeholderValues
+{
+    NSInteger placeholderCount = placeholderValues.count;
+
+    NSRegularExpression *positionalPlaceholderExpression = [NSRegularExpression regularExpressionWithPattern:@"(?:[^$]|^)(\\$([0-9]))" options:0 error:nil];
+    NSTextCheckingResult *positionalPlaceholderMatch = [positionalPlaceholderExpression firstMatchInString:string options:0 range:NSMakeRange(0, string.length)];
+
+    while (positionalPlaceholderMatch) {
+        NSInteger position = [string substringWithRange:[positionalPlaceholderMatch rangeAtIndex:2]].integerValue;
+
+        NSString *replacement;
+        if (position > 0 && position <= placeholderCount)
+            replacement = placeholderValues[position - 1];
+        else
+            replacement = @"";
+
+        NSString *stringToReplace = [string substringWithRange:[positionalPlaceholderMatch rangeAtIndex:1]];
+
+        string = [string stringByReplacingOccurrencesOfString:stringToReplace withString:replacement options:NSCaseInsensitiveSearch range:NSMakeRange(0, string.length)];
+        positionalPlaceholderMatch = [positionalPlaceholderExpression firstMatchInString:string options:0 range:NSMakeRange(0, string.length)];
+    }
+
+    return string;
+}
+
+#else
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL defaultLocale:(NSString *)defaultLocaleString uniqueIdentifier:(NSString *)uniqueIdentifier
+{
+    return [self initWithRegionalLocalization:nil languageLocalization:nil defaultLocalization:nil withBestLocale:nil uniqueIdentifier:uniqueIdentifier];
+}
+
+- (instancetype)initWithRegionalLocalization:(LocalizationDictionary *)regionalLocalization languageLocalization:(LocalizationDictionary *)languageLocalization defaultLocalization:(LocalizationDictionary *)defaultLocalization withBestLocale:(NSString *)localeString uniqueIdentifier:(NSString *)uniqueIdentifier
+{
+    return nil;
+}
+
+- (NSDictionary<NSString *, id> *)localizedDictionaryForDictionary:(NSDictionary<NSString *, id> *)dictionary
+{
+    return nil;
+}
+
+- (NSString *)localizedStringForKey:(NSString *)key withPlaceholders:(NSArray<NSString *> *)placeholders
+{
+    return nil;
+}
+
+- (NSString *)localizedStringForString:(NSString *)string
+{
+    return nil;
+}
+
+#endif // !ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm
@@ -31,6 +31,7 @@
 #import "_WKWebExtensionUtilities.h"
 
 #import "CocoaHelpers.h"
+#import "Logging.h"
 
 @implementation _WKWebExtensionUtilities
 
@@ -84,7 +85,7 @@ static NSString *classToClassString(Class classType, BOOL plural = NO)
         ASSERT([key isKindOfClass:[NSString class]]);
 
         if (![requiredKeysSet containsObject:key] && ![optionalKeysSet containsObject:key]) {
-            // FIXME: Add logging here?
+            RELEASE_LOG_ERROR(Extensions, "Found unexpected key (%{private}@), not specified in required or optional keys.", key);
             return;
         }
 
@@ -137,6 +138,6 @@ static NSString *classToClassString(Class classType, BOOL plural = NO)
     return NO;
 }
 
-#endif // ENABLE(WEB_EXTENSIONS)
+#endif // !ENABLE(WK_WEB_EXTENSIONS)
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -172,8 +172,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (NSLocale *)defaultLocale
 {
-    // FIXME: <https://webkit.org/b/246488> Handle manifest localization.
-    return nil;
+    return _webExtension->defaultLocale();
 }
 
 - (NSString *)displayName

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -785,7 +785,7 @@ void WebProcessPool::registerNotificationObservers()
     }
 #elif !PLATFORM(MACCATALYST)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    // FIXME: <https://webkit.org/b/246488> Adopt UIScreenBrightnessDidChangeNotification.
+    // FIXME: <https://webkit.org/b/255833> Adopt UIScreenBrightnessDidChangeNotification.
     addCFNotificationObserver(backlightLevelDidChangeCallback, (__bridge CFStringRef)UIBacklightLevelChangedNotification);
 ALLOW_DEPRECATED_DECLARATIONS_END
 #if PLATFORM(IOS) || PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -49,6 +49,7 @@
 #import "_WKWebExtensionContextInternal.h"
 #import "_WKWebExtensionControllerDelegatePrivate.h"
 #import "_WKWebExtensionControllerInternal.h"
+#import "_WKWebExtensionLocalization.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
 #import "_WKWebExtensionPermission.h"
 #import "_WKWebExtensionTab.h"

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -42,11 +42,13 @@ OBJC_CLASS NSBundle;
 OBJC_CLASS NSData;
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSError;
+OBJC_CLASS NSLocale;
 OBJC_CLASS NSMutableArray;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
 OBJC_CLASS _WKWebExtension;
+OBJC_CLASS _WKWebExtensionLocalization;
 OBJC_CLASS _WKWebExtensionMatchPattern;
 
 #if PLATFORM(MAC)
@@ -161,6 +163,9 @@ public:
 
     NSString *webProcessDisplayName();
 
+    _WKWebExtensionLocalization *localization();
+    NSLocale *defaultLocale();
+
     NSString *displayName();
     NSString *displayShortName();
     NSString *displayVersion();
@@ -243,6 +248,9 @@ private:
     RetainPtr<NSURL> m_resourceBaseURL;
     RetainPtr<NSDictionary> m_manifest;
     RetainPtr<NSMutableDictionary> m_resources;
+
+    RetainPtr<NSLocale> m_defaultLocale;
+    RetainPtr<_WKWebExtensionLocalization> m_localization;
 
     RetainPtr<NSMutableArray> m_errors;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -57,6 +57,8 @@ WebExtensionContext::WebExtensionContext()
 
 WebExtensionContextParameters WebExtensionContext::parameters() const
 {
+    // FIXME: <https://webkit.org/b/246488> Send over localized dictionary to the WebProcess.
+
     return WebExtensionContextParameters {
         identifier(),
         baseURL(),

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1780,12 +1780,17 @@
 		B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */; };
 		B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */ = {isa = PBXBuildFile; fileRef = B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */; };
 		B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */ = {isa = PBXBuildFile; fileRef = B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B62C01BC2A8E7AF600D6A941 /* _WKWebExtensionLocalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B62E7312143047B00069EC35 /* WKHitTestResult.h in Headers */ = {isa = PBXBuildFile; fileRef = B62E7311143047B00069EC35 /* WKHitTestResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */; };
 		B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B68437B329A3E2F500472D1B /* _WKWebExtensionLocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B6CCAAB929A445E90092E846 /* JSWebExtensionAPILocalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6CCAAB729A445E90092E846 /* JSWebExtensionAPILocalization.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */; };
+		B6E5F2A7299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = B878B613133428DC006888E9 /* CorrectionPanel.h */; };
 		BC017D0716260FF4007054F5 /* WKDOMDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017CFF16260FF4007054F5 /* WKDOMDocument.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC017D0916260FF4007054F5 /* WKDOMElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017D0116260FF4007054F5 /* WKDOMElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6365,6 +6370,8 @@
 		B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionEventListenerType.h; sourceTree = "<group>"; };
 		B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIPermissions.h; sourceTree = "<group>"; };
 		B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
+		B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionLocalization.h; sourceTree = "<group>"; };
+		B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionLocalization.mm; sourceTree = "<group>"; };
 		B62E730F143047A60069EC35 /* WKHitTestResult.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKHitTestResult.cpp; sourceTree = "<group>"; };
 		B62E7311143047B00069EC35 /* WKHitTestResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHitTestResult.h; sourceTree = "<group>"; };
 		B63403F814910D57001070B5 /* APIObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIObject.cpp; sourceTree = "<group>"; };
@@ -6376,6 +6383,11 @@
 		B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPIPermissions.h; path = WebProcess/Extensions/API/WebExtensionAPIPermissions.h; sourceTree = SOURCE_ROOT; };
 		B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIPermissionsCocoa.mm; sourceTree = "<group>"; };
 		B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIPermissionsCocoa.mm; sourceTree = "<group>"; };
+		B6CCAAB629A445E90092E846 /* JSWebExtensionAPILocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPILocalization.h; sourceTree = "<group>"; };
+		B6CCAAB729A445E90092E846 /* JSWebExtensionAPILocalization.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPILocalization.mm; sourceTree = "<group>"; };
+		B6E5F2A3299C0FFB00DBCEA3 /* WebExtensionAPILocalization.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPILocalization.idl; sourceTree = "<group>"; };
+		B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPILocalization.h; path = WebProcess/Extensions/API/WebExtensionAPILocalization.h; sourceTree = SOURCE_ROOT; };
+		B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPILocalizationCocoa.mm; sourceTree = "<group>"; };
 		B878B613133428DC006888E9 /* CorrectionPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CorrectionPanel.h; sourceTree = "<group>"; };
 		B878B614133428DC006888E9 /* CorrectionPanel.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CorrectionPanel.mm; sourceTree = "<group>"; };
 		BC017CFF16260FF4007054F5 /* WKDOMDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKDOMDocument.h; sourceTree = "<group>"; };
@@ -8546,6 +8558,7 @@
 				1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */,
 				B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */,
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
+				B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */,
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
 				B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */,
@@ -8566,6 +8579,7 @@
 				1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */,
 				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
+				B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
 				B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */,
 				1C5DC464290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm */,
@@ -8712,6 +8726,7 @@
 				1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */,
 				B6544F7C29357B1B00034EB0 /* WebExtensionAPIEvent.idl */,
 				1C9DD99028FA19A30093BDB0 /* WebExtensionAPIExtension.idl */,
+				B6E5F2A3299C0FFB00DBCEA3 /* WebExtensionAPILocalization.idl */,
 				1C9DD9A428FA19A30093BDB0 /* WebExtensionAPINamespace.idl */,
 				B6544F76293560B000034EB0 /* WebExtensionAPIPermissions.idl */,
 				1C9DD99C28FA19A30093BDB0 /* WebExtensionAPIRuntime.idl */,
@@ -11913,6 +11928,8 @@
 		B6114A8A293AE03600380B1B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */,
+				B6217BB1299C3AE300498BF8 /* _WKWebExtensionLocalization.mm */,
 				337822452947FBA4002106BB /* _WKWebExtensionUtilities.h */,
 				337822462947FBA4002106BB /* _WKWebExtensionUtilities.mm */,
 				1C2B4D412A817D6B00C528A1 /* WebExtensionAlarmParameters.h */,
@@ -13318,6 +13335,8 @@
 				B6114A7D29394A1500380B1B /* JSWebExtensionAPIEvent.mm */,
 				1C5DC462290B1C470061EC62 /* JSWebExtensionAPIExtension.h */,
 				1C5DC460290B1C440061EC62 /* JSWebExtensionAPIExtension.mm */,
+				B6CCAAB629A445E90092E846 /* JSWebExtensionAPILocalization.h */,
+				B6CCAAB729A445E90092E846 /* JSWebExtensionAPILocalization.mm */,
 				1C5DC4532908AC260061EC62 /* JSWebExtensionAPINamespace.h */,
 				1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */,
 				B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */,
@@ -14163,6 +14182,7 @@
 				1C3BEB5A28875CE500E66E38 /* _WKWebExtensionControllerInternal.h in Headers */,
 				1C3BEB5C28875CE500E66E38 /* _WKWebExtensionControllerPrivate.h in Headers */,
 				1C3BEB722888842F00E66E38 /* _WKWebExtensionInternal.h in Headers */,
+				B68437B329A3E2F500472D1B /* _WKWebExtensionLocalization.h in Headers */,
 				1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */,
 				1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */,
 				1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */,
@@ -14913,6 +14933,7 @@
 				1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */,
 				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
+				B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
 				1C5DC46B290B271E0061EC62 /* WebExtensionAPIObject.h in Headers */,
 				B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */,
@@ -17029,6 +17050,7 @@
 				1C0234D428A0135600AC1E5B /* _WKWebExtensionContext.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
 				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
+				B62C01BC2A8E7AF600D6A941 /* _WKWebExtensionLocalization.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
 				1C5ACF902A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.mm in Sources */,
@@ -17072,6 +17094,7 @@
 				1C2B4D4B2A819D0D00C528A1 /* JSWebExtensionAPIAlarms.mm in Sources */,
 				B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */,
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
+				B6CCAAB929A445E90092E846 /* JSWebExtensionAPILocalization.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
 				B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */,
 				1C5DC472290B33A60061EC62 /* JSWebExtensionAPIRuntime.mm in Sources */,
@@ -17399,6 +17422,7 @@
 				1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */,
 				B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */,
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
+				B6E5F2A7299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
 				B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */,
 				1C5DC466290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -32,7 +32,6 @@
 
 #import "MessageSenderInlines.h"
 #import "WebExtensionContextMessages.h"
-#import "WebPageProxy.h"
 #import "WebProcess.h"
 #import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/ScriptCallStack.h>

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -46,6 +46,8 @@ bool WebExtensionAPIExtension::isPropertyAllowed(String name, WebPage*)
 
 NSURL *WebExtensionAPIExtension::getURL(NSString *resourcePath, NSString **errorString)
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL
+
     URL baseURL = extensionContext().baseURL();
     return resourcePath.length ? URL { baseURL, resourcePath } : baseURL;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPILocalization.h"
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+#import "MessageSenderInlines.h"
+#import "WebExtensionContextMessages.h"
+#import "WebProcess.h"
+#import "_WKWebExtensionLocalization.h"
+#import <JavaScriptCore/APICast.h>
+#import <JavaScriptCore/ScriptCallStack.h>
+#import <JavaScriptCore/ScriptCallStackFactory.h>
+#include <wtf/CompletionHandler.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+class JSWebExtensionWrappable;
+
+NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id substitutions)
+{
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
+
+    // FIXME: <https://webkit.org/b/246488> Retrieve localized dictionary from the WebExtensionContextProxy.
+    _WKWebExtensionLocalization *localizedDictionary;
+    NSArray<NSString *> *substitutionsArray;
+    if ([substitutions isKindOfClass:NSString.class])
+        substitutionsArray = @[ substitutions ];
+    else if ([substitutions isKindOfClass:NSArray.class]) {
+        substitutionsArray = filterObjects((NSArray *)substitutions, ^bool(id, id value) {
+            return [value isKindOfClass:NSString.class];
+        });
+    }
+
+    return [localizedDictionary localizedStringForKey:messageName withPlaceholders:substitutionsArray];
+}
+
+NSString *WebExtensionAPILocalization::getUILanguage()
+{
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
+
+    RELEASE_LOG_INFO(Extensions, "i18n.getUILanguage()");
+
+    return localeStringInWebExtensionFormat(NSLocale.currentLocale);
+}
+
+void WebExtensionAPILocalization::getAcceptLanguages(Ref<WebExtensionCallbackHandler>&& callback)
+{
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
+
+    RELEASE_LOG_INFO(Extensions, "i18n.getAcceptedLanguages()");
+
+    NSArray<NSString *> *preferredLocaleIdentifiers = NSLocale.preferredLanguages;
+    NSMutableOrderedSet<NSString *> *acceptLanguages = [NSMutableOrderedSet orderedSetWithCapacity:preferredLocaleIdentifiers.count];
+    for (NSString *localeIdentifier in preferredLocaleIdentifiers) {
+        [acceptLanguages addObject:localeIdentifier];
+        [acceptLanguages addObject:[NSLocale localeWithLocaleIdentifier:localeIdentifier].languageCode];
+    }
+
+    callback->call(acceptLanguages.array);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -67,6 +67,13 @@ WebExtensionAPIExtension& WebExtensionAPINamespace::extension()
     return *m_extension;
 }
 
+WebExtensionAPILocalization& WebExtensionAPINamespace::i18n()
+{
+    if (!m_i18n)
+        m_i18n = WebExtensionAPILocalization::create(forMainWorld(), runtime(), extensionContext());
+    return *m_i18n;
+}
+
 WebExtensionAPIPermissions& WebExtensionAPINamespace::permissions()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/permissions

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -46,6 +46,10 @@ static NSString *originsKey = @"origins";
 
 void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callback)
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/getAll
+
+    RELEASE_LOG(Extensions, "permissions.getAll()");
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<String> permissions, Vector<String> origins) {
         callback->call(@{
             permissionsKey: createNSArray(permissions).get(),
@@ -56,6 +60,10 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
 
 void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/contains
+
+    RELEASE_LOG(Extensions, "permissions.contains()");
+
     HashSet<String> permissions, origins;
     WebExtension::MatchPatternSet matchPatterns;
     parseDetailsDictionary(details, permissions, origins);
@@ -70,6 +78,10 @@ void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensio
 
 void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request
+
+    RELEASE_LOG(Extensions, "permissions.request()");
+
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);
 
@@ -102,6 +114,10 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
 
 void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove
+
+    RELEASE_LOG(Extensions, "permissions.remove()");
+
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);
 
@@ -207,6 +223,8 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
 
 WebExtensionAPIEvent& WebExtensionAPIPermissions::onAdded()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onAdded
+
     if (!m_onAdded)
         m_onAdded = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PermissionsOnAdded);
 
@@ -215,6 +233,8 @@ WebExtensionAPIEvent& WebExtensionAPIPermissions::onAdded()
 
 WebExtensionAPIEvent& WebExtensionAPIPermissions::onRemoved()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/onRemoved
+
     if (!m_onRemoved)
         m_onRemoved = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PermissionsOnRemoved);
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -36,6 +36,8 @@ namespace WebKit {
 
 WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onBeforeNavigate()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate
+
     if (!m_onBeforeNavigateEvent)
         m_onBeforeNavigateEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnBeforeNavigate);
     return *m_onBeforeNavigateEvent;
@@ -43,6 +45,8 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onBeforeNavigat
 
 WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onCommitted()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted
+
     if (!m_onCommittedEvent)
         m_onCommittedEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnCommitted);
     return *m_onCommittedEvent;
@@ -50,6 +54,8 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onCommitted()
 
 WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onDOMContentLoaded()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded
+
     if (!m_onDOMContentLoadedEvent)
         m_onDOMContentLoadedEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded);
     return *m_onDOMContentLoadedEvent;
@@ -57,6 +63,8 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onDOMContentLoa
 
 WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onCompleted()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted
+
     if (!m_onCompletedEvent)
         m_onCompletedEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnCompleted);
     return *m_onCompletedEvent;
@@ -64,6 +72,8 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onCompleted()
 
 WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onErrorOccurred()
 {
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred
+
     if (!m_onErrorOccurredEvent)
         m_onErrorOccurredEvent = WebExtensionAPIWebNavigationEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebNavigationOnErrorOccurred);
     return *m_onErrorOccurredEvent;
@@ -71,12 +81,16 @@ WebExtensionAPIWebNavigationEvent& WebExtensionAPIWebNavigation::onErrorOccurred
 
 void WebExtensionAPIWebNavigation::getAllFrames(WebPage* webPage, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **errorString)
 {
-    // FIXME: Implement this.
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames
+
+    // FIXME: <https://webkit.org/b/260160> Implement this.
 }
 
 void WebExtensionAPIWebNavigation::getFrame(WebPage* webPage, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **errorString)
 {
-    // FIXME: Implement this.
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame
+
+    // FIXME: <https://webkit.org/b/260160> Implement this.
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,22 +27,18 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "APIData.h"
-#include "WebExtensionContextIdentifier.h"
-#include <wtf/URL.h>
+#include "JSWebExtensionAPILocalization.h"
+#include "WebExtensionAPIObject.h"
 
 namespace WebKit {
 
-struct WebExtensionContextParameters {
-    WebExtensionContextIdentifier identifier;
+class WebExtensionAPILocalization : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPILocalization, localization);
 
-    URL baseURL;
-    String uniqueIdentifier;
-    Ref<API::Data> manifestJSON;
-    double manifestVersion;
-    bool testingMode;
-
-    // FIXME: <https://webkit.org/b/246488> Add localized dictionary.
+public:
+    NSString *getMessage(NSString* messageName, id substitutions);
+    NSString *getUILanguage();
+    void getAcceptLanguages(Ref<WebExtensionCallbackHandler>&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -30,6 +30,7 @@
 #include "JSWebExtensionAPINamespace.h"
 #include "WebExtensionAPIAlarms.h"
 #include "WebExtensionAPIExtension.h"
+#include "WebExtensionAPILocalization.h"
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionAPIPermissions.h"
 #include "WebExtensionAPIRuntime.h"
@@ -52,6 +53,7 @@ public:
 
     WebExtensionAPIAlarms& alarms();
     WebExtensionAPIExtension& extension();
+    WebExtensionAPILocalization& i18n();
     WebExtensionAPIPermissions& permissions();
     WebExtensionAPIRuntime& runtime() final;
     WebExtensionAPITest& test();
@@ -63,6 +65,7 @@ public:
 private:
     RefPtr<WebExtensionAPIAlarms> m_alarms;
     RefPtr<WebExtensionAPIExtension> m_extension;
+    RefPtr<WebExtensionAPILocalization> m_i18n;
     RefPtr<WebExtensionAPIPermissions> m_permissions;
     RefPtr<WebExtensionAPIRuntime> m_runtime;
     RefPtr<WebExtensionAPITabs> m_tabs;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+[
+    Conditional=WK_WEB_EXTENSIONS,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPILocalization {
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+    // Get the localized string for the given message in the current locale, optionally providing up 9 substitutions.
+    DOMString getMessage([CannotBeEmpty] DOMString name, [Optional, NSObject] any substitutions);
 
-#include "APIData.h"
-#include "WebExtensionContextIdentifier.h"
-#include <wtf/URL.h>
+    // Get the UI language of the browser.
+    DOMString getUILanguage();
 
-namespace WebKit {
+    void getAcceptLanguages([Optional, CallbackHandler] function callback);
 
-struct WebExtensionContextParameters {
-    WebExtensionContextIdentifier identifier;
-
-    URL baseURL;
-    String uniqueIdentifier;
-    Ref<API::Data> manifestJSON;
-    double manifestVersion;
-    bool testingMode;
-
-    // FIXME: <https://webkit.org/b/246488> Add localized dictionary.
 };
-
-} // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -32,6 +32,8 @@
 
     readonly attribute WebExtensionAPIExtension extension;
 
+    readonly attribute WebExtensionAPILocalization i18n;
+
     readonly attribute WebExtensionAPIRuntime runtime;
 
     [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;


### PR DESCRIPTION
#### f756fa5b5b9132fec9add4ec28cb6f91c1d70409
<pre>
Add initial support for the browser.i18n Web Extension API.
<a href="https://webkit.org/b/246488">https://webkit.org/b/246488</a>
rdar://102720462 (Web Extensions in WebKit: Add support for i18n(Localization) in WebKit)

Reviewed by Timothy Hatcher.

This patch exposes the i18n API to the browser namespace. In addition, it add support for the methods:
- i18n.getAcceptLanguages()
- i18n.getUILanguage()

To do:
- Add support for i18n.getMessage().

Testing:
- Localized names for extensions show up in UI.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::dictionaryWithLowercaseKeys):
(WebKit::mergeDictionaries): Helper method that merges two dictionaries together.
(WebKit::mergeDictionariesAndSetValues): Helper method that merges two dictionaries together,
overwriting existing values.
(WebKit::localeStringInWebExtensionFormat):
(WebKit::privacyPreservingDescription):
(WebKit::toImpl):
(WebKit::toImplSet):

* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h: Added.
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm: Added.
(localizationDictionaryAtURL):
(+[_WKWebExtensionLocalization supportsSecureCoding]):
(-[_WKWebExtensionLocalization initWithBundleURL:defaultLocale:uniqueIdentifier:]):
(-[_WKWebExtensionLocalization initWithRegionalLocalization:languageLocalization:defaultLocalization:withBestLocale:uniqueIdentifier:]):
(-[_WKWebExtensionLocalization localizedDictionaryForDictionary:]):
(-[_WKWebExtensionLocalization localizedStringForKey:withPlaceholders:]):
(-[_WKWebExtensionLocalization _localizedArrayForArray:]):
(-[_WKWebExtensionLocalization localizedStringForString:]):
(-[_WKWebExtensionLocalization _predefinedMessagesForLocale:]):
(-[_WKWebExtensionLocalization _stringByReplacingNamedPlaceholdersInString:withNamedPlaceholders:]):
(-[_WKWebExtensionLocalization _stringByReplacingPositionalPlaceholdersInString:withValues:]):
(-[_WKWebExtensionLocalization encodeWithCoder:]):
(-[_WKWebExtensionLocalization initWithCoder:]):

* Source/WebKit/Shared/Extensions/_WKWebExtensionUtilities.mm:
(+[_WKWebExtensionUtilities validateContentsOfDictionary:requiredKeys:optionalKeys:keyToExpectedValueType:outExceptionString:]):
Add error message.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension defaultLocale]):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
Update FIXME with appropriate bug URL.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::manifest):
(WebKit::WebExtension::localization):
(WebKit::WebExtension::defaultLocale):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
FIXME to add localization dictionary to parameters struct.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:

(WebKit::WebExtensionAPIExtension::getURL):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm: Added.
(WebKit::WebExtensionAPILocalization::getMessage):
(WebKit::WebExtensionAPILocalization::getUILanguage):
(WebKit::WebExtensionAPILocalization::getAcceptLanguages):

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::i18n):
Add i18n to the browser namespace.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
Add links to documentation for Permissions APIs.
(WebKit::WebExtensionAPIPermissions::getAll):
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
(WebKit::WebExtensionAPIPermissions::onAdded):
(WebKit::WebExtensionAPIPermissions::onRemoved):

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
Add links to documentation for Web Navigation APIs.
(WebKit::WebExtensionAPIWebNavigation::onBeforeNavigate):
(WebKit::WebExtensionAPIWebNavigation::onCommitted):
(WebKit::WebExtensionAPIWebNavigation::onDOMContentLoaded):
(WebKit::WebExtensionAPIWebNavigation::onCompleted):
(WebKit::WebExtensionAPIWebNavigation::onErrorOccurred):
(WebKit::WebExtensionAPIWebNavigation::getAllFrames):
(WebKit::WebExtensionAPIWebNavigation::getFrame):

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h: Copied from Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl: Copied from Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
Add i18n to the browser namespace.

Canonical link: <a href="https://commits.webkit.org/267316@main">https://commits.webkit.org/267316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e15f1c1690565abdb998eeda87cc5bdb2a9aac50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17621 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18759 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14113 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21523 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18093 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13099 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19041 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1997 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->