### PR TITLE
StyleImages need to know if they are painting a first-line so they can use the firstLineStyle() instead of style()

### DIFF
--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -50,10 +50,7 @@ static inline std::optional<StyleColor> computeStyleColor(const RefPtr<CSSPrimit
     if (!color)
         return std::nullopt;
 
-    // FIXME: This should call state.colorFromPrimitiveValue(*color) instead, but doing so is
-    // blocked on fixing an issue where we don't respect ::first-line in StyleImage correctly.
-    // See https://webkit.org/b/247127.
-    return StyleColor { state.colorFromPrimitiveValueWithResolvedCurrentColor(*color) };
+    return state.colorFromPrimitiveValue(*color);
 }
 
 static decltype(auto) computeStops(const CSSGradientColorStopList& stops, Style::BuilderState& state)

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -397,7 +397,8 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
 
         geometry.clip(LayoutRect(pixelSnappedRect));
         RefPtr<Image> image;
-        if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize))) {
+        bool isFirstLine = box && box->lineBox()->isFirst();
+        if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, isFirstLine))) {
             context.setDrawLuminanceMask(bgLayer.maskMode() == MaskMode::Luminance);
 
             if (is<BitmapImage>(image))

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -201,7 +201,7 @@ bool StyleCachedImage::hasImage() const
     return m_cachedImage->hasImage();
 }
 
-RefPtr<Image> StyleCachedImage::image(const RenderElement* renderer, const FloatSize&) const
+RefPtr<Image> StyleCachedImage::image(const RenderElement* renderer, const FloatSize&, bool) const
 {
     ASSERT(!m_isPending);
     if (!m_cachedImage)

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -64,7 +64,7 @@ public:
     void removeClient(RenderElement&) final;
     bool hasClient(RenderElement&) const final;
     bool hasImage() const final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     float imageScaleFactor() const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     bool usesDataProtocol() const final;

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -71,7 +71,7 @@ void StyleCanvasImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
 }
 
-RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const FloatSize&) const
+RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const FloatSize&, bool) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleCanvasImage.h
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.h
@@ -54,7 +54,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final;

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
@@ -134,7 +134,7 @@ void StyleCrossfadeImage::load(CachedResourceLoader& loader, const ResourceLoade
     m_inputImagesAreReady = true;
 }
 
-RefPtr<Image> StyleCrossfadeImage::image(const RenderElement* renderer, const FloatSize& size) const
+RefPtr<Image> StyleCrossfadeImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
 {
     if (!renderer)
         return &Image::nullImage();
@@ -145,8 +145,8 @@ RefPtr<Image> StyleCrossfadeImage::image(const RenderElement* renderer, const Fl
     if (!m_from || !m_to)
         return &Image::nullImage();
 
-    auto fromImage = m_from->image(renderer, size);
-    auto toImage = m_to->image(renderer, size);
+    auto fromImage = m_from->image(renderer, size, isForFirstLine);
+    auto toImage = m_to->image(renderer, size, isForFirstLine);
 
     if (!fromImage || !toImage)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.h
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.h
@@ -56,7 +56,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -109,7 +109,7 @@ void StyleFilterImage::load(CachedResourceLoader& cachedResourceLoader, const Re
     m_inputImageIsReady = true;
 }
 
-RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const FloatSize& size) const
+RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
 {
     if (!renderer)
         return &Image::nullImage();
@@ -120,7 +120,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     if (!m_image)
         return &Image::nullImage();
 
-    auto image = m_image->image(renderer, size);
+    auto image = m_image->image(renderer, size, isForFirstLine);
     if (!image || image->isNull())
         return &Image::nullImage();
 

--- a/Source/WebCore/rendering/style/StyleFilterImage.h
+++ b/Source/WebCore/rendering/style/StyleFilterImage.h
@@ -56,7 +56,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -181,7 +181,7 @@ void StyleGradientImage::load(CachedResourceLoader&, const ResourceLoaderOptions
 {
 }
 
-RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const FloatSize& size) const
+RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
 {
     if (!renderer)
         return &Image::nullImage();
@@ -189,7 +189,9 @@ RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const Flo
     if (size.isEmpty())
         return nullptr;
 
-    bool cacheable = m_knownCacheableBarringFilter && !renderer->style().hasAppleColorFilter();
+    auto& style = isForFirstLine ? renderer->firstLineStyle() : renderer->style();
+
+    bool cacheable = m_knownCacheableBarringFilter && !style.hasAppleColorFilter();
     if (cacheable) {
         if (!clients().contains(const_cast<RenderElement&>(*renderer)))
             return nullptr;
@@ -199,7 +201,7 @@ RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const Flo
 
     auto gradient = WTF::switchOn(m_data,
         [&] (auto& data) -> Ref<Gradient> {
-            return createGradient(data, *renderer, size);
+            return createGradient(data, *renderer, size, style);
         }
     );
 
@@ -894,7 +896,7 @@ static inline float horizontalEllipseRadius(const FloatSize& p, float aspectRati
 
 // MARK: - Linear create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const LinearData& linear, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const LinearData& linear, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -902,7 +904,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const LinearData& linear, const
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto [firstPoint, secondPoint] = WTF::switchOn(linear.data.gradientLine,
         [&] (std::monostate) -> std::pair<FloatPoint, FloatPoint> {
@@ -944,14 +946,14 @@ Ref<Gradient> StyleGradientImage::createGradient(const LinearData& linear, const
 
     Gradient::LinearData data { firstPoint, secondPoint };
     LinearGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, renderer.style(), 1, linear.repeating);
+    auto stops = computeStops(adapter, conversionData, style, 1, linear.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 // MARK: - Prefixed Linear create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const PrefixedLinearData& linear, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const PrefixedLinearData& linear, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -959,7 +961,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const PrefixedLinearData& linea
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto [firstPoint, secondPoint] = WTF::switchOn(linear.data.gradientLine,
         [&] (std::monostate) -> std::pair<FloatPoint, FloatPoint> {
@@ -1012,14 +1014,14 @@ Ref<Gradient> StyleGradientImage::createGradient(const PrefixedLinearData& linea
 
     Gradient::LinearData data { firstPoint, secondPoint };
     LinearGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, renderer.style(), 1, linear.repeating);
+    auto stops = computeStops(adapter, conversionData, style, 1, linear.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 // MARK: - Deprecated Linear create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedLinearData& linear, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedLinearData& linear, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -1027,21 +1029,21 @@ Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedLinearData& lin
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto firstPoint = computeEndPoint(linear.data.firstX, linear.data.firstY, conversionData, size);
     auto secondPoint = computeEndPoint(linear.data.secondX, linear.data.secondY, conversionData, size);
 
     Gradient::LinearData data { firstPoint, secondPoint };
     LinearGradientAdapter adapter { data };
-    auto stops = computeStopsForDeprecatedVariants(adapter, conversionData, renderer.style());
+    auto stops = computeStopsForDeprecatedVariants(adapter, conversionData, style);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 // MARK: - Radial create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const RadialData& radial, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const RadialData& radial, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -1049,7 +1051,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const RadialData& radial, const
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto computeCenterPoint = [&](const CSSGradientPosition& position) -> FloatPoint {
         return computeEndPoint(position.first, position.second, conversionData, size);
@@ -1189,14 +1191,14 @@ Ref<Gradient> StyleGradientImage::createGradient(const RadialData& radial, const
     float maxExtent = radial.repeating == CSSGradientRepeat::Repeating ? distanceToFarthestCorner(data.point1, size).distance : 0;
 
     RadialGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, renderer.style(), maxExtent, radial.repeating);
+    auto stops = computeStops(adapter, conversionData, style, maxExtent, radial.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 // MARK: - Prefixed Radial create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const PrefixedRadialData& radial, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const PrefixedRadialData& radial, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -1204,7 +1206,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const PrefixedRadialData& radia
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto computeCircleRadius = [&](CSSPrefixedRadialGradientValue::ExtentKeyword extent, FloatPoint centerPoint) -> std::pair<float, float> {
         switch (extent) {
@@ -1307,14 +1309,14 @@ Ref<Gradient> StyleGradientImage::createGradient(const PrefixedRadialData& radia
     float maxExtent = radial.repeating == CSSGradientRepeat::Repeating ? distanceToFarthestCorner(data.point1, size).distance : 0;
 
     RadialGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, renderer.style(), maxExtent, radial.repeating);
+    auto stops = computeStops(adapter, conversionData, style, maxExtent, radial.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 // MARK: - Deprecated Radial create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedRadialData& radial, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedRadialData& radial, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -1322,7 +1324,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedRadialData& rad
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto firstPoint = computeEndPoint(radial.data.firstX, radial.data.firstY, conversionData, size);
     auto secondPoint = computeEndPoint(radial.data.secondX, radial.data.secondY, conversionData, size);
@@ -1333,14 +1335,14 @@ Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedRadialData& rad
 
     Gradient::RadialData data { firstPoint, secondPoint, firstRadius, secondRadius, aspectRatio };
     RadialGradientAdapter adapter { data };
-    auto stops = computeStopsForDeprecatedVariants(adapter, conversionData, renderer.style());
+    auto stops = computeStopsForDeprecatedVariants(adapter, conversionData, style);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 // MARK: - Conic create.
 
-Ref<Gradient> StyleGradientImage::createGradient(const ConicData& conic, const RenderElement& renderer, const FloatSize& size) const
+Ref<Gradient> StyleGradientImage::createGradient(const ConicData& conic, const RenderElement& renderer, const FloatSize& size, const RenderStyle& style) const
 {
     ASSERT(!size.isEmpty());
 
@@ -1348,14 +1350,14 @@ Ref<Gradient> StyleGradientImage::createGradient(const ConicData& conic, const R
     if (auto* documentElement = renderer.document().documentElement())
         rootStyle = documentElement->renderStyle();
 
-    CSSToLengthConversionData conversionData(renderer.style(), rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
+    CSSToLengthConversionData conversionData(style, rootStyle, renderer.parentStyle(), &renderer.view(), renderer.generatingElement());
 
     auto centerPoint = conic.data.position ? computeEndPoint(conic.data.position->first, conic.data.position->second, conversionData, size) : FloatPoint { size.width() / 2, size.height() / 2 };
     auto angleRadians = conic.data.angle.value ? conic.data.angle.value->floatValue(CSSUnitType::CSS_RAD) : 0;
 
     Gradient::ConicData data { centerPoint, angleRadians };
     ConicGradientAdapter adapter;
-    auto stops = computeStops(adapter, conversionData, renderer.style(), 1, conic.repeating);
+    auto stops = computeStops(adapter, conversionData, style, 1, conic.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }

--- a/Source/WebCore/rendering/style/StyleGradientImage.h
+++ b/Source/WebCore/rendering/style/StyleGradientImage.h
@@ -88,19 +88,19 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }
     void didRemoveClient(RenderElement&) final { }
 
-    Ref<Gradient> createGradient(const LinearData&, const RenderElement&, const FloatSize&) const;
-    Ref<Gradient> createGradient(const PrefixedLinearData&, const RenderElement&, const FloatSize&) const;
-    Ref<Gradient> createGradient(const DeprecatedLinearData&, const RenderElement&, const FloatSize&) const;
-    Ref<Gradient> createGradient(const RadialData&, const RenderElement&, const FloatSize&) const;
-    Ref<Gradient> createGradient(const PrefixedRadialData&, const RenderElement&, const FloatSize&) const;
-    Ref<Gradient> createGradient(const DeprecatedRadialData&, const RenderElement&, const FloatSize&) const;
-    Ref<Gradient> createGradient(const ConicData&, const RenderElement&, const FloatSize&) const;
+    Ref<Gradient> createGradient(const LinearData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
+    Ref<Gradient> createGradient(const PrefixedLinearData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
+    Ref<Gradient> createGradient(const DeprecatedLinearData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
+    Ref<Gradient> createGradient(const RadialData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
+    Ref<Gradient> createGradient(const PrefixedRadialData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
+    Ref<Gradient> createGradient(const DeprecatedRadialData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
+    Ref<Gradient> createGradient(const ConicData&, const RenderElement&, const FloatSize&, const RenderStyle&) const;
 
     template<typename GradientAdapter> GradientColorStops computeStops(GradientAdapter&, const CSSToLengthConversionData&, const RenderStyle&, float maxLengthForRepeat, CSSGradientRepeat) const;
     template<typename GradientAdapter> GradientColorStops computeStopsForDeprecatedVariants(GradientAdapter&, const CSSToLengthConversionData&, const RenderStyle&) const;

--- a/Source/WebCore/rendering/style/StyleImage.h
+++ b/Source/WebCore/rendering/style/StyleImage.h
@@ -77,7 +77,7 @@ public:
     virtual bool imageHasNaturalDimensions() const { return true; }
 
     // Image.
-    virtual RefPtr<Image> image(const RenderElement*, const FloatSize&) const = 0;
+    virtual RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine = false) const = 0;
     virtual StyleImage* selectedImage() { return this; }
     virtual const StyleImage* selectedImage() const { return this; }
     virtual CachedImage* cachedImage() const { return nullptr; }

--- a/Source/WebCore/rendering/style/StyleInvalidImage.cpp
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.cpp
@@ -46,7 +46,7 @@ void StyleInvalidImage::load(CachedResourceLoader&, const ResourceLoaderOptions&
 {
 }
 
-RefPtr<Image> StyleInvalidImage::image(const RenderElement*, const FloatSize&) const
+RefPtr<Image> StyleInvalidImage::image(const RenderElement*, const FloatSize&, bool) const
 {
     return &Image::nullImage();
 }

--- a/Source/WebCore/rendering/style/StyleInvalidImage.h
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.h
@@ -56,7 +56,7 @@ private:
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool knownToBeOpaque(const RenderElement&) const { return false; }
 
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const;
 };
 

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -177,11 +177,11 @@ bool StyleMultiImage::hasClient(RenderElement& renderer) const
     return m_selectedImage->hasClient(renderer);
 }
 
-RefPtr<Image> StyleMultiImage::image(const RenderElement* renderer, const FloatSize& size) const
+RefPtr<Image> StyleMultiImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
 {
     if (!m_selectedImage)
         return nullptr;
-    return m_selectedImage->image(renderer, size);
+    return m_selectedImage->image(renderer, size, isForFirstLine);
 }
 
 float StyleMultiImage::imageScaleFactor() const

--- a/Source/WebCore/rendering/style/StyleMultiImage.h
+++ b/Source/WebCore/rendering/style/StyleMultiImage.h
@@ -72,7 +72,7 @@ private:
     void addClient(RenderElement&) final;
     void removeClient(RenderElement&) final;
     bool hasClient(RenderElement&) const final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     float imageScaleFactor() const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     const StyleImage* selectedImage() const final { return m_selectedImage.get(); }

--- a/Source/WebCore/rendering/style/StyleNamedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleNamedImage.cpp
@@ -64,7 +64,7 @@ void StyleNamedImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
 }
 
-RefPtr<Image> StyleNamedImage::image(const RenderElement* renderer, const FloatSize& size) const
+RefPtr<Image> StyleNamedImage::image(const RenderElement* renderer, const FloatSize& size, bool) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleNamedImage.h
+++ b/Source/WebCore/rendering/style/StyleNamedImage.h
@@ -50,7 +50,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StylePaintImage.cpp
+++ b/Source/WebCore/rendering/style/StylePaintImage.cpp
@@ -67,7 +67,7 @@ void StylePaintImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
 }
 
-RefPtr<Image> StylePaintImage::image(const RenderElement* renderer, const FloatSize& size) const
+RefPtr<Image> StylePaintImage::image(const RenderElement* renderer, const FloatSize& size, bool) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StylePaintImage.h
+++ b/Source/WebCore/rendering/style/StylePaintImage.h
@@ -53,7 +53,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }


### PR DESCRIPTION
#### e993429b13d827f663f596be484fa14cce95b6b1
<pre>
StyleImages need to know if they are painting a first-line so they can use the firstLineStyle() instead of style()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247127">https://bugs.webkit.org/show_bug.cgi?id=247127</a>
rdar://101911951

Reviewed by Alan Baradlay.

This allows fixing a case where we incorrectly resolve currentColor at style resolution time.

* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::computeStyleColor):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
(WebCore::StyleCachedImage::image const):
* Source/WebCore/rendering/style/StyleCachedImage.h:
* Source/WebCore/rendering/style/StyleCanvasImage.cpp:
(WebCore::StyleCanvasImage::image const):
* Source/WebCore/rendering/style/StyleCanvasImage.h:
* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::image const):
* Source/WebCore/rendering/style/StyleCrossfadeImage.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/style/StyleFilterImage.h:
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::image const):
(WebCore::StyleGradientImage::createGradient const):
* Source/WebCore/rendering/style/StyleGradientImage.h:
* Source/WebCore/rendering/style/StyleImage.h:
* Source/WebCore/rendering/style/StyleInvalidImage.cpp:
(WebCore::StyleInvalidImage::image const):
* Source/WebCore/rendering/style/StyleInvalidImage.h:
* Source/WebCore/rendering/style/StyleMultiImage.cpp:
(WebCore::StyleMultiImage::image const):
* Source/WebCore/rendering/style/StyleMultiImage.h:
* Source/WebCore/rendering/style/StyleNamedImage.cpp:
(WebCore::StyleNamedImage::image const):
* Source/WebCore/rendering/style/StyleNamedImage.h:
* Source/WebCore/rendering/style/StylePaintImage.cpp:
(WebCore::StylePaintImage::image const):
* Source/WebCore/rendering/style/StylePaintImage.h:

Canonical link: <a href="https://commits.webkit.org/266988@main">https://commits.webkit.org/266988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04481cbeac2a4ccbc2e77d1155dd4683ad2cede9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17693 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20678 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17139 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13724 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3676 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->