### PR TITLE
Add initial support for _WKWebExtensionWindow and _WKWebExtensionTab APIs to _WKWebExtensionController and _WkWebExtensionContext.

### DIFF
--- a/Source/WTF/wtf/WeakObjCPtr.h
+++ b/Source/WTF/wtf/WeakObjCPtr.h
@@ -82,10 +82,8 @@ public:
         return *this;
     }
 
-    bool operator!() const
-    {
-        return !get();
-    }
+    bool operator!() const { return !get(); }
+    explicit operator bool() const { return !!get(); }
 
     RetainPtr<ValueType> get() const;
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -36,6 +36,10 @@ OBJC_CLASS NSSet;
 OBJC_CLASS NSString;
 OBJC_CLASS NSUUID;
 
+#define THROW_UNLESS(condition, message) \
+    if (UNLIKELY(!(condition))) \
+        [NSException raise:NSInternalInconsistencyException format:message]
+
 namespace WebKit {
 
 template<typename T> T *filterObjects(T *container, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value));

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
@@ -23,23 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+#pragma once
 
-#import <WebKit/WebKit.h>
+#include <wtf/ObjectIdentifier.h>
 
-#import <WebKit/_WKWebExtensionControllerDelegate.h>
-#import <WebKit/_WKWebExtensionMatchPattern.h>
-#import <WebKit/_WKWebExtensionPermission.h>
-#import <WebKit/_WKWebExtensionTab.h>
+namespace WebKit {
 
-@interface TestWebExtensionsDelegate : NSObject <_WKWebExtensionControllerDelegate>
+struct WebExtensionTabIdentifierType;
+using WebExtensionTabIdentifier = ObjectIdentifier<WebExtensionTabIdentifierType>;
 
-@property (nonatomic, copy) NSArray<id <_WKWebExtensionWindow>> *(^openWindows)(_WKWebExtensionContext *);
-@property (nonatomic, copy) id <_WKWebExtensionWindow> (^focusedWindow)(_WKWebExtensionContext *);
-
-@property (nonatomic, copy) void (^promptForPermissions)(id <_WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<_WKWebExtensionPermission> *));
-@property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id <_WKWebExtensionTab>, NSSet<_WKWebExtensionMatchPattern *> *, void (^)(NSSet<_WKWebExtensionMatchPattern *> *));
-
-@end
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+}

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
@@ -23,23 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+#pragma once
 
-#import <WebKit/WebKit.h>
+#include <wtf/ObjectIdentifier.h>
 
-#import <WebKit/_WKWebExtensionControllerDelegate.h>
-#import <WebKit/_WKWebExtensionMatchPattern.h>
-#import <WebKit/_WKWebExtensionPermission.h>
-#import <WebKit/_WKWebExtensionTab.h>
+namespace WebKit {
 
-@interface TestWebExtensionsDelegate : NSObject <_WKWebExtensionControllerDelegate>
+struct WebExtensionWindowIdentifierType;
+using WebExtensionWindowIdentifier = ObjectIdentifier<WebExtensionWindowIdentifierType>;
 
-@property (nonatomic, copy) NSArray<id <_WKWebExtensionWindow>> *(^openWindows)(_WKWebExtensionContext *);
-@property (nonatomic, copy) id <_WKWebExtensionWindow> (^focusedWindow)(_WKWebExtensionContext *);
-
-@property (nonatomic, copy) void (^promptForPermissions)(id <_WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<_WKWebExtensionPermission> *));
-@property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id <_WKWebExtensionTab>, NSSet<_WKWebExtensionMatchPattern *> *, void (^)(NSSet<_WKWebExtensionMatchPattern *> *));
-
-@end
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+}

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -147,7 +147,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic, readonly, strong) _WKWebExtension *webExtension;
 
 /*! @abstract The extension controller this context is loaded in, otherwise `nil` if it isn't loaded. */
-@property (nonatomic, readonly, weak) _WKWebExtensionController *webExtensionController;
+@property (nonatomic, readonly, weak, nullable) _WKWebExtensionController *webExtensionController;
 
 /*! @abstract A Boolean value indicating if this context is loaded in an extension controller. */
 @property (nonatomic, readonly, getter=isLoaded) BOOL loaded;
@@ -452,6 +452,119 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @param tab The tab in which to return the user gesture status.
 */
 - (BOOL)hasActiveUserGestureInTab:(id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(hasActiveUserGesture(in:));
+
+/*!
+ @abstract An array of open windows that are exposed to this extension.
+ @discussion This property holds an array of window objects that are open and visible to the extension, as updated by the `didOpenWindow:` and `didCloseWindow:` methods.
+ Initially populated by the windows returned by the extension controller delegate method `webExtensionController:openWindowsForExtensionContext:`.
+ @seealso didOpenWindow:
+ @seealso didCloseWindow:
+ */
+@property (nonatomic, readonly, copy) NSArray<id <_WKWebExtensionWindow>> *openWindows;
+
+/*!
+ @abstract The window that currently has focus.
+ @discussion This property holds the window object that currently has focus, as set by the `didFocusWindow:` method.
+ It will be \c nil if no window has focus or if a window has focus that is not visible to the extension.  Initially populated by the window
+ returned by the extension controller delegate method `webExtensionController:focusedWindowForExtensionContext:`.
+ @seealso didFocusWindow:
+ */
+@property (nonatomic, readonly, weak, nullable) id <_WKWebExtensionWindow> focusedWindow;
+
+/*!
+ @abstract A set of open tabs in all open windows that are exposed to this extension.
+ @discussion This property holds a set of tabs in all open windows that are visible to the extension, as updated by the `didOpenTab:` and `didCloseTab:` methods.
+ Initially populated by the tabs in the windows returned by the extension controller delegate method `webExtensionController:openWindowsForExtensionContext:`.
+ @seealso didOpenTab:
+ @seealso didCloseTab:
+ */
+@property (nonatomic, readonly, copy) NSSet<id <_WKWebExtensionTab>> *openTabs;
+
+/*!
+ @abstract Should be called by the app when a new window is opened to fire appropriate events with only this extension.
+ @param newWindow The newly opened window.
+ @discussion This method informs only the specific extension of the opening of a new window. If the intention is to inform all loaded
+ extensions consistently, you should use the respective method on the extension controller instead.
+ @seealso didCloseWindow:
+ @seealso openWindows
+ */
+- (void)didOpenWindow:(id <_WKWebExtensionWindow>)newWindow;
+
+/*!
+ @abstract Should be called by the app when a window is closed to fire appropriate events with only this extension.
+ @param newWindow The window that was closed.
+ @discussion This method informs only the specific extension of the closure of a window. If the intention is to inform all loaded 
+ extensions consistently, you should use the respective method on the extension controller instead.
+ @seealso didOpenWindow:
+ @seealso openWindows
+ */
+- (void)didCloseWindow:(id <_WKWebExtensionWindow>)closedWindow;
+
+/*!
+ @abstract Should be called by the app when a window gains focus to fire appropriate events with only this extension.
+ @param focusedWindow The window that gained focus, or \c nil if no window has focus or a window has focus that is not visible to this extension.
+ @discussion This method informs only the specific extension that a window has gained focus. If the intention is to inform all loaded
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didFocusWindow:(nullable id <_WKWebExtensionWindow>)focusedWindow;
+
+/*!
+ @abstract Should be called by the app when a new tab is opened to fire appropriate events with only this extension.
+ @param newTab The newly opened tab.
+ @discussion This method informs only the specific extension of the opening of a new tab. If the intention is to inform all loaded
+ extensions consistently, you should use the respective method on the extension controller instead.
+ @seealso didCloseTab:
+ @seealso openTabs
+ */
+- (void)didOpenTab:(id <_WKWebExtensionTab>)newTab;
+
+/*!
+ @abstract Should be called by the app when a tab is closed to fire appropriate events with only this extension.
+ @param closedTab The tab that was closed.
+ @param windowIsClosing A boolean value indicating whether the window containing the tab is also closing.
+ @discussion This method informs only the specific extension of the closure of a tab. If the intention is to inform all loaded 
+ extensions consistently, you should use the respective method on the extension controller instead.
+ @seealso didOpenTab:
+ @seealso openTabs
+ */
+- (void)didCloseTab:(id <_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing;
+
+/*!
+ @abstract Should be called by the app when tabs are selected to fire appropriate events with only this extension.
+ @param selectedTabs The set of tabs that were selected. An empty set indicates that no tabs are currently selected or that the
+ selected tabs are not visible to this extension.
+ @discussion This method informs only the specific extension that tabs have been selected. If the intention is to inform all loaded
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didSelectTabs:(NSSet<id <_WKWebExtensionTab>> *)selectedTabs;
+
+/*!
+ @abstract Should be called by the app when a tab is moved to fire appropriate events with only this extension.
+ @param movedTab The tab that was moved.
+ @param index The old index of the tab within the window.
+ @param oldWindow The window that the tab was moved from, or \c nil if the window stayed the same.
+ @discussion This method informs only the specific extension that a tab has been moved. If the intention is to inform all loaded 
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didMoveTab:(id <_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <_WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
+
+/*!
+ @abstract Should be called by the app when a tab is replaced by another tab to fire appropriate events with only this extension.
+ @param oldTab The tab that was replaced.
+ @param newTab The tab that replaced the old tab.
+ @discussion This method informs only the specific extension that a tab has been replaced. If the intention is to inform all loaded 
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didReplaceTab:(id <_WKWebExtensionTab>)oldTab withTab:(id <_WKWebExtensionTab>)newTab NS_SWIFT_NAME(didReplaceTab(_:with:));
+
+/*!
+ @abstract Should be called by the app when the properties of a tab are changed to fire appropriate events with only this extension.
+ @param properties The properties of the tab that were changed.
+ @param changedTab The tab whose properties were changed.
+ @discussion This method informs only the specific extension of the changes to a tab's properties. If the intention is to inform all loaded 
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id <_WKWebExtensionTab>)changedTab NS_SWIFT_NAME(didChangeTabProperties(_:for:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -28,6 +28,8 @@
 #import <Foundation/Foundation.h>
 
 #import <WebKit/_WKWebExtensionControllerDelegate.h>
+#import <WebKit/_WKWebExtensionTab.h>
+#import <WebKit/_WKWebExtensionWindow.h>
 
 @class _WKWebExtension;
 @class _WKWebExtensionContext;
@@ -109,6 +111,88 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @seealso extensions
 */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionContext *> *extensionContexts;
+
+/*!
+ @abstract Should be called by the app when a new window is opened to fire appropriate events with all loaded web extensions.
+ @param newWindow The newly opened window.
+ @discussion This method informs all loaded extensions of the opening of a new window, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ @seealso didCloseWindow:
+ */
+- (void)didOpenWindow:(id <_WKWebExtensionWindow>)newWindow;
+
+/*!
+ @abstract Should be called by the app when a window is closed to fire appropriate events with all loaded web extensions.
+ @param newWindow The window that was closed.
+ @discussion This method informs all loaded extensions of the closure of a window, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ @seealso didOpenWindow:
+ */
+- (void)didCloseWindow:(id <_WKWebExtensionWindow>)closedWindow;
+
+/*!
+ @abstract Should be called by the app when a window gains focus to fire appropriate events with all loaded web extensions.
+ @param focusedWindow The window that gained focus, or \c nil if no window has focus or a window has focus that is not visible to extensions.
+ @discussion This method informs all loaded extensions of the focused window, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ */
+- (void)didFocusWindow:(nullable id <_WKWebExtensionWindow>)focusedWindow;
+
+/*!
+ @abstract Should be called by the app when a new tab is opened to fire appropriate events with all loaded web extensions.
+ @param newTab The newly opened tab.
+ @discussion This method informs all loaded extensions of the opening of a new tab, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ @seealso didCloseTab:
+ */
+- (void)didOpenTab:(id <_WKWebExtensionTab>)newTab;
+
+/*!
+ @abstract Should be called by the app when a tab is closed to fire appropriate events with all loaded web extensions.
+ @param closedTab The tab that was closed.
+ @param windowIsClosing A boolean value indicating whether the window containing the tab is also closing.
+ @discussion This method informs all loaded extensions of the closing of a tab, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ @seealso didOpenTab:
+ */
+- (void)didCloseTab:(id <_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing;
+
+/*!
+ @abstract Should be called by the app when tabs are selected to fire appropriate events with all loaded web extensions.
+ @param selectedTabs The set of tabs that were selected. An empty set indicates that no tabs are currently selected or that the
+ selected tabs are not visible to extensions.
+ @discussion This method informs all loaded extensions of the selection of tabs, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ */
+- (void)didSelectTabs:(NSSet<id <_WKWebExtensionTab>> *)selectedTabs;
+
+/*!
+ @abstract Should be called by the app when a tab is moved to fire appropriate events with all loaded web extensions.
+ @param movedTab The tab that was moved.
+ @param index The old index of the tab within the window.
+ @param oldWindow The window that the tab was moved from, or \c nil if the window stayed the same.
+ @discussion This method informs all loaded extensions of the movement of a tab, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ */
+- (void)didMoveTab:(id <_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <_WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
+
+/*!
+ @abstract Should be called by the app when a tab is replaced by another tab to fire appropriate events with all loaded web extensions.
+ @param oldTab The tab that was replaced.
+ @param newTab The tab that replaced the old tab.
+ @discussion This method informs all loaded extensions of the replacement of a tab, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ */
+- (void)didReplaceTab:(id <_WKWebExtensionTab>)oldTab withTab:(id <_WKWebExtensionTab>)newTab NS_SWIFT_NAME(didReplaceTab(_:with:));
+
+/*!
+ @abstract Should be called by the app when the properties of a tab are changed to fire appropriate events with all loaded web extensions.
+ @param properties The properties of the tab that were changed.
+ @param changedTab The tab whose properties were changed.
+ @discussion This method informs all loaded extensions of changes to tab properties, ensuring a unified understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ */
+- (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id <_WKWebExtensionTab>)changedTab NS_SWIFT_NAME(didChangeTabProperties(_:for:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -100,7 +100,7 @@
 }
 
 template<typename T>
-static inline NSSet *toAPI(const T& inputSet)
+static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
     if (inputSet.isEmpty())
         return [NSSet set];
@@ -115,13 +115,88 @@ static inline NSSet *toAPI(const T& inputSet)
 
 - (NSSet<_WKWebExtension *> *)extensions
 {
-    auto extensions = _webExtensionController->extensions();
-    return toAPI(extensions);
+    return toAPI(_webExtensionController->extensions());
 }
 
 - (NSSet<_WKWebExtensionContext *> *)extensionContexts
 {
     return toAPI(_webExtensionController->extensionContexts());
+}
+
+- (void)didOpenWindow:(id<_WKWebExtensionWindow>)newWindow
+{
+    NSParameterAssert([newWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didOpenWindow:newWindow];
+}
+
+- (void)didCloseWindow:(id<_WKWebExtensionWindow>)closedWindow
+{
+    NSParameterAssert([closedWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didCloseWindow:closedWindow];
+}
+
+- (void)didFocusWindow:(id<_WKWebExtensionWindow>)focusedWindow
+{
+    if (focusedWindow)
+        NSParameterAssert([focusedWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didFocusWindow:focusedWindow];
+}
+
+- (void)didOpenTab:(id<_WKWebExtensionTab>)newTab
+{
+    NSParameterAssert([newTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didOpenTab:newTab];
+}
+
+- (void)didCloseTab:(id<_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
+{
+    NSParameterAssert([closedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didCloseTab:closedTab windowIsClosing:windowIsClosing];
+}
+
+- (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
+{
+    NSParameterAssert([selectedTabs isKindOfClass:NSSet.class]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didSelectTabs:selectedTabs];
+}
+
+- (void)didMoveTab:(id<_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<_WKWebExtensionWindow>)oldWindow
+{
+    NSParameterAssert([movedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+    if (oldWindow)
+        NSParameterAssert([oldWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didMoveTab:movedTab fromIndex:index inWindow:oldWindow];
+}
+
+- (void)didReplaceTab:(id<_WKWebExtensionTab>)oldTab withTab:(id<_WKWebExtensionTab>)newTab
+{
+    NSParameterAssert([oldTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+    NSParameterAssert([newTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didReplaceTab:oldTab withTab:newTab];
+}
+
+- (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id<_WKWebExtensionTab>)changedTab
+{
+    NSParameterAssert([changedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didChangeTabProperties:properties forTab:changedTab];
 }
 
 #pragma mark WKObject protocol implementation
@@ -176,6 +251,42 @@ static inline NSSet *toAPI(const T& inputSet)
 - (NSSet<_WKWebExtensionContext *> *)extensionContexts
 {
     return nil;
+}
+
+- (void)didOpenWindow:(id<_WKWebExtensionWindow>)newWindow
+{
+}
+
+- (void)didCloseWindow:(id<_WKWebExtensionWindow>)closedWindow
+{
+}
+
+- (void)didFocusWindow:(id<_WKWebExtensionWindow>)focusedWindow
+{
+}
+
+- (void)didOpenTab:(id<_WKWebExtensionTab>)newTab
+{
+}
+
+- (void)didCloseTab:(id<_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
+{
+}
+
+- (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
+{
+}
+
+- (void)didMoveTab:(id<_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<_WKWebExtensionWindow>)oldWindow
+{
+}
+
+- (void)didReplaceTab:(id<_WKWebExtensionTab>)oldTab withTab:(id<_WKWebExtensionTab>)newTab
+{
+}
+
+- (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id<_WKWebExtensionTab>)changedTab
+{
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -33,12 +33,39 @@
 @class _WKWebExtensionMatchPattern;
 @class _WKWebExtensionController;
 @protocol _WKWebExtensionTab;
+@protocol _WKWebExtensionWindow;
 
 NS_ASSUME_NONNULL_BEGIN
 
 WK_API_AVAILABLE(macos(13.3), ios(16.4))
 @protocol _WKWebExtensionControllerDelegate <NSObject>
 @optional
+
+/*!
+ @abstract Called when an extension context requests the list of ordered open windows.
+ @param controller The web extension controller that is managing the extension.
+ @param extensionContext The context in which the web extension is running.
+ @return The array of ordered open windows.
+ @discussion This method should be implemented by the app to provide the extension with a list of ordered open windows. Depending on your
+ app's requirements, you may return different windows for each extension or the same windows for all extensions. The first window in the returned
+ windows must correspond to the focused window and match the result of `webExtensionController:focusedWindowForExtensionContext:`.
+ If `webExtensionController:focusedWindowForExtensionContext:` returns `nil`, indicating that no window has focus or the focused
+ window is not visible the extension, the first window in the list returned by this method will be considered the presumed focused window. An empty result
+ indicates no open windows are available for the extension. Defaults to empty array if not implemented.
+ @seealso webExtensionController:focusedWindowForExtensionContext:
+ */
+- (NSArray<id <_WKWebExtensionWindow>> *)webExtensionController:(_WKWebExtensionController *)controller openWindowsForExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_NAME(webExtensionController(_:windowsFor:));
+
+/*!
+ @abstract Called when an extension context requests the currently focused window.
+ @param controller The web extension controller that is managing the extension.
+ @param extensionContext The context in which the web extension is running.
+ @return The window that has focus, or \c nil if no window has focus or a window has focus that is not visible to the extension.
+ @discussion This method can be optionally implemented by the app to designate the window currently in focus to the extension.
+ If not implemented, the first window in the result of `webExtensionController:openWindowsForExtensionContext:` is used.
+ @seealso webExtensionController:openWindowsForExtensionContext:
+ */
+- (nullable id <_WKWebExtensionWindow>)webExtensionController:(_WKWebExtensionController *)controller focusedWindowForExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_NAME(webExtensionController(_:focusedWindowFor:));
 
 /*!
  @abstract Called when an extension context requests permissions.
@@ -48,8 +75,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param extensionContext The context in which the web extension is running.
  @param completionHandler A block to be called with the set of allowed permissions.
  @discussion This method should be implemented by the app to prompt the user for permission and call the completion block with the
- set of permissions that were granted. If the completion block is not called within a reasonable amount of time, the request
- is assumed to have been denied.
+ set of permissions that were granted. If not implemented or the completion block is not called within a reasonable amount of time, the
+ request is assumed to have been denied.
  */
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissions:in:for:completionHandler:));
 
@@ -61,8 +88,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param extensionContext The context in which the web extension is running.
  @param completionHandler A block to be called with the set of allowed URLs.
  @discussion This method should be implemented by the app to prompt the user for permission and call the completion block with the
- set of URLs that were granted access to. If the completion block is not called within a reasonable amount of time, the request
- is assumed to have been denied.
+ set of URLs that were granted access to. If not implemented or the completion block is not called within a reasonable amount of time, the
+ request is assumed to have been denied.
  */
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionToAccessURLs:(NSSet<NSURL *> *)urls inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<NSURL *> *allowedURLs))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionToAccess:in:for:completionHandler:));
 
@@ -74,8 +101,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param extensionContext The context in which the web extension is running.
  @param completionHandler A block to be called with the set of allowed match patterns.
  @discussion This method should be implemented by the app to prompt the user for permission and call the completion block with the
- set of match patterns that were granted access to. If the completion block is not called within a reasonable amount of time, the request
- is assumed to have been denied.
+ set of match patterns that were granted access to. If not implemented or the completion block is not called within a reasonable amount of time,
+ the request is assumed to have been denied.
  */
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -36,28 +36,28 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @abstract Constants used by @link WKWebExtensionController @/link to indicate tab changes.
  @constant WKWebExtensionTabChangedPropertiesNone  Indicates nothing changed.
- @constant WKWebExtensionTabChangedPropertiesLoading  Indicates the loading state changed.
- @constant WKWebExtensionTabChangedPropertiesTitle  Indicates the title changed.
- @constant WKWebExtensionTabChangedPropertiesURL  Indicates the URL changed.
- @constant WKWebExtensionTabChangedPropertiesSize  Indicates the size changed.
- @constant WKWebExtensionTabChangedPropertiesZoomFactor  Indicates the zoom factor changed.
  @constant WKWebExtensionTabChangedPropertiesAudible  Indicates the audible state changed.
+ @constant WKWebExtensionTabChangedPropertiesLoading  Indicates the loading state changed.
  @constant WKWebExtensionTabChangedPropertiesMuted  Indicates the muted state changed.
  @constant WKWebExtensionTabChangedPropertiesPinned  Indicates the pinned state changed.
  @constant WKWebExtensionTabChangedPropertiesReaderMode  Indicates the reader mode state changed.
+ @constant WKWebExtensionTabChangedPropertiesSize  Indicates the size changed.
+ @constant WKWebExtensionTabChangedPropertiesTitle  Indicates the title changed.
+ @constant WKWebExtensionTabChangedPropertiesURL  Indicates the URL changed.
+ @constant WKWebExtensionTabChangedPropertiesZoomFactor  Indicates the zoom factor changed.
  @constant WKWebExtensionTabChangedPropertiesAll  Indicates all properties changed.
  */
 typedef NS_OPTIONS(NSUInteger, _WKWebExtensionTabChangedProperties) {
     _WKWebExtensionTabChangedPropertiesNone       = 0,
-    _WKWebExtensionTabChangedPropertiesLoading    = 1 << 1,
-    _WKWebExtensionTabChangedPropertiesTitle      = 1 << 2,
-    _WKWebExtensionTabChangedPropertiesURL        = 1 << 3,
-    _WKWebExtensionTabChangedPropertiesSize       = 1 << 4,
-    _WKWebExtensionTabChangedPropertiesZoomFactor = 1 << 5,
-    _WKWebExtensionTabChangedPropertiesAudible    = 1 << 6,
-    _WKWebExtensionTabChangedPropertiesMuted      = 1 << 7,
-    _WKWebExtensionTabChangedPropertiesPinned     = 1 << 8,
-    _WKWebExtensionTabChangedPropertiesReaderMode = 1 << 9,
+    _WKWebExtensionTabChangedPropertiesAudible    = 1 << 1,
+    _WKWebExtensionTabChangedPropertiesLoading    = 1 << 2,
+    _WKWebExtensionTabChangedPropertiesMuted      = 1 << 3,
+    _WKWebExtensionTabChangedPropertiesPinned     = 1 << 4,
+    _WKWebExtensionTabChangedPropertiesReaderMode = 1 << 5,
+    _WKWebExtensionTabChangedPropertiesSize       = 1 << 6,
+    _WKWebExtensionTabChangedPropertiesTitle      = 1 << 7,
+    _WKWebExtensionTabChangedPropertiesURL        = 1 << 8,
+    _WKWebExtensionTabChangedPropertiesZoomFactor = 1 << 9,
     _WKWebExtensionTabChangedPropertiesAll        = NSUIntegerMax,
 } WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
@@ -66,34 +66,34 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 @optional
 
 /*!
- @abstract Called when the parent tab for the tab is needed.
- @param context The context in which the web extension is running.
- @return The parent tab of the tab, if the tab was opened from another tab.
- @discussion Defaults to `nil` if not implemented.
- */
-- (id <_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context;
-
-/*!
  @abstract Called when the window containing the tab is needed.
  @param context The context in which the web extension is running.
  @return The window containing the tab.
  @discussion Defaults to `nil` if not implemented.
  */
-- (id <_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable id <_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the main web view for the window is needed.
+ @abstract Called when the parent tab for the tab is needed.
+ @param context The context in which the web extension is running.
+ @return The parent tab of the tab, if the tab was opened from another tab.
+ @discussion Defaults to `nil` if not implemented.
+ */
+- (nullable id <_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called when the main web view for the tab is needed.
  @param context The context in which the web extension is running.
  @return The main web view for the tab.
  @discussion Defaults to `nil` if not implemented.
  */
-- (WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the web views for the window are needed.
+ @abstract Called when the web views for the tab are needed.
  @param context The context in which the web extension is running.
  @return An array of web views for the tab.
- @discussion Defaults to an empty array if not implemented.
+ @discussion Defaults to an array containing the main web view if not implemented.
  */
 - (NSArray<WKWebView *> *)webViewsForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -101,9 +101,9 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the title of the tab is needed.
  @param context The context in which the web extension is running.
  @return The title of the tab.
- @discussion Defaults to an empty string if not implemented.
+ @discussion Defaults to the title of the main web view if not implemented.
  */
-- (NSString *)tabTitleForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable NSString *)tabTitleForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called when the selected state of the tab is needed.
@@ -183,10 +183,10 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the size of the tab in the window is needed.
+ @abstract Called when the size of the tab is needed.
  @param context The context in which the web extension is running.
  @return The size of the tab.
- @discussion Defaults to `CGSizeZero` if not implemented.
+ @discussion Defaults to size of the main web view if not implemented.
  */
 - (CGSize)sizeForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -194,7 +194,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the zoom factor of the tab is needed.
  @param context The context in which the web extension is running.
  @return The zoom factor of the tab.
- @discussion Defaults to `1.0` if not implemented.
+ @discussion Defaults to zoom factor of the main web view if not implemented.
  */
 - (double)zoomFactorForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -202,9 +202,9 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the URL of the tab is needed.
  @param context The context in which the web extension is running.
  @return The URL of the tab.
- @discussion Defaults to `nil` if not implemented.
+ @discussion Defaults to the URL of the main web view if not implemented.
  */
-- (NSURL *)urlForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable NSURL *)urlForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called when the pending URL of the tab is needed.
@@ -213,13 +213,13 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @discussion The pending URL is the URL of a page that is in the process of loading. If there is no pending URL, return `nil`.
  Defaults to `nil` if not implemented.
  */
-- (NSURL *)pendingURLForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable NSURL *)pendingURLForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called to check if the tab has finished loading.
  @param context The context in which the web extension is running.
  @return `YES` if the tab has finished loading, `NO` otherwise.
- @discussion Defaults to `YES` if not implemented.
+ @discussion Defaults to the loading state of the main web view if not implemented.
  */
 - (BOOL)isLoadingCompleteForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -227,8 +227,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to detect the locale of the webpage currently loaded in the tab.
  @param context The context in which the web extension is running.
  @param completionHandler A block to be called when the locale has been detected. The block takes a single argument, the
- detected locale, which may be `nil` if no locale could be detected.
- @discussion No language detection is performed if not implemented.
+ detected locale, which may be \c nil if no locale could be detected.
+ @discussion Defaults to calling the `completionHandler` with `nil` if not implemented.
  */
 - (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale * _Nullable locale))completionHandler;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -75,7 +75,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @return The active tab in the window.
  @discussion Defaults to `nil` if not implemented.
  */
-- (id <_WKWebExtensionTab>)activeTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable id <_WKWebExtensionTab>)activeTabForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called when the type of the window is needed.
@@ -92,14 +92,6 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @discussion Defaults to`WKWebExtensionWindowStateNormal` if not implemented.
  */
 - (_WKWebExtensionWindowState)windowStateForWebExtensionContext:(_WKWebExtensionContext *)context;
-
-/*!
- @abstract Called when the focused state of the window is needed.
- @param context The context in which the web extension is running.
- @return `YES` if the window is focused, `NO` otherwise.
- @discussion Defaults to `NO` if not implemented.
- */
-- (BOOL)isFocusedForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called when the ephemeral state of the window is needed.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm
@@ -43,7 +43,7 @@ void WebExtensionContext::testResult(bool result, String message, String sourceU
     if (!isLoaded())
         return;
 
-    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    auto delegate = extensionController()->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
         [delegate _webExtensionController:extensionController()->wrapper() recordTestAssertionResult:result withMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
         return;
@@ -63,7 +63,7 @@ void WebExtensionContext::testEqual(bool result, String expectedValue, String ac
     if (!isLoaded())
         return;
 
-    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    auto delegate = extensionController()->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
         [delegate _webExtensionController:extensionController()->wrapper() recordTestEqualityResult:result expectedValue:expectedValue actualValue:actualValue withMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
         return;
@@ -83,7 +83,7 @@ void WebExtensionContext::testMessage(String message, String sourceURL, unsigned
     if (!isLoaded())
         return;
 
-    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    auto delegate = extensionController()->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
         [delegate _webExtensionController:extensionController()->wrapper() recordTestMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
         return;
@@ -100,7 +100,7 @@ void WebExtensionContext::testYielded(String message, String sourceURL, unsigned
     if (!isLoaded())
         return;
 
-    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    auto delegate = extensionController()->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestYieldedWithMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
         [delegate _webExtensionController:extensionController()->wrapper() recordTestYieldedWithMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
         return;
@@ -117,7 +117,7 @@ void WebExtensionContext::testFinished(bool result, String message, String sourc
     if (!isLoaded())
         return;
 
-    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    auto delegate = extensionController()->delegate();
     if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:forExtensionContext:)]) {
         [delegate _webExtensionController:extensionController()->wrapper() recordTestFinishedWithResult:result message:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
         return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionTab.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WKWebView.h"
+#import "WKWebViewConfigurationPrivate.h"
+#import "WebExtensionContext.h"
+#import "_WKWebExtensionTab.h"
+
+namespace WebKit {
+
+WebExtensionTab::WebExtensionTab(const WebExtensionContext& context, _WKWebExtensionTab *delegate)
+    : m_identifier(WebExtensionTabIdentifier::generate())
+    , m_extensionContext(context)
+    , m_delegate(delegate)
+    , m_respondsToWindow([delegate respondsToSelector:@selector(windowForWebExtensionContext:)])
+    , m_respondsToParentTab([delegate respondsToSelector:@selector(parentTabForWebExtensionContext:)])
+    , m_respondsToMainWebView([delegate respondsToSelector:@selector(mainWebViewForWebExtensionContext:)])
+    , m_respondsToWebViews([delegate respondsToSelector:@selector(webViewsForWebExtensionContext:)])
+    , m_respondsToTabTitle([delegate respondsToSelector:@selector(tabTitleForWebExtensionContext:)])
+    , m_respondsToIsSelected([delegate respondsToSelector:@selector(isSelectedForWebExtensionContext:)])
+    , m_respondsToIsPinned([delegate respondsToSelector:@selector(isPinnedForWebExtensionContext:)])
+    , m_respondsToIsEphemeral([delegate respondsToSelector:@selector(isEphemeralForWebExtensionContext:)])
+    , m_respondsToIsReaderModeAvailable([delegate respondsToSelector:@selector(isReaderModeAvailableForWebExtensionContext:)])
+    , m_respondsToIsShowingReaderMode([delegate respondsToSelector:@selector(isShowingReaderModeForWebExtensionContext:)])
+    , m_respondsToToggleReaderMode([delegate respondsToSelector:@selector(toggleReaderModeForWebExtensionContext:)])
+    , m_respondsToIsAudible([delegate respondsToSelector:@selector(isAudibleForWebExtensionContext:)])
+    , m_respondsToIsMuted([delegate respondsToSelector:@selector(isMutedForWebExtensionContext:)])
+    , m_respondsToMute([delegate respondsToSelector:@selector(muteForWebExtensionContext:)])
+    , m_respondsToUnmute([delegate respondsToSelector:@selector(unmuteForWebExtensionContext:)])
+    , m_respondsToSize([delegate respondsToSelector:@selector(sizeForWebExtensionContext:)])
+    , m_respondsToZoomFactor([delegate respondsToSelector:@selector(zoomFactorForWebExtensionContext:)])
+    , m_respondsToURL([delegate respondsToSelector:@selector(urlForWebExtensionContext:)])
+    , m_respondsToPendingURL([delegate respondsToSelector:@selector(pendingURLForWebExtensionContext:)])
+    , m_respondsToIsLoadingComplete([delegate respondsToSelector:@selector(isLoadingCompleteForWebExtensionContext:)])
+    , m_respondsToDetectWebpageLocale([delegate respondsToSelector:@selector(detectWebpageLocaleForWebExtensionContext:completionHandler:)])
+    , m_respondsToLoadURL([delegate respondsToSelector:@selector(loadURL:forWebExtensionContext:)])
+    , m_respondsToReload([delegate respondsToSelector:@selector(reloadForWebExtensionContext:)])
+    , m_respondsToReloadFromOrigin([delegate respondsToSelector:@selector(reloadFromOriginForWebExtensionContext:)])
+    , m_respondsToGoBack([delegate respondsToSelector:@selector(goBackForWebExtensionContext:)])
+    , m_respondsToGoForward([delegate respondsToSelector:@selector(goForwardForWebExtensionContext:)])
+    , m_respondsToClose([delegate respondsToSelector:@selector(closeForWebExtensionContext:)])
+    , m_respondsToSelect([delegate respondsToSelector:@selector(selectForWebExtensionContext:)])
+{
+    ASSERT([delegate conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+}
+
+bool WebExtensionTab::operator==(const WebExtensionTab& other) const
+{
+    return this == &other || (m_identifier == other.m_identifier && m_extensionContext == other.m_extensionContext && m_delegate.get() == other.m_delegate.get());
+}
+
+RefPtr<WebExtensionWindow> WebExtensionTab::window() const
+{
+    if (!isValid() || !m_respondsToWindow)
+        return nullptr;
+
+    auto window = [m_delegate windowForWebExtensionContext:m_extensionContext->wrapper()];
+    if (!window)
+        return nullptr;
+
+    THROW_UNLESS([window conformsToProtocol:@protocol(_WKWebExtensionWindow)], @"Object returned by windowForWebExtensionContext: does not conform to the _WKWebExtensionWindow protocol");
+    auto result = m_extensionContext->getOrCreateWindow(window);
+
+    THROW_UNLESS(result->tabs().contains(*this), @"Window returned by windowForWebExtensionContext: does not contain the tab");
+
+    return result;
+}
+
+RefPtr<WebExtensionTab> WebExtensionTab::parentTab() const
+{
+    if (!isValid() || !m_respondsToParentTab)
+        return nullptr;
+
+    auto parentTab = [m_delegate parentTabForWebExtensionContext:m_extensionContext->wrapper()];
+    if (!parentTab)
+        return nullptr;
+
+    THROW_UNLESS([parentTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by parentTabForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
+    return m_extensionContext->getOrCreateTab(parentTab);
+}
+
+WKWebView *WebExtensionTab::mainWebView() const
+{
+    if (!isValid() || !m_respondsToMainWebView)
+        return nil;
+
+    auto *mainWebView = [m_delegate mainWebViewForWebExtensionContext:m_extensionContext->wrapper()];
+    if (!mainWebView)
+        return nil;
+
+    THROW_UNLESS([mainWebView isKindOfClass:WKWebView.class], @"Object returned by mainWebViewForWebExtensionContext: is not a WKWebView");
+    THROW_UNLESS(mainWebView.configuration._webExtensionController == extensionContext()->extensionController()->wrapper(), @"WKWebView returned by mainWebViewForWebExtensionContext: is not configured with the same _WKWebExtensionController as extension context");
+
+    if (m_respondsToWebViews) {
+        auto *webViews = [m_delegate webViewsForWebExtensionContext:m_extensionContext->wrapper()];
+        THROW_UNLESS([webViews isKindOfClass:NSArray.class], @"Object returned by webViewsForWebExtensionContext: is not an array");
+        THROW_UNLESS([webViews containsObject:mainWebView], @"Array returned by webViewsForWebExtensionContext: does not contain the main web view");
+    }
+
+    return mainWebView;
+}
+
+NSArray *WebExtensionTab::webViews() const
+{
+    if (!isValid() || !m_respondsToWebViews || !m_respondsToMainWebView) {
+        // This approach is nil-safe, unlike using @[ mainWebView() ].
+        return [NSArray arrayWithObjects:mainWebView(), nil];
+    }
+
+    auto *webViews = [m_delegate webViewsForWebExtensionContext:m_extensionContext->wrapper()];
+    THROW_UNLESS([webViews isKindOfClass:NSArray.class], @"Object returned by webViewsForWebExtensionContext: is not an array");
+
+    for (WKWebView *webView in webViews) {
+        THROW_UNLESS([webView isKindOfClass:WKWebView.class], @"Object in array returned by webViewsForWebExtensionContext: is not a WKWebView");
+        THROW_UNLESS(webView.configuration._webExtensionController == extensionContext()->extensionController()->wrapper(), @"WKWebView returned by webViewsForWebExtensionContext: is not configured with the same _WKWebExtensionController as extension context");
+    }
+
+    if (auto *mainWebView = [m_delegate mainWebViewForWebExtensionContext:m_extensionContext->wrapper()])
+        THROW_UNLESS([webViews containsObject:mainWebView], @"Array returned by webViewsForWebExtensionContext: does not contain the main web view");
+
+    return webViews;
+}
+
+String WebExtensionTab::title() const
+{
+    if (!isValid() || !m_respondsToTabTitle)
+        return mainWebView().title;
+
+    auto *tabTitle = [m_delegate tabTitleForWebExtensionContext:m_extensionContext->wrapper()];
+    THROW_UNLESS(!tabTitle || [tabTitle isKindOfClass:NSString.class], @"Object returned by tabTitleForWebExtensionContext: is not a string");
+
+    return tabTitle;
+}
+
+bool WebExtensionTab::isSelected() const
+{
+    if (!isValid() || !m_respondsToIsSelected)
+        return false;
+
+    return [m_delegate isSelectedForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+bool WebExtensionTab::isPinned() const
+{
+    if (!isValid() || !m_respondsToIsPinned)
+        return false;
+
+    return [m_delegate isPinnedForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::toggleReaderMode()
+{
+    if (!isValid() || !m_respondsToToggleReaderMode)
+        return;
+
+    [m_delegate toggleReaderModeForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+bool WebExtensionTab::isReaderModeAvailable() const
+{
+    if (!isValid() || !m_respondsToIsReaderModeAvailable)
+        return false;
+
+    return [m_delegate isReaderModeAvailableForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+bool WebExtensionTab::isShowingReaderMode() const
+{
+    if (!isValid() || !m_respondsToIsShowingReaderMode)
+        return false;
+
+    return [m_delegate isShowingReaderModeForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::mute()
+{
+    if (!isValid() || !m_respondsToMute)
+        return;
+
+    [m_delegate muteForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::unmute()
+{
+    if (!isValid() || !m_respondsToUnmute)
+        return;
+
+    [m_delegate unmuteForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+bool WebExtensionTab::isAudible() const
+{
+    if (!isValid() || !m_respondsToIsAudible)
+        return false;
+
+    return [m_delegate isAudibleForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+bool WebExtensionTab::isMuted() const
+{
+    if (!isValid() || !m_respondsToIsMuted)
+        return false;
+
+    return [m_delegate isMutedForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+CGSize WebExtensionTab::size() const
+{
+    if (!isValid() || !m_respondsToSize)
+        return mainWebView().frame.size;
+
+    return [m_delegate sizeForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+double WebExtensionTab::zoomFactor() const
+{
+    if (!isValid() || !m_respondsToZoomFactor)
+        return mainWebView().pageZoom;
+
+    return [m_delegate zoomFactorForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+URL WebExtensionTab::url() const
+{
+    if (!isValid() || !m_respondsToURL)
+        return mainWebView().URL;
+
+    auto *url = [m_delegate urlForWebExtensionContext:m_extensionContext->wrapper()];
+    THROW_UNLESS(!url || [url isKindOfClass:NSURL.class], @"Object returned by urlForWebExtensionContext: is not a URL");
+
+    return url;
+}
+
+URL WebExtensionTab::pendingURL() const
+{
+    if (!isValid() || !m_respondsToPendingURL)
+        return { };
+
+    auto *pendingURL = [m_delegate pendingURLForWebExtensionContext:m_extensionContext->wrapper()];
+    THROW_UNLESS(!pendingURL || [pendingURL isKindOfClass:NSURL.class], @"Object returned by pendingURLForWebExtensionContext: is not a URL");
+
+    return pendingURL;
+}
+
+bool WebExtensionTab::isLoadingComplete() const
+{
+    if (!isValid() || !m_respondsToIsLoadingComplete)
+        return !mainWebView().isLoading;
+
+    return [m_delegate isLoadingCompleteForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::detectWebpageLocale(CompletionHandler<void(NSLocale *)>&& completionHandler)
+{
+    if (!isValid() || !m_respondsToDetectWebpageLocale) {
+        completionHandler(nil);
+        return;
+    }
+
+    [m_delegate detectWebpageLocaleForWebExtensionContext:m_extensionContext->wrapper() completionHandler:^(NSLocale *locale) {
+        THROW_UNLESS(!locale || [locale isKindOfClass:NSLocale.class], @"Object passed to completionHandler of detectWebpageLocaleForWebExtensionContext:completionHandler: is not an NSLocale");
+        completionHandler(locale);
+    }];
+}
+
+void WebExtensionTab::loadURL(URL url)
+{
+    if (!isValid() || !m_respondsToLoadURL) {
+        [mainWebView() loadRequest:[NSURLRequest requestWithURL:url]];
+        return;
+    }
+
+    [m_delegate loadURL:url forWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::reload()
+{
+    if (!isValid() || !m_respondsToReload) {
+        [mainWebView() reload];
+        return;
+    }
+
+    [m_delegate reloadForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::reloadFromOrigin()
+{
+    if (!isValid() || !m_respondsToReloadFromOrigin) {
+        [mainWebView() reloadFromOrigin];
+        return;
+    }
+
+    [m_delegate reloadFromOriginForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::goBack()
+{
+    if (!isValid() || !m_respondsToGoBack) {
+        [mainWebView() goBack];
+        return;
+    }
+
+    [m_delegate goBackForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::goForward()
+{
+    if (!isValid() || !m_respondsToGoForward) {
+        [mainWebView() goForward];
+        return;
+    }
+
+    [m_delegate goForwardForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::close()
+{
+    if (!isValid() || !m_respondsToClose)
+        return;
+
+    [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionTab::select()
+{
+    if (!isValid() || !m_respondsToSelect)
+        return;
+
+    [m_delegate selectForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionWindow.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WebExtensionContext.h"
+#import "_WKWebExtensionTab.h"
+#import "_WKWebExtensionWindow.h"
+
+namespace WebKit {
+
+WebExtensionWindow::WebExtensionWindow(const WebExtensionContext& context, _WKWebExtensionWindow* delegate)
+    : m_identifier(WebExtensionWindowIdentifier::generate())
+    , m_extensionContext(context)
+    , m_delegate(delegate)
+    , m_respondsToTabs([delegate respondsToSelector:@selector(tabsForWebExtensionContext:)])
+    , m_respondsToActiveTab([delegate respondsToSelector:@selector(activeTabForWebExtensionContext:)])
+    , m_respondsToWindowType([delegate respondsToSelector:@selector(windowTypeForWebExtensionContext:)])
+    , m_respondsToWindowState([delegate respondsToSelector:@selector(windowStateForWebExtensionContext:)])
+    , m_respondsToIsEphemeral([delegate respondsToSelector:@selector(isEphemeralForWebExtensionContext:)])
+    , m_respondsToFrame([delegate respondsToSelector:@selector(frameForWebExtensionContext:)])
+{
+    ASSERT([delegate conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
+}
+
+bool WebExtensionWindow::operator==(const WebExtensionWindow& other) const
+{
+    return this == &other || (m_identifier == other.m_identifier && m_extensionContext == other.m_extensionContext && m_delegate.get() == other.m_delegate.get());
+}
+
+WebExtensionWindow::TabVector WebExtensionWindow::tabs() const
+{
+    TabVector result;
+
+    if (!isValid() || !m_respondsToTabs || !m_respondsToActiveTab)
+        return result;
+
+    auto *tabs = [m_delegate tabsForWebExtensionContext:m_extensionContext->wrapper()];
+    THROW_UNLESS([tabs isKindOfClass:NSArray.class], @"Object returned by tabsForWebExtensionContext: is not an array");
+
+    if (!tabs.count)
+        return result;
+
+    result.reserveInitialCapacity(tabs.count);
+
+    for (id<_WKWebExtensionTab> tab in tabs) {
+        THROW_UNLESS([tab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object in array returned by tabsForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
+        result.uncheckedAppend(m_extensionContext->getOrCreateTab(tab));
+    }
+
+    if (auto activeTab = [m_delegate activeTabForWebExtensionContext:m_extensionContext->wrapper()]) {
+        THROW_UNLESS([activeTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by activeTabForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
+        THROW_UNLESS([tabs containsObject:activeTab], @"Array returned by tabsForWebExtensionContext: does not contain the active tab");
+    }
+
+    return result;
+}
+
+RefPtr<WebExtensionTab> WebExtensionWindow::activeTab() const
+{
+    if (!isValid() || !m_respondsToActiveTab || !m_respondsToTabs)
+        return nullptr;
+
+    auto activeTab = [m_delegate activeTabForWebExtensionContext:m_extensionContext->wrapper()];
+    if (!activeTab)
+        return nullptr;
+
+    THROW_UNLESS([activeTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by activeTabForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
+    auto result = m_extensionContext->getOrCreateTab(activeTab);
+
+    auto *tabs = [m_delegate tabsForWebExtensionContext:m_extensionContext->wrapper()];
+    THROW_UNLESS([tabs isKindOfClass:NSArray.class], @"Object returned by tabsForWebExtensionContext: is not an array");
+    THROW_UNLESS([tabs containsObject:activeTab], @"Array returned by tabsForWebExtensionContext: does not contain the active tab");
+
+    return result;
+}
+
+static inline WebExtensionWindow::Type toImpl(_WKWebExtensionWindowType type)
+{
+    switch (type) {
+    case _WKWebExtensionWindowTypeNormal:
+        return WebExtensionWindow::Type::Normal;
+    case _WKWebExtensionWindowTypePopup:
+        return WebExtensionWindow::Type::Popup;
+    }
+
+    ASSERT_NOT_REACHED();
+    return WebExtensionWindow::Type::Normal;
+}
+
+WebExtensionWindow::Type WebExtensionWindow::type() const
+{
+    if (!isValid() || !m_respondsToWindowType)
+        return Type::Normal;
+
+    return toImpl([m_delegate windowTypeForWebExtensionContext:m_extensionContext->wrapper()]);
+}
+
+static inline WebExtensionWindow::State toImpl(_WKWebExtensionWindowState state)
+{
+    switch (state) {
+    case _WKWebExtensionWindowStateNormal:
+        return WebExtensionWindow::State::Normal;
+    case _WKWebExtensionWindowStateMinimized:
+        return WebExtensionWindow::State::Minimized;
+    case _WKWebExtensionWindowStateMaximized:
+        return WebExtensionWindow::State::Maximized;
+    case _WKWebExtensionWindowStateFullscreen:
+        return WebExtensionWindow::State::Fullscreen;
+    }
+
+    ASSERT_NOT_REACHED();
+    return WebExtensionWindow::State::Normal;
+}
+
+WebExtensionWindow::State WebExtensionWindow::state() const
+{
+    if (!isValid() || !m_respondsToWindowState)
+        return State::Normal;
+
+    return toImpl([m_delegate windowStateForWebExtensionContext:m_extensionContext->wrapper()]);
+}
+
+bool WebExtensionWindow::isFocused() const
+{
+    if (!isValid())
+        return false;
+
+    return this == m_extensionContext->focusedWindow();
+}
+
+bool WebExtensionWindow::isEphemeral() const
+{
+    if (!isValid() || !m_respondsToIsEphemeral)
+        return false;
+
+    return [m_delegate isEphemeralForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+CGRect WebExtensionWindow::frame() const
+{
+    if (!isValid() || !m_respondsToFrame)
+        return CGRectZero;
+
+    return [m_delegate frameForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -42,7 +42,11 @@
 #include <wtf/WeakHashSet.h>
 
 OBJC_CLASS NSError;
-OBJC_CLASS _WKWebExtensionController;
+OBJC_PROTOCOL(_WKWebExtensionControllerDelegatePrivate);
+
+#ifdef __OBJC__
+#import "_WKWebExtensionController.h"
+#endif
 
 namespace WebKit {
 
@@ -107,6 +111,7 @@ public:
 
 #ifdef __OBJC__
     _WKWebExtensionController *wrapper() const { return (_WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }
+    _WKWebExtensionControllerDelegatePrivate *delegate() const { return (_WKWebExtensionControllerDelegatePrivate *)wrapper().delegate; }
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "WebExtensionTabIdentifier.h"
+#include <wtf/Forward.h>
+#include <wtf/WeakObjCPtr.h>
+
+OBJC_CLASS NSArray;
+OBJC_CLASS NSLocale;
+OBJC_CLASS WKWebView;
+OBJC_PROTOCOL(_WKWebExtensionTab);
+
+namespace WebKit {
+
+class WebExtensionContext;
+class WebExtensionWindow;
+
+class WebExtensionTab : public RefCounted<WebExtensionTab> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionTab);
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionTab> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionTab(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionTab(const WebExtensionContext&, _WKWebExtensionTab *);
+
+    enum class ChangedProperties : uint16_t {
+        None       = 0,
+        Audible    = 1 << 1,
+        Loading    = 1 << 2,
+        Muted      = 1 << 3,
+        Pinned     = 1 << 4,
+        ReaderMode = 1 << 5,
+        Size       = 1 << 6,
+        Title      = 1 << 7,
+        URL        = 1 << 8,
+        ZoomFactor = 1 << 9,
+        All        = std::numeric_limits<uint16_t>::max(),
+    };
+
+    WebExtensionTabIdentifier identifier() const { return m_identifier; }
+    WebExtensionContext* extensionContext() const { return m_extensionContext.get(); }
+
+    bool operator==(const WebExtensionTab&) const;
+
+    RefPtr<WebExtensionWindow> window() const;
+    RefPtr<WebExtensionTab> parentTab() const;
+
+    WKWebView *mainWebView() const;
+    NSArray *webViews() const;
+
+    String title() const;
+
+    bool isSelected() const;
+    bool isPinned() const;
+
+    void toggleReaderMode();
+
+    bool isReaderModeAvailable() const;
+    bool isShowingReaderMode() const;
+
+    void mute();
+    void unmute();
+
+    bool isAudible() const;
+    bool isMuted() const;
+
+    CGSize size() const;
+    double zoomFactor() const;
+
+    URL url() const;
+    URL pendingURL() const;
+
+    bool isLoadingComplete() const;
+
+    void detectWebpageLocale(CompletionHandler<void(NSLocale *)>&&);
+
+    void loadURL(URL);
+
+    void reload();
+    void reloadFromOrigin();
+
+    void goBack();
+    void goForward();
+
+    void close();
+    void select();
+
+#ifdef __OBJC__
+    _WKWebExtensionTab *delegate() const { return m_delegate.getAutoreleased(); }
+
+    bool isValid() const { return m_extensionContext && m_delegate; }
+#endif
+
+private:
+    WebExtensionTabIdentifier m_identifier;
+    WeakPtr<WebExtensionContext> m_extensionContext;
+    WeakObjCPtr<_WKWebExtensionTab> m_delegate;
+    bool m_respondsToWindow : 1 { false };
+    bool m_respondsToParentTab : 1 { false };
+    bool m_respondsToMainWebView : 1 { false };
+    bool m_respondsToWebViews : 1 { false };
+    bool m_respondsToTabTitle : 1 { false };
+    bool m_respondsToIsSelected : 1 { false };
+    bool m_respondsToIsPinned : 1 { false };
+    bool m_respondsToIsEphemeral : 1 { false };
+    bool m_respondsToIsReaderModeAvailable : 1 { false };
+    bool m_respondsToIsShowingReaderMode : 1 { false };
+    bool m_respondsToToggleReaderMode : 1 { false };
+    bool m_respondsToIsAudible : 1 { false };
+    bool m_respondsToIsMuted : 1 { false };
+    bool m_respondsToMute : 1 { false };
+    bool m_respondsToUnmute : 1 { false };
+    bool m_respondsToSize : 1 { false };
+    bool m_respondsToZoomFactor : 1 { false };
+    bool m_respondsToURL : 1 { false };
+    bool m_respondsToPendingURL : 1 { false };
+    bool m_respondsToIsLoadingComplete : 1 { false };
+    bool m_respondsToDetectWebpageLocale : 1 { false };
+    bool m_respondsToLoadURL : 1 { false };
+    bool m_respondsToReload : 1 { false };
+    bool m_respondsToReloadFromOrigin : 1 { false };
+    bool m_respondsToGoBack : 1 { false };
+    bool m_respondsToGoForward : 1 { false };
+    bool m_respondsToClose : 1 { false };
+    bool m_respondsToSelect : 1 { false };
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "WebExtensionWindowIdentifier.h"
+#include <wtf/Forward.h>
+#include <wtf/WeakObjCPtr.h>
+
+OBJC_PROTOCOL(_WKWebExtensionWindow);
+
+namespace WebKit {
+
+class WebExtensionContext;
+class WebExtensionTab;
+
+class WebExtensionWindow : public RefCounted<WebExtensionWindow> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionWindow> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionWindow(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionWindow(const WebExtensionContext&, _WKWebExtensionWindow*);
+
+    enum class Type : bool {
+        Normal,
+        Popup,
+    };
+
+    enum class State : uint8_t {
+        Normal,
+        Minimized,
+        Maximized,
+        Fullscreen,
+    };
+
+    using TabVector = Vector<Ref<WebExtensionTab>>;
+
+    WebExtensionWindowIdentifier identifier() const { return m_identifier; }
+    WebExtensionContext* extensionContext() const { return m_extensionContext.get(); }
+
+    bool operator==(const WebExtensionWindow&) const;
+
+    TabVector tabs() const;
+    RefPtr<WebExtensionTab> activeTab() const;
+
+    Type type() const;
+    State state() const;
+
+    bool isFocused() const;
+    bool isEphemeral() const;
+
+    CGRect frame() const;
+
+#ifdef __OBJC__
+    _WKWebExtensionWindow *delegate() const { return m_delegate.getAutoreleased(); }
+
+    bool isValid() const { return m_extensionContext && m_delegate; }
+#endif
+
+private:
+    WebExtensionWindowIdentifier m_identifier;
+    WeakPtr<WebExtensionContext> m_extensionContext;
+    WeakObjCPtr<_WKWebExtensionWindow> m_delegate;
+    bool m_respondsToTabs : 1 { false };
+    bool m_respondsToActiveTab : 1 { false };
+    bool m_respondsToWindowType : 1 { false };
+    bool m_respondsToWindowState : 1 { false };
+    bool m_respondsToIsEphemeral : 1 { false };
+    bool m_respondsToFrame : 1 { false };
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -449,6 +449,12 @@
 		1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C62900D28EE2CD300C26B60 /* CoreSVGSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C62900C28EE2CD300C26B60 /* CoreSVGSPI.h */; };
 		1C62900F28EF4A1D00C26B60 /* FoundationSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C62900E28EF4A1D00C26B60 /* FoundationSPI.h */; };
+		1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */; };
+		1C66BDDB2A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDD92A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h */; };
+		1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */; };
+		1C66BDDE2A8AEADE009D4452 /* WebExtensionWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */; };
+		1C66BDE12A8C2830009D4452 /* WebExtensionWindowCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C66BDE22A8C2830009D4452 /* WebExtensionTabCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C891D6619B124FF00BA79DD /* WebInspectorUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C891D6319B124FF00BA79DD /* WebInspectorUI.h */; };
 		1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C8E28201275D15400BC7BD0 /* WebInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E281E1275D15400BC7BD0 /* WebInspector.h */; };
@@ -3475,6 +3481,12 @@
 		1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaHelpers.mm; sourceTree = "<group>"; };
 		1C62900C28EE2CD300C26B60 /* CoreSVGSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreSVGSPI.h; sourceTree = "<group>"; };
 		1C62900E28EF4A1D00C26B60 /* FoundationSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FoundationSPI.h; sourceTree = "<group>"; };
+		1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionTab.h; sourceTree = "<group>"; };
+		1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionTabIdentifier.h; sourceTree = "<group>"; };
+		1C66BDD92A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionWindowIdentifier.h; sourceTree = "<group>"; };
+		1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionWindow.h; sourceTree = "<group>"; };
+		1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionWindowCocoa.mm; sourceTree = "<group>"; };
+		1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionTabCocoa.mm; sourceTree = "<group>"; };
 		1C739E852347BCF600C621EC /* CoreTextHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreTextHelpers.mm; sourceTree = "<group>"; };
 		1C739E872347BD0F00C621EC /* CoreTextHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreTextHelpers.h; sourceTree = "<group>"; };
 		1C77C1951288A872006A742F /* WebInspectorUIProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUIProxy.messages.in; sourceTree = "<group>"; };
@@ -8589,7 +8601,9 @@
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
 				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
+				1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */,
 				1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */,
+				1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */,
 			);
 			path = Cocoa;
 			sourceTree = "<group>";
@@ -9004,7 +9018,9 @@
 				1C1549CF293817FE001B9E5B /* WebExtensionControllerConfiguration.cpp */,
 				1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */,
 				1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */,
+				1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */,
 				1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */,
+				1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -11895,6 +11911,8 @@
 				1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */,
 				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
 				8696CE2F297EB3C90081C800 /* WebExtensionEventListenerType.serialization.in */,
+				1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */,
+				1C66BDD92A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -14893,7 +14911,11 @@
 				1C3BEB7D2888A01600E66E38 /* WebExtensionControllerProxy.h in Headers */,
 				1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */,
 				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
+				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
+				1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */,
 				1CAB9B8728F746AA00E6C77E /* WebExtensionURLSchemeHandler.h in Headers */,
+				1C66BDDE2A8AEADE009D4452 /* WebExtensionWindow.h in Headers */,
+				1C66BDDB2A8ADB8A009D4452 /* WebExtensionWindowIdentifier.h in Headers */,
 				9354242C2703BDCB005CA72C /* WebFileSystemStorageConnection.h in Headers */,
 				93E799882756FAC20074008A /* WebFileSystemStorageConnectionMessages.h in Headers */,
 				1A90C1EE1264FD50003E44D4 /* WebFindOptions.h in Headers */,
@@ -17375,7 +17397,9 @@
 				1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,
+				1C66BDE22A8C2830009D4452 /* WebExtensionTabCocoa.mm in Sources */,
 				1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */,
+				1C66BDE12A8C2830009D4452 /* WebExtensionWindowCocoa.mm in Sources */,
 				93E799852756FA550074008A /* WebFileSystemStorageConnectionMessageReceiver.cpp in Sources */,
 				CD73BA4E131ACDB700EEDED2 /* WebFullScreenManagerMessageReceiver.cpp in Sources */,
 				CD73BA47131ACC9A00EEDED2 /* WebFullScreenManagerProxyMessageReceiver.cpp in Sources */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -297,7 +297,9 @@ Tests/WebKitCocoa/WKWebExtensionContext.mm
 Tests/WebKitCocoa/WKWebExtensionController.mm
 Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
 Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+Tests/WebKitCocoa/WKWebExtensionTab.mm
 Tests/WebKitCocoa/WKWebExtensionUtilities.mm
+Tests/WebKitCocoa/WKWebExtensionWindow.mm
 Tests/WebKitCocoa/WKWebViewAlwaysShowsScroller.mm
 Tests/WebKitCocoa/WKWebViewCandidateTests.mm
 Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2070,6 +2070,8 @@
 		1C46169E26BA510700F8C9F6 /* TextStreamCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextStreamCocoa.mm; sourceTree = "<group>"; };
 		1C4616A626BB172F00F8C9F6 /* TextStreamCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextStreamCocoa.cpp; sourceTree = "<group>"; };
 		1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = UserInstalledAhem.html; sourceTree = "<group>"; };
+		1C66BDE32A8D838A009D4452 /* WKWebExtensionWindow.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionWindow.mm; sourceTree = "<group>"; };
+		1C66BDEB2A8E81CB009D4452 /* WKWebExtensionTab.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionTab.mm; sourceTree = "<group>"; };
 		1C734B5220788C4800F430EA /* SystemColors.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemColors.mm; sourceTree = "<group>"; };
 		1C79201B234BDD9B001EAF23 /* CopyRTF.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CopyRTF.mm; sourceTree = "<group>"; };
 		1C7FEB1F207C0F2D00D23278 /* BackgroundColor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BackgroundColor.mm; sourceTree = "<group>"; };
@@ -4198,7 +4200,9 @@
 				1CAB9B7128F5E08900E6C77E /* WKWebExtensionController.mm */,
 				1C1549DA293A6D7F001B9E5B /* WKWebExtensionControllerConfiguration.mm */,
 				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
+				1C66BDEB2A8E81CB009D4452 /* WKWebExtensionTab.mm */,
 				339B4338294BA9A10050A7CF /* WKWebExtensionUtilities.mm */,
+				1C66BDE32A8D838A009D4452 /* WKWebExtensionWindow.mm */,
 				5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */,
 				371195AA1FE5797700A1FB92 /* WKWebViewAlwaysShowsScroller.mm */,
 				2EFF06D61D8AF34A0004BB30 /* WKWebViewCandidateTests.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionTab.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionTab.mm
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import "TestWebExtensionsDelegate.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionContextPrivate.h>
+#import <WebKit/_WKWebExtensionMatchPatternPrivate.h>
+#import <WebKit/_WKWebExtensionPermission.h>
+#import <WebKit/_WKWebExtensionPrivate.h>
+
+@interface TestTab : NSObject <_WKWebExtensionTab>
+@end
+
+@implementation TestTab
+@end
+
+@interface TestWindowForTabs : NSObject <_WKWebExtensionWindow>
+
+@property (nonatomic, copy) NSArray<id<_WKWebExtensionTab>> *tabs;
+
+@end
+
+@implementation TestWindowForTabs
+- (NSArray<id<_WKWebExtensionTab>> *)tabsForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _tabs;
+}
+
+- (id<_WKWebExtensionTab>)activeTabForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _tabs.firstObject;
+}
+@end
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionTab, OpenTabs)
+{
+    auto testExtensionOne = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    auto testContextOne = adoptNS([[_WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
+
+    auto testExtensionTwo = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    auto testContextTwo = adoptNS([[_WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
+
+    auto testWindowOne = adoptNS([[TestWindowForTabs alloc] init]);
+    auto testWindowTwo = adoptNS([[TestWindowForTabs alloc] init]);
+
+    auto testTabOne = adoptNS([[TestTab alloc] init]);
+    auto testTabTwo = adoptNS([[TestTab alloc] init]);
+    auto testTabThree = adoptNS([[TestTab alloc] init]);
+    auto testTabFour = adoptNS([[TestTab alloc] init]);
+
+    testWindowOne.get().tabs = @[ testTabOne.get() ];
+    testWindowTwo.get().tabs = @[ testTabTwo.get(), testTabThree.get() ];
+
+    auto controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+
+    controllerDelegate.get().openWindows = ^NSArray<id<_WKWebExtensionWindow>> *(_WKWebExtensionContext *context) {
+        return @[ testWindowOne.get(), testWindowTwo.get() ];
+    };
+
+    auto testController = adoptNS([[_WKWebExtensionController alloc] init]);
+    testController.get().delegate = controllerDelegate.get();
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, [NSSet set]);
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, [NSSet set]);
+
+    [testController loadExtensionContext:testContextOne.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, [NSSet set]);
+
+    [testController loadExtensionContext:testContextTwo.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), nil]));
+
+    [testContextOne didOpenTab:testTabFour.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), nil]));
+
+    testWindowTwo.get().tabs = @[ testTabTwo.get(), testTabThree.get(), testTabFour.get() ];
+    [testContextTwo didOpenTab:testTabFour.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+
+    testWindowOne.get().tabs = @[ ];
+    [testController didCloseTab:testTabOne.get() windowIsClosing:NO];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+
+    [testController unloadExtensionContext:testContextOne.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+
+    testWindowOne.get().tabs = @[ testTabOne.get() ];
+    [testController didOpenTab:testTabOne.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabOne.get(), testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+
+    [testController didCloseWindow:testWindowOne.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+
+    [testController didCloseWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openTabs, ([NSSet setWithObjects:testTabTwo.get(), testTabThree.get(), testTabFour.get(), nil]));
+    EXPECT_NS_EQUAL(testContextTwo.get().openTabs, [NSSet set]);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionWindow.mm
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestCocoa.h"
+#import "TestWebExtensionsDelegate.h"
+#import <WebKit/WKFoundation.h>
+#import <WebKit/_WKWebExtensionContextPrivate.h>
+#import <WebKit/_WKWebExtensionMatchPatternPrivate.h>
+#import <WebKit/_WKWebExtensionPermission.h>
+#import <WebKit/_WKWebExtensionPrivate.h>
+
+@interface TestWindow : NSObject <_WKWebExtensionWindow>
+@end
+
+@implementation TestWindow
+@end
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionWindow, OpenWindows)
+{
+    auto testExtensionOne = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    auto testContextOne = adoptNS([[_WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
+
+    auto testExtensionTwo = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    auto testContextTwo = adoptNS([[_WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
+
+    auto testWindowOne = adoptNS([[TestWindow alloc] init]);
+    auto testWindowTwo = adoptNS([[TestWindow alloc] init]);
+
+    auto *openWindows = @[ testWindowOne.get(), testWindowTwo.get() ];
+    auto *reversedOpenWindows = @[ testWindowTwo.get(), testWindowOne.get() ];
+
+    auto controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+
+    controllerDelegate.get().openWindows = ^NSArray<id<_WKWebExtensionWindow>> *(_WKWebExtensionContext *context) {
+        return context == testContextOne ? openWindows : reversedOpenWindows;
+    };
+
+    auto testController = adoptNS([[_WKWebExtensionController alloc] init]);
+    testController.get().delegate = controllerDelegate.get();
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, @[ ]);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, @[ ]);
+
+    [testController loadExtensionContext:testContextOne.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, @[ ]);
+
+    [testController loadExtensionContext:testContextTwo.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
+
+    [testContextOne didFocusWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, reversedOpenWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
+
+    [testContextOne didFocusWindow:testWindowOne.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
+
+    [testController didFocusWindow:testWindowOne.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, openWindows);
+
+    [testController unloadExtensionContext:testContextOne.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, openWindows);
+
+    [testController didFocusWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
+
+    [testController didCloseWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, @[ testWindowOne.get() ]);
+
+    [testController didOpenWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().openWindows, openWindows);
+    EXPECT_NS_EQUAL(testContextTwo.get().openWindows, reversedOpenWindows);
+}
+
+TEST(WKWebExtensionWindow, FocusedWindow)
+{
+    auto testExtensionOne = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    auto testContextOne = adoptNS([[_WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
+
+    auto testExtensionTwo = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    auto testContextTwo = adoptNS([[_WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
+
+    auto testWindowOne = adoptNS([[TestWindow alloc] init]);
+    auto testWindowTwo = adoptNS([[TestWindow alloc] init]);
+
+    auto controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+
+    controllerDelegate.get().openWindows = ^NSArray<id<_WKWebExtensionWindow>> *(_WKWebExtensionContext *context) {
+        return @[ testWindowOne.get(), testWindowTwo.get() ];
+    };
+
+    controllerDelegate.get().focusedWindow = ^id<_WKWebExtensionWindow> (_WKWebExtensionContext *context) {
+        return context == testContextOne ? testWindowTwo.get() : nil;
+    };
+
+    auto testController = adoptNS([[_WKWebExtensionController alloc] init]);
+    testController.get().delegate = controllerDelegate.get();
+
+    EXPECT_NULL(testContextOne.get().focusedWindow);
+    EXPECT_NULL(testContextTwo.get().focusedWindow);
+
+    [testController loadExtensionContext:testContextOne.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowTwo.get());
+    EXPECT_NULL(testContextTwo.get().focusedWindow);
+
+    [testController loadExtensionContext:testContextTwo.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowTwo.get());
+    EXPECT_NULL(testContextTwo.get().focusedWindow);
+
+    [testContextOne didFocusWindow:testWindowOne.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NULL(testContextTwo.get().focusedWindow);
+
+    [testContextOne didFocusWindow:nil];
+
+    EXPECT_NULL(testContextOne.get().focusedWindow);
+    EXPECT_NULL(testContextTwo.get().focusedWindow);
+
+    [testController didFocusWindow:testWindowOne.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NS_EQUAL(testContextTwo.get().focusedWindow, testWindowOne.get());
+
+    [testController unloadExtensionContext:testContextOne.get() error:nullptr];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NS_EQUAL(testContextTwo.get().focusedWindow, testWindowOne.get());
+
+    [testController didFocusWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NS_EQUAL(testContextTwo.get().focusedWindow, testWindowTwo.get());
+
+    [testController didCloseWindow:testWindowTwo.get()];
+
+    EXPECT_NS_EQUAL(testContextOne.get().focusedWindow, testWindowOne.get());
+    EXPECT_NULL(testContextTwo.get().focusedWindow);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -26,7 +26,9 @@
 #import "config.h"
 
 #import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestProtocol.h"
 #import "TestUIDelegate.h"

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -34,7 +34,23 @@
 
 @implementation TestWebExtensionsDelegate
 
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler
+- (NSArray<id<_WKWebExtensionWindow>> *)webExtensionController:(_WKWebExtensionController *)controller openWindowsForExtensionContext:(_WKWebExtensionContext *)extensionContext
+{
+    if (_openWindows)
+        return _openWindows(extensionContext);
+
+    return @[ ];
+}
+
+- (id<_WKWebExtensionWindow>)webExtensionController:(_WKWebExtensionController *)controller focusedWindowForExtensionContext:(_WKWebExtensionContext *)extensionContext
+{
+    if (_focusedWindow)
+        return _focusedWindow(extensionContext);
+
+    return nil;
+}
+
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler
 {
     if (_promptForPermissions)
         _promptForPermissions(tab, permissions, completionHandler);
@@ -42,7 +58,7 @@
         completionHandler(permissions);
 }
 
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler
 {
     if (_promptForPermissionMatchPatterns)
         _promptForPermissionMatchPatterns(tab, matchPatterns, completionHandler);


### PR DESCRIPTION
#### fd7774b7dda952470cd5dfed81eb97f08ca8cdbb
<pre>
Add initial support for _WKWebExtensionWindow and _WKWebExtensionTab APIs to _WKWebExtensionController and _WkWebExtensionContext.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260156">https://bugs.webkit.org/show_bug.cgi?id=260156</a>

Reviewed by Brian Weinstein.

Implements the main window and tab management APIs on _WKWebExtensionController and _WkWebExtensionContext for tracking open windows,
tabs and the focused window. Also corrects some missing nullability attributes on some methods and properties.

Added new WKWebExtensionWindow and WKWebExtensionTab tests for some of these APIs.

* Source/WTF/wtf/WeakObjCPtr.h:
(WTF::WeakObjCPtr::operator! const): Made one line.
(WTF::WeakObjCPtr::operator bool const): Added.
* Source/WebKit/Platform/cocoa/CocoaHelpers.h: Added THROW_UNLESS macro.
* Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h: Added.
* Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext openWindows]): Added.
(-[_WKWebExtensionContext focusedWindow]): Added.
(-[_WKWebExtensionContext openTabs]): Added.
(-[_WKWebExtensionContext didOpenWindow:]): Added.
(-[_WKWebExtensionContext didCloseWindow:]): Added.
(-[_WKWebExtensionContext didFocusWindow:]): Added.
(-[_WKWebExtensionContext didOpenTab:]): Added.
(-[_WKWebExtensionContext didCloseTab:windowIsClosing:]): Added.
(-[_WKWebExtensionContext didSelectTabs:]): Added.
(-[_WKWebExtensionContext didMoveTab:fromIndex:inWindow:]): Added.
(-[_WKWebExtensionContext didReplaceTab:withTab:]): Added.
(-[_WKWebExtensionContext didChangeTabProperties:forTab:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController extensions]): Stop using a variable here.
(-[_WKWebExtensionController didOpenWindow:]): Added.
(-[_WKWebExtensionController didCloseWindow:]): Added.
(-[_WKWebExtensionController didFocusWindow:]): Added.
(-[_WKWebExtensionController didOpenTab:]): Added.
(-[_WKWebExtensionController didCloseTab:windowIsClosing:]): Added.
(-[_WKWebExtensionController didSelectTabs:]): Added.
(-[_WKWebExtensionController didMoveTab:fromIndex:inWindow:]): Added.
(-[_WKWebExtensionController didReplaceTab:withTab:]): Added.
(-[_WKWebExtensionController didChangeTabProperties:forTab:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm:
(WebKit::WebExtensionContext::testResult): Use new delegate getter for cleaner approch.
(WebKit::WebExtensionContext::testEqual): Ditto.
(WebKit::WebExtensionContext::testMessage): Ditto.
(WebKit::WebExtensionContext::testYielded): Ditto.
(WebKit::WebExtensionContext::testFinished): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load): Call populateWindowsAndTabs().
(WebKit::WebExtensionContext::getOrCreateWindow): Added.
(WebKit::WebExtensionContext::getWindow): Added.
(WebKit::WebExtensionContext::getOrCreateTab): Added.
(WebKit::WebExtensionContext::getTab): Added.
(WebKit::WebExtensionContext::populateWindowsAndTabs): Added.
(WebKit::WebExtensionContext::openWindows): Added.
(WebKit::WebExtensionContext::openTabs): Added.
(WebKit::WebExtensionContext::focusedWindow): Added.
(WebKit::WebExtensionContext::didOpenWindow): Added.
(WebKit::WebExtensionContext::didCloseWindow): Added.
(WebKit::WebExtensionContext::didFocusWindow): Added.
(WebKit::WebExtensionContext::didOpenTab): Added.
(WebKit::WebExtensionContext::didCloseTab): Added.
(WebKit::WebExtensionContext::didSelectTab): Added.
(WebKit::WebExtensionContext::didMoveTab): Added.
(WebKit::WebExtensionContext::didReplaceTab): Added.
(WebKit::WebExtensionContext::didChangeTabProperties): Added.
(WebKit::WebExtensionContext::webViewConfiguration):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm: Added.
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::window const):
(WebKit::WebExtensionTab::parentTab const):
(WebKit::WebExtensionTab::mainWebView const):
(WebKit::WebExtensionTab::webViews const):
(WebKit::WebExtensionTab::title const):
(WebKit::WebExtensionTab::isSelected const):
(WebKit::WebExtensionTab::isPinned const):
(WebKit::WebExtensionTab::toggleReaderMode):
(WebKit::WebExtensionTab::isReaderModeAvailable const):
(WebKit::WebExtensionTab::isShowingReaderMode const):
(WebKit::WebExtensionTab::mute):
(WebKit::WebExtensionTab::unmute):
(WebKit::WebExtensionTab::isAudible const):
(WebKit::WebExtensionTab::isMuted const):
(WebKit::WebExtensionTab::size const):
(WebKit::WebExtensionTab::zoomFactor const):
(WebKit::WebExtensionTab::url const):
(WebKit::WebExtensionTab::pendingURL const):
(WebKit::WebExtensionTab::isLoadingComplete const):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::reloadFromOrigin):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::close):
(WebKit::WebExtensionTab::select):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm: Added.
(WebKit::WebExtensionWindow::WebExtensionWindow):
(WebKit::WebExtensionWindow::operator== const):
(WebKit::WebExtensionWindow::tabs const):
(WebKit::WebExtensionWindow::activeTab const):
(WebKit::toImpl):
(WebKit::WebExtensionWindow::type const):
(WebKit::WebExtensionWindow::state const):
(WebKit::WebExtensionWindow::isFocused const):
(WebKit::WebExtensionWindow::isEphemeral const):
(WebKit::WebExtensionWindow::frame const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::didChangeTabProperties):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::delegate const):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h: Added.
(WebKit::WebExtensionTab::create):
(WebKit::WebExtensionTab::identifier const):
(WebKit::WebExtensionTab::extensionContext const):
(WebKit::WebExtensionTab::delegate const):
(WebKit::WebExtensionTab::isValid const):
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h: Added.
(WebKit::WebExtensionWindow::create):
(WebKit::WebExtensionWindow::identifier const):
(WebKit::WebExtensionWindow::extensionContext const):
(WebKit::WebExtensionWindow::delegate const):
(WebKit::WebExtensionWindow::isValid const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionTab.mm: Added.
(-[TestWindowForTabs tabsForWebExtensionContext:]):
(-[TestWindowForTabs activeTabForWebExtensionContext:]):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionWindow.mm: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm: Fix build by including missing headers.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:openWindowsForExtensionContext:]):
(-[TestWebExtensionsDelegate webExtensionController:focusedWindowForExtensionContext:]):

Canonical link: <a href="https://commits.webkit.org/267104@main">https://commits.webkit.org/267104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8a8b01d2f34657cbebc45f612c6cbde7e32d6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15671 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16080 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18174 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13593 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14145 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13465 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17570 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14914 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12636 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15862 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14157 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3990 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18521 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/16101 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1910 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14722 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3799 "Passed tests") | 
<!--EWS-Status-Bubble-End-->