### PR TITLE
WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp: warning: lambda capture 'thisPointerForLog' is not used

### DIFF
--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -331,7 +331,7 @@ void Connection::EventListener::open(Function<void()>&& handler)
 
     BOOL result;
     result = ::RegisterWaitForSingleObject(&m_waitHandle, m_state.hEvent, callback, this, INFINITE, WT_EXECUTEDEFAULT);
-    ASSERT(result);
+    ASSERT_UNUSED(result, result);
 }
 
 void Connection::EventListener::callback(void* data, BOOLEAN timerOrWaitFired)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -168,6 +168,9 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
 
     ASSERT(policyDecisionMode == PolicyDecisionMode::Asynchronous);
     webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForNavigationActionAsync(m_frame->info(), documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.resourceRequest(), request, IPC::FormDataReference { request.httpBody() }), [thisPointerForLog = this, frame = m_frame, listenerID, requestIdentifier] (PolicyDecision&& policyDecision) {
+#if RELEASE_LOG_DISABLED
+        UNUSED_PARAM(thisPointerForLog);
+#endif
         RELEASE_LOG(Network, WebFrameLoaderClient_PREFIX_PARAMETERS "dispatchDecidePolicyForNavigationAction: Got policyAction %u from async IPC", thisPointerForLog, frame.ptr(), frame->frameID().object().toUInt64(), frame->page(), frame->page() ? frame->page()->identifier().toUInt64() : 0, (unsigned)policyDecision.policyAction);
 
         frame->didReceivePolicyDecision(listenerID, requestIdentifier, WTFMove(policyDecision));


### PR DESCRIPTION
#### dc38df83a8f6b257aaba0bf89ae1c1ebd4936eb7
<pre>
WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp: warning: lambda capture &apos;thisPointerForLog&apos; is not used
<a href="https://bugs.webkit.org/show_bug.cgi?id=260329">https://bugs.webkit.org/show_bug.cgi?id=260329</a>

Reviewed by Ross Kirsling.

clang-cl reported the following warnings for Windows port.

&gt; WebKit\Platform\IPC\win\ConnectionWin.cpp(332,10): warning: variable &apos;result&apos; set but not used [-Wunused-but-set-variable]
&gt; WebKit\WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp(170,325): warning: lambda capture &apos;thisPointerForLog&apos; is not used [-Wunused-lambda-capture]

* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
(IPC::Connection::EventListener::open):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/266993@main">https://commits.webkit.org/266993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46290242f2ead11aec035dcd54e86cfa2b9131b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17067 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15714 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17801 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13198 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13978 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14552 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13822 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3679 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->