### PR TITLE
[CMake] Generate a usable compile_commands.json

### DIFF
--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -235,6 +235,23 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     endif ()
 
     # -----------------------------------------------------------------------------
+    # Generate a usable compile_commands.json when using unified builds
+    # -----------------------------------------------------------------------------
+    if (CMAKE_EXPORT_COMPILE_COMMANDS AND ENABLE_UNIFIED_BUILDS)
+        add_custom_target(RewriteCompileCommands
+            ALL
+            BYPRODUCTS webkit_compile_commands.json
+            DEPENDS "${CMAKE_BINARY_DIR}/compile_commands.json"
+            COMMAND "${PYTHON_EXECUTABLE}"
+                    "${CMAKE_SOURCE_DIR}/Tools/Scripts/rewrite-compile-commands"
+                    "${CMAKE_BINARY_DIR}/compile_commands.json"
+                    "${CMAKE_BINARY_DIR}/webkit_compile_commands.json"
+                    "${CMAKE_SOURCE_DIR}"
+                    "${CMAKE_BINARY_DIR}"
+        )
+    endif ()
+
+    # -----------------------------------------------------------------------------
     # Job pool to avoid running too many memory hungry processes
     # -----------------------------------------------------------------------------
     if (DEFINED ENV{WEBKIT_NINJA_LINK_MAX})

--- a/Tools/Scripts/rewrite-compile-commands
+++ b/Tools/Scripts/rewrite-compile-commands
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Apple Inc. ("Apple") nor the names of
+# its contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+import os
+import re
+
+parser = argparse.ArgumentParser(
+    description='This tool takes the compile_commands.json output by CMake and expands any UnifiedSources in it to regular sources.'
+)
+parser.add_argument('input_file')
+parser.add_argument('output_file')
+parser.add_argument('source_dir')
+parser.add_argument('build_dir')
+
+args = parser.parse_args()
+source_dir = args.source_dir
+build_dir = args.build_dir
+
+generated_compile_commands = []
+
+with open(args.input_file) as f:
+    compile_commands = json.load(f)
+
+for entry in compile_commands:
+    entry_file = entry['file']
+    if not 'UnifiedSource' in entry_file:
+        generated_compile_commands.append(entry)
+        continue
+
+    # The paths we expect are in the style of:
+    # - WebKit/WebKitBuild/Release/DerivedSources/WebKit/unified-sources/UnifiedSource-54928a2b-29.cpp
+    # - WebKit/WebKitBuild/Release/WebCore/DerivedSources/unified-sources/UnifiedSource-42f7b70e-5.cpp
+    # And Windows too:
+    # - WebKit\WebKitBuild\Release\WebCore\DerivedSources\unified-sources\UnifiedSource-42f7b70e-5.cpp
+    # So we extract the parent folders to map them to the source folders.
+    parent_dir_1, parent_dir_2 = entry_file.rsplit(os.path.sep, maxsplit=4)[1:3]
+    search_directories = [
+        os.path.join(build_dir, parent_dir_1, parent_dir_2),
+    ]
+
+    if parent_dir_1 == 'DerivedSources':
+        search_directories.append(os.path.join(source_dir, 'Source', parent_dir_2))
+    else:
+        search_directories.append(os.path.join(source_dir, 'Source', parent_dir_1))
+
+    with open(entry_file) as f:
+        for line in f.readlines():
+            include_path = line[10:-2]  # Extract header from `#include "HEADER"\n`
+            for d in search_directories:
+                include_file = os.path.join(d, include_path)
+
+                if os.path.exists(include_file):
+                    generated_compile_commands.append({
+                        "directory": entry["directory"],
+                        "command": entry["command"].replace(entry_file, include_file),
+                        "file": include_file,
+                    })
+                    break
+            else:
+                print('Failed to find', include_path)
+
+with open(args.output_file, 'w') as f:
+    json.dump(generated_compile_commands, f, indent=2)


### PR DESCRIPTION
#### 5c9dd47913bc1cc71ae7cea6916a1b5eae19b5e3
<pre>
[CMake] Generate a usable compile_commands.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=260218">https://bugs.webkit.org/show_bug.cgi?id=260218</a>

Reviewed by Michael Catanzaro.

When using unified builds CMake generates a compile_commands.json
that isn&apos;t useful by many tools as it lacks much of the sources.

This adds a script to expand UnifiedSources into the full list
of sources. It outputs it to webkit_compile_commands.json.

* Source/cmake/WebKitCommon.cmake:
* Tools/Scripts/rewrite-compile-commands: Added.

Canonical link: <a href="https://commits.webkit.org/266947@main">https://commits.webkit.org/266947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94635253a4879c3e8f139be0435a0f678753409b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15617 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17703 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20688 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13032 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17149 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12254 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15407 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13734 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3929 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3658 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18078 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15642 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14296 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3740 "Passed tests") | 
<!--EWS-Status-Bubble-End-->