### PR TITLE
WebVTT regions are not positioned according to the spec

### DIFF
--- a/LayoutTests/media/track/captions-webvtt/regions.vtt
+++ b/LayoutTests/media/track/captions-webvtt/regions.vtt
@@ -1,0 +1,11 @@
+WEBVTT
+
+REGION
+id:tl
+width:40%
+lines:3
+regionanchor:0%,0%
+viewportanchor:0%,0%
+
+00:00:00.000 --> 00:00:05.000 region:tl
+Top left

--- a/LayoutTests/media/track/webvtt-region-position-expected.txt
+++ b/LayoutTests/media/track/webvtt-region-position-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(canplay)
+EVENT(addtrack)
+EXPECTED (video.textTracks.length == '1') OK
+RUN(video.textTracks[0].mode = 'showing')
+RUN(video.currentTime = 1)
+EVENT(seeked)
+EXPECTED (window.internals.shadowRoot(video).querySelector('div[pseudo=-webkit-media-text-track-region]') != 'null') OK
+EXPECTED (region.offsetLeft == 0 == 'true') OK
+EXPECTED (region.offsetTop == 0 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/track/webvtt-region-position.html
+++ b/LayoutTests/media/track/webvtt-region-position.html
@@ -1,0 +1,36 @@
+<html>
+    <head>
+        <title>Test Positioning of WebVTT Regions</title>
+        <script src=../../resources/js-test-pre.js></script>
+        <script src=../video-test.js></script>
+        <script src=../media-file.js></script>
+        <script>
+            async function runTest()
+            {
+                video = document.getElementById('video');
+                video.src = findMediaFile('video', '../content/test');
+                await waitFor(video, 'canplay');
+                let track = document.createElement('track');
+                track.src = 'captions-webvtt/regions.vtt';
+                video.appendChild(track);
+
+                await waitFor(video.textTracks, 'addtrack');
+                testExpected("video.textTracks.length", 1);
+                run("video.textTracks[0].mode = 'showing'");
+
+                run("video.currentTime = 1");
+                await waitFor(video, 'seeked');
+
+                window.internals.ensureUserAgentShadowRoot(video);
+                await testExpectedEventually("window.internals.shadowRoot(video).querySelector('div[pseudo=-webkit-media-text-track-region]')", null, "!=", 1000);
+                region = window.internals.shadowRoot(video).querySelector('div[pseudo=-webkit-media-text-track-region]');
+                await testExpected("region.offsetLeft == 0", true);
+                await testExpected("region.offsetTop == 0", true);
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video id="video" width="320px" height="240px" paused></video>
+    </body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -58,12 +58,12 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 }
 
 ::-webkit-media-text-track-display {
-    position: absolute;
     unicode-bidi: plaintext;
     overflow: visible;
     writing-mode: writing-mode;
     overflow-wrap: break-word;
     white-space: pre-line;
+    text-wrap: balance;
 }
 
 ::-webkit-media-text-track-display {
@@ -74,6 +74,20 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 
 ::-webkit-media-text-track-display-backdrop {
     display: inline-block;
+}
+
+::-webkit-media-text-track-region {
+    position: absolute;
+    writing-mode: horizontal-tb;
+    background: rgba(0,0,0,0.8);
+    overflow-wrap: break-word;
+    font: 5cqh sans-serif;
+    color: rgba(255,255,255,1);
+    overflow: hidden;
+    min-height: 0px;
+    display: inline-flex;
+    flex-flow: column;
+    justify-content: flex-end;
 }
 
 ::cue(:future) {

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -111,7 +111,7 @@ void MediaControlTextTrackContainerElement::updateDisplay()
     // cover the same region as the user interface.
 
     // 5. If the last time these rules were run, the user agent was not exposing
-    // a user interface for video, but now it is, let reset be true. Otherwise,
+    // a user interface for video, but now it is, optionally let reset be true. Otherwise,
     // let reset be false.
 
     // There is nothing to be done explicitly for 4th and 5th steps, as
@@ -127,13 +127,22 @@ void MediaControlTextTrackContainerElement::updateDisplay()
     // track's list of cues that have their text track cue active flag set.
     CueList activeCues = video.currentlyActiveCues();
 
-    // 9. If reset is false, then, for each text track cue cue in cues: if cue's
-    // text track cue display state has a set of CSS boxes, then add those boxes
-    // to output, and remove cue from cues.
+    // 9. Let regions be an empty list of WebVTT regions.
+
+    // 10. For each track track in tracks, append to regions all the regions with an
+    // identifier from track’s list of regions.
+
+    // Steps 9 and 10 are unneccesary because we will initialize each region
+    // individually in text track cue order.
 
     // There is nothing explicitly to be done here, as all the caching occurs
     // within the TextTrackCue instance itself. If parameters of the cue change,
     // the display tree is cleared.
+
+    // 11. If reset is false, then, for each WebVTT region in regions let regionNode
+    // be a WebVTT region object.
+
+    // Steps 12 and 13 are performed in VTTRegion
 
     // If the number of CSS boxes in the output is less than the number of cues
     // we wish to render (e.g., we are adding another cue in a set of roll-up
@@ -207,7 +216,6 @@ void MediaControlTextTrackContainerElement::updateTextTrackRepresentationImageIf
 void MediaControlTextTrackContainerElement::processActiveVTTCue(VTTCue& cue)
 {
     DEBUG_LOG(LOGIDENTIFIER, "adding and positioning cue: \"", cue.text(), "\", start=", cue.startTime(), ", end=", cue.endTime());
-    Ref<TextTrackCueBox> displayBox = *cue.getDisplayTree();
 
     if (auto region = cue.track()->regions()->getRegionById(cue.regionId())) {
         // Let region be the WebVTT region whose region identifier
@@ -217,11 +225,12 @@ void MediaControlTextTrackContainerElement::processActiveVTTCue(VTTCue& cue)
         if (!contains(regionNode.ptr()))
             appendChild(region->getDisplayTree());
 
-        region->appendTextTrackCueBox(WTFMove(displayBox));
+        region->appendTextTrackCueBox(*cue.getDisplayTree());
     } else {
         // If cue has an empty text track cue region identifier or there is no
         // WebVTT region whose region identifier is identical to cue's text
         // track cue region identifier, run the following substeps:
+        Ref<TextTrackCueBox> displayBox = *cue.getDisplayTree();
         if (displayBox->hasChildNodes() && !contains(displayBox.ptr())) {
             // Note: the display tree of a cue is removed when the active flag of the cue is unset.
             appendChild(displayBox);

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -89,6 +89,7 @@ public:
     static Ref<VTTCueBox> create(Document&, VTTCue&);
 
     void applyCSSProperties() override;
+    void applyCSSPropertiesWithRegion();
 
     void setFontSizeFromCaptionUserPrefs(int fontSize) { m_fontSizeFromCaptionUserPrefs = fontSize; }
 
@@ -232,6 +233,7 @@ private:
 
     void determineTextDirection();
     void calculateDisplayParameters();
+    void calculateDisplayParametersWithRegion();
     void obtainCSSBoxes();
 
     enum CueSetting {

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -52,7 +52,7 @@ namespace WebCore {
 // https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/region.html
 
 // Default region line-height (vh units)
-static const float lineHeight = 5.33;
+static const float lineHeight = 6;
 
 // Default scrolling animation time period (s).
 static const Seconds scrollTime { 433_ms };
@@ -331,30 +331,6 @@ void VTTRegion::prepareRegionDisplayTree()
     // FIXME: Change the code below to use viewport units when
     // http://crbug/244618 is fixed.
 
-    // Let regionWidth be the text track region width.
-    // Let width be 'regionWidth vw' ('vw' is a CSS unit)
-    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyWidth, m_width, CSSUnitType::CSS_PERCENTAGE);
-
-    // Let lineHeight be '0.0533vh' ('vh' is a CSS unit) and regionHeight be
-    // the text track region height. Let height be 'lineHeight' multiplied
-    // by regionHeight.
-    double height = lineHeight * m_lines;
-    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyHeight, height, CSSUnitType::CSS_VH);
-
-    // Let viewportAnchorX be the x dimension of the text track region viewport
-    // anchor and regionAnchorX be the x dimension of the text track region
-    // anchor. Let leftOffset be regionAnchorX multiplied by width divided by
-    // 100.0. Let left be leftOffset subtracted from 'viewportAnchorX vw'.
-    double leftOffset = m_regionAnchor.x() * m_width / 100;
-    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyLeft, m_viewportAnchor.x() - leftOffset, CSSUnitType::CSS_PERCENTAGE);
-
-    // Let viewportAnchorY be the y dimension of the text track region viewport
-    // anchor and regionAnchorY be the y dimension of the text track region
-    // anchor. Let topOffset be regionAnchorY multiplied by height divided by
-    // 100.0. Let top be topOffset subtracted from 'viewportAnchorY vh'.
-    double topOffset = m_regionAnchor.y() * height / 100;
-    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyTop, m_viewportAnchor.y() - topOffset, CSSUnitType::CSS_PERCENTAGE);
-
     // The cue container is used to wrap the cues and it is the object which is
     // gradually scrolled out as multiple cues are appended to the region.
     if (!m_cueContainer) {
@@ -362,7 +338,39 @@ void VTTRegion::prepareRegionDisplayTree()
         m_cueContainer->setPseudo(ShadowPseudoIds::webkitMediaTextTrackRegionContainer());
         m_regionDisplayTree->appendChild(*m_cueContainer);
     }
-    m_cueContainer->setInlineStyleProperty(CSSPropertyTop, 0.0f, CSSUnitType::CSS_PX);
+
+    // Let regionWidth be the WebVTT region width.
+    // Let width be 'regionWidth vw' ('vw' is a CSS unit)
+    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyWidth, m_width, CSSUnitType::CSS_CQW);
+    m_cueContainer->setInlineStyleProperty(CSSPropertyWidth, m_width, CSSUnitType::CSS_CQW);
+
+    // Let lineHeight be '6vh' ('vh' is a CSS unit) and regionHeight be
+    // the WebVTT region lines. Let lines be 'lineHeight' multiplied
+    // by regionHeight.
+    double lines = lineHeight * m_lines;
+
+    // Although the spec does not say to set the height property to lines, without doing so,
+    // the caption is not visible
+    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyHeight, lines, CSSUnitType::CSS_CQH);
+    m_cueContainer->setInlineStyleProperty(CSSPropertyHeight, lines, CSSUnitType::CSS_CQH);
+
+    // Let viewportAnchorX be the x dimension of the WebVTT viewport
+    // anchor and regionAnchorX be the x dimension of the WebVTT region
+    // anchor. Let leftOffset be regionAnchorX multiplied by width divided by
+    // 100.0. Let left be leftOffset subtracted from 'viewportAnchorX vw'.
+    double leftOffset = m_regionAnchor.x() * m_width / 100;
+    double left = m_viewportAnchor.x() - leftOffset;
+    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_CQW);
+    m_cueContainer->setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_CQW);
+
+    // Let viewportAnchorY be the y dimension of the WebVTT region viewport
+    // anchor and regionAnchorY be the y dimension of the WebVTT region
+    // anchor. Let topOffset be regionAnchorY multiplied by lines divided by
+    // 100.0. Let top be topOffset subtracted from 'viewportAnchorY vh'.
+    double topOffset = m_regionAnchor.y() * lines / 100;
+    double top = m_viewportAnchor.y() - topOffset;
+    m_regionDisplayTree->setInlineStyleProperty(CSSPropertyTop, top, CSSUnitType::CSS_CQH);
+    m_cueContainer->setInlineStyleProperty(CSSPropertyTop, top, CSSUnitType::CSS_CQH);
 
     // 7.5 Every WebVTT region object is initialised with the following CSS
 


### PR DESCRIPTION
#### eae66f440e600b0d39e9bcbd60582c96cc4c35a0
<pre>
WebVTT regions are not positioned according to the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=260402">https://bugs.webkit.org/show_bug.cgi?id=260402</a>
rdar://23091897

Reviewed by Eric Carlson.

Updating WebVTT code to reflect changes that have been made to the W3C WebVTT spec,
specifically in section 7 (<a href="https://www.w3.org/TR/webvtt1/#processing-model).">https://www.w3.org/TR/webvtt1/#processing-model).</a>
In step 14.2 in section 7.1, there is a split in logic depending on if the cue
Is within a region or not. Currently, the code always follows the path for
Cues without regions. I updated this so that step 14.3 of the spec would be
executed for cues assigned to regions. I also updated the CSS applied to the
region and text track display divs to conform to section 7.4 &quot;Applying CSS
Properties to WebVTT Node Objects&quot;.

* LayoutTests/media/track/captions-webvtt/regions.vtt: Added.
* LayoutTests/media/track/webvtt-region-position-expected.txt: Added.
* LayoutTests/media/track/webvtt-region-position.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
(::-webkit-media-text-track-display):
(::-webkit-media-text-track-region):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::processActiveVTTCue):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSPropertiesWithRegion):
(WebCore::VTTCueBox::applyCSSProperties):
(WebCore::VTTCue::calculateDisplayParametersWithRegion):
(WebCore::VTTCue::obtainCSSBoxes):
(WebCore::VTTCue::getDisplayTree):
* Source/WebCore/html/track/VTTCue.h:
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::prepareRegionDisplayTree):

Canonical link: <a href="https://commits.webkit.org/268787@main">https://commits.webkit.org/268787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6484e7704efcef67b54733b983bafd39695138c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23312 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24960 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22898 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16523 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18518 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4962 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->