### PR TITLE
[motion-path] Implement offset-position: normal

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5280,10 +5280,6 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-009.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/motion/offset-path-url-010.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyFailure ]
 
-# CSS motion path tests for missing offset-position: normal support in ray().
-imported/w3c/web-platform-tests/css/motion/offset-path-ray-011.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-ray-014.html [ ImageOnlyFailure ]
-
 # CSS motion path tests <basic-shape> misc bugs.
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/inheritance-expected.txt
@@ -5,7 +5,7 @@ PASS Property offset-distance has initial value 0px
 PASS Property offset-distance does not inherit
 PASS Property offset-path has initial value none
 PASS Property offset-path does not inherit
-FAIL Property offset-position has initial value normal assert_equals: expected "normal" but got "auto"
+PASS Property offset-position has initial value normal
 PASS Property offset-position does not inherit
 PASS Property offset-rotate has initial value ['auto 0deg' or 'auto']
 PASS Property offset-rotate does not inherit

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-parsing-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-parsing-valid-expected.txt
@@ -1,7 +1,7 @@
 
 PASS e.style['offset'] = "100px none auto 90deg" should set the property value
 PASS e.style['offset'] = "100px" should set the property value
-FAIL e.style['offset'] = "normal none reverse" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['offset'] = "normal none reverse" should set the property value
 PASS e.style['offset'] = "auto" should set the property value
 PASS e.style['offset'] = "center bottom path(\"M 1 2 V 3 Z\")" should set the property value
 FAIL e.style['offset'] = "center center path(\"M 0 0 L 100 100 M 100 200 L 200 200 Z L 300 300 Z\") 100% 90deg / left bottom" should set the property value assert_equals: serialization should be canonical expected "center center path(\"M 0 0 L 100 100 M 100 200 L 200 200 Z L 300 300 Z\") 100% 90deg / left bottom" but got "center path(\"M 0 0 L 100 100 M 100 200 L 200 200 Z L 300 300 Z\") 100% 90deg / left bottom"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-position-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-position-computed-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Property offset-position value 'auto'
-FAIL Property offset-position value 'normal' assert_true: 'normal' is a supported value for offset-position. expected true got false
+PASS Property offset-position value 'normal'
 PASS Property offset-position value 'left bottom'
 PASS Property offset-position value 'center center'
 PASS Property offset-position value 'right center'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-position-parsing-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-position-parsing-valid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS e.style['offset-position'] = "auto" should set the property value
-FAIL e.style['offset-position'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['offset-position'] = "normal" should set the property value
 PASS e.style['offset-position'] = "left bottom" should set the property value
 FAIL e.style['offset-position'] = "center center" should set the property value assert_equals: serialization should be canonical expected "center center" but got "center"
 PASS e.style['offset-position'] = "right center" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-shorthand-expected.txt
@@ -14,7 +14,7 @@ PASS e.style['offset'] = "top right / top left" should not set unrelated longhan
 PASS e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should set offset-anchor
 PASS e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should set offset-distance
 PASS e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should set offset-path
-FAIL e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should set offset-position assert_equals: offset-position should be canonical expected "normal" but got "auto"
+PASS e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should set offset-position
 PASS e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should set offset-rotate
 PASS e.style['offset'] = "path(\"M 0 0 H 2\") reverse 50%" should not set unrelated longhands
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -1011,9 +1011,9 @@ private:
 };
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(LengthPointPropertyWrapper);
 
-// This class extends LengthPointPropertyWrapper to accommodate `auto` value expressed as
-// LengthPoint(Length(LengthType::Auto), Length(LengthType::Auto)). This is used for 
-// offset-anchor and offset-position, which allows `auto`, and is expressed like so.
+// This class extends LengthPointPropertyWrapper to accommodate `auto` or `normal` values expressed as
+// LengthPoint(Length(LengthType::Auto/Normal), Length(LengthType::Auto/Normal)). This is used for
+// offset-anchor and offset-position, which allows `auto` and `normal`, and is expressed like so.
 class LengthPointOrAutoPropertyWrapper : public LengthPointPropertyWrapper {
 public:
     LengthPointOrAutoPropertyWrapper(CSSPropertyID property, const LengthPoint& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(LengthPoint))
@@ -1023,13 +1023,13 @@ public:
 
 private:
     // Check if it's possible to interpolate between the from and to values. In particular,
-    // it's only possible if they're both not auto.
+    // it's only possible if they're both not auto or normal.
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
     {
-        bool fromIsAuto = value(from).x().isAuto() && value(from).y().isAuto();
-        bool toIsAuto = value(to).x().isAuto() && value(to).y().isAuto();
+        auto valueFrom = value(from);
+        auto valueTo = value(to);
 
-        return (!fromIsAuto && !toIsAuto); 
+        return !valueFrom.x().isAuto() && !valueTo.x().isAuto() && !valueFrom.x().isNormal() && !valueTo.x().isNormal();
     }
 };
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -516,6 +516,10 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(const Length& length)
         return create(CSSValueAuto);
     case LengthType::Content:
         return create(CSSValueContent);
+    case LengthType::FillAvailable:
+        return create(CSSValueWebkitFillAvailable);
+    case LengthType::FitContent:
+        return create(CSSValueFitContent);
     case LengthType::Fixed:
         return create(length.value(), CSSUnitType::CSS_PX);
     case LengthType::Intrinsic:
@@ -526,10 +530,8 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(const Length& length)
         return create(CSSValueMinContent);
     case LengthType::MaxContent:
         return create(CSSValueMaxContent);
-    case LengthType::FillAvailable:
-        return create(CSSValueWebkitFillAvailable);
-    case LengthType::FitContent:
-        return create(CSSValueFitContent);
+    case LengthType::Normal:
+        return create(CSSValueNormal);
     case LengthType::Percent:
         ASSERT(std::isfinite(length.percent()));
         return create(length.percent(), CSSUnitType::CSS_PERCENTAGE);
@@ -546,12 +548,13 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(const Length& length, const Ren
     switch (length.type()) {
     case LengthType::Auto:
     case LengthType::Content:
+    case LengthType::FillAvailable:
+    case LengthType::FitContent:
     case LengthType::Intrinsic:
     case LengthType::MinIntrinsic:
     case LengthType::MinContent:
     case LengthType::MaxContent:
-    case LengthType::FillAvailable:
-    case LengthType::FitContent:
+    case LengthType::Normal:
     case LengthType::Percent:
         return create(length);
     case LengthType::Fixed:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4792,12 +4792,13 @@
         },
         "offset-position": {
             "values": [
+                "normal",
                 "auto"
             ],
             "codegen-properties": {
-                "converter": "PositionOrAuto",
+                "converter": "PositionOrAutoOrNormal",
                 "settings-flag": "cssMotionPathEnabled",
-                "parser-grammar": "auto | <position>"
+                "parser-grammar": "normal | auto | <position>"
             },
             "specification": {
                 "category": "css-motion-path",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1639,11 +1639,25 @@ static bool isAuto(const LengthPoint& position)
     return position.x().isAuto() && position.y().isAuto();
 }
 
+static bool isNormal(const LengthPoint& position)
+{
+    return position.x().isNormal();
+}
+
 static Ref<CSSValue> valueForPositionOrAuto(const RenderStyle& style, const LengthPoint& position)
 {
-    if (position.x().isAuto() && position.y().isAuto())
+    if (isAuto(position))
         return CSSPrimitiveValue::create(CSSValueAuto);
+    return valueForPosition(style, position);
+}
 
+
+static Ref<CSSValue> valueForPositionOrAutoOrNormal(const RenderStyle& style, const LengthPoint& position)
+{
+    if (isAuto(position))
+        return CSSPrimitiveValue::create(CSSValueAuto);
+    if (isNormal(position))
+        return CSSPrimitiveValue::create(CSSValueNormal);
     return valueForPosition(style, position);
 }
 
@@ -2720,8 +2734,8 @@ static Ref<CSSValue> valueForOffsetShorthand(const RenderStyle& style)
 
     CSSValueListBuilder innerList;
 
-    if (!isAuto(style.offsetPosition()))
-        innerList.append(valueForPositionOrAuto(style, style.offsetPosition()));
+    if (!isAuto(style.offsetPosition()) && !isNormal(style.offsetPosition()))
+        innerList.append(valueForPosition(style, style.offsetPosition()));
 
     bool nonInitialDistance = !style.offsetDistance().isZero();
     bool nonInitialRotate = style.offsetRotate() != style.initialOffsetRotate();
@@ -3561,7 +3575,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyOffsetDistance:
         return CSSPrimitiveValue::create(style.offsetDistance(), style);
     case CSSPropertyOffsetPosition:
-        return valueForPositionOrAuto(style, style.offsetPosition());
+        return valueForPositionOrAutoOrNormal(style, style.offsetPosition());
     case CSSPropertyOffsetAnchor:
         return valueForPositionOrAuto(style, style.offsetAnchor());
     case CSSPropertyOffsetRotate:

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -277,6 +277,7 @@ static RefPtr<CSSCalcExpressionNode> createCSS(const Length& length, const Rende
     case LengthType::Calculated:
         return createCSS(length.calculationValue().expression(), style);
     case LengthType::Auto:
+    case LengthType::Normal:
     case LengthType::Content:
     case LengthType::Intrinsic:
     case LengthType::MinIntrinsic:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -901,7 +901,6 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     case CSSPropertyMaskBorderWidth:
     case CSSPropertyMaskSize:
     case CSSPropertyOffsetAnchor:
-    case CSSPropertyOffsetPosition:
     case CSSPropertyOffsetRotate:
     case CSSPropertyOverflowAnchor:
     case CSSPropertyOverscrollBehaviorBlock:
@@ -964,6 +963,7 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     case CSSPropertyJustifyContent:
     case CSSPropertyLetterSpacing:
     case CSSPropertyLineHeight:
+    case CSSPropertyOffsetPosition:
     case CSSPropertyOverflowWrap:
     case CSSPropertyRowGap:
     case CSSPropertyScrollSnapStop:

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -284,7 +284,7 @@ static Length blendMixedTypes(const Length& from, const Length& to, const Blendi
 
 Length blend(const Length& from, const Length& to, const BlendingContext& context)
 {
-    if ((from.isAuto() || to.isAuto()) || (from.isUndefined() || to.isUndefined()))
+    if (from.isAuto() || to.isAuto() || from.isUndefined() || to.isUndefined() || from.isNormal() || to.isNormal())
         return context.progress < 0.5 ? from : to;
 
     if (from.isCalculated() || to.isCalculated() || (from.type() != to.type()))
@@ -333,17 +333,18 @@ static TextStream& operator<<(TextStream& ts, LengthType type)
 {
     switch (type) {
     case LengthType::Auto: ts << "auto"; break;
-    case LengthType::Relative: ts << "relative"; break;
-    case LengthType::Percent: ts << "percent"; break;
+    case LengthType::Calculated: ts << "calc"; break;
+    case LengthType::Content: ts << "content"; break;
+    case LengthType::FillAvailable: ts << "fill-available"; break;
+    case LengthType::FitContent: ts << "fit-content"; break;
     case LengthType::Fixed: ts << "fixed"; break;
     case LengthType::Intrinsic: ts << "intrinsic"; break;
     case LengthType::MinIntrinsic: ts << "min-intrinsic"; break;
     case LengthType::MinContent: ts << "min-content"; break;
     case LengthType::MaxContent: ts << "max-content"; break;
-    case LengthType::FillAvailable: ts << "fill-available"; break;
-    case LengthType::FitContent: ts << "fit-content"; break;
-    case LengthType::Calculated: ts << "calc"; break;
-    case LengthType::Content: ts << "content"; break;
+    case LengthType::Normal: ts << "normal"; break;
+    case LengthType::Percent: ts << "percent"; break;
+    case LengthType::Relative: ts << "relative"; break;
     case LengthType::Undefined: ts << "undefined"; break;
     }
     return ts;
@@ -354,6 +355,7 @@ TextStream& operator<<(TextStream& ts, Length length)
     switch (length.type()) {
     case LengthType::Auto:
     case LengthType::Content:
+    case LengthType::Normal:
     case LengthType::Undefined:
         ts << length.type();
         break;

--- a/Source/WebCore/platform/Length.h
+++ b/Source/WebCore/platform/Length.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 enum class LengthType : uint8_t {
     Auto,
+    Normal,
     Relative,
     Percent,
     Fixed,
@@ -97,6 +98,7 @@ public:
     bool isFixed() const;
     bool isMaxContent() const;
     bool isMinContent() const;
+    bool isNormal() const;
     bool isPercent() const;
     bool isRelative() const;
     bool isUndefined() const;
@@ -236,6 +238,7 @@ inline void Length::initialize(const Length& other)
 
     switch (m_type) {
     case LengthType::Auto:
+    case LengthType::Normal:
     case LengthType::Content:
     case LengthType::Undefined:
         m_intValue = 0;
@@ -269,6 +272,7 @@ inline void Length::initialize(Length&& other)
 
     switch (m_type) {
     case LengthType::Auto:
+    case LengthType::Normal:
     case LengthType::Content:
     case LengthType::Undefined:
         m_intValue = 0;
@@ -396,6 +400,11 @@ inline void Length::setValue(LengthType type, LayoutUnit value)
     m_type = type;
     m_floatValue = value;
     m_isFloat = true;
+}
+
+inline bool Length::isNormal() const
+{
+    return type() == LengthType::Normal;
 }
 
 inline bool Length::isAuto() const

--- a/Source/WebCore/platform/LengthFunctions.cpp
+++ b/Source/WebCore/platform/LengthFunctions.cpp
@@ -45,6 +45,7 @@ LayoutUnit valueForLength(const Length& length, LayoutUnit maximumValue)
         return minimumValueForLength(length, maximumValue);
     case LengthType::FillAvailable:
     case LengthType::Auto:
+    case LengthType::Normal:
         return maximumValue;
     case LengthType::Relative:
     case LengthType::Intrinsic:
@@ -71,6 +72,7 @@ float floatValueForLength(const Length& length, LayoutUnit maximumValue)
         return static_cast<float>(maximumValue * length.percent() / 100.0f);
     case LengthType::FillAvailable:
     case LengthType::Auto:
+    case LengthType::Normal:
         return static_cast<float>(maximumValue);
     case LengthType::Calculated:
         return length.nonNanCalculatedValue(maximumValue);
@@ -98,6 +100,7 @@ float floatValueForLength(const Length& length, float maximumValue)
         return static_cast<float>(maximumValue * length.percent() / 100.0f);
     case LengthType::FillAvailable:
     case LengthType::Auto:
+    case LengthType::Normal:
         return static_cast<float>(maximumValue);
     case LengthType::Calculated:
         return length.nonNanCalculatedValue(maximumValue);

--- a/Source/WebCore/platform/LengthFunctions.h
+++ b/Source/WebCore/platform/LengthFunctions.h
@@ -59,6 +59,7 @@ inline LayoutUnit minimumValueForLength(const Length& length, LayoutUnit maximum
         return LayoutUnit(length.nonNanCalculatedValue(maximumValue));
     case LengthType::FillAvailable:
     case LengthType::Auto:
+    case LengthType::Normal:
     case LengthType::Content:
         return 0;
     case LengthType::Relative:

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -46,6 +46,13 @@ static FloatRoundedRect containingBlockRectForRenderer(const RenderObject& rende
     return FloatRoundedRect(referenceRect);
 }
 
+static FloatPoint normalPositionForOffsetPath(PathOperation* operation, const FloatRect& referenceRect)
+{
+    if (is<RayPathOperation>(operation))
+        return referenceRect.center();
+    return { };
+}
+
 std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const RenderElement& renderer)
 {
     MotionPathData data;
@@ -54,7 +61,9 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
         return std::nullopt;
 
     auto startingPositionForOffsetPosition = [&](const LengthPoint& offsetPosition, const FloatRect& referenceRect, RenderBlock& container) -> FloatPoint {
-        // FIXME: Implement offset-position: normal.
+        // If offset-position is normal, the element does not have an offset starting position.
+        if (offsetPosition.x().isNormal())
+            return normalPositionForOffsetPath(pathOperation, referenceRect);
         // If offset-position is auto, use top / left corner of the box.
         if (offsetPosition.x().isAuto() && offsetPosition.y().isAuto())
             return offsetFromContainer(renderer, container, referenceRect);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3521,6 +3521,7 @@ LayoutUnit RenderBox::computeReplacedLogicalWidthUsing(SizeType widthType, Lengt
     case LengthType::Intrinsic:
     case LengthType::MinIntrinsic:
     case LengthType::Auto:
+    case LengthType::Normal:
     case LengthType::Content:
     case LengthType::Relative:
     case LengthType::Undefined:

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -415,7 +415,7 @@ inline LengthPoint RenderStyle::initialObjectPosition() { return { { 50.0f, Leng
 inline Length RenderStyle::initialOffset() { return LengthType::Auto; }
 inline LengthPoint RenderStyle::initialOffsetAnchor() { return { }; }
 inline Length RenderStyle::initialOffsetDistance() { return zeroLength(); }
-inline LengthPoint RenderStyle::initialOffsetPosition() { return { }; }
+inline LengthPoint RenderStyle::initialOffsetPosition() { return { { LengthType::Normal }, { LengthType::Normal } }; }
 constexpr OffsetRotation RenderStyle::initialOffsetRotate() { return { true }; }
 inline OrderedNamedGridLinesMap RenderStyle::initialOrderedNamedGridColumnLines() { return { }; }
 inline OrderedNamedGridLinesMap RenderStyle::initialOrderedNamedGridRowLines() { return { }; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -96,6 +96,7 @@ public:
     static LengthSize convertRadius(BuilderState&, const CSSValue&);
     static LengthPoint convertPosition(BuilderState&, const CSSValue&);
     static LengthPoint convertPositionOrAuto(BuilderState&, const CSSValue&);
+    static LengthPoint convertPositionOrAutoOrNormal(BuilderState&, const CSSValue&);
     static OptionSet<TextDecorationLine> convertTextDecorationLine(BuilderState&, const CSSValue&);
     static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
     template<typename T> static T convertNumber(BuilderState&, const CSSValue&);
@@ -477,6 +478,15 @@ inline LengthPoint BuilderConverter::convertPosition(BuilderState& builderState,
     Length lengthY = convertPositionComponent<CSSValueTop, CSSValueBottom>(builderState, value.second());
 
     return LengthPoint(lengthX, lengthY);
+}
+
+inline LengthPoint BuilderConverter::convertPositionOrAutoOrNormal(BuilderState& builderState, const CSSValue& value)
+{
+    if (value.isPair())
+        return convertPosition(builderState, value);
+    if (value.valueID() == CSSValueNormal)
+        return { { LengthType::Normal }, { LengthType::Normal } };
+    return { };
 }
 
 inline LengthPoint BuilderConverter::convertPositionOrAuto(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -320,6 +320,7 @@ void ArgumentCoder<Length>::encode(Encoder& encoder, const Length& length)
 
     switch (length.type()) {
     case LengthType::Auto:
+    case LengthType::Normal:
     case LengthType::Content:
     case LengthType::Undefined:
         break;
@@ -355,6 +356,7 @@ bool ArgumentCoder<Length>::decode(Decoder& decoder, Length& length)
         return false;
 
     switch (type) {
+    case LengthType::Normal:
     case LengthType::Auto:
     case LengthType::Content:
     case LengthType::Undefined:


### PR DESCRIPTION
#### 958cc075a8612fc45d07e95dbfe9bad0547e3cd2
<pre>
[motion-path] Implement offset-position: normal
<a href="https://bugs.webkit.org/show_bug.cgi?id=259988">https://bugs.webkit.org/show_bug.cgi?id=259988</a>
rdar://113644765

Reviewed by Tim Nguyen.

Have the inital value of offset-position default to using normal rather than auto. Currently
implemented by adding a normal keyword to length and specifying this default value in
RenderStyle::initialOffsetPosition. We should update normalPositionForOffsetPath in future
patches to ensure the normal value is correct for path operations other than ray().

* LayoutTests/imported/w3c/web-platform-tests/css/motion/animation/offset-position-interpolation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/inheritance.html:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::create):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::isNormal):
(WebCore::valueForPositionOrAuto):
(WebCore::valueForOffsetShorthand):
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSS):
* Source/WebCore/platform/Length.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/Length.h:
(WebCore::Length::initialize):
(WebCore::Length::isNormal const):
* Source/WebCore/platform/LengthFunctions.cpp:
(WebCore::valueForLength):
(WebCore::floatValueForLength):
* Source/WebCore/platform/LengthFunctions.h:
(WebCore::minimumValueForLength):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeReplacedLogicalWidthUsing const):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialOffsetPosition):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertPositionOrAuto):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;Length&gt;::encode):
(IPC::ArgumentCoder&lt;Length&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/267657@main">https://commits.webkit.org/267657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/070d3c53362ccfc01b7b45f00b64bc82c794b6e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18357 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19886 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15068 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15714 "8 failures") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20210 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19983 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2114 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->