### PR TITLE
[WPE][GTK] Move `WebKitWebsiteData/memory-pressure` API test to a separate binary again

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestNetworkProcessMemoryPressure.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestNetworkProcessMemoryPressure.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "WebKitTestServer.h"
+#include "WebViewTest.h"
+#include <WebCore/SoupVersioning.h>
+
+static WebKitTestServer* kServer;
+
+#if USE(SOUP2)
+static void serverCallback(SoupServer* server, SoupMessage* message, const char* path, GHashTable*, SoupClientContext*, gpointer)
+#else
+static void serverCallback(SoupServer* server, SoupServerMessage* message, const char* path, GHashTable*, gpointer)
+#endif
+{
+    if (soup_server_message_get_method(message) != SOUP_METHOD_GET) {
+        soup_server_message_set_status(message, SOUP_STATUS_NOT_IMPLEMENTED, nullptr);
+        return;
+    }
+
+    soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
+}
+
+class MemoryPressureTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE_WITH_SETUP_TEARDOWN(MemoryPressureTest, setup, teardown);
+
+    static void setup()
+    {
+        WebKitMemoryPressureSettings* settings = webkit_memory_pressure_settings_new();
+        webkit_memory_pressure_settings_set_memory_limit(settings, 1);
+        webkit_memory_pressure_settings_set_poll_interval(settings, 0.001);
+        webkit_memory_pressure_settings_set_kill_threshold(settings, 1);
+        webkit_memory_pressure_settings_set_strict_threshold(settings, 0.75);
+        webkit_memory_pressure_settings_set_conservative_threshold(settings, 0.5);
+#if ENABLE(2022_GLIB_API)
+        webkit_network_session_set_memory_pressure_settings(settings);
+#else
+        webkit_website_data_manager_set_memory_pressure_settings(settings);
+#endif
+        webkit_memory_pressure_settings_free(settings);
+    }
+
+    static void teardown()
+    {
+#if ENABLE(2022_GLIB_API)
+        webkit_network_session_set_memory_pressure_settings(nullptr);
+#else
+        webkit_website_data_manager_set_memory_pressure_settings(nullptr);
+#endif
+    }
+
+    static gboolean loadFailedCallback(WebKitWebView* webView, WebKitLoadEvent loadEvent, const char* failingURI, GError* error, MemoryPressureTest* test)
+    {
+        g_signal_handlers_disconnect_by_func(webView, reinterpret_cast<void*>(loadFailedCallback), test);
+        g_main_loop_quit(test->m_mainLoop);
+
+        return TRUE;
+    }
+
+    void waitUntilLoadFailed()
+    {
+        g_signal_connect(m_webView, "load-failed", G_CALLBACK(MemoryPressureTest::loadFailedCallback), this);
+        g_main_loop_run(m_mainLoop);
+    }
+};
+
+static void testMemoryPressureSettings(MemoryPressureTest* test, gconstpointer)
+{
+    // We have set a memory limit of 1MB with a kill threshold of 1 and a poll interval of 0.001.
+    // The network process will use around 2MB to load the test. The MemoryPressureHandler will
+    // kill the process as soon as it detects that it's using more than 1MB, so the network process
+    // won't be able to complete the resource load. This causes an internal error and the load-failed
+    // signal is emitted.
+    GUniquePtr<char> fileURL(g_strdup_printf("file://%s/simple.html", Test::getResourcesDir(Test::WebKit2Resources).data()));
+    test->loadURI(fileURL.get());
+    test->waitUntilLoadFailed();
+}
+
+void beforeAll()
+{
+    kServer = new WebKitTestServer();
+    kServer->run(serverCallback);
+
+    MemoryPressureTest::add("WebKitWebsiteData", "memory-pressure", testMemoryPressureSettings);
+}
+
+void afterAll()
+{
+    delete kServer;
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -960,62 +960,6 @@ static void testWebViewHandleCorruptedLocalStorage(WebsiteDataTest* test, gconst
     g_assert_cmpstr(fooValue.get(), ==, "value");
 }
 
-class MemoryPressureTest : public WebViewTest {
-public:
-    MAKE_GLIB_TEST_FIXTURE_WITH_SETUP_TEARDOWN(MemoryPressureTest, setup, teardown);
-
-    static void setup()
-    {
-        WebKitMemoryPressureSettings* settings = webkit_memory_pressure_settings_new();
-        webkit_memory_pressure_settings_set_memory_limit(settings, 1);
-        webkit_memory_pressure_settings_set_poll_interval(settings, 0.001);
-        webkit_memory_pressure_settings_set_kill_threshold(settings, 1);
-        webkit_memory_pressure_settings_set_strict_threshold(settings, 0.75);
-        webkit_memory_pressure_settings_set_conservative_threshold(settings, 0.5);
-#if ENABLE(2022_GLIB_API)
-        webkit_network_session_set_memory_pressure_settings(settings);
-#else
-        webkit_website_data_manager_set_memory_pressure_settings(settings);
-#endif
-        webkit_memory_pressure_settings_free(settings);
-    }
-
-    static void teardown()
-    {
-#if ENABLE(2022_GLIB_API)
-        webkit_network_session_set_memory_pressure_settings(nullptr);
-#else
-        webkit_website_data_manager_set_memory_pressure_settings(nullptr);
-#endif
-    }
-
-    static gboolean loadFailedCallback(WebKitWebView* webView, WebKitLoadEvent loadEvent, const char* failingURI, GError* error, MemoryPressureTest* test)
-    {
-        g_signal_handlers_disconnect_by_func(webView, reinterpret_cast<void*>(loadFailedCallback), test);
-        g_main_loop_quit(test->m_mainLoop);
-
-        return TRUE;
-    }
-
-    void waitUntilLoadFailed()
-    {
-        g_signal_connect(m_webView, "load-failed", G_CALLBACK(MemoryPressureTest::loadFailedCallback), this);
-        g_main_loop_run(m_mainLoop);
-    }
-};
-
-static void testMemoryPressureSettings(MemoryPressureTest* test, gconstpointer)
-{
-    // We have set a memory limit of 1MB with a kill threshold of 1 and a poll interval of 0.001.
-    // The network process will use around 2MB to load the test. The MemoryPressureHandler will
-    // kill the process as soon as it detects that it's using more than 1MB, so the network process
-    // won't be able to complete the resource load. This causes an internal error and the load-failed
-    // signal is emitted.
-    GUniquePtr<char> fileURL(g_strdup_printf("file://%s/simple.html", Test::getResourcesDir(Test::WebKit2Resources).data()));
-    test->loadURI(fileURL.get());
-    test->waitUntilLoadFailed();
-}
-
 void beforeAll()
 {
     kServer = new WebKitTestServer();
@@ -1040,7 +984,6 @@ void beforeAll()
     WebsiteDataTest::add("WebKitWebsiteData", "service-worker-registrations", testWebsiteDataServiceWorkerRegistrations);
     WebsiteDataTest::add("WebKitWebsiteData", "dom-cache", testWebsiteDataDOMCache);
     WebsiteDataTest::add("WebKitWebsiteData", "handle-corrupted-local-storage", testWebViewHandleCorruptedLocalStorage);
-    MemoryPressureTest::add("WebKitWebsiteData", "memory-pressure", testMemoryPressureSettings);
     WebsiteDataTest::add("WebKitWebsiteData", "origin-and-total-storage-ratio", testWebsiteDataOriginAndTotalStorageRatio);
 }
 

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -153,6 +153,7 @@ ADD_WK2_TEST(TestEditor ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestEditor.c
 ADD_WK2_TEST(TestFrame ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestFrame.cpp)
 ADD_WK2_TEST(TestLoaderClient ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestLoaderClient.cpp)
 ADD_WK2_TEST(TestMultiprocess ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp)
+ADD_WK2_TEST(TestNetworkProcessMemoryPressure ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestNetworkProcessMemoryPressure.cpp)
 ADD_WK2_TEST(TestOptionMenu ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestOptionMenu.cpp)
 ADD_WK2_TEST(TestResources ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp)
 ADD_WK2_TEST(TestSSL ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp)


### PR DESCRIPTION
#### c49fe081e57387496b5a4ca3e863ae4d2133acaf
<pre>
[WPE][GTK] Move `WebKitWebsiteData/memory-pressure` API test to a separate binary again
<a href="https://bugs.webkit.org/show_bug.cgi?id=260256">https://bugs.webkit.org/show_bug.cgi?id=260256</a>

Reviewed by Carlos Garcia Campos.

This test verifies that the network process will be killed if the memory
limit is reached.

It&apos;s done by calling `webkit_network_session_set_memory_pressure_settings()`.
The settings passed as an argument are later applied during the creation
of a new network process.

Before 259433@main a new network process was created for every network
session but now only one network process is created.

Since this test is not the first one in the test suite, the network
process was already created and the memory pressure settings have no effect.

Also, the name of the function is misleading now,
because the memory pressure settings are applied to all sessions.

The previous PR 266946@main was reverted because it caused a build failure.
It happened due to a missing header. This PR fixes it.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestNetworkProcessMemoryPressure.cpp: Added.
(serverCallback):
(MemoryPressureTest::setup):
(MemoryPressureTest::teardown):
(MemoryPressureTest::loadFailedCallback):
(MemoryPressureTest::waitUntilLoadFailed):
(testMemoryPressureSettings):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(beforeAll):
(MemoryPressureTest::setup): Deleted.
(MemoryPressureTest::teardown): Deleted.
(MemoryPressureTest::loadFailedCallback): Deleted.
(MemoryPressureTest::waitUntilLoadFailed): Deleted.
(testMemoryPressureSettings): Deleted.
* Tools/TestWebKitAPI/glib/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/267000@main">https://commits.webkit.org/267000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e42a640c4bd16b40666e99c8bc8c2a654b6ae20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17080 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16984 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17814 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20772 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12340 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13835 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3687 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->