### PR TITLE
[SVG] Make 'paint-order' property inherits

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/inheritance-expected.txt
@@ -28,7 +28,7 @@ PASS Property marker-mid inherits
 PASS Property marker-end has initial value none
 PASS Property marker-end inherits
 PASS Property paint-order has initial value normal
-FAIL Property paint-order inherits assert_equals: expected "markers stroke" but got "normal"
+PASS Property paint-order inherits
 PASS Property color-interpolation has initial value srgb
 PASS Property color-interpolation inherits
 PASS Property shape-rendering has initial value auto

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5218,6 +5218,7 @@
             }
         },
         "paint-order": {
+            "inherited": true,
             "codegen-properties": {
                 "converter": "PaintOrder",
                 "parser-function": "consumePaintOrder",


### PR DESCRIPTION
#### cd422b00b1bd6aed13324a3a25438212c5166321
<pre>
[SVG] Make &apos;paint-order&apos; property inherits

<a href="https://bugs.webkit.org/show_bug.cgi?id=260335">https://bugs.webkit.org/show_bug.cgi?id=260335</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Blink / Chromium, Gecko / Firefox and Web-Spec [1].

This PR makes &apos;paint-order&apos; property to be inherited as per spec.

[1] <a href="https://svgwg.org/svg2-draft/painting.html#PaintOrder">https://svgwg.org/svg2-draft/painting.html#PaintOrder</a>

* Source/WebCore/css/CSSProperties.json: &apos;paint-order&apos; to be inherited
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/inheritance-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/267002@main">https://commits.webkit.org/267002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad8c6619f02f9e8e4262a6970bf28a80ce83cbeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16983 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17813 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12339 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13834 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3688 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->