### PR TITLE
Weave the InteractionRegion layers into the content layer tree

### DIFF
--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -9,47 +9,10 @@
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=1536 height=5013)
-      )
-      (children 3
-        (GraphicsLayer
-          (preserves3D 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 1536.00 2008.00)
-              (event region
-                (rect (0,0) width=1536 height=2008)
 
-              (interaction regions [
-                (occlusion (0,0) width=1536 height=2008)
-                (borderRadius 0.00)])
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (bounds 1536.00 2008.00)
-          (opacity 0.50)
-          (contentsOpaque 1)
-          (event region
-            (rect (0,0) width=1536 height=2008)
-
-          (interaction regions [
-            (occlusion (0,0) width=1536 height=2008)
-            (borderRadius 0.00)])
-          )
-        )
-        (GraphicsLayer
-          (bounds 1536.00 5000.00)
-          (opacity 0.50)
-          (contentsOpaque 1)
-          (event region
-            (rect (0,0) width=1536 height=5000)
-
-          (interaction regions [
-            (occlusion (0,0) width=1536 height=5000)
-            (borderRadius 0.00)])
-          )
-        )
+      (interaction regions [
+        (occlusion (0,0) width=1536 height=5000)
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/full-page-overlay.html
+++ b/LayoutTests/interaction-region/full-page-overlay.html
@@ -14,35 +14,19 @@
             width: 100%;
             height: 100%;
             z-index: 1;
-            opacity: 0.5;
             background-color: purple;
-        }
-
-        .tappable-overlay {
-            cursor: pointer;
         }
 
         .spacer {
             height: 5000px;
         }
-
-        #fixed-overlay {
-            position: fixed;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            background: rgba(0, 0, 0, 0.3);
-        }
     </style>
     <script src="../resources/ui-helper.js"></script>
 </head>
 <body>
-<div class="tappable-overlay overlay"></div>
 <div class="spacer">
     <div id="dynamic" class="overlay"></div>
 </div>
-<div id="fixed-overlay"></div>
 
 <pre id="results"></pre>
 <script>

--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -43,18 +43,9 @@
                                       (layer anchorPoint [x: 0 y: 0]))))
                                 (
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (layer anchorPoint [x: 0 y: 0]))))))
-                        (
-                          (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                          (layer position [x: 400 y: 400])
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                              (layer anchorPoint [x: 0 y: 0])
-                              (sublayers
+                                  (layer anchorPoint [x: 0 y: 0]))
                                 (
-                                  (layer bounds [x: 0 y: 0 width: 800 height: 86050])
-                                  (layer anchorPoint [x: 0 y: 0])
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                   (sublayers
                                     (
                                       (type 0)
@@ -90,20 +81,7 @@
                                       (type 0)
                                       (layer bounds [x: 0 y: 0 width: 700 height: 36])
                                       (layer position [x: 400 y: 400])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 512])
-                                          (layer anchorPoint [x: 0 y: 0]))
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 512])
-                                          (layer position [x: 0 y: 0])
-                                          (layer anchorPoint [x: 0 y: 0]))))
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                      (layer anchorPoint [x: 0 y: 0]))))))))))))))
+                                      (layer cornerRadius 8))))))))))))))
             (
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -39,31 +39,6 @@
                                       (layer anchorPoint [x: 0 y: 0]))))
                                 (
                                   (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                  (layer anchorPoint [x: 0 y: 0])
-                                  (sublayers
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 200 height: 200])
-                                      (layer position [x: 100 y: 100])
-                                      (layer opacity 0))
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
-                                      (layer opacity 0.8)
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 20])
-                                          (layer position [x: 400 y: 400]))))))))))
-                        (
-                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                          (layer position [x: 400 y: 400])
-                          (sublayers
-                            (
-                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                              (layer anchorPoint [x: 0 y: 0])
-                              (sublayers
-                                (
-                                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                  (layer anchorPoint [x: 0 y: 0])
                                   (sublayers
                                     (
                                       (type 0)
@@ -78,44 +53,58 @@
                                     (
                                       (type 0)
                                       (layer bounds [x: 0 y: 0 width: 200 height: 100])
-                                      (layer position [x: 100 y: 100]))
+                                      (layer position [x: 100 y: 100]))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
                                     (
-                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+                                      (layer position [x: 100 y: 100])
+                                      (layer opacity 0)
                                       (sublayers
                                         (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                          (layer anchorPoint [x: 0 y: 0]))))
-                                    (
-                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                      (layer anchorPoint [x: 0 y: 0])
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 200 height: 200])
-                                          (layer position [x: 100 y: 100])
-                                          (layer opacity 0)
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                           (sublayers
                                             (
                                               (type 0)
                                               (layer bounds [x: 0 y: 0 width: 76 height: 27])
                                               (layer position [x: 34 y: 34])
-                                              (layer cornerRadius 8))))
+                                              (layer cornerRadius 8))))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (layer opacity 0.8)
+                                      (sublayers
                                         (
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                          (layer position [x: 400 y: 400])
-                                          (layer opacity 0.8)
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                          (layer position [x: 400 y: 400]))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                           (sublayers
-                                            (
-                                              (type 1)
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                              (layer position [x: 400 y: 400]))
                                             (
                                               (type 0)
                                               (layer bounds [x: 0 y: 0 width: 33 height: 27])
                                               (layer position [x: 12.5 y: 12.5])
-                                              (layer cornerRadius 8))
+                                              (layer cornerRadius 8))))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 40])
+                                          (layer position [x: 400 y: 400])
+                                          (sublayers
                                             (
                                               (layer bounds [x: 0 y: 0 width: 800 height: 20])
-                                              (layer position [x: 400 y: 400]))))))))))))))))))
+                                              (layer position [x: 400 y: 400]))
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (sublayers
+                                                (
+                                                  (type 0)
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 27])
+                                                  (layer position [x: 156 y: 156])
+                                                  (layer cornerRadius 8))))))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 20])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
             (
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (

--- a/LayoutTests/interaction-region/layer-tree.html
+++ b/LayoutTests/interaction-region/layer-tree.html
@@ -19,7 +19,7 @@
 
         background-color: #333;
     }
-    #nested {
+    .composited {
         will-change: transform;
     }
     #faded {
@@ -46,7 +46,17 @@
     <iframe></iframe>
     <div id="overlay">
         <a href="#">link</a>
-        <div id="nested">layered content</div>
+        <div class="composited">layered content</div>
+        <div class="composited">
+            layered content <a href="#">with interactions</a>
+            <div class="composited">
+                layered content
+                <div class="composited" id="to-hide">
+                    layered content <a href="#">with interactions</a>
+                </div>
+            </div>
+        </div>
+        <div class="composited">layered content</div>
     </div>
     <div id="faded">
         <a href="#">Faded link</a>
@@ -75,6 +85,9 @@ window.onload = async function () {
 
     await UIHelper.animationFrame();
     document.getElementById("resized").style.width = "200px";
+
+    await UIHelper.animationFrame();
+    document.getElementById("to-hide").style.display = "none";
 
     await UIHelper.ensureStablePresentationUpdate();
     results.textContent = await UIHelper.getCALayerTree();

--- a/LayoutTests/interaction-region/overlay-expected.txt
+++ b/LayoutTests/interaction-region/overlay-expected.txt
@@ -27,10 +27,6 @@
               (drawsContent 1)
               (event region
                 (rect (0,0) width=200 height=200)
-
-              (interaction regions [
-                (occlusion (0,0) width=200 height=200)
-                (borderRadius 0.00)])
               )
             )
           )
@@ -58,10 +54,6 @@
               (contentsOpaque 1)
               (event region
                 (rect (0,0) width=200 height=200)
-
-              (interaction regions [
-                (occlusion (0,0) width=200 height=200)
-                (borderRadius 0.00)])
               )
             )
           )

--- a/LayoutTests/interaction-region/position-only-update-expected.txt
+++ b/LayoutTests/interaction-region/position-only-update-expected.txt
@@ -13,8 +13,6 @@ compositing
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (0,0) width=800 height=140)
-        (borderRadius 0.00),
         (interaction (107,76) width=83 height=27)
         (borderRadius 8.00)])
       )

--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -147,6 +147,7 @@ typedef struct _CARenderContext CARenderContext;
 - (void)removePresentationModifier:(CAPresentationModifier *)modifier;
 @property BOOL allowsGroupBlending;
 @property BOOL allowsHitTesting;
+@property BOOL hitTestsContentsAlphaChannel;
 @property BOOL canDrawConcurrently;
 @property BOOL contentsOpaque;
 @property BOOL hitTestsAsOpaque;

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -162,18 +162,6 @@ void ScrollingStateNode::setLayer(const LayerRepresentation& layerRepresentation
     setPropertyChanged(Property::Layer);
 }
 
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-void ScrollingStateNode::setInteractionRegionsLayer(const LayerRepresentation& layerRepresentation)
-{
-    if (layerRepresentation == m_interactionRegionsLayer)
-        return;
-
-    m_interactionRegionsLayer = layerRepresentation;
-
-    // Piggybacks on other property changed flags: Property::Layer and Property::ScrollContainerLayer.
-}
-#endif
-
 void ScrollingStateNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     if (behavior & ScrollingStateTreeAsTextBehavior::IncludeNodeIDs)

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -299,11 +299,6 @@ public:
     const LayerRepresentation& layer() const { return m_layer; }
     WEBCORE_EXPORT void setLayer(const LayerRepresentation&);
 
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    const LayerRepresentation& interactionRegionsLayer() const { return m_interactionRegionsLayer; }
-    WEBCORE_EXPORT void setInteractionRegionsLayer(const LayerRepresentation&);
-#endif
-
     ScrollingStateTree& scrollingStateTree() const { return m_scrollingStateTree; }
 
     ScrollingNodeID scrollingNodeID() const { return m_nodeID; }
@@ -351,9 +346,6 @@ private:
     Vector<Ref<ScrollingStateNode>> m_children;
 
     LayerRepresentation m_layer;
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    LayerRepresentation m_interactionRegionsLayer;
-#endif
 };
 
 inline ScrollingNodeID ScrollingStateNode::parentNodeID() const

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -51,9 +51,6 @@ private:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
 
     RetainPtr<CALayer> m_layer;
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RetainPtr<CALayer> m_interactionRegionsLayer;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -54,12 +54,8 @@ bool ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren(const ScrollingState
         return false;
 
     const auto& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
-    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
         m_layer = static_cast<CALayer*>(fixedStateNode.layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(fixedStateNode.interactionRegionsLayer());
-#endif
-    }
 
     return ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
 }
@@ -79,9 +75,6 @@ void ScrollingTreeFixedNodeCocoa::applyLayerPositions()
 #endif
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [m_interactionRegionsLayer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
-#endif
 }
 
 void ScrollingTreeFixedNodeCocoa::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
@@ -45,9 +45,6 @@ protected:
     CALayer* layer() const override { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RetainPtr<CALayer> m_interactionRegionsLayer;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
@@ -48,13 +48,8 @@ ScrollingTreeOverflowScrollProxyNodeCocoa::~ScrollingTreeOverflowScrollProxyNode
 
 bool ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
         m_layer = static_cast<CALayer*>(stateNode.layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(stateNode.interactionRegionsLayer());
-#endif
-    }
-
 
     return ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(stateNode);
 }
@@ -65,10 +60,6 @@ void ScrollingTreeOverflowScrollProxyNodeCocoa::applyLayerPositions()
 
     LOG_WITH_STREAM(ScrollingTree, stream << "ScrollingTreeOverflowScrollProxyNodeCocoa " << scrollingNodeID() << " applyLayerPositions: setting bounds origin to " << scrollOffset);
     [m_layer _web_setLayerBoundsOrigin:scrollOffset];
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [m_interactionRegionsLayer _web_setLayerBoundsOrigin:scrollOffset];
-#endif
-
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
@@ -48,9 +48,6 @@ private:
     CALayer *layer() const override { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RetainPtr<CALayer> m_interactionRegionsLayer;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
@@ -48,12 +48,8 @@ ScrollingTreePositionedNodeCocoa::~ScrollingTreePositionedNodeCocoa() = default;
 
 bool ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
         m_layer = static_cast<CALayer*>(stateNode.layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(stateNode.interactionRegionsLayer());
-#endif
-    }
 
     return ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
 }
@@ -66,9 +62,6 @@ void ScrollingTreePositionedNodeCocoa::applyLayerPositions()
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [m_interactionRegionsLayer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -49,9 +49,6 @@ private:
     CALayer* layer() const final { return m_layer.get(); }
 
     RetainPtr<CALayer> m_layer;
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RetainPtr<CALayer> m_interactionRegionsLayer;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -49,12 +49,8 @@ ScrollingTreeStickyNodeCocoa::ScrollingTreeStickyNodeCocoa(ScrollingTree& scroll
 
 bool ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
         m_layer = static_cast<CALayer*>(stateNode.layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(stateNode.interactionRegionsLayer());
-#endif
-    }
 
     return ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
 }
@@ -74,9 +70,6 @@ void ScrollingTreeStickyNodeCocoa::applyLayerPositions()
 #endif
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [m_interactionRegionsLayer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
-#endif
 }
 
 FloatPoint ScrollingTreeStickyNodeCocoa::layerTopLeft() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -150,17 +150,9 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
     };
     Vector<LayerAndClone> clonesToUpdate;
 
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    bool rootLayerHierarchyChanged = false;
-#endif
     auto layerContentsType = this->layerContentsType();
     for (auto& [layerID, propertiesPointer] : transaction.changedLayerProperties()) {
         const auto& properties = *propertiesPointer;
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        if (layerID == transaction.rootLayerID())
-            rootLayerHierarchyChanged = true;
-#endif
 
         auto* node = nodeForID(layerID);
         ASSERT(node);
@@ -216,14 +208,6 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
     // the backing store in the commit that reparents them.
     for (auto& newlyUnreachableLayerID : transaction.layerIDsWithNewlyUnreachableBackingStore())
         layerForID(newlyUnreachableLayerID).contents = nullptr;
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (rootLayerChanged || rootLayerHierarchyChanged) {
-        // The Interaction Regions subtree is always on top.
-        [m_rootNode->interactionRegionsLayer() removeFromSuperlayer];
-        [m_rootNode->layer() addSublayer:m_rootNode->interactionRegionsLayer()];
-    }
-#endif
 
 #if PLATFORM(MAC)
     if (updateBannerLayers(transaction))

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h
@@ -35,8 +35,7 @@ OBJC_CLASS NSMutableArray;
 
 namespace WebKit {
 
-void updateLayersForInteractionRegions(const RemoteLayerTreeNode&);
-void insertInteractionRegionLayersForLayer(NSMutableArray *, CALayer *);
+void updateLayersForInteractionRegions(RemoteLayerTreeNode&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -57,8 +57,6 @@ public:
 
     CALayer *layer() const { return m_layer.get(); }
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    CALayer *interactionRegionsLayer() const { return m_interactionRegionsLayer.get(); }
-
     struct VisibleRectMarkableTraits {
         static bool isEmptyValue(const WebCore::FloatRect& value)
         {
@@ -73,6 +71,10 @@ public:
 
     const Markable<WebCore::FloatRect, VisibleRectMarkableTraits> visibleRect() const { return m_visibleRect; }
     void setVisibleRect(const WebCore::FloatRect& value) { m_visibleRect = value; }
+
+    CALayer *ensureInteractionRegionsContainer();
+    void removeInteractionRegionsContainer();
+    void updateInteractionRegionAfterHierarchyChange();
 #endif
 #if PLATFORM(IOS_FAMILY)
     UIView *uiView() const { return m_uiView.get(); }
@@ -138,8 +140,18 @@ private:
 
     RetainPtr<CALayer> m_layer;
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RetainPtr<CALayer> m_interactionRegionsLayer;
     Markable<WebCore::FloatRect, VisibleRectMarkableTraits> m_visibleRect;
+
+    void repositionInteractionRegionsContainerIfNeeded();
+    enum class InteractionRegionsInSubtree : bool { Yes, Unknown };
+    void propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree);
+
+    bool hasInteractionRegions() const;
+    bool hasInteractionRegionsDescendant() const { return m_hasInteractionRegionsDescendant; }
+    void setHasInteractionRegionsDescendant(bool value) { m_hasInteractionRegionsDescendant = value; }
+
+    bool m_hasInteractionRegionsDescendant { false };
+    RetainPtr<CALayer> m_interactionRegionsContainer;
 #endif
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<UIView> m_uiView;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -34,9 +34,16 @@
 #import <UIKit/UIView.h>
 #endif
 
+#if PLATFORM(VISION)
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#endif
+
 namespace WebKit {
 
 static NSString *const WKRemoteLayerTreeNodePropertyKey = @"WKRemoteLayerTreeNode";
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+static NSString *const WKInteractionRegionContainerKey = @"WKInteractionRegionContainer";
+#endif
 
 RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier layerID, Markable<WebCore::LayerHostingContextIdentifier> hostIdentifier, RetainPtr<CALayer> layer)
     : m_layerID(layerID)
@@ -61,6 +68,9 @@ RemoteLayerTreeNode::RemoteLayerTreeNode(WebCore::PlatformLayerIdentifier layerI
 RemoteLayerTreeNode::~RemoteLayerTreeNode()
 {
     [layer() setValue:nil forKey:WKRemoteLayerTreeNodePropertyKey];
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    removeInteractionRegionsContainer();
+#endif
 }
 
 std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeNode::createWithPlainLayer(WebCore::PlatformLayerIdentifier layerID)
@@ -72,9 +82,8 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeNode::createWithPlainLayer(W
 void RemoteLayerTreeNode::detachFromParent()
 {
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [interactionRegionsLayer() removeFromSuperlayer];
+    removeInteractionRegionsContainer();
 #endif
-
 #if PLATFORM(IOS_FAMILY)
     if (auto view = uiView()) {
         [view removeFromSuperview];
@@ -93,11 +102,124 @@ void RemoteLayerTreeNode::initializeLayer()
 {
     [layer() setValue:[NSValue valueWithPointer:this] forKey:WKRemoteLayerTreeNodePropertyKey];
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    m_interactionRegionsLayer = adoptNS([[CALayer alloc] init]);
-    [m_interactionRegionsLayer setName:@"InteractionRegions Container"];
-    [m_interactionRegionsLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
+    if (![layer() isKindOfClass:[CATransformLayer class]])
+        [layer() setHitTestsContentsAlphaChannel:YES];
 #endif
 }
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+CALayer* RemoteLayerTreeNode::ensureInteractionRegionsContainer()
+{
+    if (m_interactionRegionsContainer)
+        return m_interactionRegionsContainer.get();
+
+    m_interactionRegionsContainer = adoptNS([[CALayer alloc] init]);
+    [m_interactionRegionsContainer setName:@"InteractionRegions Container"];
+    [m_interactionRegionsContainer setValue:@(YES) forKey:WKInteractionRegionContainerKey];
+    [m_interactionRegionsContainer setDelegate:[WebActionDisablingCALayerDelegate shared]];
+
+    repositionInteractionRegionsContainerIfNeeded();
+    propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree::Yes);
+
+    return m_interactionRegionsContainer.get();
+}
+
+void RemoteLayerTreeNode::removeInteractionRegionsContainer()
+{
+    if (!m_interactionRegionsContainer)
+        return;
+
+    [m_interactionRegionsContainer removeFromSuperlayer];
+    m_interactionRegionsContainer = nullptr;
+
+    propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree::Unknown);
+}
+
+void RemoteLayerTreeNode::updateInteractionRegionAfterHierarchyChange()
+{
+    repositionInteractionRegionsContainerIfNeeded();
+
+    bool hasInteractionRegionsDescendant = false;
+    for (CALayer *sublayer in layer().sublayers) {
+        if (auto *subnode = forCALayer(sublayer)) {
+            if (subnode->hasInteractionRegions()) {
+                hasInteractionRegionsDescendant = true;
+                break;
+            }
+        }
+    }
+
+    if (m_hasInteractionRegionsDescendant == hasInteractionRegionsDescendant)
+        return;
+
+    setHasInteractionRegionsDescendant(hasInteractionRegionsDescendant);
+    propagateInteractionRegionsChangeInHierarchy(hasInteractionRegionsDescendant ? InteractionRegionsInSubtree::Yes : InteractionRegionsInSubtree::Unknown);
+}
+
+bool RemoteLayerTreeNode::hasInteractionRegions() const
+{
+    return m_hasInteractionRegionsDescendant || m_interactionRegionsContainer;
+}
+
+void RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded()
+{
+    if (!m_interactionRegionsContainer)
+        return;
+
+    NSUInteger insertionPoint = 0;
+    for (CALayer *sublayer in layer().sublayers) {
+        if ([sublayer valueForKey:WKInteractionRegionContainerKey])
+            continue;
+
+        if (auto *subnode = forCALayer(sublayer)) {
+            if (subnode->hasInteractionRegions())
+                break;
+        }
+
+        insertionPoint++;
+    }
+
+    if ([layer().sublayers objectAtIndex:insertionPoint] == m_interactionRegionsContainer)
+        return;
+
+    [m_interactionRegionsContainer removeFromSuperlayer];
+    [layer() insertSublayer:m_interactionRegionsContainer.get() atIndex:insertionPoint];
+}
+
+void RemoteLayerTreeNode::propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree interactionRegionsInSubtree)
+{
+    for (auto* parentNode = forCALayer(layer().superlayer); parentNode; parentNode = forCALayer(parentNode->layer().superlayer)) {
+        parentNode->repositionInteractionRegionsContainerIfNeeded();
+
+        bool originalFlag = parentNode->hasInteractionRegionsDescendant();
+
+        if (originalFlag && interactionRegionsInSubtree == InteractionRegionsInSubtree::Yes)
+            break;
+
+        if (interactionRegionsInSubtree == InteractionRegionsInSubtree::Yes) {
+            parentNode->setHasInteractionRegionsDescendant(true);
+            continue;
+        }
+
+        bool hasInteractionRegionsDescendant = false;
+        for (CALayer *sublayer in parentNode->layer().sublayers) {
+            if (auto *subnode = forCALayer(sublayer)) {
+                if (subnode->hasInteractionRegions()) {
+                    hasInteractionRegionsDescendant = true;
+                    break;
+                }
+            }
+        }
+
+        if (originalFlag == hasInteractionRegionsDescendant)
+            break;
+
+        parentNode->setHasInteractionRegionsDescendant(hasInteractionRegionsDescendant);
+        if (hasInteractionRegionsDescendant)
+            interactionRegionsInSubtree = InteractionRegionsInSubtree::Yes;
+    }
+}
+#endif
 
 WebCore::PlatformLayerIdentifier RemoteLayerTreeNode::layerID(CALayer *layer)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -113,12 +113,8 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
         if (currNode->hasChangedProperty(ScrollingStateNode::Property::Layer)) {
             auto platformLayerID = PlatformLayerID { currNode->layer() };
             auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
-            if (remoteLayerTreeNode) {
+            if (remoteLayerTreeNode)
                 currNode->setLayer(remoteLayerTreeNode->layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-                currNode->setInteractionRegionsLayer(remoteLayerTreeNode->interactionRegionsLayer());
-#endif
-            }
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
             if (platformLayerID && (currNode->isFixedNode() || currNode->isStickyNode()))
                 m_fixedScrollingNodeLayerIDs.add(platformLayerID);
@@ -132,12 +128,8 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = PlatformLayerID { scrollingStateNode.scrollContainerLayer() };
                 auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
-                if (remoteLayerTreeNode) {
+                if (remoteLayerTreeNode)
                     scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-                    scrollingStateNode.setInteractionRegionsLayer(remoteLayerTreeNode->interactionRegionsLayer());
-#endif
-                }
             }
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
@@ -151,12 +143,8 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = PlatformLayerID { scrollingStateNode.scrollContainerLayer() };
                 auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
-                if (remoteLayerTreeNode) {
+                if (remoteLayerTreeNode)
                     scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-                    scrollingStateNode.setInteractionRegionsLayer(remoteLayerTreeNode->interactionRegionsLayer());
-#endif
-                }
             }
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -46,10 +46,6 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/SetForScope.h>
 
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-#import <WebCore/WebCoreCALayerExtras.h>
-#endif
-
 @implementation WKScrollingNodeScrollViewDelegate
 
 - (instancetype)initWithScrollingTreeNodeDelegate:(WebKit::ScrollingTreeScrollingNodeDelegateIOS*)delegate
@@ -222,12 +218,8 @@ void ScrollingTreeScrollingNodeDelegateIOS::resetScrollViewDelegate()
 
 void ScrollingTreeScrollingNodeDelegateIOS::commitStateBeforeChildren(const ScrollingStateScrollingNode& scrollingStateNode)
 {
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
         m_scrollLayer = static_cast<CALayer*>(scrollingStateNode.scrollContainerLayer());
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(scrollingStateNode.interactionRegionsLayer());
-#endif
-    }
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior(UIScrollView *scrollView, const WebCore::OverscrollBehavior horizontalOverscrollBehavior, WebCore::OverscrollBehavior verticalOverscrollBehavior, AllowOverscrollToPreventScrollPropagation allowPropogation)
@@ -356,10 +348,6 @@ void ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers()
 
     [scrollView() setContentOffset:scrollingNode().currentScrollOffset()];
     END_BLOCK_OBJC_EXCEPTIONS
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [m_interactionRegionsLayer _web_setLayerBoundsOrigin:scrollingNode().currentScrollOffset()];
-#endif
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::scrollWillStart() const


### PR DESCRIPTION
#### b6bfbe1b58219e8ce3d8a546248a62730168ce1c
<pre>
Weave the InteractionRegion layers into the content layer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=260386">https://bugs.webkit.org/show_bug.cgi?id=260386</a>
&lt;rdar://102758344&gt;

Reviewed by Tim Horton.

InteractionRegion layers lived in a &quot;duplicated&quot;, always-on-top, layer tree.
This patch merges them back into the content&apos;s layer tree. This makes
for an overall lighter tree, but the main goal is to let content layers
partially occlude the glow effects.
When a compositing layer has Interaction Regions, we create and insert an
InteractionRegions container as one of its sublayers. *Positioning is key!*
It&apos;s always positioned below the first sublayer that contains other
Interaction Regions.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
(WebKit::applyCommonPropertiesToLayer): Deleted.
(WebKit::applyInteractionRegionsHierarchyUpdate): Deleted.
Remove the &quot;duplicated&quot; layer tree code paths.
(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
Signal the RemoteLayerTreeNode when an hierarchy update happened.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
Remove the code that was keeping the &quot;duplicated&quot; InteractionRegion layer
tree always on top.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::isAnyInteractionRegionLayer): Deleted.
(WebKit::insertInteractionRegionLayersForLayer): Deleted.
Remove the code that was maintaining the &quot;duplicated&quot; InteractionRegion
layer tree.
(WebKit::updateLayersForInteractionRegions):
Remove the InteractionRegions container from the node when it contains no
Interaction Region.
Re-introduce the HashSet preventing duplicated layers with the same
rect.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::interactionRegionsLayer const): Deleted.
Rename the node&apos;s `interactionRegionsLayer` as
`interactionRegionsContainer`.
Change the API so that it&apos;s lazily created when needed.
(WebKit::RemoteLayerTreeNode::hasInteractionRegionsDescendant const):
(WebKit::RemoteLayerTreeNode::setHasInteractionRegionsDescendant):
Introduce a new `hasInteractionRegionsDescendant` flag.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::~RemoteLayerTreeNode):
Remove the InteractionRegions container, if any, in the destructor.
(WebKit::RemoteLayerTreeNode::detachFromParent):
Remove the InteractionRegions container, if any, when detaching.
(WebKit::RemoteLayerTreeNode::initializeLayer):
Set layers as `hitTestsContentsAlphaChannel`, this is key for the glow
effect to work properly while the InteractionRegion layers are weaved
into the content tree.
(WebKit::RemoteLayerTreeNode::ensureInteractionRegionsContainer):
Return the existing InteractionRegions container if it exists.
Create and position an InteractionRegions container otherwise.
Adding a new container can impact the positioning of containers higher
in the tree given our positioning rule.
(WebKit::RemoteLayerTreeNode::removeInteractionRegionsContainer):
Remove and release the InteractionRegions container if it exists.
Remove a container can impact the positioning of containers higher in
the tree.
(WebKit::RemoteLayerTreeNode::updateInteractionRegionAfterHierarchyChange):
React to a hierarchy change (sublayers update):
- reposition the InteractionRegions container if needed.
- update the `hasInteractionRegionsDescendant` flag if needed.
(WebKit::RemoteLayerTreeNode::hasInteractionRegions const):
A node &quot;has interaction regions&quot; if it owns an InteractionRegions
container or if one of its descendants does.
(WebKit::RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded):
Find the correct position of the InteractionRegions container and move
it here if needed.
(WebKit::RemoteLayerTreeNode::propagateInteractionRegionsChangeInHierarchy):
Traverse the node&apos;s hierarchy to maintain the containers positions and
`hasInteractionRegionsDescendant` flags.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
Add the SPI for `hitTestsContentsAlphaChannel`.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldGetOcclusion):
(WebCore::isOverlay): Deleted.
Rename `isOverlay` to `shouldGetOcclusion`.
(WebCore::interactionRegionForRenderedRegion):
Don&apos;t generate extra occlusion layers when the compositing layer is
already occluding.

* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::setInteractionRegionsLayer): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::interactionRegionsLayer const): Deleted.
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
(WebCore::ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreeFixedNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm:
(WebCore::ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreeOverflowScrollProxyNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm:
(WebCore::ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreePositionedNodeCocoa::applyLayerPositions):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren):
(WebCore::ScrollingTreeStickyNodeCocoa::applyLayerPositions):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateBeforeChildren):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers):
Remove the code that was maintaining the &quot;duplicated&quot; InteractionRegion
layer tree.

* LayoutTests/interaction-region/full-page-overlay.html:
* LayoutTests/interaction-region/full-page-overlay-expected.txt:
Cover the overlay detection logic without compositing.
* LayoutTests/interaction-region/layer-tree.html:
* LayoutTests/interaction-region/layer-tree-expected.txt:
Update the layer tree test to exercise more of the RemoteLayerTreeNode
logic.
* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
Test expectation update: new layer tree structure.
* LayoutTests/interaction-region/overlay-expected.txt:
* LayoutTests/interaction-region/position-only-update-expected.txt:

Test expectation update: removed occlusion layers.
Canonical link: <a href="https://commits.webkit.org/267441@main">https://commits.webkit.org/267441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00768a271b802c10e0f22820854aef7650b28033

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21501 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18061 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13073 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->