### PR TITLE
DrawingArea should use a smart pointer to point to WebPage

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -184,12 +184,13 @@ protected:
 
     template<typename T> bool send(T&& message)
     {
-        return m_webPage.send(WTFMove(message), m_identifier.toUInt64(), { });
+        Ref webPage = m_webPage.get();
+        return webPage->send(WTFMove(message), m_identifier.toUInt64(), { });
     }
 
     const DrawingAreaType m_type;
     DrawingAreaIdentifier m_identifier;
-    WebPage& m_webPage;
+    CheckedRef<WebPage> m_webPage;
     WebCore::IntSize m_lastViewSizeForScaleToFit;
     WebCore::IntSize m_lastDocumentSizeForScaleToFit;
     bool m_isScalingViewToFitDocument { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -405,7 +405,7 @@ class PlatformXRSystemProxy;
 using SnapshotOptions = uint32_t;
 using WKEventModifiers = uint32_t;
 
-class WebPage : public API::ObjectImpl<API::Object::Type::BundlePage>, public IPC::MessageReceiver, public IPC::MessageSender {
+class WebPage : public API::ObjectImpl<API::Object::Type::BundlePage>, public IPC::MessageReceiver, public IPC::MessageSender, public CanMakeCheckedPtr {
 public:
     static Ref<WebPage> create(WebCore::PageIdentifier, WebPageCreationParameters&&);
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -71,14 +71,15 @@ void RemoteLayerTreeDrawingAreaMac::mainFrameContentSizeChanged(WebCore::FrameId
 
 void RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage(double scale, FloatPoint origin)
 {
-    auto* frameView = m_webPage.localMainFrameView();
+    Ref webPage = m_webPage.get();
+    RefPtr frameView = webPage->localMainFrameView();
     if (!frameView)
         return;
 
     auto unscrolledOrigin = origin;
     FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     unscrolledOrigin.moveBy(-unobscuredContentRect.location());
-    m_webPage.scalePage(scale / m_webPage.viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
+    webPage->scalePage(scale / webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
     updateRendering();
 }
 
@@ -86,7 +87,7 @@ void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::F
 {
     LOG_WITH_STREAM(ViewGestures, stream << "RemoteLayerTreeDrawingAreaMac::adjustTransientZoom - scale " << scale << " origin " << origin);
 
-    auto totalScale = scale * m_webPage.viewScaleFactor();
+    auto totalScale = scale * m_webPage->viewScaleFactor();
 
     // FIXME: Need to trigger some re-rendering here to render at the new scale, so tiles update while zooming.
 
@@ -97,7 +98,7 @@ void RemoteLayerTreeDrawingAreaMac::commitTransientZoom(double scale, WebCore::F
 {
     LOG_WITH_STREAM(ViewGestures, stream << "RemoteLayerTreeDrawingAreaMac::commitTransientZoom - scale " << scale << " origin " << origin);
 
-    scale *= m_webPage.viewScaleFactor();
+    scale *= m_webPage->viewScaleFactor();
     
     applyTransientZoomToPage(scale, origin);
 }
@@ -105,7 +106,7 @@ void RemoteLayerTreeDrawingAreaMac::commitTransientZoom(double scale, WebCore::F
 void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(RemoteLayerTreeTransaction& transaction)
 {
     // FIXME: Probably need something here for PDF.
-    auto* frameView = m_webPage.localMainFrameView();
+    RefPtr frameView = m_webPage->localMainFrameView();
     if (!frameView)
         return;
 


### PR DESCRIPTION
#### 7d2d82a98ab418210eb88862912a64fdaa061741
<pre>
DrawingArea should use a smart pointer to point to WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=260332">https://bugs.webkit.org/show_bug.cgi?id=260332</a>

Reviewed by Simon Fraser.

Use CheckedRef&lt;WebPage&gt; instead of WebPage&amp;.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::setNeedsDisplay):
(WebKit::DrawingAreaCoordinatedGraphics::setNeedsDisplayInRect):
(WebKit::DrawingAreaCoordinatedGraphics::forceRepaint):
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
(WebKit::DrawingAreaCoordinatedGraphics::setDeviceScaleFactor):
(WebKit::DrawingAreaCoordinatedGraphics::registerScrollingTree):
(WebKit::DrawingAreaCoordinatedGraphics::unregisterScrollingTree):
(WebKit::DrawingAreaCoordinatedGraphics::activityStateDidChange):
(WebKit::DrawingAreaCoordinatedGraphics::updateGeometry):
(WebKit::DrawingAreaCoordinatedGraphics::adjustTransientZoom):
(WebKit::DrawingAreaCoordinatedGraphics::commitTransientZoom):
(WebKit::DrawingAreaCoordinatedGraphics::suspendPainting):
(WebKit::DrawingAreaCoordinatedGraphics::resumePainting):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode):
(WebKit::DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode):
(WebKit::DrawingAreaCoordinatedGraphics::display):
(WebKit::DrawingAreaCoordinatedGraphics::forceUpdate):
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::willStartRenderingUpdateDisplay):
(WebKit::DrawingArea::didCompleteRenderingUpdateDisplay):
(WebKit::DrawingArea::didCompleteRenderingFrame):
(WebKit::DrawingArea::mainFrameTiledBacking const):
(WebKit::DrawingArea::prepopulateRectForZoom):
(WebKit::DrawingArea::scaleViewToFitDocumentIfNeeded):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::send):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea):
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::shouldUseTiledBackingForFrameView const):
(WebKit::RemoteLayerTreeDrawingArea::updatePreferences):
(WebKit::RemoteLayerTreeDrawingArea::setDeviceScaleFactor):
(WebKit::RemoteLayerTreeDrawingArea::forceRepaint):
(WebKit::RemoteLayerTreeDrawingArea::setViewExposedRect):
(WebKit::RemoteLayerTreeDrawingArea::exposedContentRect const):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplay):
(WebKit::RemoteLayerTreeDrawingArea::renderingUpdateFramesPerSecondChanged):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):
(WebKit::RemoteLayerTreeDrawingAreaMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaMac::commitTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::TiledCoreAnimationDrawingArea):
(WebKit::TiledCoreAnimationDrawingArea::registerScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::unregisterScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::forceRepaint):
(WebKit::TiledCoreAnimationDrawingArea::forceRepaintAsync):
(WebKit::TiledCoreAnimationDrawingArea::updatePreferences):
(WebKit::TiledCoreAnimationDrawingArea::dispatchAfterEnsuringUpdatedScrollPosition):
(WebKit::TiledCoreAnimationDrawingArea::sendPendingNewlyReachedPaintingMilestones):
(WebKit::TiledCoreAnimationDrawingArea::addCommitHandlers):
(WebKit::TiledCoreAnimationDrawingArea::updateRendering):
(WebKit::TiledCoreAnimationDrawingArea::handleActivityStateChangeCallbacks):
(WebKit::TiledCoreAnimationDrawingArea::handleActivityStateChangeCallbacksIfNeeded):
(WebKit::TiledCoreAnimationDrawingArea::activityStateDidChange):
(WebKit::TiledCoreAnimationDrawingArea::setViewExposedRect):
(WebKit::TiledCoreAnimationDrawingArea::updateGeometry):
(WebKit::TiledCoreAnimationDrawingArea::setDeviceScaleFactor):
(WebKit::TiledCoreAnimationDrawingArea::updateLayerHostingContext):
(WebKit::TiledCoreAnimationDrawingArea::setRootCompositingLayer):
(WebKit::TiledCoreAnimationDrawingArea::shouldUseTiledBackingForFrameView const):
(WebKit::TiledCoreAnimationDrawingArea::layerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::shadowLayerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToLayers):
(WebKit::TiledCoreAnimationDrawingArea::adjustTransientZoom):
(WebKit::TiledCoreAnimationDrawingArea::commitTransientZoom):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToPage):

Canonical link: <a href="https://commits.webkit.org/267261@main">https://commits.webkit.org/267261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a4ea09309353810a5b7741508fa47a64cae74ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17895 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15138 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16558 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18659 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14032 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17993 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15353 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18948 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1977 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->