### PR TITLE
CSS Custom Highlights sometimes does not repaint when live ranges are changed

### DIFF
--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -131,6 +131,7 @@ ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
     updateAssociatedSelection();
     updateDocument();
     m_didChangeHighlight = true;
+    m_ownerDocument->updateHighlightPositions();
     return { };
 }
 
@@ -146,6 +147,7 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
     updateAssociatedSelection();
     updateDocument();
     m_didChangeHighlight = true;
+    m_ownerDocument->updateHighlightPositions();
     return { };
 }
 


### PR DESCRIPTION
#### 2dc62c758a31ec48e4656a0903c1c79e759e7ea9
<pre>
CSS Custom Highlights sometimes does not repaint when live ranges are changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=259897">https://bugs.webkit.org/show_bug.cgi?id=259897</a>
rdar://113518997

Reviewed by NOBODY (OOPS!).

[In-Progress Patch]
A page is not aware when a live range is changed, so we never trigger a repaint when live ranges are changed.

The main idea is to repaint the old range, then repaint the new range, similar to Selection which is working as expected.
However, Selection is singular with one range while custom highlights and ranges are a &quot;many to many&quot; relationship.
A range can belong to multiple highlights and a highlight can have multiple ranges.

In this tentative solution, we manually call updateHighlightPositions() whenever a ranges&apos; endpoints are set, which then calls repaint on the old range,
set the range to its new positions, and calls repaint on the new range.
If a range&apos;s start and end is set, we will repaint four times (oldSetStartRange, newSetStartRange, oldSetEndRange, newSetEndRange).
For this case, it is better to wait until both points are set to do call repaint (oldRange, newRange).
Unfortunately, since one can set the start only or end only, this &quot;problem&quot; remains unresolved.

A better, more correct solution to the tentative solution is to:
1. Check if the range that is changing belongs to a highlight, since ranges are not highlight-specific.
2. If range belongs to highlight, remember the old range and the new range after it is done being set.
3. Then, signal to the page that there are dirty ranges and we should repaint.

This better, more correct solution is tricky to implement as ranges are set in Range (DOM based), which has no information or knowledge about highlights.
In addition, Range should NOT have information about highlights because a range can belong/be associated with anything, not only highlights.

updateHighlightPositions() belongs in Document (DOM based), and Document does store information about highlights and Page.
The ranges associated with highlights are stored as HighlightRangeData (DOM based) which contains an AbstractRange (DOM based).
- AbstractRange can be static or live ranges.

In the Selection case, SelectionRangeData is a HighlightData.
HighlightData (Render based) is where we would add the logic for repainting old and new ranges.
Given this, a HighlightRangeData should inherit from HighlightData so ranges of highlights can repaint.

Somehow, we should be able to communicate that a highlight range is dirty to the page, which should call HighlightData::repaint()?

* Source/WebCore/dom/Document.cpp:
(WebCore::repaintingRange):
(WebCore::Document::updateHighlightPositions):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::setStart):
(WebCore::Range::setEnd):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dc62c758a31ec48e4656a0903c1c79e759e7ea9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17033 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17882 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20832 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17318 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12399 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->