### PR TITLE
Remove ShadowRoot::resetStyleInheritance mechanism

### DIFF
--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -218,12 +218,6 @@ bool ShadowRoot::childTypeAllowed(NodeType type) const
     }
 }
 
-void ShadowRoot::setResetStyleInheritance(bool value)
-{
-    // If this was ever changed after initialization, child styles would need to be invalidated here.
-    m_resetStyleInheritance = value;
-}
-
 Ref<Node> ShadowRoot::cloneNodeInternal(Document& targetDocument, CloningOperation type)
 {
     RELEASE_ASSERT(m_mode != ShadowRootMode::UserAgent);

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -71,9 +71,6 @@ public:
     WEBCORE_EXPORT Style::Scope& styleScope();
     StyleSheetList& styleSheets();
 
-    bool resetStyleInheritance() const { return m_resetStyleInheritance; }
-    void setResetStyleInheritance(bool);
-
     bool delegatesFocus() const { return m_delegatesFocus; }
     bool containsFocusedElement() const { return m_containsFocusedElement; }
     void setContainsFocusedElement(bool flag) { m_containsFocusedElement = flag; }
@@ -144,7 +141,6 @@ private:
 
     void childrenChanged(const ChildChange&) override;
 
-    bool m_resetStyleInheritance : 1 { false };
     bool m_hasBegunDeletingDetachedChildren : 1 { false };
     bool m_delegatesFocus : 1 { false };
     bool m_isCloneable : 1 { false };

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -261,8 +261,6 @@ void HTMLPlugInElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     if (!m_pluginReplacement || !document().page() || displayState() != PreparingPluginReplacement)
         return;
     
-    root.setResetStyleInheritance(true);
-
     m_pluginReplacement->installReplacement(root);
 
     setDisplayState(DisplayingPluginReplacement);

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.cpp
@@ -207,12 +207,6 @@ const AtomString& webkitMeterEvenLessGoodValue()
     return webkitMeterEvenLessGoodValue;
 }
 
-const AtomString& webkitPluginReplacement()
-{
-    static MainThreadNeverDestroyed<const AtomString> webkitPluginReplacement("-webkit-plugin-replacement"_s);
-    return webkitPluginReplacement;
-}
-
 const AtomString& webkitProgressBar()
 {
     static MainThreadNeverDestroyed<const AtomString> webkitProgressBar("-webkit-progress-bar"_s);

--- a/Source/WebCore/html/shadow/ShadowPseudoIds.h
+++ b/Source/WebCore/html/shadow/ShadowPseudoIds.h
@@ -75,8 +75,6 @@ const AtomString& webkitMeterOptimumValue();
 const AtomString& webkitMeterSuboptimumValue();
 const AtomString& webkitMeterEvenLessGoodValue();
 
-const AtomString& webkitPluginReplacement();
-
 const AtomString& webkitProgressBar();
 const AtomString& webkitProgressValue();
 const AtomString& webkitProgressInnerElement();

--- a/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
+++ b/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(YouTubeEmbedShadowElement);
 Ref<YouTubeEmbedShadowElement> YouTubeEmbedShadowElement::create(Document& document)
 {
     auto element = adoptRef(*new YouTubeEmbedShadowElement(document));
-    element->setPseudo(ShadowPseudoIds::webkitPluginReplacement());
+    element->setInlineStyleProperty(CSSPropertyAll, CSSValueInitial);
     return element;
 }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -99,10 +99,6 @@ public:
         : m_element(&element)
         , m_parentStyle(parentStyle)
     {
-        bool resetStyleInheritance = hasShadowRootParent(element) && downcast<ShadowRoot>(element.parentNode())->resetStyleInheritance();
-        if (resetStyleInheritance)
-            m_parentStyle = nullptr;
-
         auto& document = element.document();
         auto* documentElement = document.documentElement();
         if (!documentElement || documentElement == &element)


### PR DESCRIPTION
#### 121c1a436df1474c86708c050d6f5577ba86f125
<pre>
Remove ShadowRoot::resetStyleInheritance mechanism
<a href="https://bugs.webkit.org/show_bug.cgi?id=260338">https://bugs.webkit.org/show_bug.cgi?id=260338</a>
rdar://114015755

Reviewed by Alan Baradlay.

UA shadow trees should just use &apos;all: initial&apos; if needed.

* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setResetStyleInheritance): Deleted.
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::didAddUserAgentShadowRoot):
* Source/WebCore/html/shadow/ShadowPseudoIds.cpp:
(WebCore::ShadowPseudoIds::webkitPluginReplacement): Deleted.

Also remove this non-referenced pseudo element name.

* Source/WebCore/html/shadow/ShadowPseudoIds.h:
* Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp:

This is the only client for the mechanism, use &apos;all:initial&apos; instead.

(WebCore::YouTubeEmbedShadowElement::create):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::State):

Canonical link: <a href="https://commits.webkit.org/266999@main">https://commits.webkit.org/266999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c995fda3b44c9a8e9fef9e0c7422b7549be5d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17076 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17810 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20768 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12336 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13831 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3685 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->