### PR TITLE
Deploy more smart pointers in WebProcess.cpp

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -37,13 +37,13 @@
 
 namespace WebKit {
 
-Ref<WebFileSystemStorageConnection> WebFileSystemStorageConnection::create(IPC::Connection& connection)
+Ref<WebFileSystemStorageConnection> WebFileSystemStorageConnection::create(Ref<IPC::Connection>&& connection)
 {
-    return adoptRef(*new WebFileSystemStorageConnection(connection));
+    return adoptRef(*new WebFileSystemStorageConnection(WTFMove(connection)));
 }
 
-WebFileSystemStorageConnection::WebFileSystemStorageConnection(IPC::Connection& connection)
-    : m_connection(&connection)
+WebFileSystemStorageConnection::WebFileSystemStorageConnection(Ref<IPC::Connection>&& connection)
+    : m_connection(WTFMove(connection))
 {
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -65,12 +65,12 @@ namespace WebKit {
 
 class WebFileSystemStorageConnection final : public WebCore::FileSystemStorageConnection {
 public:
-    static Ref<WebFileSystemStorageConnection> create(IPC::Connection&);
+    static Ref<WebFileSystemStorageConnection> create(Ref<IPC::Connection>&&);
     void connectionClosed();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
 private:
-    explicit WebFileSystemStorageConnection(IPC::Connection&);
+    explicit WebFileSystemStorageConnection(Ref<IPC::Connection>&&);
 
     // FileSystemStorageConnection
     void closeHandle(WebCore::FileSystemHandleIdentifier) final;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -857,8 +857,8 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
         result.iterator->value = page.ptr();
 
 #if ENABLE(GPU_PROCESS)
-        if (m_gpuProcessConnection)
-            page->gpuProcessConnectionDidBecomeAvailable(*m_gpuProcessConnection);
+        if (RefPtr gpuProcessConnection = m_gpuProcessConnection)
+            page->gpuProcessConnectionDidBecomeAvailable(*gpuProcessConnection);
 #endif
 
         // Balanced by an enableTermination in removeWebPage.
@@ -1123,7 +1123,7 @@ void WebProcess::setJavaScriptGarbageCollectorTimerEnabled(bool flag)
 
 void WebProcess::handleInjectedBundleMessage(const String& messageName, const UserData& messageBody)
 {
-    InjectedBundle* injectedBundle = WebProcess::singleton().injectedBundle();
+    RefPtr injectedBundle = WebProcess::singleton().injectedBundle();
     if (!injectedBundle)
         return;
 
@@ -1132,7 +1132,7 @@ void WebProcess::handleInjectedBundleMessage(const String& messageName, const Us
 
 void WebProcess::setInjectedBundleParameter(const String& key, const IPC::DataReference& value)
 {
-    InjectedBundle* injectedBundle = WebProcess::singleton().injectedBundle();
+    RefPtr injectedBundle = WebProcess::singleton().injectedBundle();
     if (!injectedBundle)
         return;
 
@@ -1141,7 +1141,7 @@ void WebProcess::setInjectedBundleParameter(const String& key, const IPC::DataRe
 
 void WebProcess::setInjectedBundleParameters(const IPC::DataReference& value)
 {
-    InjectedBundle* injectedBundle = WebProcess::singleton().injectedBundle();
+    RefPtr injectedBundle = WebProcess::singleton().injectedBundle();
     if (!injectedBundle)
         return;
 
@@ -1197,7 +1197,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
 
     // If we've lost our connection to the network process (e.g. it crashed) try to re-establish it.
     if (!m_networkProcessConnection) {
-        auto connectionInfo = getNetworkProcessConnection(*parentProcessConnection());
+        auto connectionInfo = getNetworkProcessConnection(Ref { *parentProcessConnection() });
 
         m_networkProcessConnection = NetworkProcessConnection::create(IPC::Connection::Identifier { WTFMove(connectionInfo.connection) }, connectionInfo.cookieAcceptPolicy);
 #if HAVE(AUDIT_TOKEN)
@@ -1311,7 +1311,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
 WebFileSystemStorageConnection& WebProcess::fileSystemStorageConnection()
 {
     if (!m_fileSystemStorageConnection)
-        m_fileSystemStorageConnection = WebFileSystemStorageConnection::create(ensureNetworkProcessConnection().connection());
+        m_fileSystemStorageConnection = WebFileSystemStorageConnection::create(Ref { ensureNetworkProcessConnection().connection() });
 
     return *m_fileSystemStorageConnection;
 }
@@ -1329,13 +1329,13 @@ GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
 
     // If we've lost our connection to the GPU process (e.g. it crashed) try to re-establish it.
     if (!m_gpuProcessConnection) {
-        m_gpuProcessConnection = GPUProcessConnection::create(*parentProcessConnection());
+        m_gpuProcessConnection = GPUProcessConnection::create(Ref { *parentProcessConnection() });
         if (!m_gpuProcessConnection)
             CRASH();
         for (auto& page : m_pageMap.values()) {
             // If page is null, then it is currently being constructed.
             if (page)
-                page->gpuProcessConnectionDidBecomeAvailable(*m_gpuProcessConnection);
+                page->gpuProcessConnectionDidBecomeAvailable(Ref { *m_gpuProcessConnection });
         }
     }
     return *m_gpuProcessConnection;
@@ -1381,18 +1381,18 @@ void WebProcess::setEnhancedAccessibility(bool flag)
 
 void WebProcess::remotePostMessage(WebCore::FrameIdentifier identifier, std::optional<WebCore::SecurityOriginData> target, const WebCore::MessageWithMessagePorts& message)
 {
-    auto* webFrame = WebProcess::singleton().webFrame(identifier);
+    RefPtr webFrame = WebProcess::singleton().webFrame(identifier);
     if (!webFrame)
         return;
 
     if (!webFrame->coreLocalFrame())
         return;
 
-    auto* domWindow = webFrame->coreLocalFrame()->window();
+    RefPtr domWindow = webFrame->coreLocalFrame()->window();
     if (!domWindow)
         return;
 
-    auto* frame = domWindow->frame();
+    RefPtr frame = domWindow->frame();
     if (!frame)
         return;
 
@@ -1406,13 +1406,13 @@ void WebProcess::remotePostMessage(WebCore::FrameIdentifier identifier, std::opt
 
 void WebProcess::renderTreeAsText(WebCore::FrameIdentifier frameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior, CompletionHandler<void(String)>&& completionHandler)
 {
-    auto* webFrame = WebProcess::singleton().webFrame(frameIdentifier);
+    RefPtr webFrame = WebProcess::singleton().webFrame(frameIdentifier);
     if (!webFrame) {
         ASSERT_NOT_REACHED();
         return completionHandler({ });
     }
 
-    auto* coreLocalFrame = webFrame->coreLocalFrame();
+    RefPtr coreLocalFrame = webFrame->coreLocalFrame();
     if (!coreLocalFrame) {
         ASSERT_NOT_REACHED();
         return completionHandler({ });
@@ -2003,16 +2003,16 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
     // We are in the Remote Worker context process and the call below establishes our connection to the Network Process
     // by calling ensureNetworkProcessConnection. SWContextManager / SharedWorkerContextManager need to use the same underlying IPC::Connection as the
     // NetworkProcessConnection for synchronization purposes.
-    auto& ipcConnection = ensureNetworkProcessConnection().connection();
+    Ref ipcConnection = ensureNetworkProcessConnection().connection();
     switch (workerType) {
     case RemoteWorkerType::ServiceWorker:
 #if ENABLE(SERVICE_WORKER)
-        SWContextManager::singleton().setConnection(WebSWContextManagerConnection::create(ipcConnection, WTFMove(registrableDomain), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
+        SWContextManager::singleton().setConnection(WebSWContextManagerConnection::create(WTFMove(ipcConnection), WTFMove(registrableDomain), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
         SWContextManager::singleton().connection()->establishConnection(WTFMove(completionHandler));
 #endif
         break;
     case RemoteWorkerType::SharedWorker:
-        SharedWorkerContextManager::singleton().setConnection(makeUnique<WebSharedWorkerContextManagerConnection>(ipcConnection, WTFMove(registrableDomain), pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
+        SharedWorkerContextManager::singleton().setConnection(makeUnique<WebSharedWorkerContextManagerConnection>(WTFMove(ipcConnection), WTFMove(registrableDomain), pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData)));
         SharedWorkerContextManager::singleton().connection()->establishConnection(WTFMove(completionHandler));
         break;
     }
@@ -2301,7 +2301,7 @@ bool WebProcess::shouldUseRemoteRenderingForWebGL() const
 SpeechRecognitionRealtimeMediaSourceManager& WebProcess::ensureSpeechRecognitionRealtimeMediaSourceManager()
 {
     if (!m_speechRecognitionRealtimeMediaSourceManager)
-        m_speechRecognitionRealtimeMediaSourceManager = makeUnique<SpeechRecognitionRealtimeMediaSourceManager>(*parentProcessConnection());
+        m_speechRecognitionRealtimeMediaSourceManager = makeUnique<SpeechRecognitionRealtimeMediaSourceManager>(Ref { *parentProcessConnection() });
 
     return *m_speechRecognitionRealtimeMediaSourceManager;
 }


### PR DESCRIPTION
#### 153a083bdd040be3159962114d3f337a86a4498a
<pre>
Deploy more smart pointers in WebProcess.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=260249">https://bugs.webkit.org/show_bug.cgi?id=260249</a>

Reviewed by Sihui Liu.

Deployed more smart pointers.

* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::create):
(WebKit::WebFileSystemStorageConnection::WebFileSystemStorageConnection):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::handleInjectedBundleMessage):
(WebKit::WebProcess::setInjectedBundleParameter):
(WebKit::WebProcess::setInjectedBundleParameters):
(WebKit::WebProcess::ensureNetworkProcessConnection):
(WebKit::WebProcess::fileSystemStorageConnection):
(WebKit::WebProcess::ensureGPUProcessConnection):
(WebKit::WebProcess::remotePostMessage):
(WebKit::WebProcess::renderTreeAsText):
(WebKit::WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcess::ensureSpeechRecognitionRealtimeMediaSourceManager):

Canonical link: <a href="https://commits.webkit.org/266952@main">https://commits.webkit.org/266952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c125599f669d9ae7f1a08c983e6a66bd936fe80c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14307 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15633 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17719 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13133 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20701 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17164 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12268 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18094 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1842 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->