### PR TITLE
[Glib] Initialize `WebProcessExtension`s in API tests on demand

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
@@ -150,6 +150,8 @@ static void testWebKitConsoleMessageSecurityError(ConsoleMessageTest* test, gcon
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     ConsoleMessageTest::add("WebKitConsoleMessage", "console-api", testWebKitConsoleMessageConsoleAPI);
     ConsoleMessageTest::add("WebKitConsoleMessage", "js-exception", testWebKitConsoleMessageJavaScriptException);
     ConsoleMessageTest::add("WebKitConsoleMessage", "network-error", testWebKitConsoleMessageNetworkError);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestDOMElement.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestDOMElement.cpp
@@ -29,6 +29,8 @@ static void testWebKitDOMElementAutoFill(WebViewTest* test, gconstpointer)
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitDOMElement", "auto-fill", testWebKitDOMElementAutoFill);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestEditor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestEditor.cpp
@@ -29,6 +29,8 @@ static void testWebKitWebEditorSelectionChanged(WebViewTest* test, gconstpointer
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitWebEditor", "selection-changed", testWebKitWebEditorSelectionChanged);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestFrame.cpp
@@ -50,6 +50,8 @@ static void testWebKitFrameSubframe(WebViewTest* test, gconstpointer)
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitFrame", "main-frame", testWebKitFrameMainFrame);
     WebViewTest::add("WebKitFrame", "uri", testWebKitFrameURI);
     WebViewTest::add("WebKitFrame", "javascript-context", testWebKitFrameJavaScriptContext);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestLoaderClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestLoaderClient.cpp
@@ -828,6 +828,8 @@ void beforeAll()
     kServer = new WebKitTestServer();
     kServer->run(serverCallback);
 
+    Test::shouldInitializeWebProcessExtensions = true;
+
     LoadTrackingTest::add("WebKitWebView", "loading-status", testLoadingStatus);
     LoadTrackingTest::add("WebKitWebView", "loading-error", testLoadingError);
     LoadTrackingTest::add("WebKitWebView", "load-html", testLoadHtml);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp
@@ -250,6 +250,8 @@ static void testMultiprocessWebViewCreateReadyClose(UIClientMultiprocessTest* te
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     MultiprocessTest::add("WebKitWebContext", "process-per-web-view", testProcessPerWebView);
     UIClientMultiprocessTest::add("WebKitWebView", "multiprocess-create-ready-close", testMultiprocessWebViewCreateReadyClose);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
@@ -903,6 +903,8 @@ void beforeAll()
     kServer = new WebKitTestServer(WebKitTestServer::ServerOptions::ServerRunInThread);
     kServer->run(serverCallback);
 
+    Test::shouldInitializeWebProcessExtensions = true;
+
     ResourcesTest::add("WebKitWebView", "resources", testWebViewResources);
     SingleResourceLoadTest::add("WebKitWebResource", "loading", testWebResourceLoading);
     SingleResourceLoadTest::add("WebKitWebResource", "response", testWebResourceResponse);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
@@ -678,6 +678,8 @@ void beforeAll()
     kServer = new WebKitTestServer();
     kServer->run(serverCallback);
 
+    Test::shouldInitializeWebProcessExtensions = true;
+
     Test::add("WebKitWebView", "new-with-user-content-manager", testWebViewNewWithUserContentManager);
     WebViewTest::add("WebKitUserContentManager", "injected-style-sheet", testUserContentManagerInjectedStyleSheet);
     WebViewTest::add("WebKitUserContentManager", "injected-script", testUserContentManagerInjectedScript);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
@@ -781,6 +781,8 @@ static void testWebProcessExtensionWindowObjectCleared(UserMessageTest* test, gc
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitWebProcessExtension", "dom-document-title", testWebProcessExtensionGetTitle);
 #if PLATFORM(GTK)
     WebViewTest::add("WebKitWebProcessExtension", "dom-input-element-is-user-edited", testWebProcessExtensionInputElementIsUserEdited);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestAutocleanups.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestAutocleanups.cpp
@@ -60,6 +60,8 @@ static void testWebProcessAutocleanups(WebViewTest* test, gconstpointer)
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("Autocleanups", "ui-process-autocleanups", testUIProcessAutocleanups);
     WebViewTest::add("Autocleanups", "web-process-autocleanups", testWebProcessAutocleanups);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -1167,6 +1167,8 @@ void beforeAll()
     kServer = new WebKitTestServer();
     kServer->run(serverCallback);
 
+    Test::shouldInitializeWebProcessExtensions = true;
+
     ContextMenuDefaultTest::add("WebKitWebView", "default-menu", testContextMenuDefaultMenu);
     ContextMenuDefaultTest::add("WebKitWebView", "context-menu-key", testContextMenuKey);
     ContextMenuDefaultTest::add("WebKitWebView", "popup-event-signal", testPopupEventSignal);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMClientRect.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMClientRect.cpp
@@ -45,6 +45,8 @@ static void testWebKitDOMClientRectDivClientRectsPositionAndLength(WebViewTest* 
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitDOMClientRect", "div-bounding-client-rect-position", testWebKitDOMClientRectDivBoundingClientRectPosition);
     WebViewTest::add("WebKitDOMClientRect", "div-client-rects-position-and-length", testWebKitDOMClientRectDivClientRectsPositionAndLength);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMNode.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMNode.cpp
@@ -69,6 +69,8 @@ static void testWebKitDOMObjectCache(WebViewTest* test, gconstpointer)
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitDOMNode", "hierarchy-navigation", testWebKitDOMNodeHierarchyNavigation);
     WebViewTest::add("WebKitDOMNode", "insertion", testWebKitDOMNodeInsertion);
     WebViewTest::add("WebKitDOMNode", "tag-names-node-list", testWebKitDOMNodeTagNamesNodeList);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMNodeFilter.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMNodeFilter.cpp
@@ -43,6 +43,8 @@ static void testWebKitDOMNodeFilterNodeIterator(WebViewTest* test, gconstpointer
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitDOMNodeFilter", "tree-walker", testWebKitDOMNodeFilterTreeWalker);
     WebViewTest::add("WebKitDOMNodeFilter", "node-iterator", testWebKitDOMNodeFilterNodeIterator);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMXPathNSResolver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMXPathNSResolver.cpp
@@ -42,6 +42,8 @@ static void testWebKitDOMXPathNSResolverCustom(WebViewTest* test, gconstpointer)
 
 void beforeAll()
 {
+    Test::shouldInitializeWebProcessExtensions = true;
+
     WebViewTest::add("WebKitDOMXPathNSResolver", "native", testWebKitDOMXPathNSResolverNative);
     WebViewTest::add("WebKitDOMXPathNSResolver", "custom", testWebKitDOMXPathNSResolverCustom);
 }

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
@@ -27,6 +27,8 @@
 #include <gtk/gtk.h>
 #endif
 
+bool Test::shouldInitializeWebProcessExtensions = false;
+
 GRefPtr<GDBusServer> Test::s_dbusServer;
 Vector<GRefPtr<GDBusConnection>> Test::s_dbusConnections;
 HashMap<uint64_t, GDBusConnection*> Test::s_dbusConnectionPageMap;

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -113,6 +113,8 @@ public:
 
     static const char* dataDirectory();
 
+    static bool shouldInitializeWebProcessExtensions;
+
     static void initializeWebProcessExtensionsCallback(WebKitWebContext* context, Test* test)
     {
         test->initializeWebProcessExtensions();
@@ -141,11 +143,14 @@ public:
             nullptr)));
 #endif
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_webContext.get()));
+
+        if (shouldInitializeWebProcessExtensions) {
 #if ENABLE(2022_GLIB_API)
-        g_signal_connect(m_webContext.get(), "initialize-web-process-extensions", G_CALLBACK(initializeWebProcessExtensionsCallback), this);
+            g_signal_connect(m_webContext.get(), "initialize-web-process-extensions", G_CALLBACK(initializeWebProcessExtensionsCallback), this);
 #else
-        g_signal_connect(m_webContext.get(), "initialize-web-extensions", G_CALLBACK(initializeWebProcessExtensionsCallback), this);
+            g_signal_connect(m_webContext.get(), "initialize-web-extensions", G_CALLBACK(initializeWebProcessExtensionsCallback), this);
 #endif
+        }
     }
 
     virtual ~Test()


### PR DESCRIPTION
#### f7d2305bf1ed1a256d04dfd67db540cb28ba221f
<pre>
[Glib] Initialize `WebProcessExtension`s in API tests on demand
<a href="https://bugs.webkit.org/show_bug.cgi?id=260382">https://bugs.webkit.org/show_bug.cgi?id=260382</a>

Reviewed by Carlos Garcia Campos and Michael Catanzaro.

Currently, `WebProcessExtension`s are initialized for each API test.
It&apos;s not only unnecessary but can lead to flakiness.

This patch requires API tests using extensions to explicitly state this
by setting `Test::shouldInitializeWebProcessExtensions` to `true`.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestDOMElement.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestEditor.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestFrame.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestLoaderClient.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestMultiprocess.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestAutocleanups.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMClientRect.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMNode.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMNodeFilter.cpp:
(beforeAll):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMXPathNSResolver.cpp:
(beforeAll):
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp:
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::Test):

Canonical link: <a href="https://commits.webkit.org/267125@main">https://commits.webkit.org/267125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30eaf31f2e299c952573d13262872552df6a47a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17213 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18156 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21049 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12620 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14142 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->