### PR TITLE
Scheduling requestIdleCallback should not block a timer from firing

### DIFF
--- a/LayoutTests/requestidlecallback/requestidlecallback-does-not-block-timer-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-does-not-block-timer-expected.txt
@@ -1,0 +1,13 @@
+This tests that scheduling an idle callback would not delay the firing of a timer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didFireTimer is true
+PASS idleDeadline.timeRemaining() > 0 is true
+PASS idleDeadline.timeRemaining() is 0
+PASS didRunIdleCallback is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-does-not-block-timer.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-does-not-block-timer.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+
+description('This tests that scheduling an idle callback would not delay the firing of a timer.');
+
+jsTestIsAsync = true;
+
+function synchronouslyWait(milliseconds) {
+    let start = performance.now();
+    while (performance.now() - start < milliseconds);
+}
+
+let didRunIdleCallback = false;
+let didFireTimer = false;
+onload = () => {
+    requestIdleCallback((idleDeadline) => {
+        shouldBeTrue('didFireTimer');
+        window.idleDeadline = idleDeadline;
+        shouldBeTrue('idleDeadline.timeRemaining() > 0');
+        synchronouslyWait(50);
+        shouldBe('idleDeadline.timeRemaining()', '0');
+        didRunIdleCallback = true;
+    });
+    setTimeout(() => {
+        didFireTimer = true;
+    }, 0);
+    setTimeout(() => {
+        shouldBeTrue('didRunIdleCallback');
+        finishJSTest();
+    }, 100);
+}
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### f92900fd3d98e945b2cfa8c54fd0611bead3472b
<pre>
Scheduling requestIdleCallback should not block a timer from firing
<a href="https://bugs.webkit.org/show_bug.cgi?id=203840">https://bugs.webkit.org/show_bug.cgi?id=203840</a>

Reviewed by Wenson Hsieh.

Added a test to verify scheduling of an idle callback would not block the timer from running soon.

* LayoutTests/requestidlecallback/requestidlecallback-does-not-block-timer-expected.txt: Added.
* LayoutTests/requestidlecallback/requestidlecallback-does-not-block-timer.html: Added.

Canonical link: <a href="https://commits.webkit.org/267029@main">https://commits.webkit.org/267029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e276fadaacc1d0cae56bf70156f7a57c081982e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16024 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17925 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17349 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14661 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13765 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18280 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1878 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->