### PR TITLE
[visionOS] Safari URL bar goes up a bit when entering fullscreen, and back down when exiting

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
@@ -90,6 +90,8 @@ typedef void (^MRUIWindowSceneResizeRequestCompletion)(CGSize grantedSize, NSErr
 
 @interface MRUIPlatterOrnament : NSObject
 @property (nonatomic, assign, getter=_depthDisplacement, setter=_setDepthDisplacement:) CGFloat depthDisplacement;
+@property (nonatomic, assign) CGPoint offset2D;
+@property (nonatomic, assign) CGPoint sceneAnchorPoint;
 @property (nonatomic, readwrite, strong) UIViewController *viewController;
 @end
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -496,6 +496,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 @property (nonatomic, readonly) CGFloat depthDisplacement;
 @property (nonatomic, readonly) CGFloat windowAlpha;
+@property (nonatomic, readonly) CGPoint offset2D;
 
 - (instancetype)initWithOrnament:(MRUIPlatterOrnament *)ornament;
 
@@ -510,6 +511,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
     _depthDisplacement = ornament._depthDisplacement;
     _windowAlpha = ornament.viewController.view.window.alpha;
+    _offset2D = ornament.offset2D;
 
     return self;
 }
@@ -520,6 +522,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 @property (nonatomic, readonly) CATransform3D transform3D;
 @property (nonatomic, readonly) Class windowClass;
+@property (nonatomic, readonly) CGSize sceneSize;
 @property (nonatomic, readonly) CGSize sceneMinimumSize;
 @property (nonatomic, readonly) RSSSceneChromeOptions sceneChromeOptions;
 @property (nonatomic, readonly) MRUISceneResizingBehavior sceneResizingBehavior;
@@ -545,6 +548,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     _preferredDarkness = UIApplication.sharedApplication.mrui_activeStage.preferredDarkness;
 
     UIWindowScene *windowScene = window.windowScene;
+    _sceneSize = windowScene.coordinateSpace.bounds.size;
     _sceneMinimumSize = windowScene.sizeRestrictions.minimumSize;
     _sceneChromeOptions = windowScene.mrui_placement.preferredChromeOptions;
     _sceneResizingBehavior = windowScene.mrui_placement.preferredResizingBehavior;
@@ -1692,7 +1696,31 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         OBJC_ALWAYS_LOG(logIdentifier, "resize completed");
         [_lastKnownParentWindow setFrame:adjustedOriginalWindowFrame];
         [_window setFrame:adjustedFullscreenWindowFrame];
+
+        [self _updateOrnamentOffsetsForTemporarySceneSize:[_window windowScene].coordinateSpace.bounds.size];
     });
+}
+
+- (void)_updateOrnamentOffsetsForTemporarySceneSize:(CGSize)newSceneSize
+{
+    CGSize originalSceneSize = [_parentWindowState sceneSize];
+
+    CGFloat sceneWidthDifference = newSceneSize.width - originalSceneSize.width;
+    CGFloat sceneHeightDifference = newSceneSize.height - originalSceneSize.height;
+
+    // The temporary scene size will always be greater than or equal to the original scene size,
+    // and the position of the original scene will always be centered relative to the new size.
+
+    ASSERT(sceneWidthDifference >= 0);
+    ASSERT(sceneHeightDifference >= 0);
+
+    for (MRUIPlatterOrnament *ornament in [_parentWindowState ornamentProperties]) {
+        CGPoint originalOffset2D = [[[_parentWindowState ornamentProperties] objectForKey:ornament] offset2D];
+        ornament.offset2D = CGPointMake(
+            originalOffset2D.x + sceneWidthDifference * (0.5 - ornament.sceneAnchorPoint.x),
+            originalOffset2D.y + sceneHeightDifference * (0.5 - ornament.sceneAnchorPoint.y)
+        );
+    }
 }
 
 - (void)_setOrnamentsHidden:(BOOL)hidden
@@ -1771,6 +1799,9 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
                 scene.mrui_placement.preferredResizingBehavior = [originalState sceneResizingBehavior];
                 if (auto delegate = dynamic_objc_cast<WKFullscreenWindowSceneDelegate>(scene.delegate))
                     scene.delegate = [delegate originalDelegate];
+
+                for (MRUIPlatterOrnament *ornament in [originalState ornamentProperties])
+                    ornament.offset2D = [[[originalState ornamentProperties] objectForKey:ornament] offset2D];
             }
 
             scene.mrui_placement.preferredChromeOptions = [originalState sceneChromeOptions];


### PR DESCRIPTION
#### 2e3db948f82fab5aa0533be7f38aff5d263334b2
<pre>
[visionOS] Safari URL bar goes up a bit when entering fullscreen, and back down when exiting
<a href="https://bugs.webkit.org/show_bug.cgi?id=260315">https://bugs.webkit.org/show_bug.cgi?id=260315</a>
rdar://113512242

Reviewed by Tim Horton and Richard Robinson.

Safari&apos;s URL bar is implemented as an ornament. An ornament&apos;s position is
determined relative to its scene, using its `sceneAnchorPoint`. When performing
the fullscreen transition, the scene is temporarily resized to fit the original
window, as well as the fullscreen window. Since ornaments are anchored to scenes,
they move along with the resize.

Fix by temporarily updating ornament offsets to account for the temporary scene
size.

* Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h:

`offset2D` is relative to the `sceneAnchorPoint`.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKMRUIPlatterOrnamentProperties initWithOrnament:]):

Store the original `offset2D`, so that it can be restored when exiting fullscreen.

(-[WKFullScreenParentWindowState initWithWindow:]):

Store the original scene size, in order to determine the relative change in an
ornament&apos;s position.

(-[WKFullScreenWindowController _configureSpatialFullScreenTransition]):
(-[WKFullScreenWindowController _updateOrnamentOffsetsForTemporarySceneSize:]):

Update ornaments offsets to account for the temporary scene size.

(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Restore the original ornament offsets when exiting fullscreen.

Canonical link: <a href="https://commits.webkit.org/266984@main">https://commits.webkit.org/266984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/845d25716bcd4b8ebc68f9c54979576aec9605f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14345 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16951 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17769 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13169 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20736 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17205 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13792 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3673 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->