### PR TITLE
[import-w3c-tests] Honor skip expectation with --src-dir

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_downloader.py
+++ b/Tools/Scripts/webkitpy/w3c/test_downloader.py
@@ -113,7 +113,7 @@ class TestDownloader(object):
     def _add_test_suite_paths(self, test_paths, directory, webkit_path):
         for name in self._filesystem.listdir(directory):
             original_path = self._filesystem.join(webkit_path, name)
-            if not name.startswith('.') and not original_path in self.paths_to_skip:
+            if not name.startswith('.'):
                 test_paths.append(original_path)
 
     def _empty_directory(self, directory):
@@ -151,17 +151,10 @@ class TestDownloader(object):
             if relative_path == ".":
                 return True
 
-            potential_copy_paths = [copy_directory for copy_directory in copy_paths if relative_path.startswith(copy_directory)]
-            if (not potential_copy_paths):
-                return False
-
-            potential_skip_paths = [skip_directory for skip_directory in self.paths_to_skip if relative_path.startswith(skip_directory)]
-            if (not potential_skip_paths):
+            if any(relative_path.startswith(copy_directory) for copy_directory in copy_paths):
                 return True
 
-            longest_copy_path = longest_path(filesystem, potential_copy_paths)
-            longest_skip_path = longest_path(filesystem, potential_skip_paths)
-            return longest_copy_path.startswith(longest_skip_path)
+            return False
 
         # Compute directories for which we should copy direct children
         directories_to_copy = self._filesystem.dirs_under(self.repository_directory, should_copy_dir)
@@ -171,8 +164,6 @@ class TestDownloader(object):
             relative_path = self._filesystem.relpath(full_path, self.repository_directory)
             if relative_path in copy_paths:
                 return True
-            if relative_path in self.paths_to_skip:
-                return False
             return dirname in directories_to_copy
 
         for source_path in self._filesystem.files_under(self.repository_directory, file_filter=should_copy_file):


### PR DESCRIPTION
#### e21f2280dbbbfe4fcc4801dcf4ad83d09f0621d8
<pre>
[import-w3c-tests] Honor skip expectation with --src-dir
<a href="https://bugs.webkit.org/show_bug.cgi?id=257198">https://bugs.webkit.org/show_bug.cgi?id=257198</a>
rdar://problem/110004053

Reviewed by Jonathan Bedard.

Previously, we only applied the skip logic in test_downloader, and hence
it only had any effect when downloading tests, and not when importing
from a given --src-dir.

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader._add_test_suite_paths):
(TestDownloader.copy_tests.should_copy_dir):
(TestDownloader.copy_tests.should_copy_file):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.should_skip_path):
(TestImporter.find_importable_tests):
(TestImporter.should_skip_file): Deleted.
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:

Canonical link: <a href="https://commits.webkit.org/267088@main">https://commits.webkit.org/267088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e60ef94b5aaefe53ae20116c5e3a248125b343d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17078 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17964 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/15574 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20883 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17384 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12451 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18316 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1903 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->