### PR TITLE
[build.webkit.org][WPE] Step for rebooting the RPi boards is not retrying the build

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1529,4 +1529,9 @@ class RebootWithUpdatedCrossTargetImage(shell.ShellCommandNewStyle):
     @defer.inlineCallbacks
     def run(self):
         rc = yield super().run()
-        defer.returnValue(FAILURE)
+        # The command reboot return success when it instructs the machine to reboot,
+        # but the machine can still take a while to stop services and actually reboot.
+        # Retry the build if reboot end sucesfully before the connection is lost.
+        if rc == SUCCESS:
+            self.build.buildFinished(['Rebooting with updated image, retrying build'], RETRY)
+        defer.returnValue(rc)


### PR DESCRIPTION
#### d4d4372742ae26bcbe87f5f0bee0b0c60d787a16
<pre>
[build.webkit.org][WPE] Step for rebooting the RPi boards is not retrying the build
<a href="https://bugs.webkit.org/show_bug.cgi?id=260223">https://bugs.webkit.org/show_bug.cgi?id=260223</a>

Reviewed by Aakash Jain.

The build should be restared after executing the step RebootWithUpdatedCrossTargetImage()

* Tools/CISupport/build-webkit-org/steps.py:
(RebootWithUpdatedCrossTargetImage.run):

Canonical link: <a href="https://commits.webkit.org/267084@main">https://commits.webkit.org/267084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b47d5228fd218d0703866fc22e0d0d4acf99d0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16911 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17710 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20693 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17155 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14466 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12260 "13 flakes 3 failures") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/15119 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18085 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1901 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->