### PR TITLE
WebValidationMessageClient should use WeakPtr to WebPage, not a raw reference

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
@@ -62,27 +62,29 @@ void WebValidationMessageClient::showValidationMessage(const Element& anchor, co
 
     m_currentAnchor = &anchor;
     m_currentAnchorRect = anchor.boundingBoxInRootViewCoordinates();
-    m_page.send(Messages::WebPageProxy::ShowValidationMessage(m_currentAnchorRect, message));
+    Ref { *m_page }->send(Messages::WebPageProxy::ShowValidationMessage(m_currentAnchorRect, message));
 }
 
 void WebValidationMessageClient::hideValidationMessage(const Element& anchor)
 {
-    if (!isValidationMessageVisible(anchor))
+    RefPtr page = m_page.get();
+    if (!isValidationMessageVisible(anchor) || !page)
         return;
 
     m_currentAnchor = nullptr;
     m_currentAnchorRect = { };
-    m_page.send(Messages::WebPageProxy::HideValidationMessage());
+    page->send(Messages::WebPageProxy::HideValidationMessage());
 }
 
 void WebValidationMessageClient::hideAnyValidationMessage()
 {
-    if (!m_currentAnchor)
+    RefPtr page = m_page.get();
+    if (!m_currentAnchor || !page)
         return;
 
     m_currentAnchor = nullptr;
     m_currentAnchorRect = { };
-    m_page.send(Messages::WebPageProxy::HideValidationMessage());
+    page->send(Messages::WebPageProxy::HideValidationMessage());
 }
 
 bool WebValidationMessageClient::isValidationMessageVisible(const Element& anchor)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/IntRect.h>
 #include <WebCore/ValidationMessageClient.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
@@ -46,7 +47,7 @@ public:
     void updateValidationBubbleStateIfNeeded() final;
 
 private:
-    WebPage& m_page;
+    WeakPtr<WebPage> m_page;
     const WebCore::Element* m_currentAnchor { nullptr };
     WebCore::IntRect m_currentAnchorRect;
 };


### PR DESCRIPTION
#### 305367d61f5be4bb48833b09bfbbeffe1b10d521
<pre>
WebValidationMessageClient should use WeakPtr to WebPage, not a raw reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=260230">https://bugs.webkit.org/show_bug.cgi?id=260230</a>

Reviewed by Wenson Hsieh.

Deploy WeakPtr in WebValidationMessageClient.

* Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp:
(WebKit::WebValidationMessageClient::showValidationMessage):
(WebKit::WebValidationMessageClient::hideValidationMessage):
(WebKit::WebValidationMessageClient::hideAnyValidationMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.h:

Canonical link: <a href="https://commits.webkit.org/266937@main">https://commits.webkit.org/266937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87eb29b57110c7f8701e3f973b710870311bc41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14253 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15575 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17659 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13079 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20644 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17099 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14417 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12212 "1 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18036 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1838 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->