### PR TITLE
Port InspectorOverlayHighlight types to the new IPC serialization format

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -65,7 +65,7 @@ class Page;
 struct InspectorOverlayHighlight {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    enum class Type {
+    enum class Type : uint8_t {
         None, // Provides only non-quad information, including grid overlays.
         Node, // Provides 4 quads: margin, border, padding, content.
         NodeList, // Provides a list of nodes.
@@ -90,11 +90,6 @@ struct InspectorOverlayHighlight {
             WTF_MAKE_STRUCT_FAST_ALLOCATED;
             String name;
             FloatQuad quad;
-
-#if PLATFORM(IOS_FAMILY)
-            template<class Encoder> void encode(Encoder&) const;
-            template<class Decoder> static std::optional<Area> decode(Decoder&);
-#endif
         };
 
         Color color;
@@ -102,11 +97,6 @@ struct InspectorOverlayHighlight {
         Vector<FloatQuad> gaps;
         Vector<Area> areas;
         Vector<InspectorOverlayLabel> labels;
-
-#if PLATFORM(IOS_FAMILY)
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<GridHighlightOverlay> decode(Decoder&);
-#endif
     };
 
     struct FlexHighlightOverlay {
@@ -120,11 +110,6 @@ struct InspectorOverlayHighlight {
         Vector<FloatQuad> spaceBetweenItemsAndCrossAxisSpace;
         Vector<FloatQuad> crossAxisGaps;
         Vector<InspectorOverlayLabel> labels;
-
-#if PLATFORM(IOS_FAMILY)
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<FlexHighlightOverlay> decode(Decoder&);
-#endif
     };
 
     void setDataFromConfig(const Config& config)
@@ -282,84 +267,5 @@ private:
     bool m_showRulers { false };
     bool m_showRulersForNodeHighlight { false };
 };
-
-#if PLATFORM(IOS_FAMILY)
-
-template<class Encoder> void InspectorOverlayHighlight::FlexHighlightOverlay::encode(Encoder& encoder) const
-{
-    encoder << color;
-    encoder << containerBounds;
-    encoder << itemBounds;
-    encoder << mainAxisGaps;
-    encoder << mainAxisSpaceBetweenItemsAndGaps;
-    encoder << spaceBetweenItemsAndCrossAxisSpace;
-    encoder << crossAxisGaps;
-    encoder << labels;
-}
-
-template<class Decoder> std::optional<InspectorOverlayHighlight::FlexHighlightOverlay> InspectorOverlayHighlight::FlexHighlightOverlay::decode(Decoder& decoder)
-{
-    FlexHighlightOverlay flexHighlightOverlay;
-    if (!decoder.decode(flexHighlightOverlay.color))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.containerBounds))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.itemBounds))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.mainAxisGaps))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.mainAxisSpaceBetweenItemsAndGaps))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.spaceBetweenItemsAndCrossAxisSpace))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.crossAxisGaps))
-        return { };
-    if (!decoder.decode(flexHighlightOverlay.labels))
-        return { };
-    return { flexHighlightOverlay };
-}
-
-template<class Encoder> void InspectorOverlayHighlight::GridHighlightOverlay::encode(Encoder& encoder) const
-{
-    encoder << color;
-    encoder << gridLines;
-    encoder << gaps;
-    encoder << areas;
-    encoder << labels;
-}
-
-template<class Decoder> std::optional<InspectorOverlayHighlight::GridHighlightOverlay> InspectorOverlayHighlight::GridHighlightOverlay::decode(Decoder& decoder)
-{
-    GridHighlightOverlay gridHighlightOverlay;
-    if (!decoder.decode(gridHighlightOverlay.color))
-        return { };
-    if (!decoder.decode(gridHighlightOverlay.gridLines))
-        return { };
-    if (!decoder.decode(gridHighlightOverlay.gaps))
-        return { };
-    if (!decoder.decode(gridHighlightOverlay.areas))
-        return { };
-    if (!decoder.decode(gridHighlightOverlay.labels))
-        return { };
-    return { gridHighlightOverlay };
-}
-
-template<class Encoder> void InspectorOverlayHighlight::GridHighlightOverlay::Area::encode(Encoder& encoder) const
-{
-    encoder << name;
-    encoder << quad;
-}
-
-template<class Decoder> std::optional<InspectorOverlayHighlight::GridHighlightOverlay::Area> InspectorOverlayHighlight::GridHighlightOverlay::Area::decode(Decoder& decoder)
-{
-    Area area;
-    if (!decoder.decode(area.name))
-        return { };
-    if (!decoder.decode(area.quad))
-        return { };
-    return { area };
-}
-
-#endif
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -760,52 +760,6 @@ bool ArgumentCoder<ResourceError>::decode(Decoder& decoder, ResourceError& resou
     return true;
 }
 
-#if PLATFORM(IOS_FAMILY)
-
-void ArgumentCoder<InspectorOverlay::Highlight>::encode(Encoder& encoder, const InspectorOverlay::Highlight& highlight)
-{
-    encoder << static_cast<uint32_t>(highlight.type);
-    encoder << highlight.usePageCoordinates;
-    encoder << highlight.contentColor;
-    encoder << highlight.contentOutlineColor;
-    encoder << highlight.paddingColor;
-    encoder << highlight.borderColor;
-    encoder << highlight.marginColor;
-    encoder << highlight.quads;
-    encoder << highlight.gridHighlightOverlays;
-    encoder << highlight.flexHighlightOverlays;
-}
-
-bool ArgumentCoder<InspectorOverlay::Highlight>::decode(Decoder& decoder, InspectorOverlay::Highlight& highlight)
-{
-    uint32_t type;
-    if (!decoder.decode(type))
-        return false;
-    highlight.type = (InspectorOverlay::Highlight::Type)type;
-
-    if (!decoder.decode(highlight.usePageCoordinates))
-        return false;
-    if (!decoder.decode(highlight.contentColor))
-        return false;
-    if (!decoder.decode(highlight.contentOutlineColor))
-        return false;
-    if (!decoder.decode(highlight.paddingColor))
-        return false;
-    if (!decoder.decode(highlight.borderColor))
-        return false;
-    if (!decoder.decode(highlight.marginColor))
-        return false;
-    if (!decoder.decode(highlight.quads))
-        return false;
-    if (!decoder.decode(highlight.gridHighlightOverlays))
-        return false;
-    if (!decoder.decode(highlight.flexHighlightOverlays))
-        return false;
-    return true;
-}
-
-#endif
-
 void ArgumentCoder<FixedPositionViewportConstraints>::encode(Encoder& encoder, const FixedPositionViewportConstraints& viewportConstraints)
 {
     encoder << viewportConstraints.alignmentOffset();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -240,14 +240,6 @@ template<> struct ArgumentCoder<WebCore::KeypressCommand> {
 
 #endif // PLATFORM(COCOA)
 
-#if PLATFORM(IOS_FAMILY)
-template<> struct ArgumentCoder<WebCore::InspectorOverlay::Highlight> {
-    static void encode(Encoder&, const WebCore::InspectorOverlay::Highlight&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::InspectorOverlay::Highlight&);
-};
-
-#endif
-
 #if USE(APPKIT)
 
 template<> struct ArgumentCoder<WebCore::AppKitControlSystemImage> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5726,3 +5726,94 @@ struct WebCore::CookieStoreGetOptions {
     String mimeType()
     URL url()
 }
+
+#if PLATFORM(IOS_FAMILY)
+[Nested] enum class WebCore::InspectorOverlayLabel::Arrow::Direction : uint8_t {
+    None,
+    Down,
+    Up,
+    Left,
+    Right
+};
+
+[Nested] enum class WebCore::InspectorOverlayLabel::Arrow::Alignment : uint8_t {
+    None,
+    Leading,
+    Middle,
+    Trailing,
+};
+
+[Nested] enum class WebCore::InspectorOverlayLabel::Content::Decoration::Type : uint8_t {
+    None,
+    Bordered
+};
+
+[Nested] struct WebCore::InspectorOverlayLabel::Content::Decoration {
+    WebCore::InspectorOverlayLabel::Content::Decoration::Type type;
+    WebCore::Color color;
+};
+
+[Nested] struct WebCore::InspectorOverlayLabel::Content {
+    String text;
+    WebCore::Color textColor;
+    WebCore::InspectorOverlayLabel::Content::Decoration decoration;
+};
+
+[Nested] struct WebCore::InspectorOverlayLabel::Arrow {
+    WebCore::InspectorOverlayLabel::Arrow::Direction direction;
+    WebCore::InspectorOverlayLabel::Arrow::Alignment alignment
+};
+
+class WebCore::InspectorOverlayLabel {
+    Vector<WebCore::InspectorOverlayLabel::Content> m_contents;
+    WebCore::FloatPoint m_location;
+    WebCore::Color m_backgroundColor;
+    WebCore::InspectorOverlayLabel::Arrow m_arrow;
+};
+
+[Nested] struct WebCore::InspectorOverlayHighlight::FlexHighlightOverlay {
+        WebCore::Color color;
+        WebCore::FloatQuad containerBounds;
+        Vector<WebCore::FloatQuad> itemBounds;
+        Vector<WebCore::FloatQuad> mainAxisGaps;
+        Vector<WebCore::FloatQuad> mainAxisSpaceBetweenItemsAndGaps;
+        Vector<WebCore::FloatQuad> spaceBetweenItemsAndCrossAxisSpace;
+        Vector<WebCore::FloatQuad> crossAxisGaps;
+        Vector<WebCore::InspectorOverlayLabel> labels;
+};
+
+[Nested] struct WebCore::InspectorOverlayHighlight::GridHighlightOverlay::Area {
+    String name;
+    WebCore::FloatQuad quad;
+};
+
+[Nested] struct WebCore::InspectorOverlayHighlight::GridHighlightOverlay {
+    WebCore::Color color;
+    Vector<WebCore::FloatLine> gridLines;
+    Vector<WebCore::FloatQuad> gaps;
+    Vector<WebCore::InspectorOverlayHighlight::GridHighlightOverlay::Area> areas;
+    Vector<WebCore::InspectorOverlayLabel> labels;
+};
+
+[Nested] enum class WebCore::InspectorOverlayHighlight::Type : uint8_t {
+    None,
+    Node,
+    NodeList,
+    Rects,
+};
+
+header: <WebCore/InspectorOverlay.h>
+[CustomHeader] struct WebCore::InspectorOverlayHighlight {
+    WebCore::Color contentColor;
+    WebCore::Color contentOutlineColor;
+    WebCore::Color paddingColor;
+    WebCore::Color borderColor;
+    WebCore::Color marginColor;
+    WebCore::InspectorOverlayHighlight::Type type;
+    Vector<WebCore::FloatQuad> quads;
+    Vector<WebCore::InspectorOverlayHighlight::GridHighlightOverlay> gridHighlightOverlays;
+    Vector<WebCore::InspectorOverlayHighlight::FlexHighlightOverlay> flexHighlightOverlays;
+    bool usePageCoordinates;
+};
+
+#endif


### PR DESCRIPTION
#### a96175a20d33787743bd635c04d1de7e5ed8445f
<pre>
Port InspectorOverlayHighlight types to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=260263">https://bugs.webkit.org/show_bug.cgi?id=260263</a>
rdar://113971275

Reviewed by Alex Christensen.

This change ports InspectorOverlayHighlight and various related types to the new
IPC serialization format. That includes:
    - WebCore::InspectorOverlayLabel::Arrow::Direction
    - WebCore::InspectorOverlayLabel::Arrow::Alignment
    - WebCore::InspectorOverlayLabel::Content::Decoration::Type
    - WebCore::InspectorOverlayLabel::Content::Decoration
    - WebCore::InspectorOverlayLabel::Content
    - WebCore::InspectorOverlayLabel::Arrow
    - WebCore::InspectorOverlayLabel
    - WebCore::InspectorOverlayHighlight::FlexHighlightOverlay
    - WebCore::InspectorOverlayHighlight::GridHighlightOverlay::Area
    - WebCore::InspectorOverlayHighlight::GridHighlightOverlay
    - WebCore::InspectorOverlayHighlight::Type
    - WebCore::InspectorOverlayHighlight

* Source/WebCore/inspector/InspectorOverlay.h:
(WebCore::InspectorOverlayHighlight::FlexHighlightOverlay::encode const): Deleted.
(WebCore::InspectorOverlayHighlight::FlexHighlightOverlay::decode): Deleted.
(WebCore::InspectorOverlayHighlight::GridHighlightOverlay::encode const): Deleted.
(WebCore::InspectorOverlayHighlight::GridHighlightOverlay::decode): Deleted.
(WebCore::InspectorOverlayHighlight::GridHighlightOverlay::Area::encode const): Deleted.
(WebCore::InspectorOverlayHighlight::GridHighlightOverlay::Area::decode): Deleted.
* Source/WebCore/inspector/InspectorOverlayLabel.h:
(WebCore::InspectorOverlayLabel::Arrow::Arrow):
(WebCore::InspectorOverlayLabel::encode const): Deleted.
(WebCore::InspectorOverlayLabel::decode): Deleted.
(WebCore::InspectorOverlayLabel::Arrow::encode const): Deleted.
(WebCore::InspectorOverlayLabel::Arrow::decode): Deleted.
(WebCore::InspectorOverlayLabel::Content::encode const): Deleted.
(WebCore::InspectorOverlayLabel::Content::decode): Deleted.
(WebCore::InspectorOverlayLabel::Content::Decoration::encode const): Deleted.
(WebCore::InspectorOverlayLabel::Content::Decoration::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;InspectorOverlay::Highlight&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;InspectorOverlay::Highlight&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/266996@main">https://commits.webkit.org/266996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d01956b9f2257ffc870ee198f83219b69b596f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16912 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17711 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20695 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17157 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13742 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3683 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->