### PR TITLE
Enable usage of MotionMark 1.2 and Speedometer 3 in compare-results

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -46,6 +46,7 @@ except:
     print("ERROR: numpy package is not installed. Run `pip install numpy`")
     sys.exit(1)
 
+
 def readJSONFile(path):
     with open(path, 'r') as contents:
         result = json.loads(contents.read())
@@ -53,6 +54,7 @@ def readJSONFile(path):
             del result['debugOutput']
         return result
 
+Speedometer3 = "Speedometer3"
 Speedometer2 = "Speedometer2"
 JetStream3 = "JetStream3"
 JetStream2 = "JetStream2"
@@ -62,8 +64,38 @@ PLUM3 = "PLUM3"
 MotionMark = "MotionMark"
 MotionMark1_1 = "MotionMark-1.1"
 MotionMark1_1_1 = "MotionMark-1.1.1"
+MotionMark1_2 = "MotionMark-1.2"
 
 unitMarker = "__unit__"
+
+
+def speedometer3Breakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "ms"
+    for test in breakdown._results["Speedometer-3"]["tests"].keys():
+        result[test] = breakdown._results["Speedometer-3"]["tests"][test]["metrics"]["Time"]["Total"]["current"]
+    return result
+
+def speedometer3BreakdownSyncAsync(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "ms"
+    for test in breakdown._results["Speedometer-3"]["tests"].keys():
+        syncTime = None
+        asyncTime = None
+        for value in breakdown._results["Speedometer-3"]["tests"][test]["tests"].values():
+            syncArray = value["tests"]["Sync"]["metrics"]["Time"][None]["current"]
+            asyncArray = value["tests"]["Async"]["metrics"]["Time"][None]["current"]
+            if not syncTime:
+                syncTime = syncArray
+                asyncTime = asyncArray
+            else:
+                syncTime = [x + y for x, y in zip(syncTime, syncArray)]
+                asyncTime = [x + y for x, y in zip(asyncTime, asyncArray)]
+        result[test + "-sync"] = syncTime
+        result[test + "-async"] = asyncTime
+    return result
 
 def speedometer2Breakdown(jsonObject):
     breakdown = BenchmarkResults(jsonObject)
@@ -137,8 +169,10 @@ def motionMarkBreakdown(jsonObject):
         name = "MotionMark"
     elif detectMotionMark1_1(jsonObject):
         name = "MotionMark-1.1"
-    else:
+    elif detectMotionMark1_1_1(jsonObject):
         name = "MotionMark-1.1.1"
+    elif detectMotionMark1_2(jsonObject):
+        name = "MotionMark-1.2"
 
     for test in breakdown._results[name]["tests"].keys():
         result[test] = breakdown._results[name]["tests"][test]["metrics"]["Score"][None]["current"]
@@ -393,13 +427,24 @@ def JetStream3Results(payload):
 
     return results
 
+
 def detectSpeedometer2(payload):
     return "Speedometer-2" in payload
+
+def detectSpeedometer3(payload):
+    return "Speedometer-3" in payload
 
 def Speedometer2Results(payload):
     assert detectSpeedometer2(payload)
     results = []
     for arr in payload["Speedometer-2"]["metrics"]["Score"]["current"]:
+        results.append(numpy.mean(arr))
+    return results
+
+def Speedometer3Results(payload):
+    assert detectSpeedometer3(payload)
+    results = []
+    for arr in payload["Speedometer-3"]["metrics"]["Score"]["current"]:
         results.append(numpy.mean(arr))
     return results
 
@@ -466,14 +511,20 @@ def detectMotionMark1_1(payload):
 def detectMotionMark1_1_1(payload):
     return "MotionMark-1.1.1" in payload
 
+def detectMotionMark1_2(payload):
+    return "MotionMark-1.2" in payload
+
+
 def motionMarkResults(payload):
-    assert detectMotionMark(payload) or detectMotionMark1_1(payload) or detectMotionMark1_1_1(payload)
+    assert any(validMotionMarkDetector(payload) for validMotionMarkDetector in [detectMotionMark, detectMotionMark1_1, detectMotionMark1_1_1, detectMotionMark1_2])
     if detectMotionMark(payload):
         payload = payload["MotionMark"]
     elif detectMotionMark1_1(payload):
         payload = payload["MotionMark-1.1"]
-    else:
+    elif detectMotionMark1_1_1(payload):
         payload = payload["MotionMark-1.1.1"]
+    else:
+        payload = payload["MotionMark-1.2"]
     testNames = list(payload["tests"].keys())
     numTests = len(payload["tests"][testNames[0]]["metrics"]["Score"]["current"])
     results = []
@@ -492,6 +543,8 @@ def detectBenchmark(payload):
         return JetStream2
     if detectSpeedometer2(payload):
         return Speedometer2
+    if detectSpeedometer3(payload):
+        return Speedometer3
     if detectPLT5(payload):
         return PLT5
     if detectCompetitivePLT(payload):
@@ -504,28 +557,17 @@ def detectBenchmark(payload):
         return MotionMark1_1
     if detectMotionMark1_1_1(payload):
         return MotionMark1_1
+    if detectMotionMark1_2(payload):
+        return MotionMark1_2
     return None
 
 def biggerIsBetter(benchmarkType):
-    if benchmarkType == JetStream3:
+    if benchmarkType in [JetStream2, JetStream3, Speedometer2, Speedometer3, MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2]:
         return True
-    if benchmarkType == JetStream2:
-        return True
-    if benchmarkType == Speedometer2:
-        return True
-    if benchmarkType == MotionMark:
-        return True
-    if benchmarkType == MotionMark1_1:
-        return True
-    if benchmarkType == PLT5:
+    elif benchmarkType in [PLT5, CompetitivePLT, PLUM3]:
         return False
-    if benchmarkType == CompetitivePLT:
-        return False
-    if benchmarkType == PLUM3:
-        return False
-
-    print("Should not be reached.")
-    assert False
+    else:
+        raise Exception('An unknown benchmark type was passed into biggerIsBetter: {}. It should not be possible to hit this.'.format(benchmarkType))
 
 def ttest(benchmarkType, a, b):
     # We use two-tailed Welch's
@@ -643,7 +685,18 @@ def main():
         if args.csv:
             writeCSV(speedometer2Breakdown(a), speedometer2Breakdown(b), args.csv)
 
-    elif typeA == MotionMark or typeA == MotionMark1_1 or typeA == MotionMark1_1_1:
+    elif typeA == Speedometer3:
+        if args.breakdown:
+            if args.detailed_breakdown:
+                dumpBreakdowns(speedometer3BreakdownSyncAsync(a), speedometer3BreakdownSyncAsync(b))
+            else:
+                dumpBreakdowns(speedometer3Breakdown(a), speedometer3Breakdown(b))
+
+        ttest(typeA, Speedometer3Results(a), Speedometer3Results(b))
+
+        if args.csv:
+            writeCSV(speedometer3Breakdown(a), speedometer3Breakdown(b), args.csv)
+    elif any(typeA == validMotionMarkTest for validMotionMarkTest in [MotionMark, MotionMark1_1, MotionMark1_1_1, MotionMark1_2]):
         if args.breakdown:
             dumpBreakdowns(motionMarkBreakdown(a), motionMarkBreakdown(b))
 


### PR DESCRIPTION
#### de4f30975494b850fa1bae1d84151d71e34a335c
<pre>
Enable usage of MotionMark 1.2 and Speedometer 3 in compare-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=260311">https://bugs.webkit.org/show_bug.cgi?id=260311</a>

Reviewed by Dewei Zhu.

This adds support for comparing results for MotionMark 1.2 and Speedometer 3.
The implementation is identical to their previous versions because their results are formatted the same.
Minor refactoring around MotionMark results detection.

* Tools/Scripts/compare-results:
(readJSONFile):
(speedometer3Breakdown):
(speedometer3BreakdownSyncAsync):
(motionMarkBreakdown):
(JetStream3Results):
(detectSpeedometer2):
(detectSpeedometer3):
(Speedometer2Results):
(Speedometer3Results):
(detectMotionMark1_1_1):
(detectMotionMark1_2):
(motionMarkResults):
(detectBenchmark):
(biggerIsBetter):
(main):

Canonical link: <a href="https://commits.webkit.org/267291@main">https://commits.webkit.org/267291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f8baf9ed7024ed347f35f57716815ae3b389a40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16632 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18732 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14661 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18057 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15423 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14650 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3870 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->