### PR TITLE
[inert][iOS] Can't scroll element after inert attribute has been removed

### DIFF
--- a/LayoutTests/fast/scrolling/ios/overflow-scroll-after-inert-change-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/overflow-scroll-after-inert-change-expected.txt
@@ -1,0 +1,20 @@
+Tests that toggling `inert` doesn't prevent scrolling.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.scrollY is 0
+PASS outerScrollElement.scrollTop is 0
+PASS innerScrollElement.scrollTop is 0
+Setting pointer-events: none through inert.
+PASS window.scrollY is non-zero.
+PASS outerScrollElement.scrollTop is 0
+PASS innerScrollElement.scrollTop is 0
+Removing pointer-events: none by removing inert.
+PASS window.scrollY is 0
+PASS outerScrollElement.scrollTop is 0
+PASS innerScrollElement.scrollTop is non-zero.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/overflow-scroll-after-inert-change.html
+++ b/LayoutTests/fast/scrolling/ios/overflow-scroll-after-inert-change.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/basic-gestures.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.outer-scroll { height: 100vh; }
+.inner-scroll { height: 100vh; overflow-y: auto; }
+.box { height: 100vh; }
+</style>
+<script>
+window.jsTestIsAsync = true;
+
+async function runTest() {
+    if (!window.testRunner) {
+        finishJSTest();
+        return;
+    }
+
+    description("Tests that toggling `inert` doesn't prevent scrolling.");
+
+    globalThis.outerScrollElement = document.querySelector(".outer-scroll");
+    globalThis.innerScrollElement = document.querySelector(".inner-scroll");
+
+    let scrollStartX = outerScrollElement.offsetLeft + (outerScrollElement.offsetWidth / 2);
+    let scrollStartY = outerScrollElement.offsetTop + (outerScrollElement.offsetHeight / 2) + 50;
+    let scrollEndX = scrollStartX;
+    let scrollEndY = scrollStartY - 100;
+
+    shouldBeZero("window.scrollY");
+    shouldBeZero("outerScrollElement.scrollTop");
+    shouldBeZero("innerScrollElement.scrollTop");
+
+    debug("Setting pointer-events: none through inert.");
+    outerScrollElement.inert = true;
+    await UIHelper.renderingUpdate();
+    await touchAndDragFromPointToPoint(scrollStartX, scrollStartY, scrollEndX, scrollEndY);
+    await liftUpAtPoint(scrollEndX, scrollEndY);
+    shouldBeNonZero("window.scrollY");
+    shouldBeZero("outerScrollElement.scrollTop");
+    shouldBeZero("innerScrollElement.scrollTop");
+
+    await UIHelper.immediateScrollTo(0, 0);
+
+    debug("Removing pointer-events: none by removing inert.");
+    outerScrollElement.inert = false;
+    await UIHelper.renderingUpdate();
+    await touchAndDragFromPointToPoint(scrollStartX, scrollStartY, scrollEndX, scrollEndY);
+    await liftUpAtPoint(scrollEndX, scrollEndY);
+    shouldBeZero("window.scrollY");
+    shouldBeZero("outerScrollElement.scrollTop");
+    shouldBeNonZero("innerScrollElement.scrollTop");
+
+    finishJSTest();
+}
+</script>
+<body onload="runTest()">
+    <div class="outer-scroll">
+        <div class="inner-scroll">
+            <div class="box" style="background-color: red;"></div>
+            <div class="box" style="background-color: green;"></div>
+            <div class="box" style="background-color: blue;"></div>
+        </div>
+    </div>
+    <p id="description"></p>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1216,7 +1216,8 @@ static bool rareDataChangeRequiresRepaint(const StyleRareNonInheritedData& first
 
 static bool rareInheritedDataChangeRequiresRepaint(const StyleRareInheritedData& first, const StyleRareInheritedData& second)
 {
-    return first.userModify != second.userModify
+    return first.effectiveInert != second.effectiveInert
+        || first.userModify != second.userModify
         || first.userSelect != second.userSelect
         || first.appleColorFilter != second.appleColorFilter
         || first.imageRendering != second.imageRendering
@@ -1360,6 +1361,9 @@ bool RenderStyle::changeRequiresRecompositeLayer(const RenderStyle& other, Optio
             || m_nonInheritedData->rareData->overscrollBehaviorY != other.m_nonInheritedData->rareData->overscrollBehaviorY)
             return true;
     }
+
+    if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr() && m_rareInheritedData->effectiveInert != other.m_rareInheritedData->effectiveInert)
+        return true;
 
     return false;
 }


### PR DESCRIPTION
#### cd37141f0b593a94350acf162e5f527a54568ae9
<pre>
[inert][iOS] Can&apos;t scroll element after inert attribute has been removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=259684">https://bugs.webkit.org/show_bug.cgi?id=259684</a>
rdar://113239461

Reviewed by Wenson Hsieh.

inert use the same invalidation as pointer-events / user-select as effectivePointerEvents / effectiveUserSelect both read effectiveInert.

* LayoutTests/fast/scrolling/ios/overflow-scroll-after-inert-change-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/overflow-scroll-after-inert-change.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareInheritedDataChangeRequiresRepaint):
(WebCore::RenderStyle::changeRequiresRecompositeLayer const):

Canonical link: <a href="https://commits.webkit.org/267030@main">https://commits.webkit.org/267030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eb918fc0aabe32ea7ed759e34b1a4ca5ca5b664

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17931 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13923 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14666 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13771 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3706 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->