### PR TITLE
Deploy more smart pointers in WebFrame.cpp, WebPageOverlay.cpp, PageBannerMac.mm,

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -86,12 +86,14 @@ void WebPageOverlay::clear()
 
 void WebPageOverlay::willMoveToPage(PageOverlay&, Page* page)
 {
-    m_client->willMoveToPage(*this, page ? WebPage::fromCorePage(*page) : nullptr);
+    RefPtr webPage = page ? WebPage::fromCorePage(*page) : nullptr;
+    m_client->willMoveToPage(*this, webPage.get());
 }
 
 void WebPageOverlay::didMoveToPage(PageOverlay&, Page* page)
 {
-    m_client->didMoveToPage(*this, page ? WebPage::fromCorePage(*page) : nullptr);
+    RefPtr webPage = page ? WebPage::fromCorePage(*page) : nullptr;
+    m_client->didMoveToPage(*this, webPage.get());
 }
 
 void WebPageOverlay::drawRect(PageOverlay&, GraphicsContext& context, const IntRect& dirtyRect)
@@ -106,7 +108,8 @@ bool WebPageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& event)
 
 void WebPageOverlay::didScrollFrame(PageOverlay&, LocalFrame& frame)
 {
-    m_client->didScrollFrame(*this, WebFrame::fromCoreFrame(frame));
+    RefPtr webFrame = WebFrame::fromCoreFrame(frame);
+    m_client->didScrollFrame(*this, webFrame.get());
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
@@ -115,7 +115,7 @@ void PageBanner::showIfHidden()
 
     // This will re-create a parent layer in the WebCore layer tree, and we will re-add
     // m_layer as a child of it. 
-    addToPage(m_type, m_webPage.get());
+    addToPage(m_type, RefPtr { m_webPage.get() }.get());
 }
 
 void PageBanner::didChangeDeviceScaleFactor(float scaleFactor)
@@ -129,7 +129,7 @@ bool PageBanner::mouseEvent(const WebMouseEvent& mouseEvent)
     if (m_isHidden)
         return false;
 
-    auto* frameView = m_webPage->localMainFrameView();
+    RefPtr frameView = m_webPage->localMainFrameView();
     if (!frameView)
         return false;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -145,12 +145,12 @@ void TiledCoreAnimationDrawingArea::sendEnterAcceleratedCompositingModeIfNeeded(
 
 void TiledCoreAnimationDrawingArea::registerScrollingTree()
 {
-    WebProcess::singleton().eventDispatcher().addScrollingTreeForPage(m_webPage);
+    WebProcess::singleton().eventDispatcher().addScrollingTreeForPage(Ref { m_webPage });
 }
 
 void TiledCoreAnimationDrawingArea::unregisterScrollingTree()
 {
-    WebProcess::singleton().eventDispatcher().removeScrollingTreeForPage(m_webPage);
+    WebProcess::singleton().eventDispatcher().removeScrollingTreeForPage(Ref { m_webPage });
 }
 
 void TiledCoreAnimationDrawingArea::setNeedsDisplay()


### PR DESCRIPTION
#### 8d57b55f8d9b3c7d561dfe3ee356be6be15739c7
<pre>
Deploy more smart pointers in WebFrame.cpp, WebPageOverlay.cpp, PageBannerMac.mm,
and TiledCoreAnimationDrawingArea.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=260279">https://bugs.webkit.org/show_bug.cgi?id=260279</a>

Reviewed by Simon Fraser.

Deployed more smart pointers in these files.

* Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp:
(WebKit::WebPageOverlay::willMoveToPage):
(WebKit::WebPageOverlay::didMoveToPage):
(WebKit::WebPageOverlay::didScrollFrame):
* Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm:
(WebKit::PageBanner::showIfHidden):
(WebKit::PageBanner::mouseEvent):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::registerScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::unregisterScrollingTree):

Canonical link: <a href="https://commits.webkit.org/266960@main">https://commits.webkit.org/266960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c75133c02cc4ac39c60b0c4fc721c13840b22de7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15642 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15422 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17728 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13141 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20710 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17173 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13758 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18103 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1847 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->