### PR TITLE
Restart XR immersive session foreground activity if needed when process is unsuspended

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1067,8 +1067,16 @@ void WebProcessPool::setProcessesShouldSuspend(bool shouldSuspend)
         return;
 
     m_processesShouldSuspend = shouldSuspend;
-    for (auto& process : m_processes)
+    for (auto& process : m_processes) {
         process->throttler().setAllowsActivities(!m_processesShouldSuspend);
+
+#if ENABLE(WEBXR) && !USE(OPENXR)
+        if (!m_processesShouldSuspend) {
+            for (auto& page : process->pages())
+                page->restartXRSessionActivityOnProcessResumeIfNeeded();
+        }
+#endif
+    }
 }
 
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7422,6 +7422,12 @@ PlatformXRSystem* WebPageProxy::xrSystem() const
 {
     return internals().xrSystem.get();
 }
+
+void WebPageProxy::restartXRSessionActivityOnProcessResumeIfNeeded()
+{
+    if (xrSystem() && xrSystem()->hasActiveSession())
+        xrSystem()->ensureImmersiveSessionActivity();
+}
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2256,6 +2256,7 @@ public:
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     PlatformXRSystem* xrSystem() const;
+    void restartXRSessionActivityOnProcessResumeIfNeeded();
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -54,6 +54,14 @@ void PlatformXRSystem::invalidate()
         xrCoordinator()->endSessionIfExists(m_page);
 }
 
+void PlatformXRSystem::ensureImmersiveSessionActivity()
+{
+    if (m_immersiveSessionActivity && m_immersiveSessionActivity->isValid())
+        return;
+
+    m_immersiveSessionActivity = m_page.process().throttler().foregroundActivity("XR immersive session"_s).moveToUniquePtr();
+}
+
 void PlatformXRSystem::enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&& completionHandler)
 {
     auto* xrCoordinator = PlatformXRSystem::xrCoordinator();
@@ -91,7 +99,7 @@ void PlatformXRSystem::initializeTrackingAndRendering(const WebCore::SecurityOri
     if (!xrCoordinator)
         return;
 
-    m_immersiveSessionActivity = m_page.process().throttler().foregroundActivity("XR immersive session"_s).moveToUniquePtr();
+    ensureImmersiveSessionActivity();
 
     WeakPtr weakThis { *this };
     xrCoordinator->startSession(m_page, weakThis, securityOriginData, mode, requestedFeatures);

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -57,6 +57,7 @@ public:
     void invalidate();
 
     bool hasActiveSession() const { return !!m_immersiveSessionActivity; }
+    void ensureImmersiveSessionActivity();
 
 private:
     static PlatformXRCoordinator* xrCoordinator();


### PR DESCRIPTION
#### ce151b92a063863286dacf717396b686b409b16f
<pre>
Restart XR immersive session foreground activity if needed when process is unsuspended
<a href="https://bugs.webkit.org/show_bug.cgi?id=260226">https://bugs.webkit.org/show_bug.cgi?id=260226</a>
rdar://107913685

Reviewed by Chris Dumez and Dean Jackson.

The &quot;XR immersive session&quot; foreground activity is added when an
XR session starts so the web process has the foreground priority
to do rendering work. That activity gets invalidated when the
process is suspended. So if the process resumes again while an
XR session is still in progress, we need to add that foreground
activity again.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::setProcessesShouldSuspend):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::restartXRSessionActivityOnProcessResumeIfNeeded):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
(WebKit::PlatformXRSystem::initializeTrackingAndRendering):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:

Canonical link: <a href="https://commits.webkit.org/267097@main">https://commits.webkit.org/267097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e330ed722cab4a24dad766a18066a74ab40451

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14248 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16872 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17649 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13073 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20641 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17095 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12209 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13686 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->