### PR TITLE
Provide an initial implementation of `text-wrap: balance`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2895,7 +2895,7 @@ webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/pre
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/seg-break-transformation-018.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/seg-break-transformation-019.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/tab-bidi-001.html [ ImageOnlyFailure ]
-webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-002.html [ ImageOnlyFailure ]
+webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-001.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-text-indent-001.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-005.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-006.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1676,8 +1676,6 @@ webkit.org/b/245727 [ Monterey ] imported/w3c/web-platform-tests/notifications/i
 
 webkit.org/b/248734 media/video-inaccurate-duration-ended.html [ Crash ]
 
-webkit.org/b/257154 [ Debug ] imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-001.html [ Skip ]
-
 webkit.org/b/254778 [ Ventura Debug arm64 ] fast/images/avif-image-decoding.html [ Pass Crash ]
 
 webkit.org/b/255407 [ Monterey x86_64 ] imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering.html [ Pass Failure ]

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1700,6 +1700,7 @@ layout/formattingContexts/flex/FlexFormattingState.cpp
 layout/floats/FloatAvoider.cpp
 layout/floats/FloatingContext.cpp
 layout/floats/FloatingState.cpp
+layout/formattingContexts/inline/InlineContentBalancer.cpp
 layout/formattingContexts/inline/InlineContentBreaker.cpp
 layout/formattingContexts/inline/InlineFormattingContext.cpp
 layout/formattingContexts/inline/InlineFormattingGeometry.cpp

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
@@ -1,0 +1,442 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InlineContentBalancer.h"
+
+#include "InlineLineBuilder.h"
+#include <limits>
+
+namespace WebCore {
+namespace Layout {
+
+// Ideally, the act of balancing inline content will use the same number of lines as if the inline content
+// was laid out via `text-wrap: wrap`. However, adhering to this ideal is expensive (quadratic in the number
+// of break opportunities), and not caring about this ideal will allow us to use a more efficient algorithm.
+// Typically, if inline content spans many lines, the likelihood of someone caring about the vertical space
+// used decreases. So, we ignore this ideal number of lines requirement beyond this threshold.
+static const size_t maximumLinesToBalanceWithLineRequirement { 12 };
+
+static Vector<size_t> computeBreakOpportunities(const InlineItems& inlineItems, InlineItemRange range)
+{
+    Vector<size_t> breakOpportunities;
+    size_t currentIndex = range.startIndex();
+    while (currentIndex < range.endIndex()) {
+        currentIndex = InlineFormattingGeometry::nextWrapOpportunity(currentIndex, range, inlineItems);
+        breakOpportunities.append(currentIndex);
+    }
+    return breakOpportunities;
+}
+
+
+static float computeCost(InlineLayoutUnit candidateLineWidth, InlineLayoutUnit idealLineWidth)
+{
+    auto difference = idealLineWidth - candidateLineWidth;
+    return difference * difference;
+};
+
+InlineContentBalancer::InlineContentBalancer(const InlineFormattingContext& inlineFormattingContext, const InlineLayoutState& inlineLayoutState, const InlineItems& inlineItems, const HorizontalConstraints& horizontalConstraints)
+    : m_inlineFormattingContext(inlineFormattingContext)
+    , m_inlineLayoutState(inlineLayoutState)
+    , m_inlineItems(inlineItems)
+    , m_horizontalConstraints(horizontalConstraints)
+{
+    initialize();
+}
+
+void InlineContentBalancer::initialize()
+{
+    if (!m_inlineLayoutState.parentBlockLayoutState().floatingState().isEmpty()) {
+        m_cannotBalanceContent = true;
+        return;
+    }
+
+    m_numberOfInlineItems = m_inlineItems.size();
+    m_maximumLineWidth = m_horizontalConstraints.logicalWidth;
+
+    // Compute inline item widths beforehand to speed up later computations
+    m_inlineItemWidths.reserveCapacity(m_numberOfInlineItems);
+    for (size_t i = 0; i < m_numberOfInlineItems; i++) {
+        const auto& item = m_inlineItems[i];
+        if (!item.layoutBox().isInlineLevelBox()) {
+            m_cannotBalanceContent = true;
+            return;
+        }
+        m_inlineItemWidths.append(m_inlineFormattingContext.formattingGeometry().inlineItemWidth(item, 0, false));
+    }
+
+    // Perform a line layout with `text-wrap: wrap` to compute useful metrics such as:
+    //  - the number of lines used
+    //  - the original widths of each line
+    //  - forced break locations
+    InlineItemRange layoutRange = InlineItemRange { 0, m_inlineItems.size() };
+    auto floatingState = FloatingState { m_inlineFormattingContext.root() };
+    auto parentBlockLayoutState = BlockLayoutState { floatingState, { } };
+    auto inlineLayoutState = InlineLayoutState { parentBlockLayoutState, { } };
+    auto lineBuilder = LineBuilder { m_inlineFormattingContext, inlineLayoutState, floatingState, m_horizontalConstraints, m_inlineItems };
+    auto previousLineEnd = std::optional<InlineItemPosition> { };
+    auto previousLine = std::optional<PreviousLine> { };
+    auto lineIndex = 0lu;
+    while (!layoutRange.isEmpty()) {
+        auto lineInitialRect = InlineRect { 0.f, m_horizontalConstraints.logicalLeft, m_horizontalConstraints.logicalWidth, 0.f };
+        auto lineLayoutResult =lineBuilder.layoutInlineContent({ layoutRange, lineInitialRect }, previousLine);
+
+        // Record relevant geometry measurements from one line layout
+        m_originalLineInlineItemRanges.append(lineLayoutResult.inlineItemRange);
+        m_originalLineEndsWithForcedBreak.append(!lineLayoutResult.inlineContent.isEmpty() && lineLayoutResult.inlineContent.last().isLineBreak());
+        SlidingWidth lineSlidingWidth { *this, m_inlineItems, lineLayoutResult.inlineItemRange.startIndex(), lineLayoutResult.inlineItemRange.endIndex() };
+        m_originalLineWidths.append(lineSlidingWidth.width());
+
+        layoutRange.start = InlineFormattingGeometry::leadingInlineItemPositionForNextLine(lineLayoutResult.inlineItemRange.end, previousLineEnd, layoutRange.end);
+        previousLineEnd = layoutRange.start;
+        previousLine = PreviousLine { lineIndex, lineLayoutResult.contentGeometry.trailingOverflowingContentWidth, !lineLayoutResult.inlineContent.isEmpty() && lineLayoutResult.inlineContent.last().isLineBreak(), lineLayoutResult.directionality.inlineBaseDirection, WTFMove(lineLayoutResult.floatContent.suspendedFloats) };
+        lineIndex++;
+    }
+
+    m_numberOfLinesInOriginalLayout = lineIndex;
+}
+
+std::optional<Vector<LayoutUnit>> InlineContentBalancer::computeBalanceConstraints()
+{
+    if (m_cannotBalanceContent)
+        return std::nullopt;
+
+    // If forced line breaks exist, then we can balance each forced-break-delimited
+    // chunk of text separately. This helps simplify first line/indentation logic.
+    Vector<size_t> chunkSizes; // Number of lines per chunk of text
+    size_t currentChunkSize = 0;
+    for (size_t i = 0; i < m_originalLineInlineItemRanges.size(); i++) {
+        currentChunkSize++;
+        if (m_originalLineEndsWithForcedBreak[i]) {
+            chunkSizes.append(currentChunkSize);
+            currentChunkSize = 0;
+        }
+    }
+    if (currentChunkSize > 0)
+        chunkSizes.append(currentChunkSize);
+
+    // Balance each chunk
+    size_t startLine = 0;
+    Vector<LayoutUnit> balancedLineWidths;
+    for (auto chunkSize : chunkSizes) {
+        auto rangeToBalance = InlineItemRange { m_originalLineInlineItemRanges[startLine].startIndex(), m_originalLineInlineItemRanges[startLine + chunkSize - 1].endIndex() };
+        InlineLayoutUnit totalWidth = 0;
+        for (size_t i = 0; i < chunkSize; i++)
+            totalWidth += m_originalLineWidths[startLine + i];
+        InlineLayoutUnit idealLineWidth = totalWidth / chunkSize;
+
+        std::optional<Vector<LayoutUnit>> balancedLineWidthsForChunk;
+        if (m_numberOfLinesInOriginalLayout <= maximumLinesToBalanceWithLineRequirement)
+            balancedLineWidthsForChunk = balanceRangeWithLineRequirement(rangeToBalance, idealLineWidth, chunkSize);
+        else
+            balancedLineWidthsForChunk = balanceRangeWithNoLineRequirement(rangeToBalance, idealLineWidth);
+
+        if (!balancedLineWidthsForChunk) {
+            for (size_t i = 0; i < chunkSize; i++)
+                balancedLineWidths.append(m_maximumLineWidth);
+        } else {
+            for (size_t i = 0; i < balancedLineWidthsForChunk->size(); i++)
+                balancedLineWidths.append(balancedLineWidthsForChunk.value()[i]);
+        }
+
+        startLine += chunkSize;
+    }
+
+    return balancedLineWidths;
+}
+
+std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithLineRequirement(InlineItemRange range, InlineLayoutUnit idealLineWidth, size_t numberOfLines)
+{
+    // breakOpportunities holds the indices i such that a line break can occur before m_inlineItems[i].
+    auto breakOpportunities = computeBreakOpportunities(m_inlineItems, range);
+
+    // We need a dummy break opportunity at the beginning for algorithmic base case purposes
+    breakOpportunities.insert(0, range.startIndex());
+    auto numberOfBreakOpportunities = breakOpportunities.size();
+
+    struct Entry {
+        float accumulatedCost { std::numeric_limits<float>::infinity() };
+        size_t previousBreakIndex { 0 };
+    };
+
+    // state[i][j] holds the optimal set of line breaks where the jth line break (1-indexed) is
+    // right before m_inlineItems[breakOpportunities[i]]. "Optimal" in this context means the
+    // lowest possible accumulated cost.
+    Vector<Vector<Entry>> state(numberOfBreakOpportunities, Vector<Entry>(numberOfLines + 1));
+    state[0][0].accumulatedCost = 0.f;
+
+    // breakOpportunities[firstStartIndex] is the first possible starting position for a candidate line
+    size_t firstStartIndex = 0;
+    SlidingWidth slidingWidth { *this, m_inlineItems, breakOpportunities[firstStartIndex], breakOpportunities[firstStartIndex] };
+    for (size_t breakIndex = 1; breakIndex < numberOfBreakOpportunities; breakIndex++) {
+        size_t end = breakOpportunities[breakIndex];
+        slidingWidth.advanceEndTo(end);
+
+        // We prune our search space by limiting the possible starting positions for our candidate line.
+        while (slidingWidth.width() > m_maximumLineWidth) {
+            firstStartIndex++;
+            if (firstStartIndex > breakIndex)
+                break;
+            slidingWidth.advanceStartTo(breakOpportunities[firstStartIndex]);
+        }
+
+        // Evaluate all possible lines that break before m_inlineItems[end]
+        auto innerSlidingWidth = slidingWidth;
+        for (size_t startIndex = firstStartIndex; startIndex < breakIndex; startIndex++) {
+            size_t start = breakOpportunities[startIndex];
+            innerSlidingWidth.advanceStartTo(start);
+            auto candidateLineWidth = innerSlidingWidth.width();
+            auto candidateLineCost = computeCost(candidateLineWidth, idealLineWidth);
+            ASSERT(candidateLineWidth <= m_maximumLineWidth);
+
+            // Compute the cost of this line based on the line index
+            for (size_t lineIndex = 1; lineIndex <= numberOfLines; lineIndex++) {
+                auto accumulatedCost = candidateLineCost + state[startIndex][lineIndex - 1].accumulatedCost;
+                if (accumulatedCost < state[breakIndex][lineIndex].accumulatedCost) {
+                    state[breakIndex][lineIndex].accumulatedCost = accumulatedCost;
+                    state[breakIndex][lineIndex].previousBreakIndex = startIndex;
+                }
+            }
+        }
+    }
+
+    // Check if we found no solution
+    if (std::isinf(state[numberOfBreakOpportunities - 1][numberOfLines].accumulatedCost))
+        return std::nullopt;
+
+    // breaks[i] equals the index into m_inlineItems before which the ith line will break
+    Vector<size_t> breaks(numberOfLines);
+    size_t breakIndex = numberOfBreakOpportunities - 1;
+    for (size_t line = numberOfLines; line > 0; line--) {
+        breaks[line - 1] = breakOpportunities[breakIndex];
+        breakIndex = state[breakIndex][line].previousBreakIndex;
+    }
+
+    // Compute final line widths
+    Vector<LayoutUnit> lineWidths(numberOfLines);
+    for (size_t i = 0; i < numberOfLines; i++) {
+        auto start = i > 0 ? breaks[i - 1] : range.startIndex();
+        auto end = breaks[i];
+        SlidingWidth slidingWidth { *this, m_inlineItems, start, end };
+        lineWidths[i] = LayoutUnit::fromFloatCeil(slidingWidth.width() + LayoutUnit::epsilon());
+    }
+
+    return lineWidths;
+}
+
+std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithNoLineRequirement(InlineItemRange range, InlineLayoutUnit idealLineWidth)
+{
+    // breakOpportunities holds the indices i such that a line break can occur before m_inlineItems[i].
+    auto breakOpportunities = computeBreakOpportunities(m_inlineItems, range);
+
+    // We need a dummy break opportunity at the beginning for algorithmic base case purposes
+    breakOpportunities.insert(0, range.startIndex());
+    auto numberOfBreakOpportunities = breakOpportunities.size();
+
+    struct Entry {
+        float accumulatedCost { std::numeric_limits<float>::infinity() };
+        size_t previousBreakIndex { 0 };
+    };
+
+    // state[i] holds the optimal set of line breaks where the last line break is right
+    // before m_inlineItems[breakOpportunities[i]]. "Optimal" in this context means the
+    // lowest possible accumulated cost.
+    Vector<Entry> state(numberOfBreakOpportunities);
+    state[0].accumulatedCost = 0.f;
+
+    // breakOpportunities[firstStartIndex] is the first possible starting position for a candidate line
+    size_t firstStartIndex = 0;
+    SlidingWidth slidingWidth { *this, m_inlineItems, breakOpportunities[firstStartIndex], breakOpportunities[firstStartIndex] };
+    for (size_t breakIndex = 1; breakIndex < numberOfBreakOpportunities; breakIndex++) {
+        size_t end = breakOpportunities[breakIndex];
+        slidingWidth.advanceEndTo(end);
+
+        // We prune our search space by limiting the possible starting positions for our candidate line.
+        while (slidingWidth.width() > m_maximumLineWidth) {
+            firstStartIndex++;
+            if (firstStartIndex > breakIndex)
+                break;
+            slidingWidth.advanceStartTo(breakOpportunities[firstStartIndex]);
+        }
+
+        // Evaluate all possible lines that break before m_inlineItems[end]
+        auto innerSlidingWidth = slidingWidth;
+        for (size_t startIndex = firstStartIndex; startIndex < breakIndex; startIndex++) {
+            size_t start = breakOpportunities[startIndex];
+            innerSlidingWidth.advanceStartTo(start);
+            auto candidateLineWidth = innerSlidingWidth.width();
+            auto candidateLineCost = computeCost(candidateLineWidth, idealLineWidth);
+            ASSERT(candidateLineWidth <= m_maximumLineWidth);
+
+            auto accumulatedCost = candidateLineCost + state[startIndex].accumulatedCost;
+            if (accumulatedCost < state[breakIndex].accumulatedCost) {
+                state[breakIndex].accumulatedCost = accumulatedCost;
+                state[breakIndex].previousBreakIndex = startIndex;
+            }
+        }
+    }
+
+    // Check if we found no solution
+    if (std::isinf(state[numberOfBreakOpportunities - 1].accumulatedCost))
+        return std::nullopt;
+
+    // breaks[i] equals the index into m_inlineItems before which the ith line will break
+    Vector<size_t> breaks;
+    size_t breakIndex = numberOfBreakOpportunities - 1;
+    do {
+        breaks.append(breakOpportunities[breakIndex]);
+        breakIndex = state[breakIndex].previousBreakIndex;
+    } while (breakIndex);
+    breaks.reverse();
+
+    // Compute final line widths
+    Vector<LayoutUnit> lineWidths(breaks.size());
+    for (size_t i = 0; i < breaks.size(); i++) {
+        auto start = i > 0 ? breaks[i - 1] : range.startIndex();
+        auto end = breaks[i];
+        SlidingWidth slidingWidth { *this, m_inlineItems, start, end };
+        lineWidths[i] = LayoutUnit::fromFloatCeil(slidingWidth.width() + LayoutUnit::epsilon());
+    }
+
+    return lineWidths;
+}
+
+InlineLayoutUnit InlineContentBalancer::inlineItemWidth(size_t inlineItemIndex) const
+{
+    return m_inlineItemWidths[inlineItemIndex];
+}
+
+bool InlineContentBalancer::shouldTrimLeading(size_t inlineItemIndex) const
+{
+    const auto& inlineItem = m_inlineItems[inlineItemIndex];
+    auto itemWidth = inlineItemWidth(inlineItemIndex);
+
+    if (inlineItem.isText() && downcast<InlineTextItem>(inlineItem).isWhitespace())
+        return true;
+    if (itemWidth <= 0)
+        return true;
+    return false;
+}
+
+bool InlineContentBalancer::shouldTrimTrailing(size_t inlineItemIndex) const
+{
+    const auto& inlineItem = m_inlineItems[inlineItemIndex];
+    auto itemWidth = inlineItemWidth(inlineItemIndex);
+
+    if (inlineItem.isText() && downcast<InlineTextItem>(inlineItem).isWhitespace())
+        return true;
+    if (itemWidth <= 0)
+        return true;
+    return false;
+}
+
+InlineContentBalancer::SlidingWidth::SlidingWidth(const InlineContentBalancer& inlineContentBalancer, const InlineItems& inlineItems, size_t start, size_t end)
+    : m_inlineContentBalancer(inlineContentBalancer)
+    , m_inlineItems(inlineItems)
+    , m_start(start)
+{
+    ASSERT(start <= end);
+    m_end = start;
+    while (m_end < end)
+        advanceEnd();
+}
+
+InlineLayoutUnit InlineContentBalancer::SlidingWidth::width()
+{
+    return m_totalWidth - m_leadingTrimmableWidth - m_trailingTrimmableWidth;
+}
+
+void InlineContentBalancer::SlidingWidth::advanceStart()
+{
+    ASSERT(m_start < m_end);
+    auto startItemIndex = m_start;
+    auto startItemWidth = m_inlineContentBalancer.inlineItemWidth(startItemIndex);
+    m_totalWidth -= startItemWidth;
+    m_start++;
+
+    if (m_inlineContentBalancer.shouldTrimLeading(startItemIndex)) {
+        m_leadingTrimmableWidth -= startItemWidth;
+        return;
+    }
+
+    m_firstLeadingNonTrimmedItem = std::nullopt;
+    m_leadingTrimmableWidth = 0;
+    for (auto current = m_start; current < m_end; current++) {
+        if (!m_inlineContentBalancer.shouldTrimLeading(current)) {
+            m_firstLeadingNonTrimmedItem = current;
+            break;
+        }
+        m_leadingTrimmableWidth += m_inlineContentBalancer.inlineItemWidth(current);
+    }
+
+    // Update trailing logic if necessary:
+    //   1: Check if the removed start item was the first trailing item
+    //   2: Check if the first non trimmed leading item surpassed the first trailing item
+    // In both cases, we should have m_leadingTrimmableWidth + m_trailingTrimmableWidth = m_totalWidth
+    if (m_leadingTrimmableWidth + m_trailingTrimmableWidth > m_totalWidth)
+        m_trailingTrimmableWidth = m_totalWidth - m_leadingTrimmableWidth;
+}
+
+void InlineContentBalancer::SlidingWidth::advanceStartTo(size_t newStart)
+{
+    ASSERT(m_start <= newStart);
+    while (m_start < newStart)
+        advanceStart();
+}
+
+void InlineContentBalancer::SlidingWidth::advanceEnd()
+{
+    ASSERT(m_end < m_inlineItems.size());
+    auto endItemIndex = m_end;
+    auto endItemWidth = m_inlineContentBalancer.inlineItemWidth(endItemIndex);
+    m_totalWidth += endItemWidth;
+    m_end++;
+
+    if (!m_firstLeadingNonTrimmedItem.has_value()) {
+        if (m_inlineContentBalancer.shouldTrimLeading(endItemIndex)) {
+            m_leadingTrimmableWidth += endItemWidth;
+            return;
+        }
+        m_firstLeadingNonTrimmedItem = endItemIndex;
+        return;
+    }
+
+    if (m_inlineContentBalancer.shouldTrimTrailing(m_end - 1)) {
+        m_trailingTrimmableWidth += endItemWidth;
+        return;
+    }
+
+    m_trailingTrimmableWidth = 0;
+}
+
+void InlineContentBalancer::SlidingWidth::advanceEndTo(size_t newEnd)
+{
+    ASSERT(m_end <= newEnd);
+    while (m_end < newEnd)
+        advanceEnd();
+}
+
+}
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FormattingConstraints.h"
+#include "InlineFormattingContext.h"
+#include "InlineFormattingGeometry.h"
+#include "InlineItem.h"
+#include "InlineLineBuilder.h"
+#include "InlineTextItem.h"
+
+namespace WebCore {
+namespace Layout {
+
+class InlineContentBalancer {
+public:
+    InlineContentBalancer(const InlineFormattingContext&, const InlineLayoutState&, const InlineItems&, const HorizontalConstraints&);
+    std::optional<Vector<LayoutUnit>> computeBalanceConstraints();
+
+private:
+    void initialize();
+
+    std::optional<Vector<LayoutUnit>> balanceRangeWithLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, size_t numberOfLines);
+    std::optional<Vector<LayoutUnit>> balanceRangeWithNoLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth);
+
+    InlineLayoutUnit inlineItemWidth(size_t inlineItemIndex) const;
+    bool shouldTrimLeading(size_t inlineItemIndex) const;
+    bool shouldTrimTrailing(size_t inlineItemIndex) const;
+
+    const InlineFormattingContext& m_inlineFormattingContext;
+    const InlineLayoutState& m_inlineLayoutState;
+    const InlineItems& m_inlineItems;
+    const HorizontalConstraints& m_horizontalConstraints;
+
+    Vector<InlineItemRange> m_originalLineInlineItemRanges;
+    Vector<float> m_originalLineWidths;
+    Vector<bool> m_originalLineEndsWithForcedBreak;
+    Vector<InlineLayoutUnit> m_inlineItemWidths;
+    size_t m_numberOfLinesInOriginalLayout { 0 };
+    size_t m_numberOfInlineItems { 0 };
+    double m_maximumLineWidth { 0 };
+    bool m_cannotBalanceContent { false };
+
+    struct SlidingWidth {
+        SlidingWidth(const InlineContentBalancer&, const InlineItems&, size_t start, size_t end);
+        InlineLayoutUnit width();
+        void advanceStart();
+        void advanceStartTo(size_t newStart);
+        void advanceEnd();
+        void advanceEndTo(size_t newEnd);
+
+    private:
+        const InlineContentBalancer& m_inlineContentBalancer;
+        const InlineItems& m_inlineItems;
+        size_t m_start { 0 };
+        size_t m_end { 0 };
+        InlineLayoutUnit m_totalWidth { 0 };
+        InlineLayoutUnit m_leadingTrimmableWidth { 0 };
+        InlineLayoutUnit m_trailingTrimmableWidth { 0 };
+        std::optional<size_t> m_firstLeadingNonTrimmedItem;
+    };
+};
+
+}
+}

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -26,8 +26,10 @@
 #include "config.h"
 #include "InlineFormattingContext.h"
 
+#include "AvailableLineWidthOverride.h"
 #include "FloatingContext.h"
 #include "FontCascade.h"
+#include "InlineContentBalancer.h"
 #include "InlineDamage.h"
 #include "InlineDisplayBox.h"
 #include "InlineDisplayContentBuilder.h"
@@ -95,6 +97,13 @@ InlineLayoutResult InlineFormattingContext::layoutInFlowAndFloatContent(const Co
         // FIXME: We should be able to extract the last line information and provide it to layout as "previous line" (ends in line break and inline direction).
         return PreviousLine { lastLineIndex, { }, { }, { }, { } };
     };
+
+    if (root().style().textWrap() == TextWrap::Balance) {
+        auto balancer = InlineContentBalancer { *this, inlineLayoutState, inlineItems, constraints.horizontal() };
+        auto balancedLineWidths = balancer.computeBalanceConstraints();
+        if (balancedLineWidths)
+            inlineLayoutState.setAvailableLineWidthOverride({ *balancedLineWidths });
+    }
 
     if (TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout(root(), formattingState(), &floatingState)) {
         auto simplifiedLineBuilder = TextOnlySimpleLineBuilder { *this, constraints.horizontal(), inlineItems };

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -373,6 +373,8 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout(cons
         return false;
     if (rootStyle.hyphenationLimitLines() != RenderStyle::initialHyphenationLimitLines())
         return false;
+    if (rootStyle.textWrap() == TextWrap::Balance)
+        return false;
 
     return true;
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -499,6 +499,8 @@ bool shouldInvalidateLineLayoutPathAfterChangeFor(const RenderBlockFlow& rootBlo
         // Single mutation only atm.
         return true;
     }
+    if (renderer.style().textWrap() == TextWrap::Balance)
+        return true;
 
     auto rootHasNonSupportedRenderer = [&] {
         for (auto* sibling = rootBlockContainer.firstChild(); sibling; sibling = sibling->nextSibling()) {


### PR DESCRIPTION
#### 2d299a2dd8bbf0374011075326ffb8c83433cc4a
<pre>
Provide an initial implementation of `text-wrap: balance`
<a href="https://bugs.webkit.org/show_bug.cgi?id=249840">https://bugs.webkit.org/show_bug.cgi?id=249840</a>
rdar://problem/103663513

Reviewed by Alan Baradlay.

This patch implements `text-wrap: balance` in IFC. It uses a Knuth-Plass
style dynamic programming algorithm to minimize the variance of all the
line lengths. There is no line limit imposed on this implementation.

Ideally, the act of balancing inline content will use the same number of
lines as if the inline content was laid out via `text-wrap: wrap`. However,
adhering to this ideal is expensive, and not caring about this ideal will
allow us to use a more efficient algorithm. Since inline content spanning
many lines is less likely to care about the exact preservation of vertical
space (i.e. number of lines used), we ignore this ideal number of lines
requirement beyond a certain line count (tentatively set to 12 lines for now).

There are two implementations of the Knuth-Plass style algorithm:
    (1) one which attempts to preserve the number of lines used, and
    (2) one that ignores that requirement.
If we let N denote the number of break opportunities, let L denote the
number of lines used, and let K denote the maximum number of inline items
that can fit in a single line, then algorithm (1) has a time complexity of
O(N * L * K), while algorithm (2) has a time complexity of O(N * K).

We use algorithm (1) when we want to preserve the number of lines used,
and we use algorithm (2) when we want to prioritize performance (i.e. when
inline content spans many lines). It is worth noting that algorithm (2)
will often also preserve the number of lines used. In the case that it
does not, the number of lines will differ only by a small amount.

This is an initial implementation, and not all features are supported.
Unsupported features include (and are not limited to):
- first-line styling
- indentation
- white-space-collapse
- tabs
- hyphens
- floats (including initial-letter)

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp: Added.
(WebCore::Layout::computeBreakOpportunities):
(WebCore::Layout::computeCost):
(WebCore::Layout::InlineContentBalancer::InlineContentBalancer):
(WebCore::Layout::InlineContentBalancer::initialize):
(WebCore::Layout::InlineContentBalancer::computeBalanceConstraints):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithLineRequirement):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithNoLineRequirement):
(WebCore::Layout::InlineContentBalancer::inlineItemWidth const):
(WebCore::Layout::InlineContentBalancer::shouldTrimLeading const):
(WebCore::Layout::InlineContentBalancer::shouldTrimTrailing const):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::SlidingWidth):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::width):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::advanceStart):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::advanceStartTo):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::advanceEnd):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::advanceEndTo):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::layoutInFlowAndFloatContent):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::shouldInvalidateLineLayoutPathAfterChangeFor):

Canonical link: <a href="https://commits.webkit.org/266980@main">https://commits.webkit.org/266980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a467cfedef116125d90805d4d91be17f02f26c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15687 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17773 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20739 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17208 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13796 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3672 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->