### PR TITLE
Deploy smart pointers in TextTrackRepresentationCocoa.mm

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -50,7 +50,7 @@ void WebTextTrackRepresentationCocoa::update()
 {
     if (!m_page)
         return;
-    auto& fullscreenManager = m_page->videoFullscreenManager();
+    Ref fullscreenManager = m_page->videoFullscreenManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
     
@@ -71,7 +71,8 @@ void WebTextTrackRepresentationCocoa::update()
     auto handle = bitmap->createHandle();
     if (!handle)
         return;
-    fullscreenManager.updateTextTrackRepresentationForVideoElement(downcast<WebCore::HTMLVideoElement>(*m_mediaElement), WTFMove(*handle));
+    Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
+    fullscreenManager->updateTextTrackRepresentationForVideoElement(videoElement, WTFMove(*handle));
 }
 
 void WebTextTrackRepresentationCocoa::setContentScale(float scale)
@@ -79,10 +80,11 @@ void WebTextTrackRepresentationCocoa::setContentScale(float scale)
     WebCore::TextTrackRepresentationCocoa::setContentScale(scale);
     if (!m_page)
         return;
-    auto& fullscreenManager = m_page->videoFullscreenManager();
+    Ref fullscreenManager = m_page->videoFullscreenManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
-    fullscreenManager.setTextTrackRepresentationContentScaleForVideoElement(downcast<WebCore::HTMLVideoElement>(*m_mediaElement), scale);
+    Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
+    fullscreenManager->setTextTrackRepresentationContentScaleForVideoElement(videoElement, scale);
 }
 
 void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
@@ -90,10 +92,11 @@ void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
     WebCore::TextTrackRepresentationCocoa::setHidden(hidden);
     if (!m_page)
         return;
-    auto& fullscreenManager = m_page->videoFullscreenManager();
+    Ref fullscreenManager = m_page->videoFullscreenManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
-    fullscreenManager.setTextTrackRepresentationIsHiddenForVideoElement(downcast<WebCore::HTMLVideoElement>(*m_mediaElement), hidden);
+    Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
+    fullscreenManager->setTextTrackRepresentationIsHiddenForVideoElement(videoElement, hidden);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### fd292c9a79f164c0fdcc972dc33d588ed1ad2c9d
<pre>
Deploy smart pointers in TextTrackRepresentationCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=260242">https://bugs.webkit.org/show_bug.cgi?id=260242</a>

Reviewed by Jer Noble.

Deployed more smart pointers.

* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::update):
(WebKit::WebTextTrackRepresentationCocoa::setContentScale):
(WebKit::WebTextTrackRepresentationCocoa::setHidden const):

Canonical link: <a href="https://commits.webkit.org/266949@main">https://commits.webkit.org/266949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677a68f1646d07dc960b9d38c47aa7d1be36aee7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16884 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17677 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13092 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20662 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12227 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18052 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1840 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->