### PR TITLE
Deploy more smart pointers in WebNotificationClient.cpp, WebProgressTrackerClient.cpp,

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
@@ -47,17 +47,19 @@ void WebProgressTrackerClient::progressStarted(LocalFrame& originatingProgressFr
     if (!originatingProgressFrame.isMainFrame())
         return;
 
-    m_webPage.setMainFrameProgressCompleted(false);
-    m_webPage.send(Messages::WebPageProxy::DidStartProgress());
+    Ref page = *m_webPage;
+    page->setMainFrameProgressCompleted(false);
+    page->send(Messages::WebPageProxy::DidStartProgress());
 }
 
 void WebProgressTrackerClient::progressEstimateChanged(LocalFrame& originatingProgressFrame)
 {
     if (!originatingProgressFrame.isMainFrame())
         return;
-    
-    double progress = m_webPage.corePage()->progress().estimatedProgress();
-    m_webPage.send(Messages::WebPageProxy::DidChangeProgress(progress));
+
+    Ref page = *m_webPage;
+    double progress = page->corePage()->progress().estimatedProgress();
+    page->send(Messages::WebPageProxy::DidChangeProgress(progress));
 }
 
 void WebProgressTrackerClient::progressFinished(LocalFrame& originatingProgressFrame)
@@ -65,12 +67,13 @@ void WebProgressTrackerClient::progressFinished(LocalFrame& originatingProgressF
     if (!originatingProgressFrame.isMainFrame())
         return;
 
-    m_webPage.setMainFrameProgressCompleted(true);
+    Ref page = *m_webPage;
+    page->setMainFrameProgressCompleted(true);
 
     // Notify the bundle client.
-    m_webPage.injectedBundleLoaderClient().didFinishProgress(m_webPage);
+    page->injectedBundleLoaderClient().didFinishProgress(page);
 
-    m_webPage.send(Messages::WebPageProxy::DidFinishProgress());
+    page->send(Messages::WebPageProxy::DidFinishProgress());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h
@@ -42,7 +42,7 @@ private:
     void progressEstimateChanged(WebCore::LocalFrame& originatingProgressFrame) override;
     void progressFinished(WebCore::LocalFrame& originatingProgressFrame) override;
 
-    WebPage& m_webPage;
+    WeakPtr<WebPage> m_webPage;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
@@ -52,11 +52,11 @@ void WebSearchPopupMenu::saveRecentSearches(const AtomString& name, const Vector
     if (name.isEmpty())
         return;
 
-    WebPage* page = m_popup->page();
+    RefPtr page = m_popup->page();
     if (!page)
         return;
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::SaveRecentSearches(name, searchItems), page->identifier());
+    RefPtr { WebProcess::singleton().parentProcessConnection() }->send(Messages::WebPageProxy::SaveRecentSearches(name, searchItems), page->identifier());
 }
 
 void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<RecentSearch>& resultItems)
@@ -64,11 +64,11 @@ void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<Recen
     if (name.isEmpty())
         return;
 
-    WebPage* page = m_popup->page();
+    RefPtr page = m_popup->page();
     if (!page)
         return;
 
-    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), page->identifier());
+    auto sendResult = RefPtr { WebProcess::singleton().parentProcessConnection() }->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), page->identifier());
     if (sendResult.succeeded())
         std::tie(resultItems) = sendResult.takeReply();
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp
@@ -44,17 +44,17 @@ Ref<WebStorageConnection> WebStorageConnection::create()
 
 void WebStorageConnection::getPersisted(WebCore::ClientOrigin&& origin, StorageConnection::PersistCallback&& completionHandler)
 {
-    connection().sendWithAsyncReply(Messages::NetworkStorageManager::Persisted(origin), WTFMove(completionHandler));
+    Ref { connection() }->sendWithAsyncReply(Messages::NetworkStorageManager::Persisted(origin), WTFMove(completionHandler));
 }
 
 void WebStorageConnection::persist(const WebCore::ClientOrigin& origin, StorageConnection::PersistCallback&& completionHandler)
 {
-    connection().sendWithAsyncReply(Messages::NetworkStorageManager::Persist(origin), WTFMove(completionHandler));
+    Ref { connection() }->sendWithAsyncReply(Messages::NetworkStorageManager::Persist(origin), WTFMove(completionHandler));
 }
 
 void WebStorageConnection::getEstimate(WebCore::ClientOrigin&& origin, StorageConnection::GetEstimateCallback&& completionHandler)
 {
-    connection().sendWithAsyncReply(Messages::NetworkStorageManager::Estimate(origin), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    Ref { connection() }->sendWithAsyncReply(Messages::NetworkStorageManager::Estimate(origin), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(WebCore::Exception { WebCore::TypeError });
 
@@ -64,8 +64,7 @@ void WebStorageConnection::getEstimate(WebCore::ClientOrigin&& origin, StorageCo
 
 void WebStorageConnection::fileSystemGetDirectory(WebCore::ClientOrigin&& origin, StorageConnection::GetDirectoryCallback&& completionHandler)
 {
-    auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
-    connection.sendWithAsyncReply(Messages::NetworkStorageManager::FileSystemGetDirectory(origin), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    Ref { connection() }->sendWithAsyncReply(Messages::NetworkStorageManager::FileSystemGetDirectory(origin), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
@@ -60,7 +60,7 @@ void WebValidationMessageClient::showValidationMessage(const Element& anchor, co
     if (m_currentAnchor)
         hideValidationMessage(*m_currentAnchor);
 
-    m_currentAnchor = &anchor;
+    m_currentAnchor = anchor;
     m_currentAnchorRect = anchor.boundingBoxInRootViewCoordinates();
     Ref { *m_page }->send(Messages::WebPageProxy::ShowValidationMessage(m_currentAnchorRect, message));
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.h
@@ -29,6 +29,13 @@
 #include <WebCore/ValidationMessageClient.h>
 #include <wtf/WeakPtr.h>
 
+namespace WebCore {
+
+class Element;
+class WeakPtrImplWithEventTargetData;
+
+}
+
 namespace WebKit {
 
 class WebPage;
@@ -48,7 +55,7 @@ public:
 
 private:
     WeakPtr<WebPage> m_page;
-    const WebCore::Element* m_currentAnchor { nullptr };
+    WeakPtr<const WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_currentAnchor;
     WebCore::IntRect m_currentAnchorRect;
 };
 


### PR DESCRIPTION
#### 1b0f878b587f0bde52bec906a5addf04e5cd2431
<pre>
Deploy more smart pointers in WebNotificationClient.cpp, WebProgressTrackerClient.cpp,
WebResourceLoadObserver.cpp, WebSearchPopupMenu.cpp, WebStorageConnection.cpp, and WebValidationMessageClient.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=260336">https://bugs.webkit.org/show_bug.cgi?id=260336</a>

Reviewed by David Kilzer.

Deployed more smart pointers.

* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::show):
(WebKit::WebNotificationClient::cancel):
(WebKit::WebNotificationClient::notificationObjectDestroyed):
(WebKit::WebNotificationClient::requestPermission):
(WebKit::WebNotificationClient::checkPermission):
* Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp:
(WebKit::WebProgressTrackerClient::progressStarted):
(WebKit::WebProgressTrackerClient::progressEstimateChanged):
(WebKit::WebProgressTrackerClient::progressFinished):
* Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::requestStorageAccessUnderOpener):
(WebKit::WebResourceLoadObserver::updateCentralStatisticsStore):
(WebKit::WebResourceLoadObserver::logSubresourceLoading):
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):
(WebKit::WebResourceLoadObserver::setDomainsWithCrossPageStorageAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::saveRecentSearches):
(WebKit::WebSearchPopupMenu::loadRecentSearches):
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp:
(WebKit::WebStorageConnection::getPersisted):
(WebKit::WebStorageConnection::persist):
(WebKit::WebStorageConnection::getEstimate):
(WebKit::WebStorageConnection::fileSystemGetDirectory):
* Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp:
(WebKit::WebValidationMessageClient::showValidationMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.h:

Canonical link: <a href="https://commits.webkit.org/267028@main">https://commits.webkit.org/267028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77b7f3e14d1d30bbd427568bf7029b621bf8bd7c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14379 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16979 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15928 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13022 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17809 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13206 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20766 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12335 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18177 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1877 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->