### PR TITLE
[WGSL] Add type declaration for bit shift operators

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -72,19 +72,6 @@ end
     }
 end
 
-# Bitwise operations
-operator :~, {
-    [T < Integer].(T) => T,
-    [T < Integer, N].(Vector[T, N]) => Vector[T, N]
-}
-
-["|", "&", "^"].each do |op|
-    operator :"#{op}", {
-        [T < Integer].(T, T) => T,
-        [T < Integer, N].(Vector[T, N], Vector[T, N]) => Vector[T, N]
-    }
-end
-
 operator :textureSample, {
     [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
     [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
@@ -104,6 +91,45 @@ operator :textureSampleBaseClampToEdge, {
   [].(TextureExternal, Sampler, Vector[F32, 2]) => Vector[F32, 4],
   [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
 }
+
+# 8.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
+
+operator :!, {
+    [].(Bool) => Bool,
+    [N].(Vector[Bool, N]) => Vector[Bool, N],
+}
+
+operator :'||', {
+    [].(Bool, Bool) => Bool,
+}
+
+operator :'&&', {
+    [].(Bool, Bool) => Bool,
+}
+
+operator :'|', {
+    [].(Bool, Bool) => Bool,
+    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+}
+
+operator :'&', {
+    [].(Bool, Bool) => Bool,
+    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+}
+
+# 8.9. Bit Expressions (https://www.w3.org/TR/WGSL/#bit-expr)
+
+operator :~, {
+    [T < Integer].(T) => T,
+    [T < Integer, N].(Vector[T, N]) => Vector[T, N]
+}
+
+["|", "&", "^", "<<", ">>"].each do |op|
+    operator :"#{op}", {
+        [T < Integer].(T, T) => T,
+        [T < Integer, N].(Vector[T, N], Vector[T, N]) => Vector[T, N]
+    }
+end
 
 # 16.1. Constructor Built-in Functions
 
@@ -213,31 +239,6 @@ operator :vec4, {
     [T < Scalar].(Vector[T, 3], T) => Vector[T, 4],
     [T < Scalar].(T, Vector[T, 3]) => Vector[T, 4],
     [].() => Vector[AbstractInt, 4],
-}
-
-# 7.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
-
-operator :!, {
-    [].(Bool) => Bool,
-    [N].(Vector[Bool, N]) => Vector[Bool, N],
-}
-
-operator :'||', {
-    [].(Bool, Bool) => Bool,
-}
-
-operator :'&&', {
-    [].(Bool, Bool) => Bool,
-}
-
-operator :'|', {
-    [].(Bool, Bool) => Bool,
-    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
-}
-
-operator :'&', {
-    [].(Bool, Bool) => Bool,
-    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
 }
 
 # 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -355,34 +355,7 @@ fn testComparison() {
   }
 }
 
-fn testBitwise()
-{
-  {
-    _ = ~0;
-    _ = ~0i;
-    _ = ~0u;
-  }
-
-  {
-    _ = 0 & 1;
-    _ = 0i & 1i;
-    _ = 0u & 1u;
-  }
-
-  {
-    _ = 0 | 1;
-    _ = 0i | 1i;
-    _ = 0u | 1u;
-  }
-
-  {
-    _ = 0 ^ 1;
-    _ = 0i ^ 1i;
-    _ = 0u ^ 1u;
-  }
-}
-
-// 7.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
+// 8.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
 
 fn testLogicalNegation()
 {
@@ -461,6 +434,47 @@ fn testLogicalAnd()
     _ = vec4( true) & vec4(false);
     _ = vec4(false) & vec4( true);
     _ = vec4( true) & vec4( true);
+}
+
+// 8.9. Bit Expressions (https://www.w3.org/TR/WGSL/#bit-expr)
+
+fn testBitwise()
+{
+  {
+    _ = ~0;
+    _ = ~0i;
+    _ = ~0u;
+  }
+
+  {
+    _ = 0 & 1;
+    _ = 0i & 1i;
+    _ = 0u & 1u;
+  }
+
+  {
+    _ = 0 | 1;
+    _ = 0i | 1i;
+    _ = 0u | 1u;
+  }
+
+  {
+    _ = 0 ^ 1;
+    _ = 0i ^ 1i;
+    _ = 0u ^ 1u;
+  }
+
+  {
+    _ = 1  << 2;
+    _ = 1i << 2i;
+    _ = 1u << 2u;
+  }
+
+  {
+    _ = 1  >> 2;
+    _ = 1i >> 2i;
+    _ = 1u >> 2u;
+  }
 }
 
 // 16.1. Constructor Built-in Functions


### PR DESCRIPTION
#### 231a040e5031a2031c5dfcaedd23ceb656975f50
<pre>
[WGSL] Add type declaration for bit shift operators
<a href="https://bugs.webkit.org/show_bug.cgi?id=260265">https://bugs.webkit.org/show_bug.cgi?id=260265</a>
rdar://problem/113972646

Reviewed by Dan Glastonbury.

We had declarations for ~, |, &amp; and ^, but &lt;&lt; and &gt;&gt; were missing.

* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/266979@main">https://commits.webkit.org/266979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8961f7c667a3cbcfa3fbcbb0390869f40af14946

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14302 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17714 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13126 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20697 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17159 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13745 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3670 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->