### PR TITLE
REGRESSION(266959@main): [ Debug ] ASSERTION FAILED: m_suspendIfNeededWasCalled

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -152,6 +152,7 @@ void SpeechSynthesis::speak(SpeechSynthesisUtterance& utterance)
         return;
 #endif
 
+    utterance.setIsActiveForEventDispatch(true);
     m_utteranceQueue.append(utterance);
     // If the queue was empty, speak this immediately and add it to the queue.
     if (m_utteranceQueue.size() == 1)

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -40,12 +40,16 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SpeechSynthesisUtterance);
     
 Ref<SpeechSynthesisUtterance> SpeechSynthesisUtterance::create(ScriptExecutionContext& context, const String& text)
 {
-    return adoptRef(*new SpeechSynthesisUtterance(context, text, { }));
+    auto utterance = adoptRef(*new SpeechSynthesisUtterance(context, text, { }));
+    utterance->suspendIfNeeded();
+    return utterance;
 }
 
 Ref<SpeechSynthesisUtterance> SpeechSynthesisUtterance::create(ScriptExecutionContext& context, const String& text, SpeechSynthesisUtterance::UtteranceCompletionHandler&& completion)
 {
-    return adoptRef(*new SpeechSynthesisUtterance(context, text, WTFMove(completion)));
+    auto utterance = adoptRef(*new SpeechSynthesisUtterance(context, text, WTFMove(completion)));
+    utterance->suspendIfNeeded();
+    return utterance;
 }
 
 SpeechSynthesisUtterance::SpeechSynthesisUtterance(ScriptExecutionContext& context, const String& text, UtteranceCompletionHandler&& completion)
@@ -111,6 +115,10 @@ void SpeechSynthesisUtterance::dispatchEventAndUpdateState(Event& event)
 
 void SpeechSynthesisUtterance::setIsActiveForEventDispatch(bool isActiveForEventDispatch)
 {
+    // When completionHandler is set, event will be passed to it instead of being dispatched.
+    if (m_completionHandler)
+        return;
+
     m_isActiveForEventDispatch = isActiveForEventDispatch;
 }
 


### PR DESCRIPTION
#### 335771b16fe5502cee59806639614d5a0b19c40c
<pre>
REGRESSION(266959@main): [ Debug ] ASSERTION FAILED: m_suspendIfNeededWasCalled
<a href="https://bugs.webkit.org/show_bug.cgi?id=260314">https://bugs.webkit.org/show_bug.cgi?id=260314</a>
rdar://113993253

Reviewed by Ryosuke Niwa.

The assertion failure happens when running layout test under LayoutTests/fast/speechsynthesis. The patch fixes it by
invoking suspendIfNeeded() upon creation of SpeechSynthesisUtterance.

This patch also contains two drive-by fixes:
1. When m_completionHandler of SpeechSynthesisUtterance is set, event is passed to the handler instead of being
dispatched, so wrapper of SpeechSynthesisUtterance does not need be kept alive for event dispatch.
2. SpeechSynthesisUtterance should be marked as active for event dispatch when it is handed over to SpeechSynthesis.

* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::speak):
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::create):
(WebCore::SpeechSynthesisUtterance::setIsActiveForEventDispatch):

Canonical link: <a href="https://commits.webkit.org/266990@main">https://commits.webkit.org/266990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0127397b1c8fcbcc34ce22a25fbe38aa255bda63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15708 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17795 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20754 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12323 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13816 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->