### PR TITLE
[GTK] Crash in GraphicsContextGLGBM::allocateDrawBufferObject

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -32,6 +32,7 @@
 #include "DMABufColorSpace.h"
 #include "GBMDevice.h"
 #include <gbm.h>
+#include <wtf/SafeStrerror.h>
 
 namespace WebCore {
 
@@ -101,7 +102,6 @@ RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDes
         if (!m_array.object[i]) {
             // If no buffer was spawned yet at this location, we do that, and return it.
             auto buffer = adoptRef(*new Buffer(m_handleGenerator++, description));
-            m_array.object[i] = buffer.copyRef();
 
             // Fill out the buffer's description and plane information for known and supported formats.
             buffer->m_description.format.numPlanes = description.format.numPlanes;
@@ -121,11 +121,17 @@ RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDes
             for (unsigned i = 0; i < buffer->m_description.format.numPlanes; ++i) {
                 auto& plane = buffer->m_planes[i];
                 plane.bo = gbm_bo_create(device, plane.width, plane.height, uint32_t(plane.fourcc), boFlags);
+                if (!plane.bo) {
+                    WTFLogAlways("Failed to get GBM buffer from swap chain: error creating plane %u of size %dx%d and format %u: %s\n",
+                        i, plane.width, plane.height, uint32_t(plane.fourcc), safeStrerror(errno).data());
+                    return nullptr;
+                }
                 plane.stride = gbm_bo_get_stride(plane.bo);
             }
 
             // Lock the buffer and return it.
             buffer->m_state.locked = true;
+            m_array.object[i] = buffer.copyRef();
             return buffer;
         }
 


### PR DESCRIPTION
#### c46b14b21386bb3975ae285adcdf1aa1f60abbbf
<pre>
[GTK] Crash in GraphicsContextGLGBM::allocateDrawBufferObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=258831">https://bugs.webkit.org/show_bug.cgi?id=258831</a>

Reviewed by Michael Catanzaro.

It seems gbm_bo_create() is failing and we use its returned value
without checking it&apos;s valid. I don&apos;t know why it fails because I can&apos;t
reproduce it, so I&apos;m adding an error message and handling the null value
for now.

* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::GBMBufferSwapchain::getBuffer):

Canonical link: <a href="https://commits.webkit.org/267048@main">https://commits.webkit.org/267048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/852716db2b44eef36673be6b3b042dbbc14b0cce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17079 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17966 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20887 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13957 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18318 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1887 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->