### PR TITLE
Migrate benchmark_json_merge in webkitpy/benchmark_runner to Python 3

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_json_merge.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_json_merge.py
@@ -24,6 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from functools import reduce
+
 
 def deepAppend(value1, value2, currentKey=None):
     if type(value1) != type(value2):
@@ -32,7 +34,7 @@ def deepAppend(value1, value2, currentKey=None):
         return value1 + value2
 
     result = {}
-    for key in (value1.keys() + value2.keys()):
+    for key in [*value1.keys(), *value2.keys()]:
         if key not in result:
             result[key] = deepAppend(value1[key], value2[key], key)
     return result


### PR DESCRIPTION
#### 1238f66382701acf7c499a4a56a314e6a1c7954e
<pre>
Migrate benchmark_json_merge in webkitpy/benchmark_runner to Python 3
<a href="https://bugs.webkit.org/show_bug.cgi?id=260307">https://bugs.webkit.org/show_bug.cgi?id=260307</a>

Reviewed by Dewei Zhu.

Imports reduce from functools since it is no longer a built-in function in Python 3.
Uses Python 3 list comprehension syntax to add the object keys.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_json_merge.py:
(deepAppend):

Canonical link: <a href="https://commits.webkit.org/267216@main">https://commits.webkit.org/267216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b189b104be8e8df2e63b397384ee2e4a8302150

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16125 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13178 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18001 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/15610 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20913 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17417 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12479 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13989 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3817 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->