### PR TITLE
Remove unused members of UniqueIDBDatabase and IDBServer

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -52,7 +52,7 @@ namespace IDBServer {
 class IDBServer : public UniqueIDBDatabaseManager {
 public:
     using StorageQuotaManagerSpaceRequester = Function<StorageQuotaManager::Decision(const ClientOrigin&, uint64_t spaceRequested)>;
-    WEBCORE_EXPORT IDBServer(PAL::SessionID, const String& databaseDirectoryPath, StorageQuotaManagerSpaceRequester&&, Lock&);
+    WEBCORE_EXPORT IDBServer(const String& databaseDirectoryPath, StorageQuotaManagerSpaceRequester&&, Lock&);
     WEBCORE_EXPORT ~IDBServer();
 
     WEBCORE_EXPORT void registerConnection(IDBConnectionToClient&);
@@ -104,9 +104,6 @@ public:
 
     WEBCORE_EXPORT static uint64_t diskUsage(const String& rootDirectory, const ClientOrigin&);
 
-    WEBCORE_EXPORT bool hasDatabaseActivitiesOnMainThread() const;
-    WEBCORE_EXPORT void stopDatabaseActivitiesOnMainThread();
-
 private:
     UniqueIDBDatabase& getOrCreateUniqueIDBDatabase(const IDBDatabaseIdentifier&);
 
@@ -115,7 +112,6 @@ private:
     void removeDatabasesModifiedSinceForVersion(WallTime, const String&);
     void removeDatabasesWithOriginsForVersion(const Vector<SecurityOriginData>&, const String&);
 
-    PAL::SessionID m_sessionID;
     HashMap<IDBConnectionIdentifier, RefPtr<IDBConnectionToClient>> m_connectionMap;
     HashMap<IDBDatabaseIdentifier, std::unique_ptr<UniqueIDBDatabase>> m_uniqueIDBDatabaseMap;
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1509,16 +1509,13 @@ bool UniqueIDBDatabase::hasDataInMemory() const
     return m_backingStore ? m_backingStore->isEphemeral() : false;
 }
 
-RefPtr<ServerOpenDBRequest> UniqueIDBDatabase::takeNextRunnableRequest(RequestType requestType)
+RefPtr<ServerOpenDBRequest> UniqueIDBDatabase::takeNextRunnableRequest()
 {
     // Connection of request may be closed or lost.
     clearStalePendingOpenDBRequests();
 
-    if (!m_pendingOpenDBRequests.isEmpty()) {
-        if (requestType == RequestType::Delete && !m_pendingOpenDBRequests.first()->isDeleteRequest())
-            return nullptr;
+    if (!m_pendingOpenDBRequests.isEmpty())
         return m_pendingOpenDBRequests.takeFirst();
-    }
 
     return nullptr;
 }

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -32,8 +32,6 @@
 #include "IDBGetResult.h"
 #include "ServerOpenDBRequest.h"
 #include "UniqueIDBDatabaseTransaction.h"
-#include <wtf/CrossThreadQueue.h>
-#include <wtf/CrossThreadTask.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/HashCountedSet.h>
@@ -128,8 +126,7 @@ private:
     void performCurrentOpenOperation();
     void performCurrentOpenOperationAfterSpaceCheck(bool isGranted);
     void performCurrentDeleteOperation();
-    enum class RequestType { Delete, Any };
-    RefPtr<ServerOpenDBRequest> takeNextRunnableRequest(RequestType = RequestType::Any);
+    RefPtr<ServerOpenDBRequest> takeNextRunnableRequest();
     void addOpenDatabaseConnection(Ref<UniqueIDBDatabaseConnection>&&);
     bool hasAnyOpenConnections() const;
     bool allConnectionsAreClosedOrClosing() const;
@@ -149,12 +146,10 @@ private:
     void didDeleteBackingStore(uint64_t deletedVersion);
     void close();
 
-    bool isCurrentlyInUse() const;
     void clearStalePendingOpenDBRequests();
 
     void clearTransactionsOnConnection(UniqueIDBDatabaseConnection&);
 
-    IDBServer* m_server;
     WeakPtr<UniqueIDBDatabaseManager> m_manager;
     IDBDatabaseIdentifier m_identifier;
 
@@ -178,8 +173,6 @@ private:
     // These sets help to decide which transactions can be started and which must be deferred.
     HashCountedSet<uint64_t> m_objectStoreTransactionCounts;
     HashSet<uint64_t> m_objectStoreWriteTransactions;
-
-    HashSet<IDBResourceIdentifier> m_cursorPrefetches;
 };
 
 } // namespace IDBServer

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -96,11 +96,11 @@ InProcessIDBServer::InProcessIDBServer(PAL::SessionID sessionID, const String& d
 {
     ASSERT(isMainThread());
     m_connectionToServer = IDBClient::IDBConnectionToServer::create(*this);
-    dispatchTask([this, protectedThis = Ref { *this }, sessionID, directory = databaseDirectoryPath.isolatedCopy(), spaceRequester = storageQuotaManagerSpaceRequester(*this)] () mutable {
+    dispatchTask([this, protectedThis = Ref { *this }, directory = databaseDirectoryPath.isolatedCopy(), spaceRequester = storageQuotaManagerSpaceRequester(*this)] () mutable {
         m_connectionToClient = IDBServer::IDBConnectionToClient::create(*this);
 
         Locker locker { m_serverLock };
-        m_server = makeUnique<IDBServer::IDBServer>(sessionID, directory, WTFMove(spaceRequester), m_serverLock);
+        m_server = makeUnique<IDBServer::IDBServer>(directory, WTFMove(spaceRequester), m_serverLock);
         m_server->registerConnection(*m_connectionToClient);
     });
 }


### PR DESCRIPTION
#### 24ed2daa491dd6a05645b17b007571ce01c1f97a
<pre>
Remove unused members of UniqueIDBDatabase and IDBServer
<a href="https://bugs.webkit.org/show_bug.cgi?id=260308">https://bugs.webkit.org/show_bug.cgi?id=260308</a>
rdar://113989871

Reviewed by Ryosuke Niwa.

This will help reduce the size of these classes.

* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::IDBServer):
(WebCore::IDBServer::IDBServer::createBackingStore):
(WebCore::IDBServer::IDBServer::hasDatabaseActivitiesOnMainThread const): Deleted.
(WebCore::IDBServer::IDBServer::stopDatabaseActivitiesOnMainThread): Deleted.
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::takeNextRunnableRequest):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebKitLegacy/Storage/InProcessIDBServer.cpp:
(InProcessIDBServer::InProcessIDBServer):

Canonical link: <a href="https://commits.webkit.org/266976@main">https://commits.webkit.org/266976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e908307c848c4b6a2f5a4181843746823ce89026

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17019 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15666 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17752 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20725 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13779 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3667 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->