### PR TITLE
STP build fix for [macOS] WebKit should not re-export WebCore

### DIFF
--- a/Source/WebKitLegacy/scripts/migrate-header-rule
+++ b/Source/WebKitLegacy/scripts/migrate-header-rule
@@ -4,12 +4,12 @@
 sed -E -e 's/<WebCore\//<WebKitLegacy\//' -e "s/(^ *)WEBCORE_EXPORT /\1/" "${INPUT_FILE_PATH}" > "${SCRIPT_OUTPUT_FILE_0}"
 
 # *_SEARCH_PATHS are already shell-escaped, convert to an array so we can pass a flag for each path.
-# Note that this method does not work for search paths which contain spaces (rdar://91303280).
 eval HEADER_SEARCH_PATHS=(${HEADER_SEARCH_PATHS} ${SYSTEM_HEADER_SEARCH_PATHS})
-eval FRAMEWORK_SEARCH_PATHS=(${FRAMEWORK_SEARCH_PATHS} ${SYSTEM_FRAMEWORK_SEARCH_PATHS})
+# Work around rdar://91303280 when building STP.
+eval FRAMEWORK_SEARCH_PATHS=(${FRAMEWORK_SEARCH_PATHS//${WK_OVERRIDE_FRAMEWORKS_DIR}/${WK_QUOTED_OVERRIDE_FRAMEWORKS_DIR}} ${SYSTEM_FRAMEWORK_SEARCH_PATHS})
 
 # Create an export list, which will be used by "Generate Export Files" to create an export symbols
 # list that includes symbols from this header.
 for WK_CURRENT_ARCH in ${ARCHS}; do
-    tapi reexport -target ${WK_CURRENT_ARCH}-${LLVM_TARGET_TRIPLE_VENDOR}-${LLVM_TARGET_TRIPLE_OS_VERSION}${LLVM_TARGET_TRIPLE_SUFFIX} -isysroot ${SDK_DIR} -I${BUILT_PRODUCTS_DIR} ${HEADER_SEARCH_PATHS[@]/#/-I} -F${BUILT_PRODUCTS_DIR} ${FRAMEWORK_SEARCH_PATHS[@]/#/-F} -DWEBCORE_EXPORT= "${SDK_DIR}/usr/include/TargetConditionals.h" "${INPUT_FILE_PATH}" -o /dev/stdout
+    tapi reexport -target ${WK_CURRENT_ARCH}-${LLVM_TARGET_TRIPLE_VENDOR}-${LLVM_TARGET_TRIPLE_OS_VERSION}${LLVM_TARGET_TRIPLE_SUFFIX} -isysroot ${SDK_DIR} -I${BUILT_PRODUCTS_DIR} "${HEADER_SEARCH_PATHS[@]/#/-I}" -F${BUILT_PRODUCTS_DIR} "${FRAMEWORK_SEARCH_PATHS[@]/#/-F}" -DWEBCORE_EXPORT= "${SDK_DIR}/usr/include/TargetConditionals.h" "${INPUT_FILE_PATH}" -o /dev/stdout
 done >> "${TARGET_TEMP_DIR}/ReexportedFromWebCore.exp"


### PR DESCRIPTION
#### 9ef92e6b63f9bd0f239c46fcc30a926d59ead191
<pre>
STP build fix for [macOS] WebKit should not re-export WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=259352">https://bugs.webkit.org/show_bug.cgi?id=259352</a>
rdar://110785133

Unreviewed.

FRAMEWORK_SEARCH_PATHS contains spaces when building STP, and
migrate-header-rule now invokes `tapi reexport` on macOS. Xcode in
general has an ambiguity problem with whitespace in string lists in
script phases (rdar://91303280), but we can work around this particular
case using WK_QUOTED_OVERRIDE_FRAMEWORKS_DIR.

* Source/WebKitLegacy/scripts/migrate-header-rule:

Canonical link: <a href="https://commits.webkit.org/267054@main">https://commits.webkit.org/267054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e1e5b5e790ba1247007e8ac6713eaaef9c8c9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14526 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15891 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13171 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/17998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13971 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20902 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13979 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3720 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->