### PR TITLE
[iOS 17] Remote inspection should be disabled for service workers used only in locked private tabs

### DIFF
--- a/Source/WebCore/workers/service/ServiceWorkerTypes.h
+++ b/Source/WebCore/workers/service/ServiceWorkerTypes.h
@@ -64,6 +64,7 @@ enum class ServiceWorkerClientFrameType : uint8_t {
     None
 };
 
+enum class ServiceWorkerIsInspectable : bool { No, Yes };
 enum class ShouldNotifyWhenResolved : bool { No, Yes };
 
 enum ServiceWorkerRegistrationIdentifierType { };

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -270,6 +270,17 @@ void SWContextManager::setAsInspected(ServiceWorkerIdentifier identifier, bool i
         m_connection->setAsInspected(identifier, isInspected);
 }
 
+void SWContextManager::setInspectable(bool inspectable)
+{
+    Vector<Ref<ServiceWorkerThreadProxy>> workers;
+    {
+        Locker locker { m_workerMapLock };
+        workers = copyToVector(m_workerMap.values());
+    }
+    for (auto& serviceWorker : workers)
+        serviceWorker->setInspectable(inspectable);
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -126,6 +126,7 @@ public:
     static constexpr Seconds syncWorkerTerminationTimeout { 100_ms }; // Only used by layout tests.
 
     WEBCORE_EXPORT void setAsInspected(ServiceWorkerIdentifier, bool);
+    WEBCORE_EXPORT void setInspectable(bool);
 
 private:
     SWContextManager() = default;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -84,7 +84,7 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(UniqueRef<Page>&& page, Servi
     allServiceWorkerThreadProxies().add(this);
 
 #if ENABLE(REMOTE_INSPECTOR)
-    m_remoteDebuggable->setInspectable(true);
+    m_remoteDebuggable->setInspectable(m_page->inspectable());
     m_remoteDebuggable->init();
 #endif
 }
@@ -475,6 +475,13 @@ void ServiceWorkerThreadProxy::setAppBadge(std::optional<uint64_t> badge)
     callOnMainRunLoop([badge = WTFMove(badge), this, protectedThis = Ref { *this }] {
         m_page->badgeClient().setAppBadge(nullptr, SecurityOriginData::fromURL(scriptURL()), badge);
     });
+}
+
+void ServiceWorkerThreadProxy::setInspectable(bool inspectable)
+{
+    ASSERT(isMainThread());
+    m_page->setInspectable(inspectable);
+    m_remoteDebuggable->setInspectable(inspectable);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -98,6 +98,8 @@ public:
     WEBCORE_EXPORT void setLastNavigationWasAppInitiated(bool);
     WEBCORE_EXPORT bool lastNavigationWasAppInitiated();
 
+    WEBCORE_EXPORT void setInspectable(bool);
+
 private:
     WEBCORE_EXPORT ServiceWorkerThreadProxy(UniqueRef<Page>&&, ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, CacheStorageProvider&, std::unique_ptr<NotificationClient>&&);
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -67,8 +67,6 @@ class SWServerToContextConnection;
 class Timer;
 
 enum class NotificationEventType : bool;
-enum class ServiceWorkerRegistrationState : uint8_t;
-enum class ServiceWorkerState : uint8_t;
 
 struct BackgroundFetchInformation;
 struct BackgroundFetchOptions;
@@ -157,12 +155,14 @@ public:
         Vector<RegistrationReadyRequest> m_registrationReadyRequests;
     };
 
-    WEBCORE_EXPORT SWServer(SWServerDelegate&, UniqueRef<SWOriginStore>&&, bool processTerminationDelayEnabled, String&& registrationDatabaseDirectory, PAL::SessionID, bool shouldRunServiceWorkersOnMainThreadForTesting, bool hasServiceWorkerEntitlement, std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue);
+    WEBCORE_EXPORT SWServer(SWServerDelegate&, UniqueRef<SWOriginStore>&&, bool processTerminationDelayEnabled, String&& registrationDatabaseDirectory, PAL::SessionID, bool shouldRunServiceWorkersOnMainThreadForTesting, bool hasServiceWorkerEntitlement, std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue, ServiceWorkerIsInspectable);
     WEBCORE_EXPORT ~SWServer();
 
     WEBCORE_EXPORT void clearAll(CompletionHandler<void()>&&);
     WEBCORE_EXPORT void clear(const SecurityOriginData&, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void clear(const ClientOrigin&, CompletionHandler<void()>&&);
+
+    WEBCORE_EXPORT void setInspectable(ServiceWorkerIsInspectable);
 
     SWServerRegistration* getRegistration(ServiceWorkerRegistrationIdentifier identifier) { return m_registrations.get(identifier); }
     WEBCORE_EXPORT SWServerRegistration* getRegistration(const ServiceWorkerRegistrationKey&);
@@ -369,6 +369,7 @@ private:
     unsigned m_uniqueRegistrationCount { 0 };
     std::optional<unsigned> m_overrideServiceWorkerRegistrationCountTestingValue;
     uint64_t m_focusOrder { 0 };
+    ServiceWorkerIsInspectable m_isInspectable { ServiceWorkerIsInspectable::Yes };
 
     std::unique_ptr<BackgroundFetchEngine> m_backgroundFetchEngine;
 };

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -98,6 +98,8 @@ public:
     virtual void connectionIsNoLongerNeeded() = 0;
     virtual void terminateDueToUnresponsiveness() = 0;
 
+    virtual void setInspectable(ServiceWorkerIsInspectable) = 0;
+
 protected:
     WEBCORE_EXPORT SWServerToContextConnection(SWServer&, RegistrableDomain&&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3000,4 +3000,14 @@ void NetworkProcess::setIsHoldingLockedFiles(bool isHoldingLockedFiles)
 }
 #endif
 
+#if ENABLE(SERVICE_WORKER)
+
+void NetworkProcess::setInspectionForServiceWorkersAllowed(PAL::SessionID sessionID, bool inspectable)
+{
+    if (auto* session = networkSession(sessionID))
+        session->setInspectionForServiceWorkersAllowed(inspectable);
+}
+
+#endif // ENABLE(SERVICE_WORKER)
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -423,6 +423,7 @@ public:
 
 #if ENABLE(SERVICE_WORKER)
     void requestBackgroundFetchPermission(PAL::SessionID, const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
+    void setInspectionForServiceWorkersAllowed(PAL::SessionID, bool);
 #endif
 
 private:

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -81,6 +81,10 @@ messages -> NetworkProcess LegacyReceiver {
 
     PreconnectTo(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier webPageID, WebCore::ResourceRequest request, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain);
 
+#if ENABLE(SERVICE_WORKER)
+    SetInspectionForServiceWorkersAllowed(PAL::SessionID sessionID, bool inspectable)
+#endif
+
 #if ENABLE(TRACKING_PREVENTION)
     ClearPrevalentResource(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> ()
     ClearUserInteraction(PAL::SessionID sessionID, WebCore::RegistrableDomain resourceDomain) -> ()

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -276,6 +276,10 @@ public:
     virtual void clearProxyConfigData() { }
     virtual void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&&) { };
 #endif
+
+#if ENABLE(SERVICE_WORKER)
+    void setInspectionForServiceWorkersAllowed(bool);
+#endif
                                     
 protected:
     NetworkSession(NetworkProcess&, const NetworkSessionCreationParameters&);
@@ -361,6 +365,7 @@ protected:
     std::optional<ServiceWorkerInfo> m_serviceWorkerInfo;
     std::unique_ptr<WebCore::SWServer> m_swServer;
     RefPtr<BackgroundFetchStoreImpl> m_backgroundFetchStore;
+    bool m_inspectionForServiceWorkersAllowed { true };
 #endif
     std::unique_ptr<WebSharedWorkerServer> m_sharedWorkerServer;
 

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -106,7 +106,7 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << cacheStorageDirectory << cacheStorageDirectoryExtensionHandle;
     encoder << generalStorageDirectory << generalStorageDirectoryHandle;
 #if ENABLE(SERVICE_WORKER)
-    encoder << serviceWorkerRegistrationDirectory << serviceWorkerRegistrationDirectoryExtensionHandle << serviceWorkerProcessTerminationDelayEnabled;
+    encoder << serviceWorkerRegistrationDirectory << serviceWorkerRegistrationDirectoryExtensionHandle << serviceWorkerProcessTerminationDelayEnabled << inspectionForServiceWorkersAllowed;
 #endif
     encoder << resourceLoadStatisticsParameters;
 }
@@ -447,6 +447,11 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     decoder >> serviceWorkerProcessTerminationDelayEnabled;
     if (!serviceWorkerProcessTerminationDelayEnabled)
         return std::nullopt;
+
+    std::optional<bool> inspectionForServiceWorkersAllowed;
+    decoder >> inspectionForServiceWorkersAllowed;
+    if (!inspectionForServiceWorkersAllowed)
+        return std::nullopt;
 #endif
 
     std::optional<ResourceLoadStatisticsParameters> resourceLoadStatisticsParameters;
@@ -531,6 +536,7 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         , WTFMove(*serviceWorkerRegistrationDirectory)
         , WTFMove(*serviceWorkerRegistrationDirectoryExtensionHandle)
         , *serviceWorkerProcessTerminationDelayEnabled
+        , *inspectionForServiceWorkersAllowed
 #endif
         , WTFMove(*resourceLoadStatisticsParameters)
     }};

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -135,6 +135,7 @@ struct NetworkSessionCreationParameters {
     String serviceWorkerRegistrationDirectory;
     SandboxExtension::Handle serviceWorkerRegistrationDirectoryExtensionHandle;
     bool serviceWorkerProcessTerminationDelayEnabled { true };
+    bool inspectionForServiceWorkersAllowed { true };
 #endif
 
     ResourceLoadStatisticsParameters resourceLoadStatisticsParameters;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -108,7 +108,7 @@ void WebSWServerToContextConnection::close()
 
 void WebSWServerToContextConnection::installServiceWorkerContext(const ServiceWorkerContextData& contextData, const ServiceWorkerData& workerData, const String& userAgent, WorkerThreadMode workerThreadMode)
 {
-    send(Messages::WebSWContextManagerConnection::InstallServiceWorker { contextData, workerData, userAgent, workerThreadMode });
+    send(Messages::WebSWContextManagerConnection::InstallServiceWorker { contextData, workerData, userAgent, workerThreadMode, m_isInspectable });
 }
 
 void WebSWServerToContextConnection::updateAppInitiatedValue(ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
@@ -373,6 +373,15 @@ void WebSWServerToContextConnection::navigate(ScriptExecutionContextIdentifier c
         });
         callback(WTFMove(clientData));
     }, 0);
+}
+
+void WebSWServerToContextConnection::setInspectable(ServiceWorkerIsInspectable inspectable)
+{
+    if (m_isInspectable == inspectable)
+        return;
+
+    m_isInspectable = inspectable;
+    send(Messages::WebSWContextManagerConnection::SetInspectable { inspectable });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -113,12 +113,15 @@ private:
 
     void connectionClosed();
 
+    void setInspectable(WebCore::ServiceWorkerIsInspectable) final;
+
     NetworkConnectionToWebProcess& m_connection;
     HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_ongoingFetches;
     HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
     bool m_isThrottleable { true };
     WebPageProxyIdentifier m_webPageProxyID;
     size_t m_processingFunctionalEventCount { 0 };
+    WebCore::ServiceWorkerIsInspectable m_isInspectable { WebCore::ServiceWorkerIsInspectable::Yes };
 }; // class WebSWServerToContextConnection
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -781,6 +781,7 @@ def headers_for_type(type):
         'WebCore::SecurityPolicyViolationEventInit': ['<WebCore/SecurityPolicyViolationEvent.h>'],
         'WebCore::SelectionDirection': ['<WebCore/VisibleSelection.h>'],
         'WebCore::SelectionGeometry': ['"EditorState.h"'],
+        'WebCore::ServiceWorkerIsInspectable': ['<WebCore/ServiceWorkerTypes.h>'],
         'WebCore::ServiceWorkerJobIdentifier': ['<WebCore/ServiceWorkerTypes.h>'],
         'WebCore::ServiceWorkerOrClientData': ['<WebCore/ServiceWorkerTypes.h>', '<WebCore/ServiceWorkerClientData.h>', '<WebCore/ServiceWorkerData.h>'],
         'WebCore::ServiceWorkerOrClientIdentifier': ['<WebCore/ServiceWorkerTypes.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4429,6 +4429,7 @@ enum class WebCore::ServiceWorkerClientFrameType : uint8_t {
     None
 };
 
+enum class WebCore::ServiceWorkerIsInspectable : bool
 enum class WebCore::ShouldNotifyWhenResolved : bool
 
 enum class WebCore::ServiceWorkerUpdateViaCache : uint8_t {

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -93,7 +93,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<WebProcessPro
     m_websiteDataStore = m_process->websiteDataStore();
     ASSERT(m_websiteDataStore);
     if (m_websiteDataStore && m_websiteDataStore != &m_page->websiteDataStore())
-        m_process->processPool().pageBeginUsingWebsiteDataStore(m_page->identifier(), *m_websiteDataStore);
+        m_process->processPool().pageBeginUsingWebsiteDataStore(m_page.get(), *m_websiteDataStore);
 
     // If we are reattaching to a SuspendedPage, then the WebProcess' WebPage already exists and
     // WebPageProxy::didCreateMainFrame() will not be called to initialize m_mainFrame. In such
@@ -123,7 +123,7 @@ ProvisionalPageProxy::~ProvisionalPageProxy()
 
         auto dataStore = m_process->websiteDataStore();
         if (dataStore && dataStore!= &m_page->websiteDataStore())
-            m_process->processPool().pageEndUsingWebsiteDataStore(m_page->identifier(), *dataStore);
+            m_process->processPool().pageEndUsingWebsiteDataStore(m_page.get(), *dataStore);
 
         if (m_process->hasConnection())
             send(Messages::WebPage::Close());

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2195,8 +2195,14 @@ bool WebPageProxy::inspectable() const
 
 void WebPageProxy::setInspectable(bool inspectable)
 {
-    if (m_inspectorDebuggable)
-        m_inspectorDebuggable->setInspectable(inspectable);
+    if (!m_inspectorDebuggable || m_inspectorDebuggable->inspectable() == inspectable)
+        return;
+
+    m_inspectorDebuggable->setInspectable(inspectable);
+
+#if ENABLE(SERVICE_WORKER)
+    websiteDataStore().updateServiceWorkerInspectability();
+#endif
 }
 
 String WebPageProxy::remoteInspectionNameOverride() const

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -211,8 +211,8 @@ public:
 
     Ref<WebPageProxy> createWebPage(PageClient&, Ref<API::PageConfiguration>&&);
 
-    void pageBeginUsingWebsiteDataStore(WebPageProxyIdentifier, WebsiteDataStore&);
-    void pageEndUsingWebsiteDataStore(WebPageProxyIdentifier, WebsiteDataStore&);
+    void pageBeginUsingWebsiteDataStore(WebPageProxy&, WebsiteDataStore&);
+    void pageEndUsingWebsiteDataStore(WebPageProxy&, WebsiteDataStore&);
     bool hasPagesUsingWebsiteDataStore(WebsiteDataStore&) const;
 
     const String& injectedBundlePath() const { return m_configuration->injectedBundlePath(); }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -738,7 +738,7 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
 
     if (beginsUsingDataStore == BeginsUsingDataStore::Yes) {
         RELEASE_ASSERT(m_processPool);
-        m_processPool->pageBeginUsingWebsiteDataStore(webPage.identifier(), webPage.websiteDataStore());
+        m_processPool->pageBeginUsingWebsiteDataStore(webPage, webPage.websiteDataStore());
     }
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
@@ -788,7 +788,7 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     reportProcessDisassociatedWithPageIfNecessary(webPage.identifier());
 
     if (endsUsingDataStore == EndsUsingDataStore::Yes)
-        m_processPool->pageEndUsingWebsiteDataStore(webPage.identifier(), webPage.websiteDataStore());
+        m_processPool->pageEndUsingWebsiteDataStore(webPage, webPage.websiteDataStore());
 
     removeVisitedLinkStoreUser(webPage.visitedLinkStore(), webPage.identifier());
     updateRegistrationWithDataStore();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -450,6 +450,13 @@ public:
     void setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit);
 #endif
 
+    void addPage(WebPageProxy&);
+    void removePage(WebPageProxy&);
+
+#if ENABLE(SERVICE_WORKER)
+    void updateServiceWorkerInspectability();
+#endif
+
     HashSet<RefPtr<WebProcessPool>> processPools(size_t limit = std::numeric_limits<size_t>::max()) const;
 
     void setServiceWorkerOverridePreferences(WebPreferences* preferences) { m_serviceWorkerOverridePreferences = preferences; }
@@ -562,6 +569,7 @@ private:
 #endif
 
     WeakHashSet<WebProcessProxy> m_processes;
+    WeakHashSet<WebPageProxy> m_pages;
 
     bool m_isTrackingPreventionStateExplicitlySet { false };
 
@@ -592,6 +600,8 @@ private:
 
     RefPtr<WebPreferences> m_serviceWorkerOverridePreferences;
     CompletionHandler<void(String&&)> m_completionHandlerForRemovalFromNetworkProcess;
+
+    bool m_inspectionForServiceWorkersAllowed { true };
 };
 
 }

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -100,7 +100,7 @@ private:
     void updatePreferencesStore(WebPreferencesStore&&);
     void serviceWorkerStarted(std::optional<WebCore::ServiceWorkerJobDataIdentifier>, WebCore::ServiceWorkerIdentifier, bool doesHandleFetch) final;
     void serviceWorkerFailedToStart(std::optional<WebCore::ServiceWorkerJobDataIdentifier>, WebCore::ServiceWorkerIdentifier, const String& exceptionMessage) final;
-    void installServiceWorker(WebCore::ServiceWorkerContextData&&, WebCore::ServiceWorkerData&&, String&& userAgent, WebCore::WorkerThreadMode);
+    void installServiceWorker(WebCore::ServiceWorkerContextData&&, WebCore::ServiceWorkerData&&, String&& userAgent, WebCore::WorkerThreadMode, WebCore::ServiceWorkerIsInspectable);
     void updateAppInitiatedValue(WebCore::ServiceWorkerIdentifier, WebCore::LastNavigationWasAppInitiated);
     void startFetch(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier, WebCore::ResourceRequest&&, WebCore::FetchOptions&&, IPC::FormDataReference&&, String&& referrer, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);
     void cancelFetch(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier);
@@ -121,6 +121,7 @@ private:
     void setUserAgent(String&& userAgent);
     void close();
     void setThrottleState(bool isThrottleable);
+    void setInspectable(WebCore::ServiceWorkerIsInspectable);
     void convertFetchToDownload(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier);
     void cancelFetchDownload(WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier);
     void navigationPreloadIsReady(WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::FetchIdentifier, WebCore::ResourceResponse&&);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(SERVICE_WORKER)
 
 messages -> WebSWContextManagerConnection {
-    InstallServiceWorker(struct WebCore::ServiceWorkerContextData contextData, struct WebCore::ServiceWorkerData workerData, String userAgent, enum:bool WebCore::WorkerThreadMode workerThreadMode)
+    InstallServiceWorker(struct WebCore::ServiceWorkerContextData contextData, struct WebCore::ServiceWorkerData workerData, String userAgent, enum:bool WebCore::WorkerThreadMode workerThreadMode, enum:bool WebCore::ServiceWorkerIsInspectable inspectable)
     UpdateAppInitiatedValue(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, enum:bool WebCore::LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
     StartFetch(WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier, WebCore::ResourceRequest request, struct WebCore::FetchOptions options, IPC::FormDataReference requestBody, String referrer, bool isServiceWorkerNavigationPreloadEnabled, String clientIdentifier, String resutlingClientIdentifier)
     CancelFetch(WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier fetchIdentifier)
@@ -46,6 +46,7 @@ messages -> WebSWContextManagerConnection {
     UpdatePreferencesStore(struct WebKit::WebPreferencesStore store)
     Close()
     SetThrottleState(bool isThrottleable)
+    SetInspectable(enum:bool WebCore::ServiceWorkerIsInspectable inspectable)
 
     ConvertFetchToDownload(WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::FetchIdentifier identifier)
 


### PR DESCRIPTION
#### 519e45961292f33fc820167bb68e57a9903be0d7
<pre>
[iOS 17] Remote inspection should be disabled for service workers used only in locked private tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=260400">https://bugs.webkit.org/show_bug.cgi?id=260400</a>
rdar://108476513

Reviewed by Patrick Angle and Chris Dumez.

Safari 17 introduces the ability to lock tabs in private browsing mode, such that they require some
form of authentication before they&apos;re visible to the user. Aside from obscuring the web views, one
of the other (myriad) ways we hide these private tabs is by making them non-web-inspectable, via
`-[WKWebView setInspectable:]`. However, there&apos;s currently a corner case where service workers that
are loaded as a part of these locked private browsing tabs will still be inspectable, even if the
page itself is not; this is because service workers are currently _always_ inspectable, regardless
of whether inspection is enabled via web view API.

To address this corner case, we propagate `WKWebView` inspectability over to service workers by
letting a website datastore allow inspection for service workers only if at least one web view using
the data store is inspectable. In practice, because private browsing tabs always use a separate,
ephemeral data stores, making web views in private tabs non-inspectable is equivalent to making any
of their service workers non-inspectable.

At a high level, the inspection state plumbing takes the following route through WebKit:

1.  UI Process
    ↳ `WKWebView`/`WebPageProxy` (source of truth)
      ↳ `WebsiteDataStore`
        ↳ `NetworkProcessProxy`

2.  Network Process
    ↳ `NetworkProcess`
      ↳ `NetworkSession`
        ↳ `SWServer`
          ↳ `WebSWServerToContextConnection`

3.  Web Process
    ↳ `WebSWContextManagerConnection`
      ↳ `SWContextManager`
        ↳ `ServiceWorkerThreadProxy` (final destination)

* Source/WebCore/workers/service/ServiceWorkerTypes.h:

Add a boolean `enum class ServiceWorkerIsInspectable` so that we can use it in `SWServer` and
adjacent code, so that the last argument to `installContextData` isn&apos;t just a plain `bool`.

* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::setInspectable):

Iterate over all `ServiceWorkerThreadProxy`s and plumb the updated inspectability state over to each
worker.

* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:

Take the inspectability state from the given `WebCore::Page`, which should now have an inspection
state that&apos;s consistent with the associated service worker.

(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
(WebCore::ServiceWorkerThreadProxy::setInspectable):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::SWServer):
(WebCore::SWServer::contextConnectionCreated):

Plumb initial inspectability state through `SWServer` into the context connection.

(WebCore::SWServer::setInspectable):

Update all context connections when inspectability changes.

* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setInspectionForServiceWorkersAllowed):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::NetworkSession):
(WebKit::NetworkSession::ensureSWServer):
(WebKit::NetworkSession::setInspectionForServiceWorkersAllowed):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):

Add a new flag to `NetworkSession`&apos;s creation parameters to indicate whether or not inspection
should be enabled. This is necessary in the case where we avoided sending any inspectability updates
eagerly, in order to avoid needlessly launching the network process.

* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::installServiceWorkerContext):
(WebKit::WebSWServerToContextConnection::setInspectable):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setInspectable):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::pageBeginUsingWebsiteDataStore):
(WebKit::WebProcessPool::pageEndUsingWebsiteDataStore):

Update the data store&apos;s set of pages when pages begin or end use; we also adjust these to take
`WebPageProxy&amp;`, so that we can pass them directly into `WebsiteDataStore`.

* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::removeWebPage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:

Maintain state on each data store, that determines whether or not service workers associated with
that data store should allow inspection. To achieve this, we maintain the set of `m_pages` currently
associated with this data store; whenever pages are added or removed, or when a page changes
inspectability, we recompute inspectability state on the data store and update the network session
if it changes.

(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::updateServiceWorkerInspectability):
(WebKit::WebsiteDataStore::addPage):
(WebKit::WebsiteDataStore::removePage):

Update `m_pages` when `WebPageProxy`s start or stop using the data store.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
(WebKit::WebSWContextManagerConnection::setThrottleState):
(WebKit::WebSWContextManagerConnection::setInspectable):

Plumb inspectability state through to `SWContextManager`.

* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/267118@main">https://commits.webkit.org/267118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e73f73271b16841d97f0dced214e14b79dabd53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16146 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18249 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/15851 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14207 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17627 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14967 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14216 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3755 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->