### PR TITLE
ASSERTION FAILED: !m_messageReceiverMapCount in IPC::MessageReceiver::~MessageReceiver() when running media layout tests

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -92,6 +92,7 @@ private:
     void waitForSeekCompleted();
     void seekCompleted();
     void setTimeFudgeFactor(const MediaTime&);
+    void disconnect();
 
     WeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     RemoteMediaSourceIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -64,8 +64,16 @@ RemoteSourceBufferProxy::RemoteSourceBufferProxy(GPUConnectionToWebProcess& conn
 RemoteSourceBufferProxy::~RemoteSourceBufferProxy()
 {
     m_sourceBufferPrivate->detach();
-    if (m_connectionToWebProcess)
-        m_connectionToWebProcess->messageReceiverMap().removeMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64());
+    disconnect();
+}
+
+void RemoteSourceBufferProxy::disconnect()
+{
+    if (!m_connectionToWebProcess)
+        return;
+
+    m_connectionToWebProcess->messageReceiverMap().removeMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64());
+    m_connectionToWebProcess = nullptr;
 }
 
 void RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&& segment, CompletionHandler<void(ReceiveResult)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -65,6 +65,8 @@ public:
     static Ref<RemoteSourceBufferProxy> create(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
     virtual ~RemoteSourceBufferProxy();
 
+    void disconnect();
+
 private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
 


### PR DESCRIPTION
#### 5b7e8de571abe57c953f584592ba4ea752156e27
<pre>
ASSERTION FAILED: !m_messageReceiverMapCount in IPC::MessageReceiver::~MessageReceiver() when running media layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=260244">https://bugs.webkit.org/show_bug.cgi?id=260244</a>
rdar://108192298

Reviewed by Jean-Yves Avenard.

GPUConnectionToWebProcess&apos;s connection closing results in RemoteMediaSourceProxy::shutdown() being
called, which sends the MediaSourcePrivateRemote::MediaSourcePrivateShuttingDown message with an
async reply. Since the connection is being closed this message is not sent successfully, but its
async reply handler keeps the RemoteMediaSourceProxy alive. When the handler is later invoked upon
message cancellation the GPUConnectionToWebProcess has been destroyed, so RemoteMediaSourceProxy is
unable to remove itself from the GPUConnectionToWebProcess::messageReceiverMap(). This leaves the
RemoteMediaSourceProxy with a non-zero m_messageReceiverMapCount, leading to the assertion mentioned
above.

Fixed this by ensuring RemoteMediaSourceProxy and its RemoteSourceBufferProxys explicitly remove
themselves from the message receiver map before the GPUConnectionToWebProcess is deallocated.

Fixes flaky crashes in existing media layout tests.

* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::disconnect):
(WebKit::RemoteMediaSourceProxy::~RemoteMediaSourceProxy):
(WebKit::RemoteMediaSourceProxy::shutdown):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::~RemoteSourceBufferProxy):
(WebKit::RemoteSourceBufferProxy::disconnect):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/266975@main">https://commits.webkit.org/266975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fee4fd9ca64e6e0edf8509e8bfa27d6dcac7fdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17743 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13156 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14499 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12286 "5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13772 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3669 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->