### PR TITLE
[JSC] Add more 'inline' specifiers for declarations

### DIFF
--- a/Source/JavaScriptCore/runtime/Butterfly.h
+++ b/Source/JavaScriptCore/runtime/Butterfly.h
@@ -149,7 +149,7 @@ public:
     }
     
     ALWAYS_INLINE static unsigned availableContiguousVectorLength(size_t propertyCapacity, unsigned vectorLength);
-    static unsigned availableContiguousVectorLength(Structure*, unsigned vectorLength);
+    ALWAYS_INLINE static unsigned availableContiguousVectorLength(Structure*, unsigned vectorLength);
     
     ALWAYS_INLINE static unsigned optimalContiguousVectorLength(size_t propertyCapacity, unsigned vectorLength);
     static unsigned optimalContiguousVectorLength(Structure*, unsigned vectorLength);
@@ -168,12 +168,12 @@ public:
     static ptrdiff_t offsetOfPublicLength() { return offsetOfIndexingHeader() + IndexingHeader::offsetOfPublicLength(); }
     static ptrdiff_t offsetOfVectorLength() { return offsetOfIndexingHeader() + IndexingHeader::offsetOfVectorLength(); }
 
-    static Butterfly* tryCreateUninitialized(VM&, JSObject* intendedOwner, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, size_t indexingPayloadSizeInBytes, GCDeferralContext* = nullptr);
-    static Butterfly* createUninitialized(VM&, JSObject* intendedOwner, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, size_t indexingPayloadSizeInBytes);
+    inline static Butterfly* tryCreateUninitialized(VM&, JSObject* intendedOwner, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, size_t indexingPayloadSizeInBytes, GCDeferralContext* = nullptr);
+    inline static Butterfly* createUninitialized(VM&, JSObject* intendedOwner, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, size_t indexingPayloadSizeInBytes);
 
-    static Butterfly* tryCreate(VM& vm, JSObject*, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, const IndexingHeader& indexingHeader, size_t indexingPayloadSizeInBytes);
-    static Butterfly* create(VM&, JSObject* intendedOwner, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, const IndexingHeader&, size_t indexingPayloadSizeInBytes);
-    static Butterfly* create(VM&, JSObject* intendedOwner, Structure*);
+    inline static Butterfly* tryCreate(VM&, JSObject*, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, const IndexingHeader&, size_t indexingPayloadSizeInBytes);
+    inline static Butterfly* create(VM&, JSObject* intendedOwner, size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, const IndexingHeader&, size_t indexingPayloadSizeInBytes);
+    inline static Butterfly* create(VM&, JSObject* intendedOwner, Structure*);
     
     IndexingHeader* indexingHeader() { return IndexingHeader::from(this); }
     const IndexingHeader* indexingHeader() const { return IndexingHeader::from(this); }
@@ -216,9 +216,9 @@ public:
     }
 
     void* base(size_t preCapacity, size_t propertyCapacity) { return propertyStorage() - propertyCapacity - preCapacity; }
-    void* base(Structure*);
+    inline void* base(Structure*);
 
-    static Butterfly* createOrGrowArrayRight(
+    inline static Butterfly* createOrGrowArrayRight(
         Butterfly*, VM&, JSObject* intendedOwner, Structure* oldStructure,
         size_t propertyCapacity, bool hadIndexingHeader,
         size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); 
@@ -228,16 +228,16 @@ public:
     // methods is not exhaustive and is not intended to encapsulate all possible allocation
     // modes of butterflies - there are code paths that allocate butterflies by calling
     // directly into Heap::tryAllocateStorage.
-    static Butterfly* createOrGrowPropertyStorage(Butterfly*, VM&, JSObject* intendedOwner, Structure*, size_t oldPropertyCapacity, size_t newPropertyCapacity);
-    Butterfly* growArrayRight(VM&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); // Assumes that preCapacity is zero, and asserts as much.
-    Butterfly* growArrayRight(VM&, JSObject* intendedOwner, Structure*, size_t newIndexingPayloadSizeInBytes);
+    inline static Butterfly* createOrGrowPropertyStorage(Butterfly*, VM&, JSObject* intendedOwner, Structure*, size_t oldPropertyCapacity, size_t newPropertyCapacity);
+    inline Butterfly* growArrayRight(VM&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); // Assumes that preCapacity is zero, and asserts as much.
+    inline Butterfly* growArrayRight(VM&, JSObject* intendedOwner, Structure*, size_t newIndexingPayloadSizeInBytes);
 
-    Butterfly* reallocArrayRightIfPossible(VM&, GCDeferralContext&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); // Assumes that preCapacity is zero, and asserts as much.
+    inline Butterfly* reallocArrayRightIfPossible(VM&, GCDeferralContext&, JSObject* intendedOwner, Structure* oldStructure, size_t propertyCapacity, bool hadIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newIndexingPayloadSizeInBytes); // Assumes that preCapacity is zero, and asserts as much.
 
-    Butterfly* resizeArray(VM&, JSObject* intendedOwner, size_t propertyCapacity, bool oldHasIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newPreCapacity, bool newHasIndexingHeader, size_t newIndexingPayloadSizeInBytes);
-    Butterfly* resizeArray(VM&, JSObject* intendedOwner, Structure*, size_t newPreCapacity, size_t newIndexingPayloadSizeInBytes); // Assumes that you're not changing whether or not the object has an indexing header.
-    Butterfly* unshift(Structure*, size_t numberOfSlots);
-    Butterfly* shift(Structure*, size_t numberOfSlots);
+    inline Butterfly* resizeArray(VM&, JSObject* intendedOwner, size_t propertyCapacity, bool oldHasIndexingHeader, size_t oldIndexingPayloadSizeInBytes, size_t newPreCapacity, bool newHasIndexingHeader, size_t newIndexingPayloadSizeInBytes);
+    inline Butterfly* resizeArray(VM&, JSObject* intendedOwner, Structure*, size_t newPreCapacity, size_t newIndexingPayloadSizeInBytes); // Assumes that you're not changing whether or not the object has an indexing header.
+    inline Butterfly* unshift(Structure*, size_t numberOfSlots);
+    inline Butterfly* shift(Structure*, size_t numberOfSlots);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/CacheableIdentifier.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifier.h
@@ -73,7 +73,7 @@ public:
     CacheableIdentifier& operator=(CacheableIdentifier&&) = default;
 
     bool operator==(const CacheableIdentifier&) const;
-    bool operator==(const Identifier&) const;
+    inline bool operator==(const Identifier&) const;
 
     static inline bool isCacheableIdentifierCell(JSCell*);
     static inline bool isCacheableIdentifierCell(JSValue);

--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -205,7 +205,7 @@ public:
         
     inline Intrinsic intrinsicFor(CodeSpecializationKind) const;
 
-    ImplementationVisibility implementationVisibility() const;
+    inline ImplementationVisibility implementationVisibility() const;
 
     CodePtr<JSEntryPtrTag> swapGeneratedJITCodeWithArityCheckForDebugger(CodeSpecializationKind kind, CodePtr<JSEntryPtrTag> jitCodeWithArityCheck)
     {

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -112,18 +112,18 @@ public:
 
     static Identifier fromString(VM&, ASCIILiteral);
     static Identifier fromString(VM&, const LChar*, int length);
-    static Identifier fromString(VM&, const UChar*, int length);
-    static Identifier fromString(VM&, const String&);
-    static Identifier fromString(VM&, AtomStringImpl*);
+    inline static Identifier fromString(VM&, const UChar*, int length);
+    inline static Identifier fromString(VM&, const String&);
+    inline static Identifier fromString(VM&, AtomStringImpl*);
     static Identifier fromString(VM&, Ref<AtomStringImpl>&&);
     static Identifier fromString(VM&, const AtomString&);
-    static Identifier fromString(VM& vm, SymbolImpl*);
-    static Identifier fromString(VM& vm, const Vector<LChar>& characters) { return fromString(vm, characters.data(), characters.size()); }
-    static Identifier fromLatin1(VM&, const char*);
+    inline static Identifier fromString(VM&, SymbolImpl*);
+    inline static Identifier fromString(VM& vm, const Vector<LChar>& characters) { return fromString(vm, characters.data(), characters.size()); }
+    inline static Identifier fromLatin1(VM&, const char*);
 
     static Identifier fromUid(VM&, UniquedStringImpl* uid);
-    static Identifier fromUid(const PrivateName&);
-    static Identifier fromUid(SymbolImpl&);
+    inline static Identifier fromUid(const PrivateName&);
+    inline static Identifier fromUid(SymbolImpl&);
 
     static Identifier createLCharFromUChar(VM& vm, const UChar* s, int length) { return Identifier(vm, add8(vm, s, length)); }
 
@@ -161,8 +161,8 @@ private:
     Identifier(VM& vm, const LChar* s, int length) : m_string(add(vm, s, length)) { ASSERT(m_string.impl()->isAtom()); }
     Identifier(VM& vm, const UChar* s, int length) : m_string(add(vm, s, length)) { ASSERT(m_string.impl()->isAtom()); }
     ALWAYS_INLINE Identifier(VM& vm, ASCIILiteral literal) : m_string(add(vm, literal)) { ASSERT(m_string.impl()->isAtom()); }
-    Identifier(VM&, AtomStringImpl*);
-    Identifier(VM&, const AtomString&);
+    inline Identifier(VM&, AtomStringImpl*);
+    inline Identifier(VM&, const AtomString&);
     Identifier(VM& vm, const String& string) : m_string(add(vm, string.impl())) { ASSERT(m_string.impl()->isAtom()); }
     Identifier(VM& vm, StringImpl* rep) : m_string(add(vm, rep)) { ASSERT(m_string.impl()->isAtom()); }
 
@@ -266,10 +266,10 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(const Identifier& identifier)
     return parseIndex(*uid);
 }
 
-JSValue identifierToJSValue(VM&, const Identifier&);
+inline JSValue identifierToJSValue(VM&, const Identifier&);
 // This will stringify private symbols. When leaking JSValues to
 // non-internal code, make sure to use this function and not the above one.
-JSValue identifierToSafePublicJSValue(VM&, const Identifier&);
+inline JSValue identifierToSafePublicJSValue(VM&, const Identifier&);
 
 // FIXME: It may be better for this to just be a typedef for PtrHash, since PtrHash may be cheaper to
 // compute than loading the StringImpl's hash from memory. That change would also reduce the likelihood of

--- a/Source/JavaScriptCore/runtime/IndexingHeader.h
+++ b/Source/JavaScriptCore/runtime/IndexingHeader.h
@@ -114,8 +114,8 @@ public:
     
     // These methods are not standalone in the sense that they cannot be
     // used on a copy of the IndexingHeader.
-    size_t preCapacity(Structure*);
-    size_t indexingPayloadSizeInBytes(Structure*);
+    inline size_t preCapacity(Structure*);
+    inline size_t indexingPayloadSizeInBytes(Structure*);
     
 private:
     friend class LLIntOffsetsExtractor;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -82,7 +82,7 @@ public:
     JSBoundFunction* boundFormat() const { return m_boundFormat.get(); }
     void setBoundFormat(VM&, JSBoundFunction*);
 
-    static IntlDateTimeFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);
+    inline static IntlDateTimeFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);
 
     enum class HourCycle : uint8_t { None, H11, H12, H23, H24 };
     static HourCycle hourCycleFromPattern(const Vector<UChar, 32>&);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -208,7 +208,7 @@ public:
 
     static ASCIILiteral notationString(IntlNotation);
 
-    static IntlNumberFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);
+    inline static IntlNumberFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);
 
     static ASCIILiteral roundingPriorityString(IntlRoundingType);
 

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -100,18 +100,18 @@ public:
     // OK to use on new arrays, but not if it might be a RegExpMatchArray or RuntimeArray.
     JS_EXPORT_PRIVATE bool setLength(JSGlobalObject*, unsigned, bool throwException = false);
 
-    void pushInline(JSGlobalObject*, JSValue);
+    ALWAYS_INLINE void pushInline(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE void push(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE JSValue pop(JSGlobalObject*);
 
     static JSArray* fastSlice(JSGlobalObject*, JSObject* source, uint64_t startIndex, uint64_t count);
 
-    bool holesMustForwardToPrototype() const;
-    bool canFastCopy(JSArray* otherArray) const;
-    bool canFastAppend(JSArray* otherArray) const;
-    bool canDoFastIndexedAccess() const;
+    ALWAYS_INLINE bool holesMustForwardToPrototype() const;
+    inline bool canFastCopy(JSArray* otherArray) const;
+    inline bool canFastAppend(JSArray* otherArray) const;
+    inline bool canDoFastIndexedAccess() const;
     // This function returns NonArray if the indexing types are not compatable for copying.
-    IndexingType mergeIndexingTypeForCopying(IndexingType other, bool allowPromotion);
+    inline IndexingType mergeIndexingTypeForCopying(IndexingType other, bool allowPromotion);
     bool appendMemcpy(JSGlobalObject*, VM&, unsigned startIndex, JSArray* otherArray);
 
     enum ShiftCountMode {

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -124,7 +124,7 @@ enum WhichValueWord {
 };
 
 int64_t tryConvertToInt52(double);
-bool isInt52(double);
+inline bool isInt52(double);
 
 enum class SourceCodeRepresentation : uint8_t {
     Other,
@@ -217,18 +217,18 @@ public:
     bool operator==(const JSValue&) const;
 
     bool isInt32() const;
-    bool isUInt32() const;
+    inline bool isUInt32() const;
     bool isDouble() const;
-    bool isTrue() const;
-    bool isFalse() const;
+    inline bool isTrue() const;
+    inline bool isFalse() const;
 
     int32_t asInt32() const;
-    uint32_t asUInt32() const;
-    std::optional<uint32_t> tryGetAsUint32Index();
-    std::optional<int32_t> tryGetAsInt32();
-    int64_t asAnyInt() const;
-    uint32_t asUInt32AsAnyInt() const;
-    int32_t asInt32AsAnyInt() const;
+    inline uint32_t asUInt32() const;
+    inline std::optional<uint32_t> tryGetAsUint32Index();
+    inline std::optional<int32_t> tryGetAsInt32();
+    inline int64_t asAnyInt() const;
+    inline uint32_t asUInt32AsAnyInt() const;
+    inline int32_t asInt32AsAnyInt() const;
     double asDouble() const;
     bool asBoolean() const;
     double asNumber() const;
@@ -236,123 +236,123 @@ public:
     int32_t bigInt32AsInt32() const; // must only be called on a BigInt32
 #endif
     
-    int32_t asInt32ForArithmetic() const; // Boolean becomes an int, but otherwise like asInt32().
+    inline int32_t asInt32ForArithmetic() const; // Boolean becomes an int, but otherwise like asInt32().
 
     // Querying the type.
     bool isEmpty() const;
-    bool isCallable() const;
-    template<Concurrency> TriState isCallableWithConcurrency() const;
-    bool isConstructor() const;
-    template<Concurrency> TriState isConstructorWithConcurrency() const;
-    bool isUndefined() const;
+    inline bool isCallable() const;
+    template<Concurrency> inline TriState isCallableWithConcurrency() const;
+    inline bool isConstructor() const;
+    template<Concurrency> inline TriState isConstructorWithConcurrency() const;
+    inline bool isUndefined() const;
     bool isNull() const;
     bool isUndefinedOrNull() const;
     bool isBoolean() const;
-    bool isAnyInt() const;
-    bool isUInt32AsAnyInt() const;
-    bool isInt32AsAnyInt() const;
+    inline bool isAnyInt() const;
+    inline bool isUInt32AsAnyInt() const;
+    inline bool isInt32AsAnyInt() const;
     bool isNumber() const;
-    bool isString() const;
+    inline bool isString() const;
     bool isBigInt() const;
     bool isHeapBigInt() const;
-    bool isBigInt32() const;
-    bool isSymbol() const;
-    bool isPrimitive() const;
+    inline bool isBigInt32() const;
+    inline bool isSymbol() const;
+    inline bool isPrimitive() const;
     bool isGetterSetter() const;
     bool isCustomGetterSetter() const;
     bool isObject() const;
-    bool inherits(const ClassInfo*) const;
-    template<typename Target> bool inherits() const;
-    const ClassInfo* classInfoOrNull() const;
+    inline bool inherits(const ClassInfo*) const;
+    template<typename Target> inline bool inherits() const;
+    inline const ClassInfo* classInfoOrNull() const;
 
     // Extracting the value.
-    bool getString(JSGlobalObject*, WTF::String&) const;
-    WTF::String getString(JSGlobalObject*) const; // null string if not a string
+    inline bool getString(JSGlobalObject*, WTF::String&) const;
+    inline WTF::String getString(JSGlobalObject*) const; // null string if not a string
     JSObject* getObject() const; // 0 if not an object
 
     // Extracting integer values.
-    bool getUInt32(uint32_t&) const;
+    ALWAYS_INLINE bool getUInt32(uint32_t&) const;
         
     // Basic conversions.
-    JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType = NoPreference) const;
-    bool toBoolean(JSGlobalObject*) const;
-    TriState pureToBoolean() const;
+    inline JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType = NoPreference) const;
+    inline bool toBoolean(JSGlobalObject*) const;
+    inline TriState pureToBoolean() const;
 
     // toNumber conversion is expected to be side effect free if an exception has
     // been set in the CallFrame already.
     double toNumber(JSGlobalObject*) const;
 
-    JSValue toNumeric(JSGlobalObject*) const;
-    JSValue toBigIntOrInt32(JSGlobalObject*) const;
+    ALWAYS_INLINE JSValue toNumeric(JSGlobalObject*) const;
+    ALWAYS_INLINE JSValue toBigIntOrInt32(JSGlobalObject*) const;
     JSBigInt* asHeapBigInt() const;
 
     // toNumber conversion if it can be done without side effects.
     std::optional<double> toNumberFromPrimitive() const;
 
-    JSString* toString(JSGlobalObject*) const; // On exception, this returns the empty string.
-    JSString* toStringOrNull(JSGlobalObject*) const; // On exception, this returns null, to make exception checks faster.
-    Identifier toPropertyKey(JSGlobalObject*) const;
-    JSValue toPropertyKeyValue(JSGlobalObject*) const;
+    inline JSString* toString(JSGlobalObject*) const; // On exception, this returns the empty string.
+    inline JSString* toStringOrNull(JSGlobalObject*) const; // On exception, this returns null, to make exception checks faster.
+    ALWAYS_INLINE Identifier toPropertyKey(JSGlobalObject*) const;
+    ALWAYS_INLINE JSValue toPropertyKeyValue(JSGlobalObject*) const;
     WTF::String toWTFString(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE WTF::String toWTFStringForConsole(JSGlobalObject*) const;
     JSObject* toObject(JSGlobalObject*) const;
 
     // Integer conversions.
     JS_EXPORT_PRIVATE double toIntegerPreserveNaN(JSGlobalObject*) const;
-    double toIntegerWithoutRounding(JSGlobalObject*) const;
-    double toIntegerOrInfinity(JSGlobalObject*) const;
-    int32_t toInt32(JSGlobalObject*) const;
-    uint32_t toUInt32(JSGlobalObject*) const;
-    uint32_t toIndex(JSGlobalObject*, const char* errorName) const;
-    size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
+    inline double toIntegerWithoutRounding(JSGlobalObject*) const;
+    inline double toIntegerOrInfinity(JSGlobalObject*) const;
+    ALWAYS_INLINE int32_t toInt32(JSGlobalObject*) const;
+    inline uint32_t toUInt32(JSGlobalObject*) const;
+    inline uint32_t toIndex(JSGlobalObject*, const char* errorName) const;
+    inline size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
     uint64_t toLength(JSGlobalObject*) const;
 
     JS_EXPORT_PRIVATE JSValue toBigInt(JSGlobalObject*) const;
     int64_t toBigInt64(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE uint64_t toBigUInt64(JSGlobalObject*) const;
 
-    std::optional<uint32_t> toUInt32AfterToNumeric(JSGlobalObject*) const;
+    ALWAYS_INLINE std::optional<uint32_t> toUInt32AfterToNumeric(JSGlobalObject*) const;
 
     // Floating point conversions (this is a convenience function for WebCore;
     // single precision float is not a representation used in JS or JSC).
     float toFloat(JSGlobalObject* globalObject) const { return static_cast<float>(toNumber(globalObject)); }
 
     // Object operations, with the toObject operation included.
-    JSValue get(JSGlobalObject*, PropertyName) const;
-    JSValue get(JSGlobalObject*, PropertyName, PropertySlot&) const;
+    ALWAYS_INLINE JSValue get(JSGlobalObject*, PropertyName) const;
+    ALWAYS_INLINE JSValue get(JSGlobalObject*, PropertyName, PropertySlot&) const;
     JSValue get(JSGlobalObject*, unsigned propertyName) const;
     JSValue get(JSGlobalObject*, unsigned propertyName, PropertySlot&) const;
     JSValue get(JSGlobalObject*, uint64_t propertyName) const;
 
     template<typename T, typename PropertyNameType>
-    T getAs(JSGlobalObject*, PropertyNameType) const;
+    ALWAYS_INLINE T getAs(JSGlobalObject*, PropertyNameType) const;
 
-    bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&) const;
-    template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, CallbackWhenNoException) const;
-    template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const;
+    ALWAYS_INLINE bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&) const;
+    template<typename CallbackWhenNoException> ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, CallbackWhenNoException) const;
+    template<typename CallbackWhenNoException> ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const;
 
-    bool getOwnPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&) const;
+    ALWAYS_INLINE bool getOwnPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&) const;
 
-    bool put(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
-    bool putInline(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    inline bool put(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    ALWAYS_INLINE bool putInline(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE bool putToPrimitive(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE bool putToPrimitiveByIndex(JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
-    bool putByIndex(JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
+    inline bool putByIndex(JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
 
-    JSValue getPrototype(JSGlobalObject*) const;
-    JSValue toThis(JSGlobalObject*, ECMAMode) const;
+    ALWAYS_INLINE JSValue getPrototype(JSGlobalObject*) const;
+    inline JSValue toThis(JSGlobalObject*, ECMAMode) const;
 
-    static bool equal(JSGlobalObject*, JSValue v1, JSValue v2);
+    inline static bool equal(JSGlobalObject*, JSValue v1, JSValue v2);
     static bool equalSlowCase(JSGlobalObject*, JSValue v1, JSValue v2);
     static bool equalSlowCaseInline(JSGlobalObject*, JSValue v1, JSValue v2);
-    static bool strictEqual(JSGlobalObject*, JSValue v1, JSValue v2);
-    static bool strictEqualForCells(JSGlobalObject*, JSCell* v1, JSCell* v2);
-    static TriState pureStrictEqual(JSValue v1, JSValue v2);
+    inline static bool strictEqual(JSGlobalObject*, JSValue v1, JSValue v2);
+    ALWAYS_INLINE static bool strictEqualForCells(JSGlobalObject*, JSCell* v1, JSCell* v2);
+    inline static TriState pureStrictEqual(JSValue v1, JSValue v2);
 
     bool isCell() const;
     JSCell* asCell() const;
 
-    Structure* structureOrNull() const;
+    inline Structure* structureOrNull() const;
 
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;
@@ -360,7 +360,7 @@ public:
     void dumpForBacktrace(PrintStream&) const;
 
     JS_EXPORT_PRIVATE JSObject* synthesizePrototype(JSGlobalObject*) const;
-    bool requireObjectCoercible(JSGlobalObject*) const;
+    ALWAYS_INLINE bool requireObjectCoercible(JSGlobalObject*) const;
 
     // Constants used for Int52. Int52 isn't part of JSValue right now, but JSValues may be
     // converted to Int52s and back again.
@@ -390,7 +390,7 @@ public:
      * cell, integer and bool values the lower 32 bits (the 'payload') contain the pointer
      * integer or boolean value; in the case of all other tags the payload is 0.
      */
-    uint32_t tag() const;
+    inline uint32_t tag() const;
     int32_t payload() const;
 
     // This should only be used by the LLInt C Loop interpreter and OSRExit code who needs

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -109,7 +109,7 @@ public:
     static JSCell* seenMultipleCalleeObjects() { return bitwise_cast<JSCell*>(static_cast<uintptr_t>(1)); }
 
     enum CreatingEarlyCellTag { CreatingEarlyCell };
-    JSCell(CreatingEarlyCellTag);
+    inline JSCell(CreatingEarlyCellTag);
     enum CreatingWellDefinedBuiltinCellTag { CreatingWellDefinedBuiltinCell };
     JSCell(CreatingWellDefinedBuiltinCellTag, StructureID, int32_t typeInfoBlob);
 
@@ -122,19 +122,19 @@ public:
     // Querying the type.
     bool isString() const;
     bool isHeapBigInt() const;
-    bool isSymbol() const;
+    inline bool isSymbol() const;
     bool isObject() const;
-    bool isGetterSetter() const;
-    bool isCustomGetterSetter() const;
-    bool isProxy() const;
-    bool isCallable();
-    bool isConstructor();
-    template<Concurrency> TriState isCallableWithConcurrency();
-    template<Concurrency> TriState isConstructorWithConcurrency();
+    inline bool isGetterSetter() const;
+    inline bool isCustomGetterSetter() const;
+    inline bool isProxy() const;
+    ALWAYS_INLINE bool isCallable();
+    ALWAYS_INLINE bool isConstructor();
+    template<Concurrency> ALWAYS_INLINE TriState isCallableWithConcurrency();
+    template<Concurrency> inline TriState isConstructorWithConcurrency();
     bool inherits(const ClassInfo*) const;
     template<typename Target> bool inherits() const;
     JS_EXPORT_PRIVATE bool isValidCallee() const;
-    bool isAPIValueWrapper() const;
+    inline bool isAPIValueWrapper() const;
     
     // Each cell has a built-in lock. Currently it's simply available for use if you need it. It's
     // a full-blown WTF::Lock. Note that this lock is currently used in JSArray and that lock's
@@ -146,7 +146,7 @@ public:
     JSCellLock& cellLock() const { return *reinterpret_cast<JSCellLock*>(const_cast<JSCell*>(this)); }
     
     JSType type() const;
-    IndexingType indexingTypeAndMisc() const;
+    inline IndexingType indexingTypeAndMisc() const;
     IndexingType indexingMode() const;
     IndexingType indexingType() const;
     StructureID structureID() const { return m_structureID; }
@@ -176,12 +176,12 @@ public:
 
     // Basic conversions.
     JS_EXPORT_PRIVATE JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
-    bool toBoolean(JSGlobalObject*) const;
-    TriState pureToBoolean() const;
+    inline bool toBoolean(JSGlobalObject*) const;
+    inline TriState pureToBoolean() const;
     JS_EXPORT_PRIVATE double toNumber(JSGlobalObject*) const;
-    JSObject* toObject(JSGlobalObject*) const;
+    inline JSObject* toObject(JSGlobalObject*) const;
 
-    JSString* toStringInline(JSGlobalObject*) const;
+    ALWAYS_INLINE JSString* toStringInline(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE JSString* toStringSlowCase(JSGlobalObject*) const;
 
     void dump(PrintStream&) const;
@@ -200,14 +200,14 @@ public:
     const MethodTable* methodTable() const;
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     static bool putByIndex(JSCell*, JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);
-    bool putInline(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    ALWAYS_INLINE bool putInline(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
         
     static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
     JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName);
     static bool deletePropertyByIndex(JSCell*, JSGlobalObject*, unsigned propertyName);
 
-    static bool canUseFastGetOwnProperty(const Structure&);
-    JSValue fastGetOwnProperty(VM&, Structure&, PropertyName);
+    inline static bool canUseFastGetOwnProperty(const Structure&);
+    ALWAYS_INLINE JSValue fastGetOwnProperty(VM&, Structure&, PropertyName);
 
     // The recommended idiom for using cellState() is to switch on it or perform an == comparison on it
     // directly. We deliberately avoid helpers for this, because we want transparency about how the various
@@ -256,8 +256,8 @@ public:
     
     static constexpr TypedArrayType TypedArrayStorageType = NotTypedArray;
 
-    void setPerCellBit(bool);
-    bool perCellBit() const;
+    inline void setPerCellBit(bool);
+    inline bool perCellBit() const;
 protected:
 
     void finishCreation(VM&);
@@ -292,10 +292,10 @@ private:
 
 class JSCellLock : public JSCell {
 public:
-    void lock();
-    bool tryLock();
-    void unlock();
-    bool isLocked() const;
+    inline void lock();
+    inline bool tryLock();
+    inline void unlock();
+    inline bool isLocked() const;
 private:
     JS_EXPORT_PRIVATE void lockSlow();
     JS_EXPORT_PRIVATE void unlockSlow();

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -82,7 +82,7 @@ public:
 
     JS_EXPORT_PRIVATE static JSFunction* create(VM&, JSGlobalObject*, unsigned length, const String& name, NativeFunction, ImplementationVisibility, Intrinsic = NoIntrinsic, NativeFunction nativeConstructor = callHostFunctionAsConstructor, const DOMJIT::Signature* = nullptr);
     
-    static JSFunction* createWithInvalidatedReallocationWatchpoint(VM&, FunctionExecutable*, JSScope*);
+    inline static JSFunction* createWithInvalidatedReallocationWatchpoint(VM&, FunctionExecutable*, JSScope*);
 
     JS_EXPORT_PRIVATE static JSFunction* create(VM&, FunctionExecutable*, JSScope*);
     static JSFunction* create(VM&, FunctionExecutable*, JSScope*, Structure*);
@@ -94,7 +94,7 @@ public:
 
     String nameWithoutGC(VM&);
 
-    JSString* asStringConcurrently() const;
+    inline JSString* asStringConcurrently() const;
 
     ExecutableBase* executable() const
     {
@@ -105,9 +105,9 @@ public:
     }
 
     // To call any of these methods include JSFunctionInlines.h
-    bool isHostFunction() const;
-    FunctionExecutable* jsExecutable() const;
-    Intrinsic intrinsic() const;
+    inline bool isHostFunction() const;
+    inline FunctionExecutable* jsExecutable() const;
+    inline Intrinsic intrinsic() const;
 
     JS_EXPORT_PRIVATE const SourceCode* sourceCode() const;
 
@@ -115,8 +115,8 @@ public:
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    TaggedNativeFunction nativeFunction();
-    TaggedNativeFunction nativeConstructor();
+    inline TaggedNativeFunction nativeFunction();
+    inline TaggedNativeFunction nativeConstructor();
 
     JS_EXPORT_PRIVATE static CallData getConstructData(JSCell*);
     JS_EXPORT_PRIVATE static CallData getCallData(JSCell*);
@@ -134,7 +134,7 @@ public:
         return bitwise_cast<FunctionRareData*>(executableOrRareData & ~rareDataTag);
     }
 
-    FunctionRareData* ensureRareDataAndAllocationProfile(JSGlobalObject*, unsigned inlineCapacity);
+    inline FunctionRareData* ensureRareDataAndAllocationProfile(JSGlobalObject*, unsigned inlineCapacity);
 
     FunctionRareData* rareData() const
     {
@@ -144,18 +144,18 @@ public:
         return nullptr;
     }
 
-    bool isHostOrBuiltinFunction() const;
-    bool isBuiltinFunction() const;
+    inline bool isHostOrBuiltinFunction() const;
+    inline bool isBuiltinFunction() const;
     JS_EXPORT_PRIVATE bool isHostFunctionNonInline() const;
-    bool isClassConstructorFunction() const;
-    bool isRemoteFunction() const;
+    inline bool isClassConstructorFunction() const;
+    inline bool isRemoteFunction() const;
 
     void setFunctionName(JSGlobalObject*, JSValue name);
 
     // Returns the __proto__ for the |this| value if this JSFunction were to be constructed.
     JSObject* prototypeForConstruction(VM&, JSGlobalObject*);
 
-    bool canUseAllocationProfile();
+    inline bool canUseAllocationProfile();
     bool canUseAllocationProfileNonInline();
 
     enum class PropertyStatus {
@@ -165,11 +165,11 @@ public:
     };
     PropertyStatus reifyLazyPropertyIfNeeded(VM&, JSGlobalObject*, PropertyName);
 
-    bool canAssumeNameAndLengthAreOriginal(VM&);
-    double originalLength(VM&);
-    JSString* originalName(JSGlobalObject*);
+    inline bool canAssumeNameAndLengthAreOriginal(VM&);
+    inline double originalLength(VM&);
+    inline JSString* originalName(JSGlobalObject*);
 
-    bool mayHaveNonReifiedPrototype();
+    inline bool mayHaveNonReifiedPrototype();
 
 protected:
     JS_EXPORT_PRIVATE JSFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*);
@@ -205,8 +205,8 @@ private:
     FunctionRareData* allocateAndInitializeRareData(JSGlobalObject*, size_t inlineCapacity);
     FunctionRareData* initializeRareData(JSGlobalObject*, size_t inlineCapacity);
 
-    bool hasReifiedLength() const;
-    bool hasReifiedName() const;
+    inline bool hasReifiedLength() const;
+    inline bool hasReifiedName() const;
     void reifyLength(VM&);
     PropertyStatus reifyName(VM&, JSGlobalObject*);
     PropertyStatus reifyName(VM&, JSGlobalObject*, String name);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -518,14 +518,14 @@ public:
     InlineWatchpointSet& typedArrayConstructorSpeciesWatchpointSet() { return m_typedArrayConstructorSpeciesWatchpointSet; }
     InlineWatchpointSet& typedArrayPrototypeIteratorProtocolWatchpointSet() { return m_typedArrayPrototypeIteratorProtocolWatchpointSet; }
 
-    bool isArrayPrototypeIteratorProtocolFastAndNonObservable();
-    bool isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(TypedArrayType);
-    bool isMapPrototypeIteratorProtocolFastAndNonObservable();
-    bool isSetPrototypeIteratorProtocolFastAndNonObservable();
-    bool isStringPrototypeIteratorProtocolFastAndNonObservable();
-    bool isMapPrototypeSetFastAndNonObservable();
-    bool isSetPrototypeAddFastAndNonObservable();
-    bool isArgumentsPrototypeIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isArrayPrototypeIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(TypedArrayType);
+    ALWAYS_INLINE bool isMapPrototypeIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isSetPrototypeIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isStringPrototypeIteratorProtocolFastAndNonObservable();
+    ALWAYS_INLINE bool isMapPrototypeSetFastAndNonObservable();
+    ALWAYS_INLINE bool isSetPrototypeAddFastAndNonObservable();
+    ALWAYS_INLINE bool isArgumentsPrototypeIteratorProtocolFastAndNonObservable();
 
 #if ENABLE(DFG_JIT)
     using ReferencedGlobalPropertyWatchpointSets = HashMap<RefPtr<UniquedStringImpl>, Ref<WatchpointSet>, IdentifierRepHash>;
@@ -545,9 +545,9 @@ public:
 
     template<typename T>
     struct WeakCustomGetterOrSetterHash {
-        static unsigned hash(const Weak<T>&);
-        static bool equal(const Weak<T>&, const Weak<T>&);
-        static unsigned hash(const PropertyName&, typename T::CustomFunctionPointer, const ClassInfo*);
+        inline static unsigned hash(const Weak<T>&);
+        inline static bool equal(const Weak<T>&, const Weak<T>&);
+        inline static unsigned hash(const PropertyName&, typename T::CustomFunctionPointer, const ClassInfo*);
 
         static constexpr bool safeToCompareToEmptyOrDeleted = false;
     };
@@ -650,38 +650,38 @@ public:
     JSFunction* parseFloatFunction() const { return m_parseFloatFunction.get(this); }
 
     JSFunction* evalFunction() const { return m_evalFunction.get(this); }
-    JSFunction* throwTypeErrorFunction() const;
+    inline JSFunction* throwTypeErrorFunction() const;
     JSFunction* objectProtoToStringFunction() const { return m_objectProtoToStringFunction.get(this); }
     JSFunction* objectProtoToStringFunctionConcurrently() const { return m_objectProtoToStringFunction.getConcurrently(); }
     JSFunction* arrayProtoToStringFunction() const { return m_arrayProtoToStringFunction.get(this); }
     JSFunction* arrayProtoValuesFunction() const { return m_arrayProtoValuesFunction.get(this); }
     JSFunction* arrayProtoValuesFunctionConcurrently() const { return m_arrayProtoValuesFunction.getConcurrently(); }
-    JSFunction* iteratorProtocolFunction() const;
-    JSFunction* newPromiseCapabilityFunction() const;
+    inline JSFunction* iteratorProtocolFunction() const;
+    inline JSFunction* newPromiseCapabilityFunction() const;
     JSFunction* promiseResolveFunction() const { return m_promiseResolveFunction.get(this); }
-    JSFunction* resolvePromiseFunction() const;
-    JSFunction* rejectPromiseFunction() const;
-    JSFunction* promiseProtoThenFunction() const;
-    JSFunction* performPromiseThenFunction() const;
+    inline JSFunction* resolvePromiseFunction() const;
+    inline JSFunction* rejectPromiseFunction() const;
+    inline JSFunction* promiseProtoThenFunction() const;
+    inline JSFunction* performPromiseThenFunction() const;
     JSFunction* objectProtoValueOfFunction() const { return m_objectProtoValueOfFunction.get(); }
     JSFunction* numberProtoToStringFunction() const { return m_numberProtoToStringFunction.getInitializedOnMainThread(this); }
     JSFunction* functionProtoHasInstanceSymbolFunction() const { return m_functionProtoHasInstanceSymbolFunction.get(); }
-    JSFunction* regExpProtoExecFunction() const;
+    inline JSFunction* regExpProtoExecFunction() const;
     JSFunction* typedArrayProtoSort() const { return m_typedArrayProtoSort.get(this); }
-    JSFunction* stringProtoSubstringFunction() const;
-    JSFunction* performProxyObjectHasFunction() const;
-    JSFunction* performProxyObjectGetFunction() const;
-    JSFunction* performProxyObjectGetFunctionConcurrently() const;
-    JSFunction* performProxyObjectGetByValFunction() const;
-    JSFunction* performProxyObjectGetByValFunctionConcurrently() const;
-    JSFunction* performProxyObjectSetSloppyFunction() const;
-    JSFunction* performProxyObjectSetSloppyFunctionConcurrently() const;
-    JSFunction* performProxyObjectSetStrictFunction() const;
-    JSFunction* performProxyObjectSetStrictFunctionConcurrently() const;
+    inline JSFunction* stringProtoSubstringFunction() const;
+    inline JSFunction* performProxyObjectHasFunction() const;
+    inline JSFunction* performProxyObjectGetFunction() const;
+    inline JSFunction* performProxyObjectGetFunctionConcurrently() const;
+    inline JSFunction* performProxyObjectGetByValFunction() const;
+    inline JSFunction* performProxyObjectGetByValFunctionConcurrently() const;
+    inline JSFunction* performProxyObjectSetSloppyFunction() const;
+    inline JSFunction* performProxyObjectSetSloppyFunctionConcurrently() const;
+    inline JSFunction* performProxyObjectSetStrictFunction() const;
+    inline JSFunction* performProxyObjectSetStrictFunctionConcurrently() const;
     JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
-    GetterSetter* regExpProtoGlobalGetter() const;
-    GetterSetter* regExpProtoUnicodeGetter() const;
-    GetterSetter* regExpProtoUnicodeSetsGetter() const;
+    inline GetterSetter* regExpProtoGlobalGetter() const;
+    inline GetterSetter* regExpProtoUnicodeGetter() const;
+    inline GetterSetter* regExpProtoUnicodeSetsGetter() const;
     GetterSetter* throwTypeErrorArgumentsCalleeGetterSetter() const { return m_throwTypeErrorArgumentsCalleeGetterSetter.get(this); }
     
     JSModuleLoader* moduleLoader() const { return m_moduleLoader.get(this); }
@@ -728,7 +728,7 @@ public:
         ASSERT(indexingType & IsArray);
         return m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(indexingType)].get();
     }
-    Structure* arrayStructureForIndexingTypeDuringAllocation(IndexingType indexingType) const
+    ALWAYS_INLINE Structure* arrayStructureForIndexingTypeDuringAllocation(IndexingType indexingType) const
     {
         ASSERT(indexingType & IsArray);
         return m_arrayStructureForIndexingShapeDuringAllocation[arrayIndexFromIndexingType(indexingType)].get();
@@ -940,12 +940,12 @@ public:
     void haveABadTime(VM&);
     void clearStructureCache(VM&);
         
-    static bool objectPrototypeIsSaneConcurrently(Structure* objectPrototypeStructure);
-    bool arrayPrototypeChainIsSaneConcurrently(Structure* arrayPrototypeStructure, Structure* objectPrototypeStructure);
-    bool stringPrototypeChainIsSaneConcurrently(Structure* stringPrototypeStructure, Structure* objectPrototypeStructure);
-    bool objectPrototypeChainIsSane();
-    bool arrayPrototypeChainIsSane();
-    bool stringPrototypeChainIsSane();
+    ALWAYS_INLINE static bool objectPrototypeIsSaneConcurrently(Structure* objectPrototypeStructure);
+    ALWAYS_INLINE bool arrayPrototypeChainIsSaneConcurrently(Structure* arrayPrototypeStructure, Structure* objectPrototypeStructure);
+    ALWAYS_INLINE bool stringPrototypeChainIsSaneConcurrently(Structure* stringPrototypeStructure, Structure* objectPrototypeStructure);
+    ALWAYS_INLINE bool objectPrototypeChainIsSane();
+    ALWAYS_INLINE bool arrayPrototypeChainIsSane();
+    ALWAYS_INLINE bool stringPrototypeChainIsSane();
 
     bool isRegExpRecompiled() const
     {
@@ -962,7 +962,7 @@ public:
 
     static bool supportsRichSourceInfo(const JSGlobalObject*) { return true; }
 
-    static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject*);
+    inline static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject*);
 
     static bool shouldInterruptScript(const JSGlobalObject*) { return true; }
     static bool shouldInterruptScriptBeforeTimeout(const JSGlobalObject*) { return false; }
@@ -998,7 +998,7 @@ public:
     VM& vm() const { return *m_vm; }
     JSObject* globalThis() const;
     WriteBarrier<JSObject>* addressOfGlobalThis() { return &m_globalThis; }
-    OptionSet<CodeGenerationMode> defaultCodeGenerationMode() const;
+    inline OptionSet<CodeGenerationMode> defaultCodeGenerationMode() const;
 
     static inline Structure* createStructure(VM&, JSValue prototype);
     static inline Structure* createStructureForShadowRealm(VM&, JSValue prototype);

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -52,11 +52,11 @@ public:
             cache(static_cast<Type>(i)).fill({ });
     }
 
-    VM& vm() const;
+    ALWAYS_INLINE VM& vm() const;
 
 private:
     template<typename CharacterType>
-    Ref<AtomStringImpl> make(Type, const CharacterType*, unsigned length);
+    ALWAYS_INLINE Ref<AtomStringImpl> make(Type, const CharacterType*, unsigned length);
 
     ALWAYS_INLINE RefPtr<AtomStringImpl>& cacheSlot(Type type, UChar firstCharacter, UChar lastCharacter, UChar length)
     {

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -157,14 +157,14 @@ public:
     T getAs(JSGlobalObject*, PropertyNameType) const;
 
     template<bool checkNullStructure = false>
-    bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&);
+    ALWAYS_INLINE bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&);
     bool getPropertySlot(JSGlobalObject*, unsigned propertyName, PropertySlot&);
-    bool getPropertySlot(JSGlobalObject*, uint64_t propertyName, PropertySlot&);
-    template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, CallbackWhenNoException) const;
-    template<typename CallbackWhenNoException> typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const;
+    ALWAYS_INLINE bool getPropertySlot(JSGlobalObject*, uint64_t propertyName, PropertySlot&);
+    template<typename CallbackWhenNoException> ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, CallbackWhenNoException) const;
+    template<typename CallbackWhenNoException> ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, bool, PropertySlot&>::type getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&, CallbackWhenNoException) const;
 
-    template<typename PropertyNameType> JSValue getIfPropertyExists(JSGlobalObject*, const PropertyNameType&);
-    bool noSideEffectMayHaveNonIndexProperty(VM&, PropertyName);
+    template<typename PropertyNameType> inline JSValue getIfPropertyExists(JSGlobalObject*, const PropertyNameType&);
+    inline bool noSideEffectMayHaveNonIndexProperty(VM&, PropertyName);
 
 private:
     static bool getOwnPropertySlotImpl(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
@@ -172,14 +172,14 @@ public:
     JS_EXPORT_PRIVATE_IF_ASSERT_ENABLED static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
 
     JS_EXPORT_PRIVATE static bool getOwnPropertySlotByIndex(JSObject*, JSGlobalObject*, unsigned propertyName, PropertySlot&);
-    bool getOwnPropertySlotInline(JSGlobalObject*, PropertyName, PropertySlot&);
+    inline bool getOwnPropertySlotInline(JSGlobalObject*, PropertyName, PropertySlot&);
 
     // The key difference between this and getOwnPropertySlot is that getOwnPropertySlot
     // currently returns incorrect results for the DOM window (with non-own properties)
     // being returned. Once this is fixed we should migrate code & remove this method.
     JS_EXPORT_PRIVATE bool getOwnPropertyDescriptor(JSGlobalObject*, PropertyName, PropertyDescriptor&);
 
-    static bool getPrivateFieldSlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
+    ALWAYS_INLINE static bool getPrivateFieldSlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     inline bool hasPrivateField(JSGlobalObject*, PropertyName);
     inline bool getPrivateField(JSGlobalObject*, PropertyName, PropertySlot&);
     inline void setPrivateField(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
@@ -202,7 +202,7 @@ public:
         return m_butterfly->vectorLength();
     }
     
-    static bool putInlineForJSObject(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    ALWAYS_INLINE static bool putInlineForJSObject(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     
     JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     static bool mightBeSpecialProperty(VM&, JSType, UniquedStringImpl*);
@@ -678,7 +678,7 @@ public:
     bool putDirect(VM&, PropertyName, JSValue, unsigned attributes = 0);
     bool putDirect(VM&, PropertyName, JSValue, unsigned attributes, PutPropertySlot&);
     bool putDirect(VM&, PropertyName, JSValue, PutPropertySlot&);
-    void putDirectWithoutTransition(VM&, PropertyName, JSValue, unsigned attributes = 0);
+    inline void putDirectWithoutTransition(VM&, PropertyName, JSValue, unsigned attributes = 0);
     bool putDirectNonIndexAccessor(VM&, PropertyName, GetterSetter*, unsigned attributes);
     void putDirectNonIndexAccessorWithoutTransition(VM&, PropertyName, GetterSetter*, unsigned attributes);
     bool putDirectAccessor(JSGlobalObject*, PropertyName, GetterSetter*, unsigned attributes);
@@ -693,15 +693,15 @@ public:
     bool hasProperty(JSGlobalObject*, uint64_t propertyName) const;
     bool hasEnumerableProperty(JSGlobalObject*, PropertyName) const;
     bool hasEnumerableProperty(JSGlobalObject*, unsigned propertyName) const;
-    bool hasOwnProperty(JSGlobalObject*, PropertyName, PropertySlot&) const;
-    bool hasOwnProperty(JSGlobalObject*, PropertyName) const;
-    bool hasOwnProperty(JSGlobalObject*, unsigned) const;
+    ALWAYS_INLINE bool hasOwnProperty(JSGlobalObject*, PropertyName, PropertySlot&) const;
+    ALWAYS_INLINE bool hasOwnProperty(JSGlobalObject*, PropertyName) const;
+    ALWAYS_INLINE bool hasOwnProperty(JSGlobalObject*, unsigned) const;
 
     JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
     JS_EXPORT_PRIVATE static bool deletePropertyByIndex(JSCell*, JSGlobalObject*, unsigned propertyName);
-    bool deleteProperty(JSGlobalObject*, PropertyName);
-    bool deleteProperty(JSGlobalObject*, uint32_t propertyName);
-    bool deleteProperty(JSGlobalObject*, uint64_t propertyName);
+    inline bool deleteProperty(JSGlobalObject*, PropertyName);
+    inline bool deleteProperty(JSGlobalObject*, uint32_t propertyName);
+    inline bool deleteProperty(JSGlobalObject*, uint64_t propertyName);
 
     JSValue ordinaryToPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
 
@@ -715,7 +715,7 @@ public:
     JS_EXPORT_PRIVATE static void getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
     JS_EXPORT_PRIVATE void getOwnIndexedPropertyNames(JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
     JS_EXPORT_PRIVATE void getOwnNonIndexPropertyNames(JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
-    void getNonReifiedStaticPropertyNames(VM&, PropertyNameArray&, DontEnumPropertiesMode);
+    ALWAYS_INLINE void getNonReifiedStaticPropertyNames(VM&, PropertyNameArray&, DontEnumPropertiesMode);
 
     JS_EXPORT_PRIVATE uint32_t getEnumerableLength();
 
@@ -814,12 +814,12 @@ public:
     //  - provides no special handling for __proto__
     //  - does not walk the prototype chain (to check for accessors or non-writable properties).
     // This is used by JSLexicalEnvironment.
-    bool putOwnDataProperty(VM&, PropertyName, JSValue, PutPropertySlot&);
-    bool putOwnDataPropertyMayBeIndex(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    inline bool putOwnDataProperty(VM&, PropertyName, JSValue, PutPropertySlot&);
+    inline bool putOwnDataPropertyMayBeIndex(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
     void putOwnDataPropertyBatching(VM&, const RefPtr<UniquedStringImpl>*, const EncodedJSValue*, unsigned size);
 private:
-    void validatePutOwnDataProperty(VM&, PropertyName, JSValue);
+    inline void validatePutOwnDataProperty(VM&, PropertyName, JSValue);
 public:
 
     // Fast access to known property offsets.
@@ -839,7 +839,7 @@ public:
     JSFunction* putDirectBuiltinFunctionWithoutTransition(VM&, JSGlobalObject*, const PropertyName&, FunctionExecutable*, unsigned attributes);
 
     JS_EXPORT_PRIVATE static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
-    bool createDataProperty(JSGlobalObject*, PropertyName, JSValue, bool shouldThrow);
+    ALWAYS_INLINE bool createDataProperty(JSGlobalObject*, PropertyName, JSValue, bool shouldThrow);
 
     bool isEnvironment() const;
     bool isGlobalObject() const;
@@ -985,11 +985,11 @@ public:
 
     JS_EXPORT_PRIVATE JSValue getMethod(JSGlobalObject*, CallData&, const Identifier&, const String& errorMessage);
 
-    bool canPerformFastPutInline(VM&, PropertyName);
-    bool canPerformFastPutInlineExcludingProto();
+    ALWAYS_INLINE bool canPerformFastPutInline(VM&, PropertyName);
+    ALWAYS_INLINE bool canPerformFastPutInlineExcludingProto();
 
-    bool mayBePrototype() const;
-    void didBecomePrototype(VM&);
+    inline bool mayBePrototype() const;
+    inline void didBecomePrototype(VM&);
 
     std::optional<Structure::PropertyHashEntry> findPropertyHashEntry(PropertyName) const;
 
@@ -1003,7 +1003,7 @@ public:
 
     JS_EXPORT_PRIVATE NEVER_INLINE bool putInlineSlow(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE NEVER_INLINE bool putInlineFastReplacingStaticPropertyIfNeeded(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
-    bool putInlineFast(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    ALWAYS_INLINE bool putInlineFast(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
 protected:
 #if ASSERT_ENABLED
@@ -1183,7 +1183,7 @@ private:
     ContiguousJSValues tryMakeWritableContiguousSlow(VM&);
     JS_EXPORT_PRIVATE ArrayStorage* ensureArrayStorageSlow(VM&);
 
-    PropertyOffset prepareToPutDirectWithoutTransition(VM&, PropertyName, unsigned attributes, StructureID, Structure*);
+    ALWAYS_INLINE PropertyOffset prepareToPutDirectWithoutTransition(VM&, PropertyName, unsigned attributes, StructureID, Structure*);
 
     AuxiliaryBarrier<Butterfly*> m_butterfly;
 #if CPU(ADDRESS32)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -110,7 +110,7 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | StructureIsImmortal | OverridesPut;
 
     static constexpr bool needsDestruction = true;
-    static void destroy(JSCell*);
+    ALWAYS_INLINE static void destroy(JSCell*);
 
     // We specialize the string subspace to get the fastest possible sweep. This wouldn't be
     // necessary if JSString didn't have a destructor.
@@ -305,7 +305,7 @@ private:
 class JSRopeString final : public JSString {
     friend class JSString;
 public:
-    static void destroy(JSCell*);
+    ALWAYS_INLINE static void destroy(JSCell*);
 
     template<typename, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -500,7 +500,7 @@ public:
 private:
     friend class LLIntOffsetsExtractor;
 
-    void convertToNonRope(String&&) const;
+    inline void convertToNonRope(String&&) const;
 
     void initializeIs8Bit(bool flag) const
     {
@@ -594,7 +594,7 @@ public:
     JS_EXPORT_PRIVATE const String& resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM) const;
 
     template<typename CharacterType>
-    static void resolveToBuffer(JSString*, JSString*, JSString*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
+    inline static void resolveToBuffer(JSString*, JSString*, JSString*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
 
 private:
     template<typename CharacterType>

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
@@ -38,7 +38,7 @@ public:
     using Cache = std::array<JSString*, capacity>;
 
     template<typename Buffer, typename Func>
-    JSString* make(VM&, Buffer&, const Func&);
+    ALWAYS_INLINE JSString* make(VM&, Buffer&, const Func&);
 
     ALWAYS_INLINE void clear()
     {

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -86,9 +86,9 @@ public:
 
     // Call these versions of the match functions if you're desperate for performance.
     template<typename VectorType, Yarr::MatchFrom thread = Yarr::MatchFrom::VMThread>
-    int matchInline(JSGlobalObject* nullOrGlobalObject, VM&, const String&, unsigned startOffset, VectorType& ovector);
+    ALWAYS_INLINE int matchInline(JSGlobalObject* nullOrGlobalObject, VM&, const String&, unsigned startOffset, VectorType& ovector);
     template<Yarr::MatchFrom thread = Yarr::MatchFrom::VMThread>
-    MatchResult matchInline(JSGlobalObject* nullOrGlobalObject, VM&, const String&, unsigned startOffset);
+    ALWAYS_INLINE MatchResult matchInline(JSGlobalObject* nullOrGlobalObject, VM&, const String&, unsigned startOffset);
     
     unsigned numSubpatterns() const { return m_numSubpatterns; }
 
@@ -136,8 +136,8 @@ public:
         return m_state == JITCode || m_state == ByteCode;
     }
 
-    bool hasCodeFor(Yarr::CharSize);
-    bool hasMatchOnlyCodeFor(Yarr::CharSize);
+    ALWAYS_INLINE bool hasCodeFor(Yarr::CharSize);
+    ALWAYS_INLINE bool hasMatchOnlyCodeFor(Yarr::CharSize);
 
     void deleteCode();
 
@@ -182,10 +182,10 @@ private:
     void byteCodeCompileIfNecessary(VM*);
 
     void compile(VM*, Yarr::CharSize, std::optional<StringView> sampleString);
-    void compileIfNecessary(VM&, Yarr::CharSize, std::optional<StringView> sampleString);
+    ALWAYS_INLINE void compileIfNecessary(VM&, Yarr::CharSize, std::optional<StringView> sampleString);
 
     void compileMatchOnly(VM*, Yarr::CharSize, std::optional<StringView> sampleString);
-    void compileIfNecessaryMatchOnly(VM&, Yarr::CharSize, std::optional<StringView> sampleString);
+    ALWAYS_INLINE void compileIfNecessaryMatchOnly(VM&, Yarr::CharSize, std::optional<StringView> sampleString);
 
 #if ENABLE(YARR_JIT_DEBUG)
     void matchCompareWithInterpreter(const String&, int startOffset, int* offsetVector, int jitResult);

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.h
@@ -38,7 +38,7 @@ public:
     void setMultiline(bool multiline) { m_multiline = multiline; }
     bool multiline() const { return m_multiline; }
 
-    void setInput(JSGlobalObject*, JSString*);
+    inline void setInput(JSGlobalObject*, JSString*);
     JSString* input() { return m_cachedResult.input(); }
 
     DECLARE_VISIT_AGGREGATE;
@@ -48,15 +48,15 @@ public:
     JSValue getLeftContext(JSGlobalObject*);
     JSValue getRightContext(JSGlobalObject*);
 
-    MatchResult performMatch(JSGlobalObject*, RegExp*, JSString*, const String&, int startOffset, int** ovector);
-    MatchResult performMatch(JSGlobalObject*, RegExp*, JSString*, const String&, int startOffset);
-    void recordMatch(VM&, JSGlobalObject*, RegExp*, JSString*, const MatchResult&);
+    ALWAYS_INLINE MatchResult performMatch(JSGlobalObject*, RegExp*, JSString*, const String&, int startOffset, int** ovector);
+    ALWAYS_INLINE MatchResult performMatch(JSGlobalObject*, RegExp*, JSString*, const String&, int startOffset);
+    ALWAYS_INLINE void recordMatch(VM&, JSGlobalObject*, RegExp*, JSString*, const MatchResult&);
 
     static ptrdiff_t offsetOfCachedResult() { return OBJECT_OFFSETOF(RegExpGlobalData, m_cachedResult); }
 
     const Vector<int>& ovector() const { return m_ovector; }
 
-    void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, Vector<int>&&);
+    inline void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, Vector<int>&&);
 
 private:
     RegExpCachedResult m_cachedResult;

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -102,7 +102,7 @@ public:
     bool test(JSGlobalObject* globalObject, JSString* string) { return !!match(globalObject, string); }
     bool testInline(JSGlobalObject* globalObject, JSString* string) { return !!matchInline(globalObject, string); }
     JSValue exec(JSGlobalObject*, JSString*);
-    JSValue execInline(JSGlobalObject*, JSString*);
+    inline JSValue execInline(JSGlobalObject*, JSString*);
     MatchResult match(JSGlobalObject*, JSString*);
     JSValue matchGlobal(JSGlobalObject*, JSString*);
 

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -146,7 +146,7 @@ protected:
     static void runConstraint(const ConcurrentJSLocker&, Visitor&, CodeBlock*);
     template<typename Visitor>
     static void visitCodeBlockEdge(Visitor&, CodeBlock*);
-    void finalizeCodeBlockEdge(VM&, WriteBarrier<CodeBlock>&);
+    inline void finalizeCodeBlockEdge(VM&, WriteBarrier<CodeBlock>&);
 
     SourceCode m_source;
     Intrinsic m_intrinsic { NoIntrinsic };

--- a/Source/JavaScriptCore/runtime/StringReplaceCache.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCache.h
@@ -51,8 +51,8 @@ public:
         Vector<int> m_lastMatch { };
     };
 
-    Entry* get(const String& subject, RegExp*);
-    void set(const String& subject, RegExp*, JSImmutableButterfly*, const Vector<int>&);
+    inline Entry* get(const String& subject, RegExp*);
+    inline void set(const String& subject, RegExp*, JSImmutableButterfly*, const Vector<int>&);
 
     void clear()
     {

--- a/Source/JavaScriptCore/runtime/StringSplitCache.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCache.h
@@ -49,8 +49,8 @@ public:
         JSImmutableButterfly* m_butterfly { nullptr };
     };
 
-    JSImmutableButterfly* get(const String& subject, const String& separator);
-    void set(const String& subject, const String& separator, JSImmutableButterfly*);
+    inline JSImmutableButterfly* get(const String& subject, const String& separator);
+    inline void set(const String& subject, const String& separator, JSImmutableButterfly*);
 
     void clear()
     {

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -284,8 +284,8 @@ public:
 
     JS_EXPORT_PRIVATE static Structure* addPropertyTransition(VM&, Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     JS_EXPORT_PRIVATE static Structure* addNewPropertyTransition(VM&, Structure*, PropertyName, unsigned attributes, PropertyOffset&, PutPropertySlot::Context = PutPropertySlot::UnknownContext, DeferredStructureTransitionWatchpointFire* = nullptr);
-    static Structure* addPropertyTransitionToExistingStructureConcurrently(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);
-    static Structure* addPropertyTransitionToExistingStructure(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
+    ALWAYS_INLINE static Structure* addPropertyTransitionToExistingStructureConcurrently(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);
+    ALWAYS_INLINE static Structure* addPropertyTransitionToExistingStructure(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     static Structure* removeNewPropertyTransition(VM&, Structure*, PropertyName, PropertyOffset&, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* removePropertyTransition(VM&, Structure*, PropertyName, PropertyOffset&, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* removePropertyTransitionFromExistingStructure(Structure*, PropertyName, PropertyOffset&);
@@ -298,7 +298,7 @@ public:
     JS_EXPORT_PRIVATE static Structure* sealTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     JS_EXPORT_PRIVATE static Structure* freezeTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
     static Structure* preventExtensionsTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
-    static Structure* nonPropertyTransition(VM&, Structure*, TransitionKind, DeferredStructureTransitionWatchpointFire*);
+    inline static Structure* nonPropertyTransition(VM&, Structure*, TransitionKind, DeferredStructureTransitionWatchpointFire*);
     static Structure* setBrandTransitionFromExistingStructureConcurrently(Structure*, UniquedStringImpl*);
     static Structure* setBrandTransition(VM&, Structure*, Symbol* brand, DeferredStructureTransitionWatchpointFire* = nullptr);
     JS_EXPORT_PRIVATE static Structure* becomePrototypeTransition(VM&, Structure*, DeferredStructureTransitionWatchpointFire* = nullptr);
@@ -316,14 +316,14 @@ public:
     // the lock. The callback is not called if there is no change being made, like if you call
     // removePropertyWithoutTransition() and the property is not found.
     template<typename Func>
-    PropertyOffset addPropertyWithoutTransition(VM&, PropertyName, unsigned attributes, const Func&);
+    inline PropertyOffset addPropertyWithoutTransition(VM&, PropertyName, unsigned attributes, const Func&);
     template<typename Func>
-    PropertyOffset removePropertyWithoutTransition(VM&, PropertyName, const Func&);
+    inline PropertyOffset removePropertyWithoutTransition(VM&, PropertyName, const Func&);
     template<typename Func>
-    PropertyOffset attributeChangeWithoutTransition(VM&, PropertyName, unsigned attributes, const Func&);
+    inline PropertyOffset attributeChangeWithoutTransition(VM&, PropertyName, unsigned attributes, const Func&);
     template<typename Func>
-    auto addOrReplacePropertyWithoutTransition(VM&, PropertyName, unsigned attributes, const Func&) -> decltype(auto);
-    void setPrototypeWithoutTransition(VM&, JSValue prototype);
+    ALWAYS_INLINE auto addOrReplacePropertyWithoutTransition(VM&, PropertyName, unsigned attributes, const Func&) -> decltype(auto);
+    ALWAYS_INLINE void setPrototypeWithoutTransition(VM&, JSValue prototype);
         
     bool isDictionary() const { return dictionaryKind() != NoneDictionaryKind; }
     bool isUncacheableDictionary() const { return dictionaryKind() == UncachedDictionaryKind; }
@@ -409,7 +409,7 @@ public:
 
     // NOTE: This method should only be called during the creation of structures, since the global
     // object of a structure is presumed to be immutable in a bunch of places.
-    void setGlobalObject(VM&, JSGlobalObject*);
+    ALWAYS_INLINE void setGlobalObject(VM&, JSGlobalObject*);
 
     ALWAYS_INLINE bool hasMonoProto() const
     {
@@ -425,14 +425,14 @@ public:
         return m_prototype.get();
     }
     JSValue storedPrototype(const JSObject*) const;
-    JSObject* storedPrototypeObject(const JSObject*) const;
-    Structure* storedPrototypeStructure(const JSObject*) const;
+    ALWAYS_INLINE JSObject* storedPrototypeObject(const JSObject*) const;
+    ALWAYS_INLINE Structure* storedPrototypeStructure(const JSObject*) const;
 
     JSObject* storedPrototypeObject() const;
-    Structure* storedPrototypeStructure() const;
-    JSValue prototypeForLookup(JSGlobalObject*) const;
-    JSValue prototypeForLookup(JSGlobalObject*, JSCell* base) const;
-    StructureChain* prototypeChain(VM&, JSGlobalObject*, JSObject* base) const;
+    inline Structure* storedPrototypeStructure() const;
+    inline JSValue prototypeForLookup(JSGlobalObject*) const;
+    inline JSValue prototypeForLookup(JSGlobalObject*, JSCell* base) const;
+    inline StructureChain* prototypeChain(VM&, JSGlobalObject*, JSObject* base) const;
     DECLARE_VISIT_CHILDREN;
     
     // A Structure is cheap to mark during GC if doing so would only add a small and bounded amount
@@ -497,7 +497,7 @@ public:
             return static_cast<StructureRareData*>(cell)->previousID();
         return static_cast<Structure*>(cell);
     }
-    bool transitivelyTransitionedFrom(Structure* structureToFind);
+    inline bool transitivelyTransitionedFrom(Structure* structureToFind);
 
     PropertyOffset maxOffset() const
     {
@@ -619,12 +619,12 @@ public:
     }
     
     bool hasIndexingHeader(const JSCell*) const;    
-    bool masqueradesAsUndefined(JSGlobalObject* lexicalGlobalObject);
+    inline bool masqueradesAsUndefined(JSGlobalObject* lexicalGlobalObject);
 
     PropertyOffset get(VM&, PropertyName);
     PropertyOffset get(VM&, PropertyName, unsigned& attributes);
 
-    bool canPerformFastPropertyEnumeration() const;
+    ALWAYS_INLINE bool canPerformFastPropertyEnumeration() const;
 
     // This is a somewhat internalish method. It will call your functor while possibly holding the
     // Structure's lock. There is no guarantee whether the lock is held or not in any particular
@@ -682,9 +682,9 @@ public:
     bool canCachePropertyNameEnumerator(VM&) const;
     bool canAccessPropertiesQuicklyForEnumeration() const;
 
-    JSImmutableButterfly* cachedPropertyNames(CachedPropertyNamesKind) const;
-    JSImmutableButterfly* cachedPropertyNamesIgnoringSentinel(CachedPropertyNamesKind) const;
-    void setCachedPropertyNames(VM&, CachedPropertyNamesKind, JSImmutableButterfly*);
+    inline JSImmutableButterfly* cachedPropertyNames(CachedPropertyNamesKind) const;
+    inline JSImmutableButterfly* cachedPropertyNamesIgnoringSentinel(CachedPropertyNamesKind) const;
+    inline void setCachedPropertyNames(VM&, CachedPropertyNamesKind, JSImmutableButterfly*);
     bool canCacheOwnPropertyNames() const;
 
     void getPropertyNamesFromStructure(VM&, PropertyNameArray&, DontEnumPropertiesMode);
@@ -695,7 +695,7 @@ public:
             return JSValue();
         return rareData()->cachedSpecialProperty(key);
     }
-    void cacheSpecialProperty(JSGlobalObject*, VM&, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
+    inline void cacheSpecialProperty(JSGlobalObject*, VM&, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
     static ptrdiff_t prototypeOffset()
     {
@@ -747,7 +747,7 @@ public:
         return OBJECT_OFFSETOF(Structure, m_propertyHash);
     }
 
-    static Structure* createStructure(VM&);
+    inline static Structure* createStructure(VM&);
         
     bool transitionWatchpointSetHasBeenInvalidated() const
     {
@@ -810,11 +810,11 @@ public:
         ensurePropertyReplacementWatchpointSet(vm, offset);
     }
     void startWatchingPropertyForReplacements(VM&, PropertyName);
-    WatchpointSet* propertyReplacementWatchpointSet(PropertyOffset);
+    inline WatchpointSet* propertyReplacementWatchpointSet(PropertyOffset);
     WatchpointSet* firePropertyReplacementWatchpointSet(VM&, PropertyOffset, const char* reason);
 
-    void didReplaceProperty(PropertyOffset);
-    void didCachePropertyReplacement(VM&, PropertyOffset);
+    inline void didReplaceProperty(PropertyOffset);
+    inline void didCachePropertyReplacement(VM&, PropertyOffset);
     
     void startWatchingInternalPropertiesIfNecessary(VM& vm)
     {
@@ -835,7 +835,7 @@ public:
 
     unsigned propertyHash() const { return m_propertyHash; }
 
-    static bool shouldConvertToPolyProto(const Structure* a, const Structure* b);
+    ALWAYS_INLINE static bool shouldConvertToPolyProto(const Structure* a, const Structure* b);
 
     UniquedStringImpl* transitionPropertyName() const { return m_transitionPropertyName.get(); }
 
@@ -925,9 +925,9 @@ private:
     JS_EXPORT_PRIVATE Structure(VM&, JSGlobalObject*, JSValue prototype, const TypeInfo&, const ClassInfo*, IndexingType, unsigned inlineCapacity);
     Structure(VM&, CreatingEarlyCellTag);
 
-    static Structure* create(VM&, Structure*, DeferredStructureTransitionWatchpointFire*);
+    inline static Structure* create(VM&, Structure*, DeferredStructureTransitionWatchpointFire*);
     
-    static Structure* addPropertyTransitionToExistingStructureImpl(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);
+    inline static Structure* addPropertyTransitionToExistingStructureImpl(Structure*, UniquedStringImpl* uid, unsigned attributes, PropertyOffset&);
     static Structure* removePropertyTransitionFromExistingStructureImpl(Structure*, PropertyName, unsigned attributes, PropertyOffset&);
     static Structure* setBrandTransitionFromExistingStructureImpl(Structure*, UniquedStringImpl*);
 
@@ -946,17 +946,17 @@ private:
 
     enum class ShouldPin : bool { No, Yes };
     template<ShouldPin, typename Func>
-    PropertyOffset add(VM&, PropertyName, unsigned attributes, const Func&);
+    inline PropertyOffset add(VM&, PropertyName, unsigned attributes, const Func&);
     PropertyOffset add(VM&, PropertyName, unsigned attributes);
     template<ShouldPin, typename Func>
-    PropertyOffset remove(VM&, PropertyName, const Func&);
+    inline PropertyOffset remove(VM&, PropertyName, const Func&);
     PropertyOffset remove(VM&, PropertyName);
     template<ShouldPin, typename Func>
-    PropertyOffset attributeChange(VM&, PropertyName, unsigned attributes, const Func&);
+    inline PropertyOffset attributeChange(VM&, PropertyName, unsigned attributes, const Func&);
     PropertyOffset attributeChange(VM&, PropertyName, unsigned attributes);
 
 #if ASSERT_ENABLED
-    void checkConsistency();
+    inline void checkConsistency();
 #else
     ALWAYS_INLINE void checkConsistency() { }
 #endif
@@ -987,12 +987,12 @@ private:
     // This will grab the lock. Do not call when holding the Structure's lock.
     JS_EXPORT_PRIVATE PropertyTable* materializePropertyTable(VM&, bool setPropertyTable = true);
     
-    void setPropertyTable(VM& vm, PropertyTable* table);
+    ALWAYS_INLINE void setPropertyTable(VM&, PropertyTable*);
     
     PropertyTable* takePropertyTableOrCloneIfPinned(VM&);
     PropertyTable* copyPropertyTableForPinning(VM&);
 
-    void setPreviousID(VM&, Structure*);
+    ALWAYS_INLINE void setPreviousID(VM&, Structure*);
 
     void clearPreviousID()
     {
@@ -1013,11 +1013,11 @@ private:
         return false;
     }
 
-    bool isValid(JSGlobalObject*, StructureChain* cachedPrototypeChain, JSObject* base) const;
+    inline bool isValid(JSGlobalObject*, StructureChain* cachedPrototypeChain, JSObject* base) const;
 
     // You have to hold the structure lock to do these.
     // Keep them inlined function since they are used in the critical path of Dictionary JSObject modification.
-    void pin(const AbstractLocker&, VM&, PropertyTable*);
+    inline void pin(const AbstractLocker&, VM&, PropertyTable*);
     void pinForCaching(const AbstractLocker&, VM&, PropertyTable*);
     
     static bool isRareData(JSCell* cell)
@@ -1026,14 +1026,14 @@ private:
     }
 
     template<typename DetailsFunc>
-    void checkOffsetConsistency(PropertyTable*, const DetailsFunc&) const;
-    void checkOffsetConsistency() const;
+    ALWAYS_INLINE void checkOffsetConsistency(PropertyTable*, const DetailsFunc&) const;
+    ALWAYS_INLINE void checkOffsetConsistency() const;
 
     JS_EXPORT_PRIVATE void allocateRareData(VM&);
     
     void startWatchingInternalProperties(VM&);
 
-    void clearCachedPrototypeChain();
+    inline void clearCachedPrototypeChain();
 
     bool holesMustForwardToPrototypeSlow(JSObject*) const;
 

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -85,21 +85,21 @@ public:
     {
         return m_previous.get();
     }
-    void setPreviousID(VM&, Structure*);
+    inline void setPreviousID(VM&, Structure*);
     void clearPreviousID();
 
     JSValue cachedSpecialProperty(CachedSpecialPropertyKey) const;
-    void cacheSpecialProperty(JSGlobalObject*, VM&, Structure* baseStructure, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
+    inline void cacheSpecialProperty(JSGlobalObject*, VM&, Structure* baseStructure, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
-    JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
-    uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
-    void setCachedPropertyNameEnumerator(VM&, Structure*, JSPropertyNameEnumerator*, StructureChain*);
-    void clearCachedPropertyNameEnumerator();
+    inline JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
+    inline uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
+    inline void setCachedPropertyNameEnumerator(VM&, Structure*, JSPropertyNameEnumerator*, StructureChain*);
+    inline void clearCachedPropertyNameEnumerator();
 
-    JSImmutableButterfly* cachedPropertyNames(CachedPropertyNamesKind) const;
-    JSImmutableButterfly* cachedPropertyNamesIgnoringSentinel(CachedPropertyNamesKind) const;
-    JSImmutableButterfly* cachedPropertyNamesConcurrently(CachedPropertyNamesKind) const;
-    void setCachedPropertyNames(VM&, CachedPropertyNamesKind, JSImmutableButterfly*);
+    inline JSImmutableButterfly* cachedPropertyNames(CachedPropertyNamesKind) const;
+    inline JSImmutableButterfly* cachedPropertyNamesIgnoringSentinel(CachedPropertyNamesKind) const;
+    inline JSImmutableButterfly* cachedPropertyNamesConcurrently(CachedPropertyNamesKind) const;
+    inline void setCachedPropertyNames(VM&, CachedPropertyNamesKind, JSImmutableButterfly*);
 
     Box<InlineWatchpointSet> copySharedPolyProtoWatchpoint() const { return m_polyProtoWatchpoint; }
     const Box<InlineWatchpointSet>& sharedPolyProtoWatchpoint() const { return m_polyProtoWatchpoint; }
@@ -156,12 +156,12 @@ private:
     void clearCachedSpecialProperty(CachedSpecialPropertyKey);
     void cacheSpecialPropertySlow(JSGlobalObject*, VM&, Structure* baseStructure, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
-    SpecialPropertyCache& ensureSpecialPropertyCache();
+    inline SpecialPropertyCache& ensureSpecialPropertyCache();
     SpecialPropertyCache& ensureSpecialPropertyCacheSlow();
-    bool canCacheSpecialProperty(CachedSpecialPropertyKey);
+    inline bool canCacheSpecialProperty(CachedSpecialPropertyKey);
     void giveUpOnSpecialPropertyCache(CachedSpecialPropertyKey);
 
-    bool tryCachePropertyNameEnumeratorViaWatchpoint(VM&, Structure*, StructureChain*);
+    inline bool tryCachePropertyNameEnumeratorViaWatchpoint(VM&, Structure*, StructureChain*);
 
     // FIXME: We should have some story for clearing these property names caches in GC.
     // https://bugs.webkit.org/show_bug.cgi?id=192659

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -63,8 +63,8 @@ public:
         , m_structureRareData(nullptr)
     { }
 
-    void install(StructureRareData*, Structure*);
-    void fireInternal(VM&, const FireDetail&);
+    inline void install(StructureRareData*, Structure*);
+    inline void fireInternal(VM&, const FireDetail&);
 
 private:
     PackedCellPtr<StructureRareData> m_structureRareData;

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -246,11 +246,11 @@ public:
 
     void add(VM&, JSCell* owner, Structure*);
     bool contains(UniquedStringImpl*, unsigned attributes, TransitionKind) const;
-    Structure* get(UniquedStringImpl*, unsigned attributes, TransitionKind) const;
+    inline Structure* get(UniquedStringImpl*, unsigned attributes, TransitionKind) const;
 
-    Structure* trySingleTransition() const;
+    inline Structure* trySingleTransition() const;
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    inline void finalizeUnconditionally(VM&, CollectionScope);
 
 private:
     friend class SingleSlotTransitionWeakOwner;

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -747,7 +747,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void finalizeUnconditionally(VM&, CollectionScope);
+    inline void finalizeUnconditionally(VM&, CollectionScope);
     void dump(PrintStream&) const;
 
     struct SymbolTableRareData {

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -281,8 +281,8 @@ struct ScratchBuffer {
 
 class ActiveScratchBufferScope {
 public:
-    ActiveScratchBufferScope(ScratchBuffer*, size_t activeScratchBufferSizeInJSValues);
-    ~ActiveScratchBufferScope();
+    inline ActiveScratchBufferScope(ScratchBuffer*, size_t activeScratchBufferSizeInJSValues);
+    inline ~ActiveScratchBufferScope();
 
 private:
     ScratchBuffer* m_scratchBuffer;
@@ -340,7 +340,7 @@ public:
 #endif
 
     FuzzerAgent* fuzzerAgent() const { return m_fuzzerAgent.get(); }
-    void setFuzzerAgent(std::unique_ptr<FuzzerAgent>&&);
+    inline void setFuzzerAgent(std::unique_ptr<FuzzerAgent>&&);
 
     VMIdentifier identifier() const { return m_identifier; }
     bool isEntered() const { return !!entryScope; }
@@ -994,7 +994,7 @@ public:
     void addDebugger(Debugger&);
     void removeDebugger(Debugger&);
     template<typename Func>
-    void forEachDebugger(const Func&);
+    inline void forEachDebugger(const Func&);
 
     Ref<Waiter> syncWaiter();
 

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -212,8 +212,8 @@ public:
     };
 
     bool isDeferringTermination() const { return m_deferTerminationCount; }
-    void deferTermination(DeferAction);
-    void undoDeferTermination(DeferAction);
+    inline void deferTermination(DeferAction);
+    inline void undoDeferTermination(DeferAction);
 
     void notifyGrabAllLocks()
     {
@@ -246,7 +246,7 @@ public:
 #endif
 
 private:
-    VM& vm() const;
+    ALWAYS_INLINE VM& vm() const;
 
     JS_EXPORT_PRIVATE void deferTerminationSlow(DeferAction);
     JS_EXPORT_PRIVATE void undoDeferTerminationSlow(DeferAction);
@@ -287,8 +287,8 @@ private:
 
 class DeferTraps {
 public:
-    DeferTraps(VM&);
-    ~DeferTraps();
+    ALWAYS_INLINE DeferTraps(VM&);
+    ALWAYS_INLINE ~DeferTraps();
 private:
     VMTraps& m_traps;
     bool m_isActive;

--- a/Source/JavaScriptCore/runtime/WeakGCMap.h
+++ b/Source/JavaScriptCore/runtime/WeakGCMap.h
@@ -101,10 +101,10 @@ public:
 
     inline bool contains(const KeyType& key) const;
 
-    void pruneStaleEntries() final;
+    NEVER_INLINE void pruneStaleEntries() final;
 
     template<typename Func>
-    void forEach(Func);
+    inline void forEach(Func);
 
 private:
     HashMapType m_map;

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -53,8 +53,8 @@ public:
     using iterator = typename HashSetType::iterator;
     using const_iterator = typename HashSetType::const_iterator;
 
-    explicit WeakGCSet(VM&);
-    ~WeakGCSet() final;
+    inline explicit WeakGCSet(VM&);
+    inline ~WeakGCSet() final;
 
     void clear()
     {

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -370,7 +370,7 @@ private:
     }
 
     enum class RehashMode { Normal, RemoveBatching };
-    void rehash(RehashMode = RehashMode::Normal);
+    inline void rehash(RehashMode = RehashMode::Normal);
 
     ALWAYS_INLINE void checkConsistency() const
     {

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -94,7 +94,7 @@ void WeakMapImpl<WeakMapBucket>::finalizeUnconditionally(VM& vm, CollectionScope
 }
 
 template<typename WeakMapBucket>
-void WeakMapImpl<WeakMapBucket>::rehash(RehashMode mode)
+inline void WeakMapImpl<WeakMapBucket>::rehash(RehashMode mode)
 {
     // Since shrinking is done just after GC runs (finalizeUnconditionally), WeakMapImpl::rehash()
     // function must not touch any GC related features. This is why we do not allocate WeakMapBuffer

--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -81,7 +81,7 @@ template <typename T, typename Traits> class WriteBarrierBase {
     using StorageType = typename Traits::StorageType;
 
 public:
-    void set(VM&, const JSCell* owner, T* value);
+    inline void set(VM&, const JSCell* owner, T* value);
     
     // This is meant to be used like operator=, but is called copyFrom instead, in
     // order to kindly inform the C++ compiler that its advice is not appreciated.
@@ -91,11 +91,11 @@ public:
         Traits::exchange(m_cell, other.m_cell);
     }
 
-    void setMayBeNull(VM&, const JSCell* owner, T* value);
+    inline void setMayBeNull(VM&, const JSCell* owner, T* value);
 
     // Should only be used by JSCell during early initialisation
     // when some basic types aren't yet completely instantiated
-    void setEarlyValue(VM&, const JSCell* owner, T* value);
+    inline void setEarlyValue(VM&, const JSCell* owner, T* value);
     
     T* get() const
     {
@@ -300,7 +300,7 @@ public:
 
     // Should only be used by JSCell during early initialisation
     // when some basic types aren't yet completely instantiated
-    void setEarlyValue(VM&, const JSCell* owner, Structure* value);
+    inline void setEarlyValue(VM&, const JSCell* owner, Structure* value);
 
     Structure* get() const
     {


### PR DESCRIPTION
#### 1e9f5d649bb13edc5181dc359e499e52a640c3ef
<pre>
[JSC] Add more &apos;inline&apos; specifiers for declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=193481">https://bugs.webkit.org/show_bug.cgi?id=193481</a>

Reviewed by NOBODY (OOPS!).

Added more &apos;inline&apos; specifiers for declarations under
JavaScriptCore/runtime directory to prevent using inline functions
without including *Inlines.h. It is problematic especially for
clang-cl builds.

This change doesn&apos;t fix all inline function definitions because some
of them report problems just by adding &apos;inline&apos; specifiers. They have
to move to *Inlines.h and the callsites have to include the
*Inlines.h. More fixes will come later.

* Source/JavaScriptCore/runtime/Butterfly.h:
* Source/JavaScriptCore/runtime/CacheableIdentifier.h:
* Source/JavaScriptCore/runtime/ExecutableBase.h:
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::fromString):
* Source/JavaScriptCore/runtime/IndexingHeader.h:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSFunction.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::arrayStructureForIndexingTypeDuringAllocation const):
* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/KeyAtomStringCache.h:
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpGlobalData.h:
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/JavaScriptCore/runtime/ScriptExecutable.h:
* Source/JavaScriptCore/runtime/StringReplaceCache.h:
* Source/JavaScriptCore/runtime/StringSplitCache.h:
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureRareData.h:
* Source/JavaScriptCore/runtime/StructureRareDataInlines.h:
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
* Source/JavaScriptCore/runtime/SymbolTable.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/VMTraps.h:
* Source/JavaScriptCore/runtime/WeakGCMap.h:
* Source/JavaScriptCore/runtime/WeakGCSet.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::rehash):
* Source/JavaScriptCore/runtime/WriteBarrier.h:
</pre>