### PR TITLE
Inline style should always be cacheable in matched declarations cache

### DIFF
--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -136,6 +136,7 @@ UniqueElementData::UniqueElementData()
 UniqueElementData::UniqueElementData(const UniqueElementData& other)
     : ElementData(other, true)
     , m_presentationalHintStyle(other.m_presentationalHintStyle)
+    , m_inlineStyleForStyleResolution(other.m_inlineStyleForStyleResolution)
     , m_attributeVector(other.m_attributeVector)
 {
     if (other.m_inlineStyle)
@@ -149,6 +150,7 @@ UniqueElementData::UniqueElementData(const ShareableElementData& other)
     // An ShareableElementData should never have a mutable inline StyleProperties attached.
     ASSERT(!other.m_inlineStyle || !other.m_inlineStyle->isMutable());
     m_inlineStyle = other.m_inlineStyle;
+    m_inlineStyleForStyleResolution = downcast<ImmutableStyleProperties>(other.m_inlineStyle);
 }
 
 Ref<UniqueElementData> ElementData::makeUniqueCopy() const

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -222,6 +222,7 @@ public:
     static ptrdiff_t attributeVectorMemoryOffset() { return OBJECT_OFFSETOF(UniqueElementData, m_attributeVector); }
 
     mutable RefPtr<ImmutableStyleProperties> m_presentationalHintStyle;
+    mutable RefPtr<ImmutableStyleProperties> m_inlineStyleForStyleResolution;
     typedef Vector<Attribute, 4> AttributeVector;
     AttributeVector m_attributeVector;
 };

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -47,7 +47,9 @@ public:
     void invalidateStyleAttribute();
 
     const StyleProperties* inlineStyle() const { return elementData() ? elementData()->m_inlineStyle.get() : nullptr; }
-    
+    // Use immutable style for style resolution for efficient caching.
+    const ImmutableStyleProperties* inlineStyleForStyleResolution() const;
+
     bool setInlineStyleProperty(CSSPropertyID, CSSValueID identifier, bool important = false);
     bool setInlineStyleProperty(CSSPropertyID, CSSPropertyID identifier, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, double value, CSSUnitType, bool important = false);

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -636,10 +636,8 @@ void ElementRuleCollector::addElementInlineStyleProperties(bool includeSMILPrope
     if (!is<StyledElement>(element()))
         return;
 
-    if (auto* inlineStyle = downcast<StyledElement>(element()).inlineStyle()) {
-        bool isInlineStyleCacheable = !inlineStyle->isMutable();
-        addElementStyleProperties(inlineStyle, RuleSet::cascadeLayerPriorityForUnlayered, isInlineStyleCacheable, FromStyleAttribute::Yes);
-    }
+    if (auto* inlineStyle = downcast<StyledElement>(element()).inlineStyleForStyleResolution())
+        addElementStyleProperties(inlineStyle, RuleSet::cascadeLayerPriorityForUnlayered, true, FromStyleAttribute::Yes);
 
     if (includeSMILProperties && is<SVGElement>(element()))
         addElementStyleProperties(downcast<SVGElement>(element()).animatedSMILStyleProperties(), RuleSet::cascadeLayerPriorityForUnlayered, false /* isCacheable */);


### PR DESCRIPTION
#### 5326da20993d8ae1af4adfcf9efecbed999adec0
<pre>
Inline style should always be cacheable in matched declarations cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=260254">https://bugs.webkit.org/show_bug.cgi?id=260254</a>
rdar://113960228

Reviewed by Alan Baradlay.

Mutable inline style (created by modification via JS wrapper) prevents style caching
in the matched declarations cache. This patch turns any mutable style immutable during
style resolution so we can cache it. Due to deduplication the cache entries can be reused
accross elements and mutations.

* Source/WebCore/dom/ElementData.cpp:
(WebCore::UniqueElementData::UniqueElementData):
* Source/WebCore/dom/ElementData.h:

Save the immutable style in UniqueElementData.

* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::styleAttributeChanged):
(WebCore::StyledElement::invalidateStyleAttribute):

Take care to invalidate the cached immutable copy.

(WebCore::StyledElement::inlineStyleForStyleResolution const):

The accessor constructs ImmutableStyleProperties lazily on demand.

* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addElementInlineStyleProperties):

Allow caching.

Canonical link: <a href="https://commits.webkit.org/267035@main">https://commits.webkit.org/267035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fe453c2b9c42938bce3aa086721bba5a4d74a07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17212 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15858 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17954 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13941 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17373 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14688 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13946 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3711 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->