### PR TITLE
[JSC] Add JSC sampling profiler SPI

### DIFF
--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -475,3 +475,47 @@ Inspector::AugmentableInspectorController* JSGlobalContextGetAugmentableInspecto
     return &globalObject->inspectorController();
 }
 #endif
+
+bool JSContextGroupEnableSamplingProfiler(JSContextGroupRef group)
+{
+    VM& vm = *toJS(group);
+    JSLockHolder locker(&vm);
+
+#if ENABLE(SAMPLING_PROFILER)
+    vm.enableSamplingProfiler();
+    return true;
+#else
+    return false;
+#endif
+}
+
+void JSContextGroupDisableSamplingProfiler(JSContextGroupRef group)
+{
+    VM& vm = *toJS(group);
+    JSLockHolder locker(&vm);
+
+#if ENABLE(SAMPLING_PROFILER)
+    vm.disableSamplingProfiler();
+#endif
+}
+
+JSStringRef JSContextGroupTakeSamplesFromSamplingProfiler(JSContextGroupRef group)
+{
+    VM& vm = *toJS(group);
+    JSLockHolder locker(&vm);
+
+#if ENABLE(SAMPLING_PROFILER)
+    auto json = vm.takeSamplingProfilerSamplesAsJSON();
+    if (UNLIKELY(!json))
+        return nullptr;
+
+    auto jsonData = json->toJSONString();
+    if (UNLIKELY(jsonData.isNull()))
+        return nullptr;
+
+    return OpaqueJSString::tryCreate(WTFMove(jsonData)).leakRef();
+#else
+    return nullptr;
+#endif
+}
+

--- a/Source/JavaScriptCore/API/JSContextRefPrivate.h
+++ b/Source/JavaScriptCore/API/JSContextRefPrivate.h
@@ -96,6 +96,31 @@ JS_EXPORT void JSContextGroupClearExecutionTimeLimit(JSContextGroupRef group) JS
 
 /*!
 @function
+@abstract Enables sampling profiler.
+@param group The JavaScript context group to start sampling.
+@result The value of the enablement, true if the sampling profiler gets enabled, otherwise false.
+@discussion Remote inspection is true by default.
+*/
+JS_EXPORT bool JSContextGroupEnableSamplingProfiler(JSContextGroupRef group) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@function
+@abstract Disables sampling profiler.
+@param group The JavaScript context group to stop sampling.
+*/
+JS_EXPORT void JSContextGroupDisableSamplingProfiler(JSContextGroupRef group) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@function
+@abstract Gets sampling profiler output in JSON form and clears the sampling profiler records.
+@param group The JavaScript context group whose sampling profile output is taken.
+@result The sampling profiler output in JSON form. NULL if sampling profiler is not enabled ever before.
+@discussion Calling this function clears the sampling data accumulated so far.
+*/
+JS_EXPORT JSStringRef JSContextGroupTakeSamplesFromSamplingProfiler(JSContextGroupRef group) JSC_API_AVAILABLE(macos(JSC_MAC_TBA), ios(JSC_IOS_TBA));
+
+/*!
+@function
 @abstract Gets a whether or not remote inspection is enabled on the context.
 @param ctx The JSGlobalContext whose setting you want to get.
 @result The value of the setting, true if remote inspection is enabled, otherwise false.


### PR DESCRIPTION
#### 6b396d264030e3621a2761a1bd5aa5719d464b6d
<pre>
[JSC] Add JSC sampling profiler SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=260247">https://bugs.webkit.org/show_bug.cgi?id=260247</a>
rdar://112146210

Reviewed by Keith Miller and Mark Lam.

This patch prototypes JSC sampling profiler SPI.
Probably we will change the output / SPI with the feedback from clients later.
We add the following three SPIs.

1. JSContextGroupEnableSamplingProfiler: enabling sampling profiler
2. JSContextGroupDisableSamplingProfiler: disabling sampling profiler
3. JSContextGroupTakeSamplesFromSamplingProfiler: take and clear the accumulated samples from the profiler, returning in JSON form.

* Source/JavaScriptCore/API/JSContextRef.cpp:
(JSContextGroupEnableSamplingProfiler):
(JSContextGroupDisableSamplingProfiler):
(JSContextGroupTakeSamplesFromSamplingProfiler):
* Source/JavaScriptCore/API/JSContextRefPrivate.h:
* Source/JavaScriptCore/API/tests/testapi.c:
(samplingProfilerTest):
(main):

Canonical link: <a href="https://commits.webkit.org/266954@main">https://commits.webkit.org/266954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d6cb211f5d382344ee11648e710e7507cc3b9ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15236 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14313 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15639 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15856 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17725 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20707 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/13054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14216 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17170 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14485 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12271 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15429 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13756 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3933 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18100 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15664 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1843 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14318 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3744 "Passed tests") | 
<!--EWS-Status-Bubble-End-->