### PR TITLE
Add WKUserScriptCreate with all parameters available.

### DIFF
--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -89,6 +89,7 @@ list(APPEND WebKit_SOURCES
     UIProcess/WebMemoryPressureHandler.cpp
     UIProcess/WebViewportAttributes.cpp
 
+    UIProcess/API/C/WKUserScriptRef.cpp
     UIProcess/API/C/WKViewportAttributes.cpp
 
     UIProcess/API/C/curl/WKProtectionSpaceCurl.cpp

--- a/Source/WebKit/UIProcess/API/C/WKUserScriptRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserScriptRef.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WKUserScriptRef.h"
 
+#include "APIArray.h"
 #include "APIUserScript.h"
 #include "WKAPICast.h"
 
@@ -34,6 +35,16 @@ using namespace WebKit;
 WKTypeID WKUserScriptGetTypeID()
 {
     return toAPI(API::UserScript::APIType);
+}
+
+WKUserScriptRef WKUserScriptCreate(WKStringRef sourceRef, WKURLRef url, WKArrayRef includeURLPatterns, WKArrayRef excludeURLPatterns, _WKUserScriptInjectionTime injectionTime, bool forMainFrameOnly)
+{
+    auto baseURLString = toWTFString(url);
+    auto allowlist = toImpl(includeURLPatterns);
+    auto blocklist = toImpl(excludeURLPatterns);
+
+    auto baseURL = baseURLString.isEmpty() ? aboutBlankURL() : URL(URL(), baseURLString);
+    return toAPI(&API::UserScript::create(WebCore::UserScript { toWTFString(sourceRef), WTFMove(baseURL), allowlist ? allowlist->toStringVector() : Vector<String>(), blocklist ? blocklist->toStringVector() : Vector<String>(), toUserScriptInjectionTime(injectionTime), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::WaitForNotificationBeforeInjecting::No }, API::ContentWorld::pageContentWorld()).leakRef());
 }
 
 WKUserScriptRef WKUserScriptCreateWithSource(WKStringRef sourceRef, _WKUserScriptInjectionTime injectionTime, bool forMainFrameOnly)

--- a/Source/WebKit/UIProcess/API/C/WKUserScriptRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKUserScriptRef.h
@@ -35,6 +35,7 @@ extern "C" {
 
 WK_EXPORT WKTypeID WKUserScriptGetTypeID(void);
 
+WK_EXPORT WKUserScriptRef WKUserScriptCreate(WKStringRef source, WKURLRef url, WKArrayRef includeURLPatterns, WKArrayRef excludeURLPatterns, _WKUserScriptInjectionTime injectionTime, bool forMainFrameOnly);
 WK_EXPORT WKUserScriptRef WKUserScriptCreateWithSource(WKStringRef source, _WKUserScriptInjectionTime injectionTime, bool forMainFrameOnly);
 
 WK_EXPORT WKStringRef WKUserScriptCopySource(WKUserScriptRef userScript);


### PR DESCRIPTION
#### ebec3b5a284a8f8b2e8358c47f8a810121672045
<pre>
Add WKUserScriptCreate with all parameters available.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260363">https://bugs.webkit.org/show_bug.cgi?id=260363</a>

Reviewed by Alex Christensen.

WKUserScriptCreateFromSource() cannot specify parameters for full WebCore::UserScript and
the feature is limited. Because WKPageGroup is deprecated on 266167@main, we cannot achieve
same thing we could do with WKPageGroupAddUserScript because of the lack of above creation API.

This patch adds WKUserScriptCreate() with all parameters available.

* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/UIProcess/API/C/WKUserScriptRef.cpp:
(WKUserScriptCreate):
* Source/WebKit/UIProcess/API/C/WKUserScriptRef.h:

Canonical link: <a href="https://commits.webkit.org/267052@main">https://commits.webkit.org/267052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f1ed0b4ccad0c3f5aaae8a8ba5b2222555ef103

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14445 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17039 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17893 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13275 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20836 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17322 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12402 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13900 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3721 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->