### PR TITLE
Use ToggleEvent for <details> element toggle event

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2743,7 +2743,6 @@ webkit.org/b/165460 compositing/repaint/scroll-fixed-layer-out-of-view.html [ Fa
 webkit.org/b/166911 fast/dom/Window/window-properties-performance.html [ Pass Failure ]
 webkit.org/b/166911 fast/dom/Window/window-properties-performance-resource-timing.html [ Pass Failure ]
 
-imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html [ Pass Failure ]
 webkit.org/b/168175 imported/w3c/web-platform-tests/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-skip-no-boxes.html [ ImageOnlyFailure ]
 webkit.org/b/168175 imported/w3c/web-platform-tests/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-menu.html [ ImageOnlyFailure ]
 webkit.org/b/168175 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/same-url.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -293,6 +293,7 @@
     "web-platform-tests/html/semantics/forms/textfieldselection/select-event.html": "skip",
     "web-platform-tests/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html": "skip",
     "web-platform-tests/html/semantics/forms/the-textarea-element": "import",
+    "web-platform-tests/html/semantics/interactive-elements/the-details-element": "import",
     "web-platform-tests/html/semantics/interactive-elements/the-dialog-element": "import",
     "web-platform-tests/html/semantics/interactive-elements/the-summary-element": "skip",
     "web-platform-tests/html/semantics/links/downloading-resources": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent-expected.txt
@@ -1,14 +1,14 @@
 
-PASS Adding open to 'details' should fire a toggle event at the 'details' element
-PASS Removing open from 'details' should fire a toggle event at the 'details' element
-PASS Adding open to 'details' (display:none) should fire a toggle event at the 'details' element
-PASS Adding open from 'details' (no children) should fire a toggle event at the 'details' element
-PASS Calling open twice on 'details' fires only one toggle event
-PASS Calling setAttribute('open', '') to 'details' should fire a toggle event at the 'details' element
-PASS Calling removeAttribute('open') to 'details' should fire a toggle event at the 'details' element
+PASS Adding open to 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
+PASS Removing open from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'
+PASS Adding open to 'details' (display:none) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
+PASS Adding open to 'details' (no children) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
+PASS Calling open twice on 'details' fires only one toggle event, with 'oldState: closed' and 'newState: open'
+PASS Calling setAttribute('open', '') from 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
+PASS Calling removeAttribute('open') from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'
 PASS Setting open=true to opened 'details' element should not fire a toggle event at the 'details' element
 PASS Setting open=false to closed 'details' element should not fire a toggle event at the 'details' element
-PASS Adding open to 'details' (not in the document) should fire a toggle event at the 'details' element
+PASS Adding open to 'details' (not in the document) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
 Lorem ipsum
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html
@@ -32,7 +32,12 @@
   <summary>Lorem ipsum</summary>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </details>
-<details id=details9 open>
+<script>
+  window.details9TogglePromise = new Promise(resolve => {
+    window.details9TogglePromiseResolver = resolve;
+  });
+</script>
+<details id=details9 ontoggle="window.details9TogglePromiseResolver()" open>
   <summary>Lorem ipsum</summary>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </details>
@@ -41,13 +46,13 @@
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </details>
 <script>
-  var t1 = async_test("Adding open to 'details' should fire a toggle event at the 'details' element"),
-  t2 = async_test("Removing open from 'details' should fire a toggle event at the 'details' element"),
-  t3 = async_test("Adding open to 'details' (display:none) should fire a toggle event at the 'details' element"),
-  t4 = async_test("Adding open from 'details' (no children) should fire a toggle event at the 'details' element"),
-  t6 = async_test("Calling open twice on 'details' fires only one toggle event"),
-  t7 = async_test("Calling setAttribute('open', '') to 'details' should fire a toggle event at the 'details' element"),
-  t8 = async_test("Calling removeAttribute('open') to 'details' should fire a toggle event at the 'details' element"),
+  var t1 = async_test("Adding open to 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
+  t2 = async_test("Removing open from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'"),
+  t3 = async_test("Adding open to 'details' (display:none) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
+  t4 = async_test("Adding open to 'details' (no children) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
+  t6 = async_test("Calling open twice on 'details' fires only one toggle event, with 'oldState: closed' and 'newState: open'"),
+  t7 = async_test("Calling setAttribute('open', '') from 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
+  t8 = async_test("Calling removeAttribute('open') from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'"),
   t9 = async_test("Setting open=true to opened 'details' element should not fire a toggle event at the 'details' element"),
   t10 = async_test("Setting open=false to closed 'details' element should not fire a toggle event at the 'details' element"),
 
@@ -66,10 +71,12 @@
     assert_true(evt.isTrusted, "event is trusted");
     assert_false(evt.bubbles, "event doesn't bubble");
     assert_false(evt.cancelable, "event is not cancelable");
-    assert_equals(Object.getPrototypeOf(evt), Event.prototype, "Prototype of toggle event is Event.prototype");
+    assert_equals(Object.getPrototypeOf(evt), ToggleEvent.prototype, "Prototype of toggle event is ToggleEvent.prototype");
   }
 
   details1.ontoggle = t1.step_func_done(function(evt) {
+    assert_equals(evt.oldState, "closed");
+    assert_equals(evt.newState, "open");+
     assert_true(details1.open);
     testEvent(evt)
   });
@@ -82,12 +89,16 @@
   details2.open = false; // closes details2
 
   details3.ontoggle = t3.step_func_done(function(evt) {
+    assert_equals(evt.oldState, "closed");
+    assert_equals(evt.newState, "open");+
     assert_true(details3.open);
     testEvent(evt);
   });
   details3.open = true; // opens details3
 
   details4.ontoggle = t4.step_func_done(function(evt) {
+    assert_equals(evt.oldState, "closed");
+    assert_equals(evt.newState, "open");
     assert_true(details4.open);
     testEvent(evt);
   });
@@ -100,11 +111,11 @@
       testEvent(evt);
     })
     details5.open = true;
-  }, "Adding open to 'details' (not in the document) should fire a toggle event at the 'details' element");
+  }, "Adding open to 'details' (not in the document) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'");
 
   details6.open = true;
   details6.open = false;
-  details6.ontoggle = t6.step_func(function() {
+  details6.ontoggle = t6.step_func(function(evt) {
     if (loop) {
       assert_unreached("toggle event fired twice");
     } else {
@@ -117,6 +128,8 @@
   }, 0);
 
   details7.ontoggle = t7.step_func_done(function(evt) {
+    assert_equals(evt.oldState, "closed");
+    assert_equals(evt.newState, "open");
     assert_true(details7.open);
     testEvent(evt)
   });
@@ -128,22 +141,20 @@
   });
   details8.removeAttribute('open'); // closes details8
 
-  var toggleFiredOnDetails9 = false;
-  details9.ontoggle = t9.step_func_done(function(evt) {
-    if (toggleFiredOnDetails9) {
+  window.details9TogglePromise.then(t9.step_func(() => {
+    // The toggle event should be fired once when declaring details9 with open
+    // attribute.
+    details9.ontoggle = t9.step_func(() => {
       assert_unreached("toggle event fired twice on opened details element");
-    } else {
-      toggleFiredOnDetails9 = true;
-    }
-  });
-  // The toggle event should be fired once when declaring details9 with open
-  // attribute.
-  details9.open = true; // opens details9
-  t9.step_timeout(function() {
-    assert_true(details9.open);
-    assert_true(toggleFiredOnDetails9);
-    t9.done();
-  }, 0);
+    });
+    // setting open=true on details9 should not fire another event since it is
+    // already open.
+    details9.open = true;
+    t9.step_timeout(() => {
+      assert_true(details9.open);
+      t9.done();
+    });
+  }));
 
   details10.ontoggle = t10.step_func_done(function(evt) {
     assert_unreached("toggle event fired on closed details element");

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -27,6 +27,16 @@ namespace WebCore {
 
 class HTMLSlotElement;
 
+enum class DetailsState : bool {
+    Open,
+    Closed,
+};
+
+struct DetailsToggleEventData {
+    DetailsState oldState;
+    DetailsState newState;
+};
+
 class HTMLDetailsElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDetailsElement);
 public:
@@ -36,6 +46,12 @@ public:
 
     bool isOpen() const { return m_isOpen; }
     bool isActiveSummary(const HTMLSummaryElement&) const;
+
+    void queueDetailsToggleEventTask(DetailsState oldState, DetailsState newState);
+
+    std::optional<DetailsToggleEventData> queuedToggleEventData() const { return m_queuedToggleEventData; }
+    void setQueuedToggleEventData(DetailsToggleEventData data) { m_queuedToggleEventData = data; }
+    void clearQueuedToggleEventData() { m_queuedToggleEventData = std::nullopt; }
 
 private:
     HTMLDetailsElement(const QualifiedName&, Document&);
@@ -51,7 +67,9 @@ private:
     WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_summarySlot;
     WeakPtr<HTMLSummaryElement, WeakPtrImplWithEventTargetData> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
-    bool m_isToggleEventTaskQueued { false };
+
+    DetailsState m_detailsState;
+    std::optional<DetailsToggleEventData> m_queuedToggleEventData;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 74637c383d415af9b4e4ca2ce7fbb3268e6ead85
<pre>
Use ToggleEvent for &lt;details&gt; element toggle event
<a href="https://bugs.webkit.org/show_bug.cgi?id=252373">https://bugs.webkit.org/show_bug.cgi?id=252373</a>

Reviewed by Tim Nguyen.

This change makes ToggleEvent be used for the event that’s fired when a
“details” element is opened or closed, while handling the case of
coalesced events.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/w3c-import.log:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::queueDetailsToggleEventTask):
(WebCore::HTMLDetailsElement::attributeChanged):
* Source/WebCore/html/HTMLDetailsElement.h:

Canonical link: <a href="https://commits.webkit.org/267076@main">https://commits.webkit.org/267076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25324c12edc811eb5c04f9991bf5ac790231b489

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14620 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17173 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18086 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20988 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13906 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3733 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->