### PR TITLE
Web Inspector: Network tab drop zone activates incorrectly

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ImageResourceContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ImageResourceContentView.js
@@ -25,7 +25,7 @@
 
 WI.ImageResourceContentView = class ImageResourceContentView extends WI.ResourceContentView
 {
-    constructor(resource, {disableInteractions} = {})
+    constructor(resource, {disableInteractions, disableDropZone} = {})
     {
         console.assert(resource instanceof WI.Resource);
 
@@ -34,6 +34,7 @@ WI.ImageResourceContentView = class ImageResourceContentView extends WI.Resource
         this._imageElement = null;
         this._draggingInternalImageElement = false;
         this._disableInteractions = disableInteractions || false;
+        this._disableDropZone = disableDropZone || false;
 
         const toolTip = WI.repeatedUIString.showTransparencyGridTooltip();
         const activatedToolTip = WI.UIString("Hide transparency grid");
@@ -123,7 +124,7 @@ WI.ImageResourceContentView = class ImageResourceContentView extends WI.Resource
             this._gestureNavigationItemsDivider.hidden = false;
             this._updateResetGestureButtonNavigationItemLabel();
 
-            if (WI.NetworkManager.supportsOverridingResponses()) {
+            if (WI.NetworkManager.supportsOverridingResponses() && !this._disableDropZone) {
                 let dropZoneView = new WI.DropZoneView(this);
                 dropZoneView.targetElement = this._imageContainer;
                 this.addSubview(dropZoneView);

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js
@@ -120,8 +120,10 @@ WI.NetworkResourceDetailView = class NetworkResourceDetailView extends WI.Networ
 
         switch (identifier) {
         case "preview":
-            if (!this._resourceContentView)
-                this._resourceContentView = this._contentBrowser.showContentViewForRepresentedObject(this.representedObject);
+            if (!this._resourceContentView) {
+                const cookie = false;
+                this._resourceContentView = this._contentBrowser.showContentViewForRepresentedObject(this.representedObject, cookie, {disableDropZone: true});
+            }
             this._contentBrowser.showContentView(this._resourceContentView, this._contentViewCookie);
             break;
         case "headers":

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js
@@ -25,13 +25,14 @@
 
 WI.ResourceClusterContentView = class ResourceClusterContentView extends WI.ClusterContentView
 {
-    constructor(resource)
+    constructor(resource, {disableDropZone} = {})
     {
         super(resource);
 
         this._resource = resource;
         this._resource.addEventListener(WI.Resource.Event.TypeDidChange, this._resourceTypeDidChange, this);
         this._resource.addEventListener(WI.Resource.Event.LoadingDidFinish, this._resourceLoadingDidFinish, this);
+        this._disableDropZone = disableDropZone || false;
 
         this._responsePathComponent = this._createPathComponent({
             displayName: WI.UIString("Response"),
@@ -263,7 +264,7 @@ WI.ResourceClusterContentView = class ResourceClusterContentView extends WI.Clus
             return new WI.TextResourceContentView(this._resource);
 
         case WI.Resource.Type.Image:
-            return new WI.ImageResourceContentView(this._resource);
+            return new WI.ImageResourceContentView(this._resource, {disableDropZone: this._disableDropZone});
 
         case WI.Resource.Type.Font:
             return new WI.FontResourceContentView(this._resource);


### PR DESCRIPTION
#### 2c09c005dd59294f1251a0007ab1e9522717235c
<pre>
Web Inspector: Network tab drop zone activates incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=260251">https://bugs.webkit.org/show_bug.cgi?id=260251</a>

Reviewed by Devin Rousso.

This PR fixes a drop zone related issues caused by ImageResourceContentView being in NetworkTabContentView.
When dragging an item in when the image preview is active, both the HAR and Local Override drop zones activate, so modify DropZoneView so only one drop zone ever activates at a time.

Combined changes:
* Source/WebInspectorUI/UserInterface/Views/ImageResourceContentView.js:
(WI.ImageResourceContentView.prototype.contentAvailable):
* Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js:
(WI.NetworkResourceDetailView.prototype.showContentViewForIdentifier):
(WI.NetworkResourceDetailView):
* Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js:
(WI.ResourceClusterContentView.prototype._contentViewForResourceType):

Canonical link: <a href="https://commits.webkit.org/270108@main">https://commits.webkit.org/270108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b2ab3f3979217c6d923ad64217aceda52991619

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15933 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18154 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19628 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13749 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15376 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5893 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->