### PR TITLE
[GTK][WPE] Add USE_LIBDRM in addition to USE_GBM

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -80,7 +80,7 @@
 #include <wtf/NeverDestroyed.h>
 #endif
 
-#if USE(EGL) && USE(GBM)
+#if USE(EGL) && USE(LIBDRM)
 #include "GBMDevice.h"
 #include <xf86drm.h>
 #ifndef EGL_DRM_RENDER_NODE_FILE_EXT
@@ -426,7 +426,7 @@ bool PlatformDisplay::destroyEGLImage(EGLImage image) const
 #endif
 }
 
-#if USE(GBM)
+#if USE(LIBDRM)
 EGLDeviceEXT PlatformDisplay::eglDevice()
 {
     if (!GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query"))
@@ -532,7 +532,9 @@ const String& PlatformDisplay::drmRenderNodeFile()
 
     return m_drmRenderNodeFile.value();
 }
+#endif // USE(LIBDRM)
 
+#if USE(GBM)
 struct gbm_device* PlatformDisplay::gbmDevice()
 {
     auto& device = GBMDevice::singleton();

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -36,8 +36,10 @@ typedef void *EGLContext;
 typedef void *EGLDisplay;
 typedef void *EGLImage;
 typedef unsigned EGLenum;
-#if USE(GBM)
+#if USE(LIBDRM)
 typedef void *EGLDeviceEXT;
+#endif
+#if USE(GBM)
 struct gbm_device;
 #endif
 #endif
@@ -113,9 +115,11 @@ public:
 
     EGLImage createEGLImage(EGLContext, EGLenum target, EGLClientBuffer, const Vector<EGLAttrib>&) const;
     bool destroyEGLImage(EGLImage) const;
-#if USE(GBM)
+#if USE(LIBDRM)
     const String& drmDeviceFile();
     const String& drmRenderNodeFile();
+#endif
+#if USE(GBM)
     struct gbm_device* gbmDevice();
 #endif
 
@@ -163,7 +167,7 @@ protected:
     bool m_eglDisplayOwned { true };
     std::unique_ptr<GLContext> m_sharingGLContext;
 
-#if USE(GBM)
+#if USE(LIBDRM)
     std::optional<String> m_drmDeviceFile;
     std::optional<String> m_drmRenderNodeFile;
 #endif
@@ -193,7 +197,7 @@ private:
 
 #if USE(EGL)
     void terminateEGLDisplay();
-#if USE(GBM)
+#if USE(LIBDRM)
     EGLDeviceEXT eglDevice();
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -316,7 +316,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     addTableRow(displayObject, "Depth"_s, String::number(screenDepth(nullptr)));
     addTableRow(displayObject, "Bits per color component"_s, String::number(screenDepthPerComponent(nullptr)));
     addTableRow(displayObject, "DPI"_s, String::number(screenDPI()));
-#if USE(GBM)
+#if USE(LIBDRM)
     if (strcmp(policy, "never")) {
         auto deviceFile = PlatformDisplay::sharedDisplay().drmDeviceFile();
         if (!deviceFile.isEmpty())

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -51,9 +51,10 @@ WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PU
 WEBKIT_OPTION_DEFINE(ENABLE_QUARTZ_TARGET "Whether to enable support for the Quartz windowing target." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(ENABLE_WAYLAND_TARGET "Whether to enable support for the Wayland windowing target." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(ENABLE_X11_TARGET "Whether to enable support for the X11 windowing target." PUBLIC ON)
-WEBKIT_OPTION_DEFINE(USE_GBM "Whether to enable usage of GBM and libdrm." PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_GBM "Whether to enable usage of GBM." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_GTK4 "Whether to enable usage of GTK4 instead of GTK3." PUBLIC OFF)
 WEBKIT_OPTION_DEFINE(USE_LCMS "Whether to enable support for image color management using libcms2." PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_LIBDRM "Whether to enable usage of libdrm." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_LIBHYPHEN "Whether to enable the default automatic hyphenation implementation." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_LIBSECRET "Whether to enable the persistent credential storage using libsecret." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_OPENGL_OR_ES "Whether to use OpenGL or ES." PUBLIC ON)
@@ -66,6 +67,7 @@ WEBKIT_OPTION_DEPEND(ENABLE_3D_TRANSFORMS USE_OPENGL_OR_ES)
 WEBKIT_OPTION_DEPEND(ENABLE_ASYNC_SCROLLING USE_OPENGL_OR_ES)
 WEBKIT_OPTION_DEPEND(ENABLE_WEBGL USE_OPENGL_OR_ES)
 WEBKIT_OPTION_DEPEND(USE_GBM USE_OPENGL_OR_ES)
+WEBKIT_OPTION_DEPEND(USE_GBM USE_LIBDRM)
 WEBKIT_OPTION_DEPEND(USE_GSTREAMER_GL USE_OPENGL_OR_ES)
 
 WEBKIT_OPTION_CONFLICT(USE_GTK4 USE_SOUP2)
@@ -331,6 +333,13 @@ endif ()
 
 SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER TRUE)
 
+if (USE_LIBDRM)
+    find_package(LibDRM)
+    if (NOT LIBDRM_FOUND)
+        message(FATAL_ERROR "libdrm is required for USE_LIBDRM")
+    endif ()
+endif ()
+
 if (USE_OPENGL_OR_ES)
 
     SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER_GL ON)
@@ -354,18 +363,9 @@ if (USE_OPENGL_OR_ES)
     endif ()
 
     if (USE_GBM)
-        # ANGLE-backed WebGL depends on DMABuf support, which at the moment is leveraged
-        # through libgbm and libdrm dependencies. When libgbm is enabled, make
-        # libdrm a requirement and define USE_TEXTURE_MAPPER_DMABUF macros.
-        # When not available, ANGLE will be used in slower software-rasterization mode.
         find_package(GBM)
         if (NOT GBM_FOUND)
             message(FATAL_ERROR "GBM is required for USE_GBM")
-        endif ()
-
-        find_package(LibDRM)
-        if (NOT LIBDRM_FOUND)
-            message(FATAL_ERROR "libdrm is required for USE_GBM")
         endif ()
 
         SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER_DMABUF ON)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -96,8 +96,9 @@ WEBKIT_OPTION_DEFINE(ENABLE_INTROSPECTION "Whether to enable GObject introspecti
 WEBKIT_OPTION_DEFINE(ENABLE_JOURNALD_LOG "Whether to enable journald logging" PUBLIC ON)
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_QT_API "Whether to enable support for the Qt5/QML plugin" PUBLIC ${ENABLE_DEVELOPER_MODE})
 WEBKIT_OPTION_DEFINE(ENABLE_WPE_1_1_API "Whether to build WPE 1.1 instead of WPE 2.0" PUBLIC OFF)
-WEBKIT_OPTION_DEFINE(USE_GBM "Whether to enable usage of GBM and libdrm." PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_GBM "Whether to enable usage of GBM." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_LCMS "Whether to enable support for image color management using libcms2." PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_LIBDRM "Whether to enable usage of libdrm." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_OPENJPEG "Whether to enable support for JPEG2000 images." PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_SOUP2 "Whether to enable usage of Soup 2 instead of Soup 3." PUBLIC OFF)
 WEBKIT_OPTION_DEFINE(USE_WOFF2 "Whether to enable support for WOFF2 Web Fonts." PUBLIC ON)
@@ -136,6 +137,7 @@ if (ENABLE_DEVELOPER_MODE)
     WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_COG PRIVATE ON)
 endif ()
 
+WEBKIT_OPTION_DEPEND(USE_GBM USE_LIBDRM)
 WEBKIT_OPTION_DEPEND(USE_GSTREAMER_HOLEPUNCH ENABLE_VIDEO)
 WEBKIT_OPTION_DEPEND(USE_EXTERNAL_HOLEPUNCH ENABLE_VIDEO)
 WEBKIT_OPTION_DEPEND(USE_WESTEROS_SINK ENABLE_VIDEO)
@@ -375,19 +377,17 @@ SET_AND_EXPOSE_TO_BUILD(USE_ANGLE ${ENABLE_WEBGL})
 SET_AND_EXPOSE_TO_BUILD(USE_THEME_ADWAITA TRUE)
 SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
 
+if (USE_LIBDRM)
+    find_package(LibDRM)
+    if (NOT LIBDRM_FOUND)
+        message(FATAL_ERROR "libdrm is required for USE_LIBDRM")
+    endif ()
+endif ()
+
 if (USE_GBM)
-    # ANGLE-backed WebGL depends on DMABuf support, which at the moment is leveraged
-    # through libgbm and libdrm dependencies. When libgbm is enabled, make
-    # libdrm a requirement and define the USE_LIBGBM and USE_TEXTURE_MAPPER_DMABUF
-    # macros. When not available, ANGLE will be used in slower software-rasterization mode.
     find_package(GBM)
     if (NOT GBM_FOUND)
         message(FATAL_ERROR "GBM is required for USE_GBM")
-    endif ()
-
-    find_package(LibDRM)
-    if (NOT LIBDRM_FOUND)
-        message(FATAL_ERROR "libdrm is required for USE_GBM")
     endif ()
 
     SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER_DMABUF TRUE)


### PR DESCRIPTION
#### b8ffa14eaad872df3a0de481297ee5c760539217
<pre>
[GTK][WPE] Add USE_LIBDRM in addition to USE_GBM
<a href="https://bugs.webkit.org/show_bug.cgi?id=260384">https://bugs.webkit.org/show_bug.cgi?id=260384</a>

Reviewed by Michael Catanzaro.

Right now we have USE_GBM to enable both GBM and DRM, because we only
need to use DRM for GBM in most of the cases. It would be possible to
get the device and render node files without GBM and we plan to add more
code that requires DRM but not GBM.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/267039@main">https://commits.webkit.org/267039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be28729ffdcbf8d70cc56832ec8f3d964d632125

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15464 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15768 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17073 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17960 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13946 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20881 "1 flakes 125 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13258 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17380 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14706 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12448 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15654 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13952 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3973 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18313 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15892 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1881 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14515 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3782 "Passed tests") | 
<!--EWS-Status-Bubble-End-->