### PR TITLE
[WGSL] Add support for built-in type aliases

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -877,7 +877,16 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
         static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> baseTypesMappings[] {
             { "f32", "float"_s },
             { "i32", "int"_s },
-            { "u32", "unsigned"_s }
+            { "u32", "uint"_s },
+            { "vec2f", "float2"_s },
+            { "vec2i", "int2"_s },
+            { "vec2u", "uint2"_s },
+            { "vec3f", "float3"_s },
+            { "vec3i", "int3"_s },
+            { "vec3u", "uint3"_s },
+            { "vec4f", "float4"_s },
+            { "vec4i", "int4"_s },
+            { "vec4u", "uint4"_s }
         };
         static constexpr SortedArrayMap baseTypes { baseTypesMappings };
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -616,6 +616,23 @@ void TypeChecker::visit(AST::CallExpression& call)
                     inferred(targetBinding->type);
                     return;
                 }
+
+                if (auto* vectorType = std::get_if<Types::Vector>(targetBinding->type)) {
+                    typeArguments.append(vectorType->element);
+                    switch (vectorType->size) {
+                    case 2:
+                        targetName = "vec2"_s;
+                        break;
+                    case 3:
+                        targetName = "vec3"_s;
+                        break;
+                    case 4:
+                        targetName = "vec4"_s;
+                        break;
+                    default:
+                        RELEASE_ASSERT_NOT_REACHED();
+                    }
+                }
             }
 
             if (targetBinding->kind == Binding::Value) {

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1,4 +1,17 @@
 # FIXME: add all the missing type declarations here
+
+suffixes = {
+  f: F32,
+  i: I32,
+  u: U32,
+}
+
+[2, 3, 4].each do |n|
+  suffixes.each do |suffix, type|
+    type_alias :"vec#{n}#{suffix}", Vector[type, n]
+  end
+end
+
 operator :+, {
     [T < Number].(T, T) => T,
 

--- a/Source/WebGPU/WGSL/tests/valid/aliases.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/aliases.wgsl
@@ -1,0 +1,24 @@
+// RUN: %metal-compile main
+
+fn f1(x: vec2f) {}
+fn f2(x: vec2i) {}
+fn f3(x: vec2u) {}
+fn f4(x: vec3f) {}
+fn f5(x: vec3i) {}
+fn f6(x: vec3u) {}
+fn f7(x: vec4f) {}
+fn f8(x: vec4i) {}
+fn f9(x: vec4u) {}
+
+@compute @workgroup_size(1)
+fn main() {
+    _ = f1(vec2f(vec2(0u)));
+    _ = f2(vec2i(vec2(0f)));
+    _ = f3(vec2u(vec2(0f)));
+    _ = f4(vec3f(vec3(0u)));
+    _ = f5(vec3i(vec3(0f)));
+    _ = f6(vec3u(vec3(0f)));
+    _ = f7(vec4f(vec4(0u)));
+    _ = f8(vec4i(vec4(0f)));
+    _ = f9(vec4u(vec4(0f)));
+}


### PR DESCRIPTION
#### a5dac911f692bd5c07551c66ba9b56394895e33f
<pre>
[WGSL] Add support for built-in type aliases
<a href="https://bugs.webkit.org/show_bug.cgi?id=260354">https://bugs.webkit.org/show_bug.cgi?id=260354</a>
rdar://114033423

Reviewed by Dan Glastonbury.

Add support for the vecN(f|i|u) type aliases.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/aliases.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/267036@main">https://commits.webkit.org/267036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56431d23ce8528507485de553b5756b6fc39e39e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17008 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17844 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13237 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20804 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17280 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12368 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13861 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3712 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->