### PR TITLE
Decomposition of 2d transform matrices doesn't follow the suggested algorithm and fails css/css-transforms/animation/transform-interpolation-005.html.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-005-expected.txt
@@ -55,62 +55,62 @@ PASS Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)] to [m
 PASS Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)] to [matrix(1, 0, 0, 1, 0, -6)] at (0.6666666666666666) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)]
 PASS Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)] to [matrix(1, 0, 0, 1, 0, -6)] at (1) should be [matrix(1, 0, 0, 1, 0, -6)]
 PASS Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)] to [matrix(1, 0, 0, 1, 0, -6)] at (2) should be [matrix(0, 5, 1, 0, -6, -12)]
-FAIL CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)] assert_equals: expected "matrix ( - 5 , 0 , - 13 , 13 , 0 , 0 ) " but got "matrix ( - 5 , 0 , - 8.9 , 16.27 , 0 , 0 ) "
+PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)]
 PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0) should be [matrix(1, 0, 0, 7, 0, 0)]
-FAIL CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)] assert_equals: expected "matrix ( 3 , 0 , 1.67 , 5 , 0 , 0 ) " but got "matrix ( 3 , 0 , 1.21 , 4.64 , 0 , 0 ) "
-FAIL CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)] assert_equals: expected "matrix ( 4 , 0 , 2 , 4 , 0 , 0 ) " but got "matrix ( 4 , 0 , 1.49 , 3.59 , 0 , 0 ) "
-FAIL CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)] assert_equals: expected "matrix ( 5 , 0 , 2 , 3 , 0 , 0 ) " but got "matrix ( 5 , 0 , 1.54 , 2.64 , 0 , 0 ) "
+PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)]
+PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)]
+PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)]
 PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (1) should be [matrix(7, 0, 1, 1, 0, 0)]
-FAIL CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)] assert_equals: expected "matrix ( 13 , 0 , - 10 , - 5 , 0 , 0 ) " but got "matrix ( 13 , 0 , - 5.9 , - 1.73 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)] assert_equals: expected "matrix ( - 5 , 0 , - 13 , 13 , 0 , 0 ) " but got "matrix ( - 5 , 0 , - 8.9 , 16.27 , 0 , 0 ) "
+PASS CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)]
+PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)]
 PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0) should be [matrix(1, 0, 0, 7, 0, 0)]
-FAIL CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)] assert_equals: expected "matrix ( 3 , 0 , 1.67 , 5 , 0 , 0 ) " but got "matrix ( 3 , 0 , 1.21 , 4.64 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)] assert_equals: expected "matrix ( 4 , 0 , 2 , 4 , 0 , 0 ) " but got "matrix ( 4 , 0 , 1.49 , 3.59 , 0 , 0 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)] assert_equals: expected "matrix ( 5 , 0 , 2 , 3 , 0 , 0 ) " but got "matrix ( 5 , 0 , 1.54 , 2.64 , 0 , 0 ) "
+PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)]
+PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)]
+PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)]
 PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (1) should be [matrix(7, 0, 1, 1, 0, 0)]
-FAIL CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)] assert_equals: expected "matrix ( 13 , 0 , - 10 , - 5 , 0 , 0 ) " but got "matrix ( 13 , 0 , - 5.9 , - 1.73 , 0 , 0 ) "
-FAIL CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)] assert_equals: expected "matrix ( - 5 , 0 , - 13 , 13 , 0 , 0 ) " but got "matrix ( - 5 , 0 , - 8.9 , 16.27 , 0 , 0 ) "
+PASS CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)]
+PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)]
 PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0) should be [matrix(1, 0, 0, 7, 0, 0)]
-FAIL CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)] assert_equals: expected "matrix ( 3 , 0 , 1.67 , 5 , 0 , 0 ) " but got "matrix ( 3 , 0 , 1.21 , 4.64 , 0 , 0 ) "
-FAIL CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)] assert_equals: expected "matrix ( 4 , 0 , 2 , 4 , 0 , 0 ) " but got "matrix ( 4 , 0 , 1.49 , 3.59 , 0 , 0 ) "
-FAIL CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)] assert_equals: expected "matrix ( 5 , 0 , 2 , 3 , 0 , 0 ) " but got "matrix ( 5 , 0 , 1.54 , 2.64 , 0 , 0 ) "
+PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)]
+PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)]
+PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)]
 PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (1) should be [matrix(7, 0, 1, 1, 0, 0)]
-FAIL CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)] assert_equals: expected "matrix ( 13 , 0 , - 10 , - 5 , 0 , 0 ) " but got "matrix ( 13 , 0 , - 5.9 , - 1.73 , 0 , 0 ) "
-FAIL Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)] assert_equals: expected "matrix ( - 5 , 0 , - 13 , 13 , 0 , 0 ) " but got "matrix ( - 5 , 0 , - 8.9 , 16.27 , 0 , 0 ) "
+PASS CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)]
+PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)]
 PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0) should be [matrix(1, 0, 0, 7, 0, 0)]
-FAIL Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)] assert_equals: expected "matrix ( 3 , 0 , 1.67 , 5 , 0 , 0 ) " but got "matrix ( 3 , 0 , 1.21 , 4.64 , 0 , 0 ) "
-FAIL Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)] assert_equals: expected "matrix ( 4 , 0 , 2 , 4 , 0 , 0 ) " but got "matrix ( 4 , 0 , 1.49 , 3.59 , 0 , 0 ) "
-FAIL Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)] assert_equals: expected "matrix ( 5 , 0 , 2 , 3 , 0 , 0 ) " but got "matrix ( 5 , 0 , 1.54 , 2.64 , 0 , 0 ) "
+PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)]
+PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)]
+PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)]
 PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (1) should be [matrix(7, 0, 1, 1, 0, 0)]
-FAIL Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)] assert_equals: expected "matrix ( 13 , 0 , - 10 , - 5 , 0 , 0 ) " but got "matrix ( 13 , 0 , - 5.9 , - 1.73 , 0 , 0 ) "
-FAIL CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)] assert_equals: expected "matrix ( - 5 , 0 , 0 , 0 , - 6 , 0 ) " but got "matrix ( - 5 , 0 , 0.59 , - 1.07 , - 6 , 0 ) "
+PASS Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)] to [matrix(7, 0, 1, 1, 0, 0)] at (2) should be [matrix(13, 0, -10, -5, 0, 0)]
+PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)]
 PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0) should be [matrix(1, 0, 0, 1, 0, 0)]
-FAIL CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)] assert_equals: expected "matrix ( 2.5 , 0 , 0.31 , 1.25 , 1.5 , 0 ) " but got "matrix ( 2.5 , 0 , 0.26 , 1.35 , 1.5 , 0 ) "
-FAIL CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)] assert_equals: expected "matrix ( 4 , 0 , 0.75 , 1.5 , 3 , 0 ) " but got "matrix ( 4 , 0 , 0.68 , 1.63 , 3 , 0 ) "
-FAIL CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)] assert_equals: expected "matrix ( 5.5 , 0 , 1.31 , 1.75 , 4.5 , 0 ) " but got "matrix ( 5.5 , 0 , 1.26 , 1.85 , 4.5 , 0 ) "
+PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)]
+PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)]
+PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)]
 PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (1) should be [matrix(7, 0, 2, 2, 6, 0)]
-FAIL CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)] assert_equals: expected "matrix ( 13 , 0 , 6 , 3 , 12 , 0 ) " but got "matrix ( 13 , 0 , 6.59 , 1.93 , 12 , 0 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)] assert_equals: expected "matrix ( - 5 , 0 , 0 , 0 , - 6 , 0 ) " but got "matrix ( - 5 , 0 , 0.59 , - 1.07 , - 6 , 0 ) "
+PASS CSS Transitions: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)]
+PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)]
 PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0) should be [matrix(1, 0, 0, 1, 0, 0)]
-FAIL CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)] assert_equals: expected "matrix ( 2.5 , 0 , 0.31 , 1.25 , 1.5 , 0 ) " but got "matrix ( 2.5 , 0 , 0.26 , 1.35 , 1.5 , 0 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)] assert_equals: expected "matrix ( 4 , 0 , 0.75 , 1.5 , 3 , 0 ) " but got "matrix ( 4 , 0 , 0.68 , 1.63 , 3 , 0 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)] assert_equals: expected "matrix ( 5.5 , 0 , 1.31 , 1.75 , 4.5 , 0 ) " but got "matrix ( 5.5 , 0 , 1.26 , 1.85 , 4.5 , 0 ) "
+PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)]
+PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)]
+PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)]
 PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (1) should be [matrix(7, 0, 2, 2, 6, 0)]
-FAIL CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)] assert_equals: expected "matrix ( 13 , 0 , 6 , 3 , 12 , 0 ) " but got "matrix ( 13 , 0 , 6.59 , 1.93 , 12 , 0 ) "
-FAIL CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)] assert_equals: expected "matrix ( - 5 , 0 , 0 , 0 , - 6 , 0 ) " but got "matrix ( - 5 , 0 , 0.59 , - 1.07 , - 6 , 0 ) "
+PASS CSS Transitions with transition: all: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)]
+PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)]
 PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0) should be [matrix(1, 0, 0, 1, 0, 0)]
-FAIL CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)] assert_equals: expected "matrix ( 2.5 , 0 , 0.31 , 1.25 , 1.5 , 0 ) " but got "matrix ( 2.5 , 0 , 0.26 , 1.35 , 1.5 , 0 ) "
-FAIL CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)] assert_equals: expected "matrix ( 4 , 0 , 0.75 , 1.5 , 3 , 0 ) " but got "matrix ( 4 , 0 , 0.68 , 1.63 , 3 , 0 ) "
-FAIL CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)] assert_equals: expected "matrix ( 5.5 , 0 , 1.31 , 1.75 , 4.5 , 0 ) " but got "matrix ( 5.5 , 0 , 1.26 , 1.85 , 4.5 , 0 ) "
+PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)]
+PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)]
+PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)]
 PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (1) should be [matrix(7, 0, 2, 2, 6, 0)]
-FAIL CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)] assert_equals: expected "matrix ( 13 , 0 , 6 , 3 , 12 , 0 ) " but got "matrix ( 13 , 0 , 6.59 , 1.93 , 12 , 0 ) "
-FAIL Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)] assert_equals: expected "matrix ( - 5 , 0 , 0 , 0 , - 6 , 0 ) " but got "matrix ( - 5 , 0 , 0.59 , - 1.07 , - 6 , 0 ) "
+PASS CSS Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)]
+PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)]
 PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0) should be [matrix(1, 0, 0, 1, 0, 0)]
-FAIL Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)] assert_equals: expected "matrix ( 2.5 , 0 , 0.31 , 1.25 , 1.5 , 0 ) " but got "matrix ( 2.5 , 0 , 0.26 , 1.35 , 1.5 , 0 ) "
-FAIL Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)] assert_equals: expected "matrix ( 4 , 0 , 0.75 , 1.5 , 3 , 0 ) " but got "matrix ( 4 , 0 , 0.68 , 1.63 , 3 , 0 ) "
-FAIL Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)] assert_equals: expected "matrix ( 5.5 , 0 , 1.31 , 1.75 , 4.5 , 0 ) " but got "matrix ( 5.5 , 0 , 1.26 , 1.85 , 4.5 , 0 ) "
+PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)]
+PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)]
+PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)]
 PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (1) should be [matrix(7, 0, 2, 2, 6, 0)]
-FAIL Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)] assert_equals: expected "matrix ( 13 , 0 , 6 , 3 , 12 , 0 ) " but got "matrix ( 13 , 0 , 6.59 , 1.93 , 12 , 0 ) "
+PASS Web Animations: property <transform> from [none] to [matrix(7, 0, 2, 2, 6, 0)] at (2) should be [matrix(13, 0, 6, 3, 12, 0)]
 PASS CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)] to [none] at (-1) should be [matrix(5, 0, 0, 9, 0, -12)]
 PASS CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)] to [none] at (0) should be [matrix(3, 0, 0, 5, 0, -6)]
 PASS CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)] to [none] at (0.25) should be [matrix(2.5, 0, 0, 4, 0, -4.5)]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-skew-composition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-skew-composition-expected.txt
@@ -41,5 +41,5 @@ PASS Compositing: property <transform> underlying [skew(10deg, 45deg)] from accu
 PASS Compositing: property <transform> underlying [skew(10deg, 45deg)] from accumulate [skew(20deg, 30deg)] to accumulate [skew(40deg, 70deg)] at (0.75) should be [skew(45deg, 105deg)]
 PASS Compositing: property <transform> underlying [skew(10deg, 45deg)] from accumulate [skew(20deg, 30deg)] to accumulate [skew(40deg, 70deg)] at (1) should be [skew(50deg, 115deg)]
 PASS Compositing: property <transform> underlying [skew(10deg, 45deg)] from accumulate [skew(20deg, 30deg)] to accumulate [skew(40deg, 70deg)] at (1.5) should be [skew(60deg, 135deg)]
-FAIL Compositing: property <transform> underlying [skewX(45deg)] from accumulate [skewY(45deg)] to accumulate [skewY(45deg)] at (0.5) should be [matrix(1, 1, 0.5, 1.5, 0, 0)] assert_equals: expected "matrix ( 1 , 1 , 0.5 , 1.5 , 0 , 0 ) " but got "matrix ( 1.71 , 0.71 , 0.71 , 1.12 , 0 , 0 ) "
+PASS Compositing: property <transform> underlying [skewX(45deg)] from accumulate [skewY(45deg)] to accumulate [skewY(45deg)] at (0.5) should be [matrix(1, 1, 0.5, 1.5, 0, 0)]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values-expected.txt
@@ -4,5 +4,5 @@ PASS Animating a custom property of type <transform-list> containing multiple va
 PASS Animating a custom property of type <transform-list> containing multiple values with additivity
 PASS Animating a custom property of type <transform-list> containing multiple values with a single keyframe and additivity
 PASS Animating a custom property of type <transform-list> containing multiple values with iterationComposite
-FAIL Animating a custom property of type <transform-list> containing multiple values and with mismatching list lengths assert_equals: expected "matrix(0, -1.5, 1.5, 0, 50, 0)" but got "matrix(0, 1.5, -1.5, 0, 50, 0)"
+PASS Animating a custom property of type <transform-list> containing multiple values and with mismatching list lengths
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2297,7 +2297,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
             if (operation->type() == TransformOperation::Type::Matrix || operation->type() == TransformOperation::Type::Matrix3D) {
                 TransformationMatrix::Decomposed2Type toDecomp;
                 // Any rotation prevents us from using a simple start/end rect union.
-                if (!transform.decompose2(toDecomp) || toDecomp.angle)
+                if (!transform.decompose2(toDecomp) || toDecomp.hasRotation())
                     return false;
             }
 
@@ -2321,7 +2321,7 @@ bool KeyframeEffect::computeTransformedExtentViaMatrix(const FloatRect& renderer
 
     TransformationMatrix::Decomposed2Type fromDecomp;
     // Any rotation prevents us from using a simple start/end rect union.
-    if (!transform.decompose2(fromDecomp) || fromDecomp.angle)
+    if (!transform.decompose2(fromDecomp) || fromDecomp.hasRotation())
         return false;
 
     bounds = LayoutRect(transform.mapRect(bounds));

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -311,15 +311,20 @@ public:
     struct Decomposed2Type {
         double scaleX, scaleY;
         double translateX, translateY;
-        double angle;
-        double m11, m12, m21, m22;
-        
+        Quaternion quaternion;
+        double skewXY;
+
         bool operator==(const Decomposed2Type& other) const
         {
             return scaleX == other.scaleX && scaleY == other.scaleY
                 && translateX == other.translateX && translateY == other.translateY
-                && angle == other.angle
-                && m11 == other.m11 && m12 == other.m12 && m21 == other.m21 && m22 == other.m22;
+                && quaternion == other.quaternion
+                && skewXY == other.skewXY;
+        }
+
+        bool hasRotation()
+        {
+            return (quaternion.x || quaternion.y || quaternion.z) && quaternion.w;
         }
     };
 


### PR DESCRIPTION
#### a88fd88eb01a2fcc76b618daf2084efa1271b432
<pre>
Decomposition of 2d transform matrices doesn&apos;t follow the suggested algorithm and fails css/css-transforms/animation/transform-interpolation-005.html.
<a href="https://bugs.webkit.org/show_bug.cgi?id=235806">https://bugs.webkit.org/show_bug.cgi?id=235806</a>
&lt;rdar://88488559&gt;

Reviewed by NOBODY (OOPS!).

The updated algorithm has been proposed in an issue for years, and taken up both both other engines and WPTs.
We should use it, and hopefully get the changes added to the actual spec.

<a href="https://github.com/w3c/csswg-drafts/issues/3713">https://github.com/w3c/csswg-drafts/issues/3713</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-skew-composition-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeTransformedExtentViaTransformList const):
(WebCore::KeyframeEffect::computeTransformedExtentViaMatrix const):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::decompose2):
(WebCore::interpolateQuaternion):
(WebCore::TransformationMatrix::blend2):
(WebCore::TransformationMatrix::decompose2 const):
(WebCore::TransformationMatrix::recompose2):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
(WebCore::TransformationMatrix::Decomposed2Type::operator== const):
(WebCore::TransformationMatrix::Decomposed2Type::hasRotation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a88fd88eb01a2fcc76b618daf2084efa1271b432

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17950 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19293 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21909 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19635 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15897 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13492 "14 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->