### PR TITLE
Adopt UIResponder API methods in lieu of handleKeyUIEvent to respond to press events

### DIFF
--- a/LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html
+++ b/LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html
@@ -8,47 +8,31 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-let step = 0;
-
-function handleKeyUp(event)
-{
-    switch (step++) {
-    case 0:
-        console.assert(event.key === "a");
-        UIHelper.keyDown("\b"); // Backspace
-        return;
-    case 1:
-        console.assert(event.key === "Backspace");
-        internals.startTrackingRepaints();
-        UIHelper.toggleCapsLock();
-        return;
-    case 2: {
-        console.assert(event.key === "CapsLock");
-        document.getElementById("result").textContent = internals.repaintRectsAsText();
-        internals.stopTrackingRepaints();
-        testRunner.notifyDone();
-        return;
-    }
-    }
-}
-
-function runTest()
+async function runTest()
 {
     if (!window.testRunner)
         return;
-
     let input = document.getElementById("input");
-    function handleFocus() {
-        function handleCapsLockEnabled(event) {
-            console.assert(event.key === "CapsLock");
-            input.addEventListener("keyup", handleKeyUp, false);
-            UIHelper.keyDown("a");
-        }
-        input.addEventListener("keydown", handleCapsLockEnabled, { once: true });
-        UIHelper.toggleCapsLock();
-    }
-    input.addEventListener("focus", handleFocus, { once: true });
-    UIHelper.activateElement(input);
+    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.toggleCapsLock();
+    }, input, "keyup");
+
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.keyDown("a");
+    }, input, "keyup");
+
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.keyDown("\b");
+    }, input, "keyup");
+
+    internals.startTrackingRepaints();
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.toggleCapsLock();
+    }, input, "keyup");
+    document.getElementById("result").textContent = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+    testRunner.notifyDone();
 }
 </script>
 </head>

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -62,6 +62,7 @@
 #import <UIKit/UIPickerView_Private.h>
 #import <UIKit/UIPopoverPresentationController_Private.h>
 #import <UIKit/UIPresentationController_Private.h>
+#import <UIKit/UIPress_Private.h>
 #import <UIKit/UIPrintPageRenderer_Private.h>
 #import <UIKit/UIResponder_Private.h>
 #import <UIKit/UIScene_Private.h>
@@ -213,6 +214,8 @@ typedef struct __IOHIDEvent* IOHIDEventRef;
 typedef struct __GSKeyboard* GSKeyboardRef;
 WTF_EXTERN_C_END
 
+@class UIPressInfo;
+
 @interface UIApplication ()
 - (UIInterfaceOrientation)interfaceOrientation;
 - (void)_cancelAllTouches;
@@ -220,7 +223,6 @@ WTF_EXTERN_C_END
 - (BOOL)isSuspendedUnderLock;
 - (void)_enqueueHIDEvent:(IOHIDEventRef)event;
 - (void)_handleHIDEvent:(IOHIDEventRef)event;
-- (void)handleKeyUIEvent:(UIEvent *)event;
 - (BOOL)_appAdoptsUISceneLifecycle;
 @end
 
@@ -498,7 +500,6 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 @end
 
 @interface UIResponder ()
-- (void)_handleKeyUIEvent:(UIEvent *)event;
 - (void)_wheelChangedWithEvent:(UIEvent *)event;
 - (void)_beginPinningInputViews;
 - (void)_endPinningInputViews;
@@ -1401,6 +1402,14 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (void)prepareKeyboardInputModeFromPreferences:(UIKeyboardInputMode *)lastUsedMode;
 - (void)syncInputManagerToAcceptedAutocorrection:(TIKeyboardCandidate *)autocorrection forInput:(TIKeyboardInput *)inputEvent;
 @property (nonatomic, readonly) UIKeyboardInputMode *currentInputModeInPreference;
+@end
+
+@interface UIApplication (IPI)
+- (UIPressInfo *)_pressInfoForPhysicalKeyboardEvent:(UIPhysicalKeyboardEvent *)physicalKeyboardEvent;
+@end
+
+@interface UIPress (IPI)
+- (void)_loadStateFromPressInfo:(UIPressInfo *)pressInfo;
 @end
 
 @class CALayerHost;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -176,6 +176,8 @@ enum class TapHandlingResult : uint8_t;
 
 - (UIColor *)_insertionPointColor;
 
+- (BOOL)_tryToHandleKeyEventInCustomContentView:(UIPressesEvent *)event;
+
 @property (nonatomic, readonly) WKPasswordView *_passwordView;
 @property (nonatomic, readonly) WKWebViewContentProviderRegistry *_contentProviderRegistry;
 @property (nonatomic, readonly) WKSelectionGranularity _selectionGranularity;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -535,22 +535,51 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
     _page->didLayoutForCustomContentProvider();
 }
 
-ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
-- (void)_handleKeyUIEvent:(::UIEvent *)event
+- (BOOL)_tryToHandleKeyEventInCustomContentView:(UIPressesEvent *)event
 {
     // We only want to handle key events from the hardware keyboard when we are
     // first responder and a custom content view is installed; otherwise,
     // WKContentView will be the first responder and expects to get key events directly.
-    if ([self isFirstResponder] && event._hidEvent) {
+    if (self.isFirstResponder && event._hidEvent) {
         if ([_customContentView respondsToSelector:@selector(web_handleKeyEvent:)]) {
             if ([_customContentView web_handleKeyEvent:event])
-                return;
+                return YES;
         }
     }
-
-    [super _handleKeyUIEvent:event];
+    return NO;
 }
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+
+- (void)pressesBegan:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
+{
+    if ([self _tryToHandleKeyEventInCustomContentView:event])
+        return;
+
+    [super pressesBegan:presses withEvent:event];
+}
+
+- (void)pressesChanged:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
+{
+    if ([self _tryToHandleKeyEventInCustomContentView:event])
+        return;
+
+    [super pressesChanged:presses withEvent:event];
+}
+
+- (void)pressesEnded:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
+{
+    if ([self _tryToHandleKeyEventInCustomContentView:event])
+        return;
+
+    [super pressesEnded:presses withEvent:event];
+}
+
+- (void)pressesCancelled:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
+{
+    if ([self _tryToHandleKeyEventInCustomContentView:event])
+        return;
+
+    [super pressesCancelled:presses withEvent:event];
+}
 
 - (void)_willInvokeUIScrollViewDelegateCallback
 {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -830,6 +830,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)beginTextRecognitionForVideoInElementFullscreen:(WebKit::ShareableBitmap::Handle&&)bitmapHandle bounds:(WebCore::FloatRect)bounds;
 - (void)cancelTextRecognitionForVideoInElementFullscreen;
 
+- (BOOL)_tryToHandlePressesEvent:(UIPressesEvent *)event;
+
 @end
 
 @interface WKContentView (WKTesting)


### PR DESCRIPTION
#### a5fcaa3c441c0f15061f29b8bc50bcd8198eb28f
<pre>
Adopt UIResponder API methods in lieu of handleKeyUIEvent to respond to press events
<a href="https://bugs.webkit.org/show_bug.cgi?id=260217">https://bugs.webkit.org/show_bug.cgi?id=260217</a>
rdar://100726289

Reviewed by Wenson Hsieh.

The handleKeyUIEvent: and _handleKeyUIEvent: SPI are both deprecated.
Instead, we choose to adopt the pressesBegan:, pressesChanged:,
pressesEnded:, and pressesCancelled: API in this commit. These methods
are forwarded events for handling in the same fashion as the SPI to be
removed.

* LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html:

After the changes introduced in this patch, this test was dumping a lot
more painted rects. This was because previous key actions (`a`/`\b`)
were bleeding into the section of the test where we wanted to track
repaints (i.e. after the capslock indicator has been hidden).

We fix this by enforcing correct event ordering through appropriate async
usage of the UIHelper functions (i.e. awaiting `keyDown()` calls and the
resulting `keyUp` events).

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

1. Remove the deprecated SPI declarations.
2. Declare the UIPressInfo interface and some associated methods to
imbibe event information into a UIPress object.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _tryToHandleKeyEventInCustomContentView:]):

Helper function to determine whether an event needs forwarding based on
whether or not a custom content view handles it. Helps deduplicate code.

(-[WKWebView pressesBegan:withEvent:]):
(-[WKWebView pressesChanged:withEvent:]):
(-[WKWebView pressesEnded:withEvent:]):
(-[WKWebView pressesCancelled:withEvent:]):
(-[WKWebView _handleKeyUIEvent:]): Deleted.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _tryToHandlePressesEvent:]):

Helper function to determine whether an event needs forwarding based on
whether or not an input peripheral handles it. Helps deduplicate code.

(-[WKContentView pressesBegan:withEvent:]):
(-[WKContentView pressesEnded:withEvent:]):
(-[WKContentView pressesChanged:withEvent:]):
(-[WKContentView pressesCancelled:withEvent:]):
(-[WKContentView _handleKeyUIEvent:]): Deleted.

(WTR::UIScriptControllerIOS::toggleCapsLock):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::createUIPhysicalKeyboardEvent):
(WTR::UIScriptControllerIOS::toggleCapsLock):

The `toggleCapsLock` implementation required two broad changes to
maintain the existing toggle behavior:

1. Simply calling `pressesBegan:` on the `UIApplication` singleton does
not suffice in getting our synthetic keyboard event sent to the content
view&apos;s overridden `pressesBegan:` definition. To work around this, we
manually create a `UIPress` object with knowledge of our synthetic
keyboard event, and then send the press/event combination directly to
our content view&apos;s `pressesBegan:` overload. This maintains the existing
toggle behavior.

2. In inspecting the press/event combinations received when toggling the
capslock key with a hardware keyboard, it was noticed that on iOS we send
both a keyDown and a keyUp event with the appropriate modifier flag
information whenever we want to toggle capslock, with the former being
sent to `pressesBegan:` and the latter being sent to `pressesEnded:`.
As such, we generate a pair of keyboard events and call the appropriate
`presses[Began/Ended]:` method directly on our content view to reflect
this behavior.

Canonical link: <a href="https://commits.webkit.org/267119@main">https://commits.webkit.org/267119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9f0c0e3299c9577dad8b8bdba654f208a87d777

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14780 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16163 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16409 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18265 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14219 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17641 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->