### PR TITLE
Stop using raw pointer in PlatformSpeechSynthesisUtteranceClient

### DIFF
--- a/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
@@ -29,10 +29,11 @@
 
 #include "PlatformSpeechSynthesisVoice.h"
 #include <wtf/MonotonicTime.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
     
-class PlatformSpeechSynthesisUtteranceClient {
+class PlatformSpeechSynthesisUtteranceClient : public CanMakeWeakPtr<PlatformSpeechSynthesisUtteranceClient> {
 };
     
 class PlatformSpeechSynthesisUtterance : public RefCounted<PlatformSpeechSynthesisUtterance> {
@@ -63,7 +64,7 @@ public:
     MonotonicTime startTime() const { return m_startTime; }
     void setStartTime(MonotonicTime startTime) { m_startTime = startTime; }
     
-    PlatformSpeechSynthesisUtteranceClient* client() const { return m_client; }
+    PlatformSpeechSynthesisUtteranceClient* client() const { return m_client.get(); }
     void setClient(PlatformSpeechSynthesisUtteranceClient* client) { m_client = client; }
 
 #if PLATFORM(COCOA)
@@ -74,7 +75,7 @@ public:
 private:
     explicit PlatformSpeechSynthesisUtterance(PlatformSpeechSynthesisUtteranceClient&);
 
-    PlatformSpeechSynthesisUtteranceClient* m_client;
+    WeakPtr<PlatformSpeechSynthesisUtteranceClient> m_client;
     String m_text;
     String m_lang;
     RefPtr<PlatformSpeechSynthesisVoice> m_voice;


### PR DESCRIPTION
#### 647e462ab39a515c2e3a1eec0a998e13ab4eed76
<pre>
Stop using raw pointer in PlatformSpeechSynthesisUtteranceClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=260304">https://bugs.webkit.org/show_bug.cgi?id=260304</a>
rdar://113988475

Reviewed by Ryosuke Niwa.

Replace it with WeakPtr for safety.

* Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h:
(WebCore::PlatformSpeechSynthesisUtterance::client const):

Canonical link: <a href="https://commits.webkit.org/266994@main">https://commits.webkit.org/266994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91939085255695188ca22c2317a020419f90032c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16935 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17740 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20718 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14496 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12285 "1 flakes 5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13770 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3682 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->