### PR TITLE
ResourceHeap clean-up

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -98,32 +98,32 @@ private:
 
     void cacheImageBuffer(WebCore::ImageBuffer& imageBuffer)
     {
-        m_resourceHeap.add(imageBuffer.renderingResourceIdentifier(), Ref { imageBuffer });
+        m_resourceHeap.add(Ref { imageBuffer });
     }
 
     void cacheNativeImage(NativeImage& image)
     {
-        m_resourceHeap.add(image.renderingResourceIdentifier(), Ref { image });
+        m_resourceHeap.add(Ref { image });
     }
 
     void cacheFont(Font& font)
     {
-        m_resourceHeap.add(font.renderingResourceIdentifier(), Ref { font });
+        m_resourceHeap.add(Ref { font });
     }
 
     void cacheDecomposedGlyphs(DecomposedGlyphs& decomposedGlyphs)
     {
-        m_resourceHeap.add(decomposedGlyphs.renderingResourceIdentifier(), Ref { decomposedGlyphs });
+        m_resourceHeap.add(Ref { decomposedGlyphs });
     }
 
     void cacheGradient(Gradient& gradient)
     {
-        m_resourceHeap.add(gradient.renderingResourceIdentifier(), Ref { gradient });
+        m_resourceHeap.add(Ref { gradient });
     }
 
     void cacheFilter(Filter& filter)
     {
-        m_resourceHeap.add(filter.renderingResourceIdentifier(), Ref { filter });
+        m_resourceHeap.add(Ref { filter });
     }
 
     static bool shouldDumpForFlags(OptionSet<AsTextFlag>, ItemHandle);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -50,38 +50,45 @@ public:
         Ref<FontCustomPlatformData>
     >;
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<ImageBuffer>&& imageBuffer)
+    void add(Ref<ImageBuffer>&& imageBuffer)
     {
+        auto renderingResourceIdentifier = imageBuffer->renderingResourceIdentifier();
         add<ImageBuffer>(renderingResourceIdentifier, WTFMove(imageBuffer), m_imageBufferCount);
     }
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<NativeImage>&& image)
+    void add(Ref<NativeImage>&& image)
     {
+        auto renderingResourceIdentifier = image->renderingResourceIdentifier();
         add<RenderingResource>(renderingResourceIdentifier, WTFMove(image), m_renderingResourceCount);
     }
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<DecomposedGlyphs>&& decomposedGlyphs)
+    void add(Ref<DecomposedGlyphs>&& decomposedGlyphs)
     {
+        auto renderingResourceIdentifier = decomposedGlyphs->renderingResourceIdentifier();
         add<RenderingResource>(renderingResourceIdentifier, WTFMove(decomposedGlyphs), m_renderingResourceCount);
     }
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Gradient>&& gradient)
+    void add(Ref<Gradient>&& gradient)
     {
+        auto renderingResourceIdentifier = gradient->renderingResourceIdentifier();
         add<RenderingResource>(renderingResourceIdentifier, WTFMove(gradient), m_renderingResourceCount);
     }
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Filter>&& filter)
+    void add(Ref<Filter>&& filter)
     {
+        auto renderingResourceIdentifier = filter->renderingResourceIdentifier();
         add<RenderingResource>(renderingResourceIdentifier, WTFMove(filter), m_renderingResourceCount);
     }
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Font>&& font)
+    void add(Ref<Font>&& font)
     {
+        auto renderingResourceIdentifier = font->renderingResourceIdentifier();
         add<Font>(renderingResourceIdentifier, WTFMove(font), m_fontCount);
     }
 
-    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<FontCustomPlatformData>&& customPlatformData)
+    void add(Ref<FontCustomPlatformData>&& customPlatformData)
     {
+        auto renderingResourceIdentifier = customPlatformData->m_renderingResourceIdentifier;
         add<FontCustomPlatformData>(renderingResourceIdentifier, WTFMove(customPlatformData), m_customPlatformDataCount);
     }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -181,14 +181,15 @@ uint64_t RemoteRenderingBackend::messageSenderDestinationID() const
     return m_renderingBackendIdentifier.toUInt64();
 }
 
-void RemoteRenderingBackend::didCreateImageBuffer(Ref<RemoteImageBuffer> imageBuffer, RenderingResourceIdentifier imageBufferIdentifier)
+void RemoteRenderingBackend::didCreateImageBuffer(Ref<RemoteImageBuffer> imageBuffer)
 {
     assertIsCurrent(workQueue());
+    auto imageBufferIdentifier = imageBuffer->renderingResourceIdentifier();
     auto remoteDisplayList = RemoteDisplayListRecorder::create(imageBuffer.get(), imageBufferIdentifier, *this);
     m_remoteDisplayLists.add(imageBufferIdentifier, WTFMove(remoteDisplayList));
     auto* sharing = imageBuffer->backend()->toBackendSharing();
     auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
-    m_remoteResourceCache.cacheImageBuffer(WTFMove(imageBuffer), imageBufferIdentifier);
+    m_remoteResourceCache.cacheImageBuffer(WTFMove(imageBuffer));
     send(Messages::RemoteImageBufferProxy::DidCreateBackend(WTFMove(handle)), imageBufferIdentifier);
 }
 
@@ -215,13 +216,15 @@ void RemoteRenderingBackend::moveToImageBuffer(RenderingResourceIdentifier image
         return;
     }
 
+    ASSERT(imageBufferIdentifier == imageBuffer->renderingResourceIdentifier());
+
     ImageBufferCreationContext creationContext { nullptr };
 #if HAVE(IOSURFACE)
     creationContext.surfacePool = &ioSurfacePool();
 #endif
     creationContext.resourceOwner = m_resourceOwner;
     imageBuffer->backend()->transferToNewContext(creationContext);
-    didCreateImageBuffer(imageBuffer.releaseNonNull(), imageBufferIdentifier);
+    didCreateImageBuffer(imageBuffer.releaseNonNull());
 }
 
 void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, RenderingResourceIdentifier imageBufferIdentifier)
@@ -250,7 +253,7 @@ void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, Ren
         ASSERT_NOT_REACHED();
         return;
     }
-    didCreateImageBuffer(imageBuffer.releaseNonNull(), imageBufferIdentifier);
+    didCreateImageBuffer(imageBuffer.releaseNonNull());
 }
 
 void RemoteRenderingBackend::getPixelBufferForImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, PixelBufferFormat&& destinationFormat, IntRect&& srcRect, CompletionHandler<void()>&& completionHandler)
@@ -352,7 +355,7 @@ void RemoteRenderingBackend::cacheNativeImage(ShareableBitmap::Handle&& handle, 
     if (!image)
         return;
 
-    m_remoteResourceCache.cacheNativeImage(image.releaseNonNull(), nativeImageIdentifier);
+    m_remoteResourceCache.cacheNativeImage(image.releaseNonNull());
 }
 
 void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, FontPlatformData::Attributes platformData, std::optional<RenderingResourceIdentifier> fontCustomPlatformDataIdentifier)
@@ -369,31 +372,31 @@ void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, F
 
     Ref<Font> font = Font::create(platform, fontAttributes.origin, fontAttributes.isInterstitial, fontAttributes.visibility, fontAttributes.isTextOrientationFallback, fontAttributes.renderingResourceIdentifier);
 
-    m_remoteResourceCache.cacheFont(WTFMove(font), font->renderingResourceIdentifier());
+    m_remoteResourceCache.cacheFont(WTFMove(font));
 }
 
 void RemoteRenderingBackend::cacheFontCustomPlatformData(Ref<FontCustomPlatformData>&& customPlatformData)
 {
     ASSERT(!RunLoop::isMain());
-    m_remoteResourceCache.cacheFontCustomPlatformData(WTFMove(customPlatformData), customPlatformData->m_renderingResourceIdentifier);
+    m_remoteResourceCache.cacheFontCustomPlatformData(WTFMove(customPlatformData));
 }
 
 void RemoteRenderingBackend::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& decomposedGlyphs)
 {
     ASSERT(!RunLoop::isMain());
-    m_remoteResourceCache.cacheDecomposedGlyphs(WTFMove(decomposedGlyphs), decomposedGlyphs->renderingResourceIdentifier());
+    m_remoteResourceCache.cacheDecomposedGlyphs(WTFMove(decomposedGlyphs));
 }
 
-void RemoteRenderingBackend::cacheGradient(Ref<Gradient>&& gradient, RenderingResourceIdentifier gradientIdentifier)
+void RemoteRenderingBackend::cacheGradient(Ref<Gradient>&& gradient)
 {
     ASSERT(!RunLoop::isMain());
-    m_remoteResourceCache.cacheGradient(WTFMove(gradient), gradientIdentifier);
+    m_remoteResourceCache.cacheGradient(WTFMove(gradient));
 }
 
-void RemoteRenderingBackend::cacheFilter(Ref<Filter>&& filter, RenderingResourceIdentifier filterIdentifier)
+void RemoteRenderingBackend::cacheFilter(Ref<Filter>&& filter)
 {
     ASSERT(!RunLoop::isMain());
-    m_remoteResourceCache.cacheFilter(WTFMove(filter), filterIdentifier);
+    m_remoteResourceCache.cacheFilter(WTFMove(filter));
 }
 
 void RemoteRenderingBackend::releaseAllDrawingResources()

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -93,7 +93,7 @@ public:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void didCreateImageBuffer(Ref<RemoteImageBuffer>, WebCore::RenderingResourceIdentifier);
+    void didCreateImageBuffer(Ref<RemoteImageBuffer>);
 
     // Runs Function in RemoteRenderingBackend task queue.
     void dispatch(Function<void()>&&);
@@ -132,8 +132,8 @@ private:
     void getFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::Filter>, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void cacheNativeImage(ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
-    void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
-    void cacheFilter(Ref<WebCore::Filter>&&, WebCore::RenderingResourceIdentifier);
+    void cacheGradient(Ref<WebCore::Gradient>&&);
+    void cacheFilter(Ref<WebCore::Filter>&&);
     void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformData::Attributes, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
     void releaseAllDrawingResources();

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -34,8 +34,8 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheFont(WebCore::Font::Attributes data, WebCore::FontPlatformData::Attributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable
     CacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData> customPlatformData) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
-    CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
-    CacheFilter(Ref<WebCore::Filter> filter, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
+    CacheGradient(Ref<WebCore::Gradient> gradient) NotStreamEncodable
+    CacheFilter(Ref<WebCore::Filter> filter) NotStreamEncodable
     ReleaseAllDrawingResources()
     ReleaseAllImageResources()
     ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -33,11 +33,10 @@
 namespace WebKit {
 using namespace WebCore;
 
-void RemoteResourceCache::cacheImageBuffer(Ref<RemoteImageBuffer>&& imageBuffer, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheImageBuffer(Ref<RemoteImageBuffer>&& imageBuffer)
 {
-    ASSERT(renderingResourceIdentifier == imageBuffer->renderingResourceIdentifier());
     Ref<ImageBuffer> buffer = WTFMove(imageBuffer);
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(buffer));
+    m_resourceHeap.add(WTFMove(buffer));
 }
 
 RemoteImageBuffer* RemoteResourceCache::cachedImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const
@@ -53,26 +52,24 @@ RefPtr<RemoteImageBuffer> RemoteResourceCache::takeImageBuffer(RenderingResource
     return buffer;
 }
 
-void RemoteResourceCache::cacheNativeImage(Ref<NativeImage>&& image, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheNativeImage(Ref<NativeImage>&& image)
 {
-    ASSERT(renderingResourceIdentifier == image->renderingResourceIdentifier());
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(image));
+    m_resourceHeap.add(WTFMove(image));
 }
 
-void RemoteResourceCache::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& decomposedGlyphs, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& decomposedGlyphs)
 {
-    ASSERT(renderingResourceIdentifier == decomposedGlyphs->renderingResourceIdentifier());
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(decomposedGlyphs));
+    m_resourceHeap.add(WTFMove(decomposedGlyphs));
 }
 
-void RemoteResourceCache::cacheGradient(Ref<Gradient>&& gradient, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheGradient(Ref<Gradient>&& gradient)
 {
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(gradient));
+    m_resourceHeap.add(WTFMove(gradient));
 }
 
-void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter)
 {
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(filter));
+    m_resourceHeap.add(WTFMove(filter));
 }
 
 NativeImage* RemoteResourceCache::cachedNativeImage(RenderingResourceIdentifier renderingResourceIdentifier) const
@@ -85,10 +82,9 @@ std::optional<WebCore::SourceImage> RemoteResourceCache::cachedSourceImage(Rende
     return m_resourceHeap.getSourceImage(renderingResourceIdentifier);
 }
 
-void RemoteResourceCache::cacheFont(Ref<Font>&& font, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheFont(Ref<Font>&& font)
 {
-    ASSERT(renderingResourceIdentifier == font->renderingResourceIdentifier());
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(font));
+    m_resourceHeap.add(WTFMove(font));
 }
 
 Font* RemoteResourceCache::cachedFont(RenderingResourceIdentifier renderingResourceIdentifier) const
@@ -96,10 +92,9 @@ Font* RemoteResourceCache::cachedFont(RenderingResourceIdentifier renderingResou
     return m_resourceHeap.getFont(renderingResourceIdentifier);
 }
 
-void RemoteResourceCache::cacheFontCustomPlatformData(Ref<FontCustomPlatformData>&& font, RenderingResourceIdentifier renderingResourceIdentifier)
+void RemoteResourceCache::cacheFontCustomPlatformData(Ref<FontCustomPlatformData>&& customPlatformData)
 {
-    ASSERT(renderingResourceIdentifier == font->m_renderingResourceIdentifier);
-    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(font));
+    m_resourceHeap.add(WTFMove(customPlatformData));
 }
 
 FontCustomPlatformData* RemoteResourceCache::cachedFontCustomPlatformData(RenderingResourceIdentifier renderingResourceIdentifier) const

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -39,13 +39,13 @@ class RemoteResourceCache {
 public:
     RemoteResourceCache() = default;
 
-    void cacheImageBuffer(Ref<RemoteImageBuffer>&&, WebCore::RenderingResourceIdentifier);
-    void cacheNativeImage(Ref<WebCore::NativeImage>&&, WebCore::RenderingResourceIdentifier);
-    void cacheFont(Ref<WebCore::Font>&&, WebCore::RenderingResourceIdentifier);
-    void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&, WebCore::RenderingResourceIdentifier);
-    void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
-    void cacheFilter(Ref<WebCore::Filter>&&, WebCore::RenderingResourceIdentifier);
-    void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&, WebCore::RenderingResourceIdentifier);
+    void cacheImageBuffer(Ref<RemoteImageBuffer>&&);
+    void cacheNativeImage(Ref<WebCore::NativeImage>&&);
+    void cacheFont(Ref<WebCore::Font>&&);
+    void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
+    void cacheGradient(Ref<WebCore::Gradient>&&);
+    void cacheFilter(Ref<WebCore::Filter>&&);
+    void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
 
     RemoteImageBuffer* cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
     RefPtr<RemoteImageBuffer> takeImageBuffer(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2500,6 +2500,7 @@ class WebCore::TransformOperations {
     WebCore::ColorInterpolationMethod colorInterpolationMethod();
     WebCore::GradientSpreadMethod spreadMethod();
     WebCore::GradientColorStops stops();
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 }
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Pattern::Parameters {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -281,14 +281,12 @@ void RemoteRenderingBackendProxy::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& 
 
 void RemoteRenderingBackendProxy::cacheGradient(Ref<Gradient>&& gradient)
 {
-    auto renderingResourceIdentifier = gradient->renderingResourceIdentifier();
-    send(Messages::RemoteRenderingBackend::CacheGradient(WTFMove(gradient), renderingResourceIdentifier));
+    send(Messages::RemoteRenderingBackend::CacheGradient(WTFMove(gradient)));
 }
 
 void RemoteRenderingBackendProxy::cacheFilter(Ref<Filter>&& filter)
 {
-    auto renderingResourceIdentifier = filter->renderingResourceIdentifier();
-    send(Messages::RemoteRenderingBackend::CacheFilter(WTFMove(filter), renderingResourceIdentifier));
+    send(Messages::RemoteRenderingBackend::CacheFilter(WTFMove(filter)));
 }
 
 void RemoteRenderingBackendProxy::releaseAllDrawingResources()

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -54,7 +54,8 @@ TEST(DisplayListTests, ReplayWithMissingResource)
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     GraphicsContextCG context { cgContext.get() };
 
-    auto imageBufferIdentifier = RenderingResourceIdentifier::generate();
+    auto imageBuffer = ImageBuffer::create({ 100, 100 }, RenderingPurpose::Unspecified, 1, colorSpace, PixelFormat::BGRA8);
+    auto imageBufferIdentifier = imageBuffer->renderingResourceIdentifier();
 
     DisplayList list;
 
@@ -73,9 +74,8 @@ TEST(DisplayListTests, ReplayWithMissingResource)
     }
 
     {
-        auto imageBuffer = ImageBuffer::create({ 100, 100 }, RenderingPurpose::Unspecified, 1, colorSpace, PixelFormat::BGRA8);
         ResourceHeap resourceHeap;
-        resourceHeap.add(imageBufferIdentifier, imageBuffer.releaseNonNull());
+        resourceHeap.add(imageBuffer.releaseNonNull());
 
         Replayer replayer { context, list, &resourceHeap };
         auto result = replayer.replay();


### PR DESCRIPTION
#### e5cffaf13292c4932f8f4a3c023ff19ee286e15c
<pre>
ResourceHeap clean-up
<a href="https://bugs.webkit.org/show_bug.cgi?id=260404">https://bugs.webkit.org/show_bug.cgi?id=260404</a>
rdar://114103796

Reviewed by Kimmo Kinnunen.

All rendering resource objects have RenderingResourceIdentifiers. So there is no
need to pass this identifier when caching the resource object in ResourceHeap.
It can be just retrieved from the resource object itself.

* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
(WebCore::DisplayList::DisplayList::cacheImageBuffer):
(WebCore::DisplayList::DisplayList::cacheNativeImage):
(WebCore::DisplayList::DisplayList::cacheFont):
(WebCore::DisplayList::DisplayList::cacheDecomposedGlyphs):
(WebCore::DisplayList::DisplayList::cacheGradient):
(WebCore::DisplayList::DisplayList::cacheFilter):
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::ResourceHeap::add):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didCreateImageBuffer):
(WebKit::RemoteRenderingBackend::moveToImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBuffer):
(WebKit::RemoteRenderingBackend::cacheNativeImage):
(WebKit::RemoteRenderingBackend::cacheFont):
(WebKit::RemoteRenderingBackend::cacheFontCustomPlatformData):
(WebKit::RemoteRenderingBackend::cacheDecomposedGlyphs):
(WebKit::RemoteRenderingBackend::cacheGradient):
(WebKit::RemoteRenderingBackend::cacheFilter):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheImageBuffer):
(WebKit::RemoteResourceCache::cacheNativeImage):
(WebKit::RemoteResourceCache::cacheDecomposedGlyphs):
(WebKit::RemoteResourceCache::cacheGradient):
(WebKit::RemoteResourceCache::cacheFilter):
(WebKit::RemoteResourceCache::cacheFont):
(WebKit::RemoteResourceCache::cacheFontCustomPlatformData):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheGradient):
(WebKit::RemoteRenderingBackendProxy::cacheFilter):
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267117@main">https://commits.webkit.org/267117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00cbff019c67794dc7714449feaa230c1dda6e1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17452 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16104 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18200 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21096 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17594 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14179 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3753 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->