### PR TITLE
Buttons on the Date/Time picker are too low on visionOS.

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -68,10 +68,6 @@ static NSString * const kDateFormatString = @"yyyy-MM-dd"; // "2011-01-27".
 static NSString * const kMonthFormatString = @"yyyy-MM"; // "2011-01".
 static NSString * const kTimeFormatString = @"HH:mm"; // "13:45".
 static NSString * const kDateTimeFormatString = @"yyyy-MM-dd'T'HH:mm"; // "2011-01-27T13:45"
-static const NSTimeInterval kMillisecondsPerSecond = 1000;
-
-static const CGFloat kDateTimePickerControlMargin = 6;
-static const CGFloat kDateTimePickerToolbarHeight = 44;
 
 - (id)initWithView:(WKContentView *)view datePickerMode:(UIDatePickerMode)mode
 {
@@ -117,7 +113,8 @@ static const CGFloat kDateTimePickerToolbarHeight = 44;
     _isDismissingDatePicker = NO;
 
     _accessoryView = adoptNS([[UIToolbar alloc] init]);
-    [[_accessoryView heightAnchor] constraintEqualToConstant:kDateTimePickerToolbarHeight].active = YES;
+    CGSize accessorySize = [_accessoryView sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+    [[_accessoryView heightAnchor] constraintEqualToConstant:accessorySize.height].active = YES;
 
 #if HAVE(UITOOLBAR_STANDARD_APPEARANCE)
     auto toolbarAppearance = adoptNS([[UIToolbarAppearance alloc] init]);


### PR DESCRIPTION
#### f08aa3ffb0503b2c808622fe6b9f37698c3ff5e6
<pre>
Buttons on the Date/Time picker are too low on visionOS.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260316">https://bugs.webkit.org/show_bug.cgi?id=260316</a>
rdar://113725970

Reviewed by Aditya Keerthi.

We had a hard coded size for the accessory view for the buttons
at the bottom of the date/time picker, and since visionOS has
a different layout, it did not look good on the platform. Use
sizeThatFits to have a good size on all platforms and remove
the constant as well as some others that are no longer used.

* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker initWithView:datePickerMode:]):

Canonical link: <a href="https://commits.webkit.org/266973@main">https://commits.webkit.org/266973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b57c77c0a9ea2f64dc939401d968fc0b7a007f8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14342 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17765 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13166 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14517 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13789 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->