### PR TITLE
WebInspector Slider horizontal mode 

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Slider.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Slider.css
@@ -39,12 +39,18 @@
 
 body[dir=ltr] .slider > img {
     left: 2px;
-    transform: translateY(var(--translate-y, 0px)) rotate(270deg);
 }
 
 body[dir=rtl] .slider > img {
     left: -6px;
-    transform: translateY(var(--translate-y, 0px)) rotate(90deg);
+}
+
+.slider img {
+    transform: translateY(var(--translate-y, 0px));
+}
+
+.slider img.horizontal{
+    transform: translateX(var(--translate-x, 0px));
 }
 
 .slider > img.dragging {


### PR DESCRIPTION
#### 088e3627e72ab3b667b28c9dfbcc01ab22798009
<pre>
Thought the slider should be horizontal as well.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260393">https://bugs.webkit.org/show_bug.cgi?id=260393</a>
rdar://114094387

Reviewed by NOBODY (OOPS!).

Just makes it so you can have a horizontal slider as well.

* Source/WebInspectorUI/UserInterface/Views/Slider.css:
(body[dir=ltr] .slider &gt; img):
(body[dir=rtl] .slider &gt; img):
(.slider img):
(.slider img.horizontal):
* Source/WebInspectorUI/UserInterface/Views/Slider.js:
(WI.Slider.prototype.get element):
(WI.Slider.prototype.get value):
(WI.Slider.prototype.set value):
(WI.Slider.prototype.set knobPosition):
(WI.Slider.prototype.get maxPosition):
(WI.Slider.prototype.recalculateKnobPosition):
(WI.Slider.prototype.handleEvent):
(WI.Slider.prototype._handleMousedown):
(WI.Slider.prototype._handleMousemove):
(WI.Slider.prototype._handleMouseup):
(WI.Slider.prototype._handleKeyDown):
(WI.Slider.prototype._localPointForEvent):
(WI.Slider):
(WI.Slider.prototype.set knobY): Deleted.
(WI.Slider.prototype.get maxY): Deleted.
(WI.Slider.prototype.recalculateKnobY): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/088e3627e72ab3b667b28c9dfbcc01ab22798009

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17234 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14514 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17977 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20896 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12461 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->