### PR TITLE
jsc.cpp(3614,1): warning: function declared 'noreturn' should not return

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -326,7 +326,7 @@ void WTFCrash()
 #else
     *(int *)(uintptr_t)0xbbadbeef = 0;
     // More reliable, but doesn't say BBADBEEF.
-#if COMPILER(GCC_COMPATIBLE)
+#if COMPILER(GCC) || COMPILER(CLANG)
     __builtin_trap();
 #else
     ((void(*)())nullptr)();

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -257,7 +257,7 @@
 
 /* NO_RETURN */
 
-#if !defined(NO_RETURN) && COMPILER(GCC_COMPATIBLE)
+#if !defined(NO_RETURN) && (COMPILER(GCC) || COMPILER(CLANG))
 #define NO_RETURN __attribute((__noreturn__))
 #endif
 
@@ -304,7 +304,7 @@
 
 /* NO_RETURN_WITH_VALUE */
 
-#if !defined(NO_RETURN_WITH_VALUE) && !COMPILER(MSVC)
+#if !defined(NO_RETURN_WITH_VALUE) && (COMPILER(GCC) || COMPILER(CLANG))
 #define NO_RETURN_WITH_VALUE NO_RETURN
 #endif
 
@@ -356,7 +356,7 @@
 
 /* UNUSED_FUNCTION */
 
-#if !defined(UNUSED_FUNCTION) && COMPILER(GCC_COMPATIBLE)
+#if !defined(UNUSED_FUNCTION) && (COMPILER(GCC) || COMPILER(CLANG))
 #define UNUSED_FUNCTION __attribute__((unused))
 #endif
 


### PR DESCRIPTION
#### 6c660bb7b4f5b27281db488bcb8890cee00a1f0b
<pre>
jsc.cpp(3614,1): warning: function declared &apos;noreturn&apos; should not return
<a href="https://bugs.webkit.org/show_bug.cgi?id=260330">https://bugs.webkit.org/show_bug.cgi?id=260330</a>

Reviewed by Ross Kirsling.

clang-cl reported the following warnings for Windows port.

&gt; WTF\wtf\Assertions.cpp(335,1): warning: function declared &apos;noreturn&apos; should not return [-Winvalid-noreturn]
&gt; JavaScriptCore\jsc.cpp(2602,1): warning: non-void function does not return a value [-Wreturn-type]
&gt; JavaScriptCore\jsc.cpp(3614,1): warning: function declared &apos;noreturn&apos; should not return [-Winvalid-noreturn]

Clang-cl should take a code path of GCC for UNUSED_FUNCTION, NO_RETURN
and NO_RETURN_WITH_VALUE macros to suppress compiler warnings.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Compiler.h:

Canonical link: <a href="https://commits.webkit.org/266995@main">https://commits.webkit.org/266995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af93ef25f23b483acf1f81efd1670b1f92c42812

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17805 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20762 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13129 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17237 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14562 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12332 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15508 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13826 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3681 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18173 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15743 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14389 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3757 "Passed tests") | 
<!--EWS-Status-Bubble-End-->