### PR TITLE
Applying wavy underline text decoration will hang if the font size is zero

### DIFF
--- a/LayoutTests/fast/text/text-zero-size-wavy-style-expected.txt
+++ b/LayoutTests/fast/text/text-zero-size-wavy-style-expected.txt
@@ -1,0 +1,1 @@
+Passes if it does not crash.

--- a/LayoutTests/fast/text/text-zero-size-wavy-style.html
+++ b/LayoutTests/fast/text/text-zero-size-wavy-style.html
@@ -1,0 +1,21 @@
+<style>
+    .class6 { 
+        font-size: 0cm; 
+        text-decoration-style: wavy;
+    }
+</style>
+<body>
+    <ins class="class6">Passes if it does not crash.</ins>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            window.requestAnimationFrame((timeStamp) => {
+                window.requestAnimationFrame((timeStamp) => {
+                    testRunner.notifyDone();
+                });
+            });
+        }
+    </script>
+</body>

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -67,6 +67,9 @@ namespace WebCore {
  */
 static void strokeWavyTextDecoration(GraphicsContext& context, const FloatRect& rect, WavyStrokeParameters wavyStrokeParameters)
 {
+    ASSERT(!rect.isEmpty());
+    ASSERT(wavyStrokeParameters.step);
+
     FloatPoint p1 = rect.minXMinYCorner();
     FloatPoint p2 = rect.maxXMinYCorner();
 
@@ -282,9 +285,9 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
         applyShadowIfNeeded();
 
         // FIXME: Add support to handle left/right case
-        if (decorationType.contains(TextDecorationLine::Underline))
+        if (decorationType.contains(TextDecorationLine::Underline) && !underlineRect.isEmpty())
             paintDecoration(TextDecorationLine::Underline, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
-        if (decorationType.contains(TextDecorationLine::Overline))
+        if (decorationType.contains(TextDecorationLine::Overline) && !overlineRect.isEmpty())
             paintDecoration(TextDecorationLine::Overline, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
         // We only want to paint the shadow, hence the transparent color, not the actual line-through,
         // which will be painted in paintForegroundDecorations().


### PR DESCRIPTION
#### 08c99bad53db78c7c665218e5fba8c86b1980ed7
<pre>
Applying wavy underline text decoration will hang if the font size is zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=260372">https://bugs.webkit.org/show_bug.cgi?id=260372</a>
rdar://113930569

Reviewed by Cameron McCormack.

Underline and overline text decoration should be ignored if the font size is zero.

* LayoutTests/fast/text/text-zero-size-wavy-style-expected.txt: Added.
* LayoutTests/fast/text/text-zero-size-wavy-style.html: Added.
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::strokeWavyTextDecoration):
(WebCore::TextDecorationPainter::paintBackgroundDecorations):

Canonical link: <a href="https://commits.webkit.org/269493@main">https://commits.webkit.org/269493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b89fd150eb3ae6929770637437aaa4b6ba935986

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17933 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19230 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21871 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19568 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13476 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18221 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14945 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5417 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19430 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19442 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15702 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4111 "Passed tests") | 
<!--EWS-Status-Bubble-End-->