### PR TITLE
Deploy smart pointers in WebEditorClientMac.mm

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -79,21 +79,21 @@ static void changeWordCase(WebPage* page, NSString *(*changeCase)(NSString *))
 
 void WebEditorClient::uppercaseWord()
 {
-    changeWordCase(m_page.get(), [] (NSString *string) {
+    changeWordCase(RefPtr { m_page.get() }.get(), [] (NSString *string) {
         return [string uppercaseString];
     });
 }
 
 void WebEditorClient::lowercaseWord()
 {
-    changeWordCase(m_page.get(), [] (NSString *string) {
+    changeWordCase(RefPtr { m_page.get() }.get(), [] (NSString *string) {
         return [string lowercaseString];
     });
 }
 
 void WebEditorClient::capitalizeWord()
 {
-    changeWordCase(m_page.get(), [] (NSString *string) {
+    changeWordCase(RefPtr { m_page.get() }.get(), [] (NSString *string) {
         return [string capitalizedString];
     });
 }
@@ -107,19 +107,19 @@ void WebEditorClient::showSubstitutionsPanel(bool)
 
 bool WebEditorClient::substitutionsPanelIsShowing()
 {
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::SubstitutionsPanelIsShowing());
+    auto sendResult = Ref { *m_page }->sendSync(Messages::WebPageProxy::SubstitutionsPanelIsShowing());
     auto [isShowing] = sendResult.takeReplyOr(false);
     return isShowing;
 }
 
 void WebEditorClient::toggleSmartInsertDelete()
 {
-    m_page->send(Messages::WebPageProxy::toggleSmartInsertDelete());
+    Ref { *m_page }->send(Messages::WebPageProxy::toggleSmartInsertDelete());
 }
 
 bool WebEditorClient::isAutomaticQuoteSubstitutionEnabled()
 {
-    if (m_page->isControlledByAutomation())
+    if (Ref { *m_page }->isControlledByAutomation())
         return false;
 
     return WebProcess::singleton().textCheckerState().isAutomaticQuoteSubstitutionEnabled;
@@ -127,7 +127,7 @@ bool WebEditorClient::isAutomaticQuoteSubstitutionEnabled()
 
 void WebEditorClient::toggleAutomaticQuoteSubstitution()
 {
-    m_page->send(Messages::WebPageProxy::toggleAutomaticQuoteSubstitution());
+    Ref { *m_page }->send(Messages::WebPageProxy::toggleAutomaticQuoteSubstitution());
 }
 
 bool WebEditorClient::isAutomaticLinkDetectionEnabled()
@@ -137,7 +137,7 @@ bool WebEditorClient::isAutomaticLinkDetectionEnabled()
 
 void WebEditorClient::toggleAutomaticLinkDetection()
 {
-    m_page->send(Messages::WebPageProxy::toggleAutomaticLinkDetection());
+    Ref { *m_page }->send(Messages::WebPageProxy::toggleAutomaticLinkDetection());
 }
 
 bool WebEditorClient::isAutomaticDashSubstitutionEnabled()
@@ -150,7 +150,7 @@ bool WebEditorClient::isAutomaticDashSubstitutionEnabled()
 
 void WebEditorClient::toggleAutomaticDashSubstitution()
 {
-    m_page->send(Messages::WebPageProxy::toggleAutomaticDashSubstitution());
+    Ref { *m_page }->send(Messages::WebPageProxy::toggleAutomaticDashSubstitution());
 }
 
 bool WebEditorClient::isAutomaticTextReplacementEnabled()
@@ -163,7 +163,7 @@ bool WebEditorClient::isAutomaticTextReplacementEnabled()
 
 void WebEditorClient::toggleAutomaticTextReplacement()
 {
-    m_page->send(Messages::WebPageProxy::toggleAutomaticTextReplacement());
+    Ref { *m_page }->send(Messages::WebPageProxy::toggleAutomaticTextReplacement());
 }
 
 bool WebEditorClient::isAutomaticSpellingCorrectionEnabled()


### PR DESCRIPTION
#### a321633b6fbc268ac5308cda35853a1dcfec6ef5
<pre>
Deploy smart pointers in WebEditorClientMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=260334">https://bugs.webkit.org/show_bug.cgi?id=260334</a>

Reviewed by Wenson Hsieh.

* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::uppercaseWord):
(WebKit::WebEditorClient::lowercaseWord):
(WebKit::WebEditorClient::capitalizeWord):
(WebKit::WebEditorClient::substitutionsPanelIsShowing):
(WebKit::WebEditorClient::toggleSmartInsertDelete):
(WebKit::WebEditorClient::isAutomaticQuoteSubstitutionEnabled):
(WebKit::WebEditorClient::toggleAutomaticQuoteSubstitution):
(WebKit::WebEditorClient::toggleAutomaticLinkDetection):
(WebKit::WebEditorClient::toggleAutomaticDashSubstitution):
(WebKit::WebEditorClient::toggleAutomaticTextReplacement):

Canonical link: <a href="https://commits.webkit.org/267006@main">https://commits.webkit.org/267006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76562d2df8e96b2574df7398fb1b210f2acaca51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14377 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16976 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17807 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13203 "2 failures") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20763 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17238 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12331 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18175 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1865 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->