### PR TITLE
Support first-line related CSS interactions in `text-wrap: balance`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2896,7 +2896,6 @@ webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/seg
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/seg-break-transformation-019.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/tab-bidi-001.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-001.html [ ImageOnlyFailure ]
-webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-text-indent-001.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-005.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-006.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-008.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h
@@ -43,12 +43,12 @@ public:
 private:
     void initialize();
 
-    std::optional<Vector<LayoutUnit>> balanceRangeWithLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, size_t numberOfLines);
-    std::optional<Vector<LayoutUnit>> balanceRangeWithNoLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth);
+    std::optional<Vector<LayoutUnit>> balanceRangeWithLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, size_t numberOfLines, bool isFirstChunk);
+    std::optional<Vector<LayoutUnit>> balanceRangeWithNoLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, bool isFirstChunk);
 
-    InlineLayoutUnit inlineItemWidth(size_t inlineItemIndex) const;
-    bool shouldTrimLeading(size_t inlineItemIndex) const;
-    bool shouldTrimTrailing(size_t inlineItemIndex) const;
+    InlineLayoutUnit inlineItemWidth(size_t inlineItemIndex, bool useFirstLineStyle) const;
+    bool shouldTrimLeading(size_t inlineItemIndex, bool useFirstLineStyle, bool isFirstLineInChunk) const;
+    bool shouldTrimTrailing(size_t inlineItemIndex, bool useFirstLineStyle) const;
 
     const InlineFormattingContext& m_inlineFormattingContext;
     const InlineLayoutState& m_inlineLayoutState;
@@ -59,13 +59,14 @@ private:
     Vector<float> m_originalLineWidths;
     Vector<bool> m_originalLineEndsWithForcedBreak;
     Vector<InlineLayoutUnit> m_inlineItemWidths;
+    Vector<InlineLayoutUnit> m_firstLineStyleInlineItemWidths;
     size_t m_numberOfLinesInOriginalLayout { 0 };
     size_t m_numberOfInlineItems { 0 };
     double m_maximumLineWidth { 0 };
     bool m_cannotBalanceContent { false };
 
     struct SlidingWidth {
-        SlidingWidth(const InlineContentBalancer&, const InlineItems&, size_t start, size_t end);
+        SlidingWidth(const InlineContentBalancer&, const InlineItems&, size_t start, size_t end, bool useFirstLineStyle, bool isFirstLineInChunk);
         InlineLayoutUnit width();
         void advanceStart();
         void advanceStartTo(size_t newStart);
@@ -77,6 +78,8 @@ private:
         const InlineItems& m_inlineItems;
         size_t m_start { 0 };
         size_t m_end { 0 };
+        bool m_useFirstLineStyle { false };
+        bool m_isFirstLineInChunk { false };
         InlineLayoutUnit m_totalWidth { 0 };
         InlineLayoutUnit m_leadingTrimmableWidth { 0 };
         InlineLayoutUnit m_trailingTrimmableWidth { 0 };


### PR DESCRIPTION
#### d25ec10246e80f42254d80a6dc7fd94050e73313
<pre>
Support first-line related CSS interactions in `text-wrap: balance`
<a href="https://bugs.webkit.org/show_bug.cgi?id=260229">https://bugs.webkit.org/show_bug.cgi?id=260229</a>
rdar://113934501

Reviewed by Alan Baradlay.

This patch implements support for first-line styling, text-indent,
and white-space-collapse in text-wrap: balance. All three of these
properties depend on special-casing the first line when balancing
inline content. In the case of white-space-collapse: preserve, we
mostly trim leading/trailing white space, except in the case where
there is preserved leading white space on the first line.

This patch also supports white-space-collapse: break-spaces.

* LayoutTests/TestExpectations:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp:
(WebCore::Layout::InlineContentBalancer::initialize):
(WebCore::Layout::InlineContentBalancer::computeBalanceConstraints):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithLineRequirement):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithNoLineRequirement):
(WebCore::Layout::InlineContentBalancer::inlineItemWidth const):
(WebCore::Layout::InlineContentBalancer::shouldTrimLeading const):
(WebCore::Layout::InlineContentBalancer::shouldTrimTrailing const):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::SlidingWidth):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::advanceStart):
(WebCore::Layout::InlineContentBalancer::SlidingWidth::advanceEnd):
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.h:

Canonical link: <a href="https://commits.webkit.org/267009@main">https://commits.webkit.org/267009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/335ad6a8786bb328a672349c34fc39383983c9b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17827 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20799 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12353 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3691 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->