### PR TITLE
Deploy more smart pointers in WebKit2 2023-08-17 edition

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProgressTrackerClient.cpp
@@ -67,13 +67,13 @@ void WebProgressTrackerClient::progressFinished(LocalFrame& originatingProgressF
     if (!originatingProgressFrame.isMainFrame())
         return;
 
-    Ref page = *m_webPage;
-    page->setMainFrameProgressCompleted(true);
+    Ref webPage = *m_webPage;
+    webPage->setMainFrameProgressCompleted(true);
 
     // Notify the bundle client.
-    page->injectedBundleLoaderClient().didFinishProgress(page);
+    webPage->injectedBundleLoaderClient().didFinishProgress(webPage);
 
-    page->send(Messages::WebPageProxy::DidFinishProgress());
+    webPage->send(Messages::WebPageProxy::DidFinishProgress());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -523,7 +523,7 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
             }
         }
 
-        if (RefPtr enclosingListElement = enclosingList(selection.start().containerNode())) {
+        if (RefPtr enclosingListElement = enclosingList(RefPtr { selection.start().containerNode() }.get())) {
             if (is<HTMLUListElement>(*enclosingListElement))
                 postLayoutData.enclosingListType = ListType::UnorderedList;
             else if (is<HTMLOListElement>(*enclosingListElement))

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1085,14 +1085,14 @@ JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JS
 
     auto [destinationID, messageName, timeout] = *info;
     auto& streamConnection = jsStreamConnection->connection();
-    auto& connection = streamConnection.connectionForTesting();
+    Ref connection = streamConnection.connectionForTesting();
 
     IPC::Connection::SyncRequestID syncRequestID;
-    auto encoder = connection.createSyncMessageEncoder(messageName, destinationID, syncRequestID);
+    auto encoder = connection->createSyncMessageEncoder(messageName, destinationID, syncRequestID);
     if (!prepareToSendOutOfStreamMessage(context, argumentCount, arguments, *jsStreamConnection->m_jsIPC, streamConnection, encoder.get(), destinationID, timeout, exception))
         return JSValueMakeUndefined(context);
 
-    auto replyDecoderOrError = connection.sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });
+    auto replyDecoderOrError = connection->sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });
     if (replyDecoderOrError.decoder) {
         auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
         auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, *replyDecoderOrError.decoder);

--- a/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
@@ -90,7 +90,8 @@ void WebContextMenu::menuItemsWithUserData(Vector<WebContextMenuItemData> &menuI
     // Give the bundle client a chance to process the menu.
     const Vector<ContextMenuItem>& coreItems = menu->items();
 
-    if (m_page->injectedBundleContextMenuClient().getCustomMenuFromDefaultItems(*m_page, controller.hitTestResult(), coreItems, menuItems, controller.context(), userData))
+    RefPtr page = m_page.get();
+    if (page->injectedBundleContextMenuClient().getCustomMenuFromDefaultItems(*page, controller.hitTestResult(), coreItems, menuItems, controller.context(), userData))
         return;
     menuItems = kitItems(coreItems);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -405,11 +405,12 @@ WebCore::Document* WebFoundTextRangeController::documentForFoundTextRange(const 
 std::optional<WebCore::SimpleRange> WebFoundTextRangeController::simpleRangeFromFoundTextRange(WebFoundTextRange range)
 {
     return m_cachedFoundRanges.ensure(range, [&] () -> std::optional<WebCore::SimpleRange> {
-        auto* document = documentForFoundTextRange(range);
+        RefPtr document = documentForFoundTextRange(range);
         if (!document)
             return std::nullopt;
 
-        return resolveCharacterRange(makeRangeSelectingNodeContents(*document->documentElement()), { range.location, range.length }, WebCore::findIteratorOptions());
+        Ref documentElement = *document->documentElement();
+        return resolveCharacterRange(makeRangeSelectingNodeContents(documentElement), { range.location, range.length }, WebCore::findIteratorOptions());
     }).iterator->value;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -591,7 +591,7 @@ String WebFrame::contentsAsString() const
     if (!document)
         return String();
 
-    auto documentElement = document->documentElement();
+    RefPtr documentElement = document->documentElement();
     if (!documentElement)
         return String();
 
@@ -806,7 +806,7 @@ void WebFrame::setAccessibleName(const AtomString& accessibleName)
     if (!document)
         return;
     
-    auto* rootObject = document->axObjectCache()->rootObject();
+    RefPtr rootObject = document->axObjectCache()->rootObject();
     if (!rootObject)
         return;
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -131,7 +131,7 @@ void RemoteRealtimeMediaSource::gpuProcessConnectionDidClose(GPUProcessConnectio
         return;
 
     m_proxy.updateConnection();
-    m_manager.remoteCaptureSampleManager().didUpdateSourceConnection(m_proxy.connection());
+    m_manager.remoteCaptureSampleManager().didUpdateSourceConnection(Ref { m_proxy.connection() });
     m_proxy.resetReady();
     createRemoteMediaSource();
 

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -703,10 +703,10 @@ void VideoFullscreenManager::didCleanupFullscreen(PlaybackSessionContextIdentifi
 
 void VideoFullscreenManager::setVideoLayerGravityEnum(PlaybackSessionContextIdentifier contextId, unsigned gravity)
 {
-    auto& model = ensureModel(contextId);
-    INFO_LOG(LOGIDENTIFIER, model.logIdentifier(), gravity);
+    Ref model = ensureModel(contextId);
+    INFO_LOG(LOGIDENTIFIER, model->logIdentifier(), gravity);
 
-    model.setVideoLayerGravity((MediaPlayerEnums::VideoGravity)gravity);
+    model->setVideoLayerGravity((MediaPlayerEnums::VideoGravity)gravity);
 }
 
 void VideoFullscreenManager::fullscreenMayReturnToInline(PlaybackSessionContextIdentifier contextId, bool isPageVisible)


### PR DESCRIPTION
#### ee3437810b68973f1bbf8c3933dbde5a10fa1e6e
<pre>
Deploy more smart pointers in WebKit2 2023-08-17 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=260371">https://bugs.webkit.org/show_bug.cgi?id=260371</a>

Reviewed by Dan Glastonbury.

Deployed more use of smart pointers.

* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::saveRecentSearches):
(WebKit::WebSearchPopupMenu::loadRecentSearches):
* Source/WebKit/WebProcess/WebCoreSupport/WebStorageConnection.cpp:
(WebKit::WebStorageConnection::getPersisted):
(WebKit::WebStorageConnection::persist):
(WebKit::WebStorageConnection::getEstimate):
(WebKit::WebStorageConnection::fileSystemGetDirectory):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::addScrollingTreeForPage):
(WebKit::EventDispatcher::dispatchWheelEvent):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
* Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp:
(WebKit::WebContextMenu::menuItemsWithUserData const):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::simpleRangeFromFoundTextRange):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::contentsAsString const):
(WebKit::WebFrame::setAccessibleName):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::reload):
(WebKit::WebPage::updateFrameSize):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::enqueueSecurityPolicyViolationEvent):
(WebKit::WebPage::notifyReportObservers):
(WebKit::WebPage::updateWebsitePolicies):
(WebKit::WebPage::addUserScript):
(WebKit::WebPage::addUserStyleSheet):
(WebKit::WebPage::removeAllUserContent):
(WebKit::WebPage::didGetLoadDecisionForIcon):
(WebKit::WebPage::setUseIconLoadingClient):
(WebKit::WebPage::completeTextManipulation):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::setVideoLayerGravityEnum):

Canonical link: <a href="https://commits.webkit.org/267057@main">https://commits.webkit.org/267057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cba77511f8392b7d766691ff63ed9dd99840af8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14482 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17064 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17943 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13321 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20870 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18297 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1889 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->