### PR TITLE
ComputedStyleExtractor methods should be const when possible.

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -574,7 +574,7 @@ static RefPtr<CSSValue> positionOffsetValue(const RenderStyle& style, CSSPropert
     return CSSPrimitiveValue::create(CSSValueAuto);
 }
 
-RefPtr<CSSValue> ComputedStyleExtractor::whiteSpaceShorthandValue(const RenderStyle& style)
+RefPtr<CSSValue> ComputedStyleExtractor::whiteSpaceShorthandValue(const RenderStyle& style) const
 {
     auto whiteSpaceCollapse = style.whiteSpaceCollapse();
     auto textWrap = style.textWrap();
@@ -1779,7 +1779,7 @@ ComputedStyleExtractor::ComputedStyleExtractor(Element* element, bool allowVisit
 {
 }
 
-RefPtr<CSSPrimitiveValue> ComputedStyleExtractor::getFontSizeCSSValuePreferringKeyword()
+RefPtr<CSSPrimitiveValue> ComputedStyleExtractor::getFontSizeCSSValuePreferringKeyword() const
 {
     if (!m_element)
         return nullptr;
@@ -1796,7 +1796,7 @@ RefPtr<CSSPrimitiveValue> ComputedStyleExtractor::getFontSizeCSSValuePreferringK
     return zoomAdjustedPixelValue(style->fontDescription().computedSize(), *style);
 }
 
-bool ComputedStyleExtractor::useFixedFontDefaultSize()
+bool ComputedStyleExtractor::useFixedFontDefaultSize() const
 {
     if (!m_element)
         return false;
@@ -2213,7 +2213,7 @@ static Ref<CSSValue> fontStyle(const RenderStyle& style)
     return fontStyle(style.fontDescription().italic(), style.fontDescription().fontStyleAxis());
 }
 
-Ref<CSSValue> ComputedStyleExtractor::fontVariantShorthandValue()
+Ref<CSSValue> ComputedStyleExtractor::fontVariantShorthandValue() const
 {
     CSSValueListBuilder list;
     for (auto longhand : fontVariantShorthand()) {
@@ -2816,7 +2816,7 @@ static inline bool isFlexOrGridItem(RenderObject* renderer)
     return box.isFlexItem() || box.isGridItem();
 }
 
-RefPtr<CSSValue> ComputedStyleExtractor::customPropertyValue(const AtomString& propertyName)
+RefPtr<CSSValue> ComputedStyleExtractor::customPropertyValue(const AtomString& propertyName) const
 {
     Element* styledElement = m_element.get();
     if (!styledElement)
@@ -2834,7 +2834,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::customPropertyValue(const AtomString& p
     return const_cast<CSSCustomPropertyValue*>(value);
 }
 
-String ComputedStyleExtractor::customPropertyText(const AtomString& propertyName)
+String ComputedStyleExtractor::customPropertyText(const AtomString& propertyName) const
 {
     RefPtr<CSSValue> propertyValue = customPropertyValue(propertyName);
     return propertyValue ? propertyValue->cssText() : emptyString();
@@ -2883,7 +2883,7 @@ static Ref<CSSFontValue> fontShorthandValue(const RenderStyle& style, ComputedSt
     return computedFont;
 }
 
-RefPtr<CSSValue> ComputedStyleExtractor::propertyValue(CSSPropertyID propertyID, UpdateLayout updateLayout, PropertyValueType valueType)
+RefPtr<CSSValue> ComputedStyleExtractor::propertyValue(CSSPropertyID propertyID, UpdateLayout updateLayout, PropertyValueType valueType) const
 {
     auto* styledElement = m_element.get();
     if (!styledElement)
@@ -2937,12 +2937,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::propertyValue(CSSPropertyID propertyID,
     return valueForPropertyInStyle(*style, propertyID, valueType == PropertyValueType::Resolved ? styledRenderer() : nullptr, valueType);
 }
 
-bool ComputedStyleExtractor::hasProperty(CSSPropertyID propertyID)
+bool ComputedStyleExtractor::hasProperty(CSSPropertyID propertyID) const
 {
     return propertyValue(propertyID);
 }
 
-RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderStyle& style, CSSPropertyID propertyID, RenderElement* renderer, PropertyValueType valueType)
+RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderStyle& style, CSSPropertyID propertyID, RenderElement* renderer, PropertyValueType valueType) const
 {
     auto& cssValuePool = CSSValuePool::singleton();
     propertyID = CSSProperty::resolveDirectionAwareProperty(propertyID, style.direction(), style.writingMode());
@@ -4446,7 +4446,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     return nullptr;
 }
 
-bool ComputedStyleExtractor::propertyMatches(CSSPropertyID propertyID, const CSSValue* value)
+bool ComputedStyleExtractor::propertyMatches(CSSPropertyID propertyID, const CSSValue* value) const
 {
     if (!m_element)
         return false;
@@ -4464,7 +4464,7 @@ bool ComputedStyleExtractor::propertyMatches(CSSPropertyID propertyID, const CSS
     return computedValue && value && computedValue->equals(*value);
 }
 
-Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties(const StylePropertyShorthand& shorthand)
+Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties(const StylePropertyShorthand& shorthand) const
 {
     CSSValueListBuilder list;
     for (auto longhand : shorthand)
@@ -4472,7 +4472,7 @@ Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProper
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand& shorthand)
+RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand& shorthand) const
 {
     // Assume the properties are in the usual order start, end.
     auto startValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
@@ -4487,7 +4487,7 @@ RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorth
     return CSSValueList::createSpaceSeparated(startValue.releaseNonNull(), endValue.releaseNonNull());
 }
 
-RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand& shorthand)
+RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand& shorthand) const
 {
     // Assume the properties are in the usual order top, right, bottom, left.
     auto topValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
@@ -4514,7 +4514,7 @@ RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorth
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand& shorthand)
+Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand& shorthand) const
 {
     CSSValueListBuilder builder;
     for (auto longhand : shorthand)
@@ -4522,7 +4522,7 @@ Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand(c
     return CSSValueList::createSlashSeparated(WTFMove(builder));
 }
 
-Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties(std::span<const CSSPropertyID> properties)
+Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties(std::span<const CSSPropertyID> properties) const
 {
     Vector<CSSProperty> vector;
     vector.reserveInitialCapacity(properties.size());
@@ -4534,7 +4534,7 @@ Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties(std::span<con
     return MutableStyleProperties::create(WTFMove(vector));
 }
 
-Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties()
+Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties() const
 {
     return MutableStyleProperties::create(WTF::compactMap(allLonghandCSSProperties(), [this] (auto property) -> std::optional<CSSProperty> {
         auto value = propertyValue(property);
@@ -4544,7 +4544,7 @@ Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties()
     }).span());
 }
 
-size_t ComputedStyleExtractor::getLayerCount(CSSPropertyID property)
+size_t ComputedStyleExtractor::getLayerCount(CSSPropertyID property) const
 {
     ASSERT(property == CSSPropertyBackground || property == CSSPropertyMask);
     if (!m_element)
@@ -4565,7 +4565,7 @@ size_t ComputedStyleExtractor::getLayerCount(CSSPropertyID property)
     return layerCount;
 }
 
-Ref<CSSValue> ComputedStyleExtractor::getFillLayerPropertyShorthandValue(CSSPropertyID property, const StylePropertyShorthand& propertiesBeforeSlashSeparator, const StylePropertyShorthand& propertiesAfterSlashSeparator, CSSPropertyID lastLayerProperty)
+Ref<CSSValue> ComputedStyleExtractor::getFillLayerPropertyShorthandValue(CSSPropertyID property, const StylePropertyShorthand& propertiesBeforeSlashSeparator, const StylePropertyShorthand& propertiesAfterSlashSeparator, CSSPropertyID lastLayerProperty) const
 {
     ASSERT(property == CSSPropertyBackground || property == CSSPropertyMask);
     size_t layerCount = getLayerCount(property);
@@ -4605,7 +4605,7 @@ Ref<CSSValue> ComputedStyleExtractor::getFillLayerPropertyShorthandValue(CSSProp
 }
 
 
-Ref<CSSValue> ComputedStyleExtractor::getBackgroundShorthandValue()
+Ref<CSSValue> ComputedStyleExtractor::getBackgroundShorthandValue() const
 {
     static const CSSPropertyID propertiesBeforeSlashSeparator[] = { CSSPropertyBackgroundImage, CSSPropertyBackgroundRepeat, CSSPropertyBackgroundAttachment, CSSPropertyBackgroundPosition };
     static const CSSPropertyID propertiesAfterSlashSeparator[] = { CSSPropertyBackgroundSize, CSSPropertyBackgroundOrigin, CSSPropertyBackgroundClip };
@@ -4613,7 +4613,7 @@ Ref<CSSValue> ComputedStyleExtractor::getBackgroundShorthandValue()
     return getFillLayerPropertyShorthandValue(CSSPropertyBackground, StylePropertyShorthand(CSSPropertyBackground, propertiesBeforeSlashSeparator), StylePropertyShorthand(CSSPropertyBackground, propertiesAfterSlashSeparator), CSSPropertyBackgroundColor);
 }
 
-Ref<CSSValue> ComputedStyleExtractor::getMaskShorthandValue()
+Ref<CSSValue> ComputedStyleExtractor::getMaskShorthandValue() const
 {
     static const CSSPropertyID propertiesBeforeSlashSeparator[2] = { CSSPropertyMaskImage, CSSPropertyMaskPosition };
     static const CSSPropertyID propertiesAfterSlashSeparator[6] = { CSSPropertyMaskSize, CSSPropertyMaskRepeat, CSSPropertyMaskOrigin, CSSPropertyMaskClip, CSSPropertyMaskComposite, CSSPropertyMaskMode };

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -61,19 +61,19 @@ public:
 
     enum class UpdateLayout : bool { No, Yes };
     enum class PropertyValueType : bool { Resolved, Computed };
-    bool hasProperty(CSSPropertyID);
-    RefPtr<CSSValue> propertyValue(CSSPropertyID, UpdateLayout = UpdateLayout::Yes, PropertyValueType = PropertyValueType::Resolved);
-    RefPtr<CSSValue> valueForPropertyInStyle(const RenderStyle&, CSSPropertyID, RenderElement* = nullptr, PropertyValueType = PropertyValueType::Resolved);
-    String customPropertyText(const AtomString& propertyName);
-    RefPtr<CSSValue> customPropertyValue(const AtomString& propertyName);
+    bool hasProperty(CSSPropertyID) const;
+    RefPtr<CSSValue> propertyValue(CSSPropertyID, UpdateLayout = UpdateLayout::Yes, PropertyValueType = PropertyValueType::Resolved) const;
+    RefPtr<CSSValue> valueForPropertyInStyle(const RenderStyle&, CSSPropertyID, RenderElement* = nullptr, PropertyValueType = PropertyValueType::Resolved) const;
+    String customPropertyText(const AtomString& propertyName) const;
+    RefPtr<CSSValue> customPropertyValue(const AtomString& propertyName) const;
 
     // Helper methods for HTML editing.
-    Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>);
-    Ref<MutableStyleProperties> copyProperties();
-    RefPtr<CSSPrimitiveValue> getFontSizeCSSValuePreferringKeyword();
-    bool useFixedFontDefaultSize();
-    bool propertyMatches(CSSPropertyID, const CSSValue*);
-    bool propertyMatches(CSSPropertyID, CSSValueID);
+    Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>) const;
+    Ref<MutableStyleProperties> copyProperties() const;
+    RefPtr<CSSPrimitiveValue> getFontSizeCSSValuePreferringKeyword() const;
+    bool useFixedFontDefaultSize() const;
+    bool propertyMatches(CSSPropertyID, const CSSValue*) const;
+    bool propertyMatches(CSSPropertyID, CSSValueID) const;
 
     enum class AdjustPixelValuesForComputedStyle : bool { No, Yes };
     static Ref<CSSValue> valueForFilter(const RenderStyle&, const FilterOperations&, AdjustPixelValuesForComputedStyle = AdjustPixelValuesForComputedStyle::Yes);
@@ -88,21 +88,21 @@ private:
     // The renderer we should use for resolving layout-dependent properties.
     RenderElement* styledRenderer() const;
 
-    RefPtr<CSSValue> svgPropertyValue(CSSPropertyID);
+    RefPtr<CSSValue> svgPropertyValue(CSSPropertyID) const;
     Ref<CSSValue> adjustSVGPaint(SVGPaintType, const String& url, Ref<CSSPrimitiveValue> color) const;
     static Ref<CSSValue> valueForShadow(const ShadowData*, CSSPropertyID, const RenderStyle&, AdjustPixelValuesForComputedStyle = AdjustPixelValuesForComputedStyle::Yes);
 
-    Ref<CSSValueList> getCSSPropertyValuesForShorthandProperties(const StylePropertyShorthand&);
-    RefPtr<CSSValueList> getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand&);
-    RefPtr<CSSValueList> getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand&);
+    Ref<CSSValueList> getCSSPropertyValuesForShorthandProperties(const StylePropertyShorthand&) const;
+    RefPtr<CSSValueList> getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand&) const;
+    RefPtr<CSSValueList> getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand&) const;
 
-    size_t getLayerCount(CSSPropertyID);
-    Ref<CSSValue> getFillLayerPropertyShorthandValue(CSSPropertyID, const StylePropertyShorthand& propertiesBeforeSlashSeparator, const StylePropertyShorthand& propertiesAfterSlashSeparator, CSSPropertyID lastLayerProperty);
-    Ref<CSSValue> getBackgroundShorthandValue();
-    Ref<CSSValue> getMaskShorthandValue();
-    Ref<CSSValueList> getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand&);
-    Ref<CSSValue> fontVariantShorthandValue();
-    RefPtr<CSSValue> whiteSpaceShorthandValue(const RenderStyle&);
+    size_t getLayerCount(CSSPropertyID) const;
+    Ref<CSSValue> getFillLayerPropertyShorthandValue(CSSPropertyID, const StylePropertyShorthand& propertiesBeforeSlashSeparator, const StylePropertyShorthand& propertiesAfterSlashSeparator, CSSPropertyID lastLayerProperty) const;
+    Ref<CSSValue> getBackgroundShorthandValue() const;
+    Ref<CSSValue> getMaskShorthandValue() const;
+    Ref<CSSValueList> getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand&) const;
+    Ref<CSSValue> fontVariantShorthandValue() const;
+    RefPtr<CSSValue> whiteSpaceShorthandValue(const RenderStyle&) const;
 
     RefPtr<Element> m_element;
     PseudoId m_pseudoElementSpecifier;

--- a/Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp
@@ -96,7 +96,7 @@ static RefPtr<CSSValue> svgMarkerValue(const String& marker, const Element* elem
     return CSSPrimitiveValue::createURI(resolvedURL.string());
 }
 
-RefPtr<CSSValue> ComputedStyleExtractor::svgPropertyValue(CSSPropertyID propertyID)
+RefPtr<CSSValue> ComputedStyleExtractor::svgPropertyValue(CSSPropertyID propertyID) const
 {
     if (!m_element)
         return nullptr;


### PR DESCRIPTION
#### f5c4eacf1b680be9ab02d77323051599228a47c0
<pre>
ComputedStyleExtractor methods should be const when possible.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260401">https://bugs.webkit.org/show_bug.cgi?id=260401</a>
rdar://problem/114099664

Reviewed by Tim Nguyen.

Many of the methods for ComputedStyleExtractor compute a value and then
return it without modifying any sort of state in the class. In these
cases we should try to mark these methods as const if this can be
easily done. This is useful for other code that many use a const
ComputedStyleExtractor and would like to use these methods. For example,
in 260397 I plan on passing in a const ComputedStyleExtractor into
ShorthandSerializer so that we can use it for the computed style
of the grid-template property.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::whiteSpaceShorthandValue const):
(WebCore::ComputedStyleExtractor::getFontSizeCSSValuePreferringKeyword const):
(WebCore::ComputedStyleExtractor::useFixedFontDefaultSize const):
(WebCore::ComputedStyleExtractor::fontVariantShorthandValue const):
(WebCore::ComputedStyleExtractor::customPropertyValue const):
(WebCore::ComputedStyleExtractor::customPropertyText const):
(WebCore::ComputedStyleExtractor::propertyValue const):
(WebCore::ComputedStyleExtractor::hasProperty const):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
(WebCore::ComputedStyleExtractor::propertyMatches const):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties const):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand const):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand const):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand const):
(WebCore::ComputedStyleExtractor::copyProperties const):
(WebCore::ComputedStyleExtractor::getLayerCount const):
(WebCore::ComputedStyleExtractor::getFillLayerPropertyShorthandValue const):
(WebCore::ComputedStyleExtractor::getBackgroundShorthandValue const):
(WebCore::ComputedStyleExtractor::getMaskShorthandValue const):
(WebCore::ComputedStyleExtractor::whiteSpaceShorthandValue): Deleted.
(WebCore::ComputedStyleExtractor::getFontSizeCSSValuePreferringKeyword): Deleted.
(WebCore::ComputedStyleExtractor::useFixedFontDefaultSize): Deleted.
(WebCore::ComputedStyleExtractor::fontVariantShorthandValue): Deleted.
(WebCore::ComputedStyleExtractor::customPropertyValue): Deleted.
(WebCore::ComputedStyleExtractor::customPropertyText): Deleted.
(WebCore::ComputedStyleExtractor::propertyValue): Deleted.
(WebCore::ComputedStyleExtractor::hasProperty): Deleted.
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle): Deleted.
(WebCore::ComputedStyleExtractor::propertyMatches): Deleted.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForShorthandProperties): Deleted.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand): Deleted.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand): Deleted.
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand): Deleted.
(WebCore::ComputedStyleExtractor::copyProperties): Deleted.
(WebCore::ComputedStyleExtractor::getLayerCount): Deleted.
(WebCore::ComputedStyleExtractor::getFillLayerPropertyShorthandValue): Deleted.
(WebCore::ComputedStyleExtractor::getBackgroundShorthandValue): Deleted.
(WebCore::ComputedStyleExtractor::getMaskShorthandValue): Deleted.
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/css/SVGCSSComputedStyleDeclaration.cpp:
(WebCore::ComputedStyleExtractor::svgPropertyValue const):
(WebCore::ComputedStyleExtractor::svgPropertyValue): Deleted.

Canonical link: <a href="https://commits.webkit.org/267055@main">https://commits.webkit.org/267055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02e913a43b34674a4d2c0322e73f0d39b9226efe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15890 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17988 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20904 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12471 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13978 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3724 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->