### PR TITLE
Clean up Web Extension logging and add some more logs.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -44,6 +44,8 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 + (instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle
 {
+    NSParameterAssert([appExtensionBundle isKindOfClass:NSBundle.class]);
+
     NSError * __autoreleasing internalError;
     auto result = WebKit::WebExtension::create(appExtensionBundle, &internalError);
 
@@ -55,6 +57,10 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 + (instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL
 {
+    NSParameterAssert([resourceBaseURL isKindOfClass:NSURL.class]);
+    NSParameterAssert([resourceBaseURL isFileURL]);
+    NSParameterAssert([resourceBaseURL hasDirectoryPath]);
+
     NSError * __autoreleasing internalError;
     auto result = WebKit::WebExtension::create(resourceBaseURL, &internalError);
 
@@ -66,7 +72,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
 {
-    NSParameterAssert(appExtensionBundle);
+    NSParameterAssert([appExtensionBundle isKindOfClass:NSBundle.class]);
 
     if (error)
         *error = nil;
@@ -88,7 +94,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
-    NSParameterAssert(resourceBaseURL);
+    NSParameterAssert([resourceBaseURL isKindOfClass:NSURL.class]);
     NSParameterAssert([resourceBaseURL isFileURL]);
     NSParameterAssert([resourceBaseURL hasDirectoryPath]);
 
@@ -112,14 +118,14 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
 {
-    NSParameterAssert(manifest);
+    NSParameterAssert([manifest isKindOfClass:NSDictionary.class]);
 
     return [self _initWithManifestDictionary:manifest resources:nil];
 }
 
 - (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
 {
-    NSParameterAssert(manifest);
+    NSParameterAssert([manifest isKindOfClass:NSDictionary.class]);
 
     if (!(self = [super init]))
         return nil;
@@ -131,7 +137,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
 {
-    NSParameterAssert(resources);
+    NSParameterAssert([resources isKindOfClass:NSDictionary.class]);
 
     if (!(self = [super init]))
         return nil;
@@ -262,7 +268,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 - (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url
 {
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     return _webExtension->hasStaticInjectedContentForURL(url);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -62,14 +62,14 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
 
 + (instancetype)contextForExtension:(_WKWebExtension *)extension
 {
-    NSParameterAssert(extension);
+    NSParameterAssert([extension isKindOfClass:_WKWebExtension.class]);
 
     return [[self alloc] initForExtension:extension];
 }
 
 - (instancetype)initForExtension:(_WKWebExtension *)extension
 {
-    NSParameterAssert(extension);
+    NSParameterAssert([extension isKindOfClass:_WKWebExtension.class]);
 
     if (!(self = [super init]))
         return nil;
@@ -109,7 +109,7 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
 
 - (void)setBaseURL:(NSURL *)baseURL
 {
-    NSParameterAssert(baseURL);
+    NSParameterAssert([baseURL isKindOfClass:NSURL.class]);
     NSAssert1(WTF::URLParser::maybeCanonicalizeScheme(String(baseURL.scheme)), @"Invalid parameter: '%@' is not a valid URL scheme", baseURL.scheme);
     NSAssert1(![WKWebView handlesURLScheme:baseURL.scheme], @"Invalid parameter: '%@' is a URL scheme that WKWebView handles natively and cannot be used for extensions", baseURL.scheme);
     NSAssert(!baseURL.path.length || [baseURL.path isEqualToString:@"/"], @"Invalid parameter: a URL with a path cannot be used");
@@ -124,7 +124,7 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
 
 - (void)setUniqueIdentifier:(NSString *)uniqueIdentifier
 {
-    NSParameterAssert(uniqueIdentifier);
+    NSParameterAssert([uniqueIdentifier isKindOfClass:NSString.class]);
 
     _webExtensionContext->setUniqueIdentifier(uniqueIdentifier);
 }
@@ -141,6 +141,7 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
 
 static inline WallTime toImpl(NSDate *date)
 {
+    NSCParameterAssert(!date || [date isKindOfClass:NSDate.class]);
     return date ? WebKit::toImpl(date) : WebKit::toImpl(NSDate.distantFuture);
 }
 
@@ -170,6 +171,8 @@ static inline WebKit::WebExtensionContext::PermissionsMap toImpl(NSDictionary<_W
     result.reserveInitialCapacity(permissions.count);
 
     [permissions enumerateKeysAndObjectsUsingBlock:^(_WKWebExtensionPermission permission, NSDate *date, BOOL *) {
+        NSCParameterAssert([permission isKindOfClass:NSString.class]);
+        NSCParameterAssert([date isKindOfClass:NSDate.class]);
         result.set(permission, toImpl(date));
     }];
 
@@ -182,6 +185,8 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
     result.reserveInitialCapacity(permissionMatchPatterns.count);
 
     [permissionMatchPatterns enumerateKeysAndObjectsUsingBlock:^(_WKWebExtensionMatchPattern *origin, NSDate *date, BOOL *) {
+        NSCParameterAssert([origin isKindOfClass:_WKWebExtensionMatchPattern.class]);
+        NSCParameterAssert([date isKindOfClass:NSDate.class]);
         result.set(origin._webExtensionMatchPattern, toImpl(date));
     }];
 
@@ -195,7 +200,7 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
 
 - (void)setGrantedPermissions:(NSDictionary<_WKWebExtensionPermission, NSDate *> *)grantedPermissions
 {
-    NSParameterAssert(grantedPermissions);
+    NSParameterAssert([grantedPermissions isKindOfClass:NSDictionary.class]);
 
     _webExtensionContext->setGrantedPermissions(toImpl(grantedPermissions));
 }
@@ -207,7 +212,7 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
 
 - (void)setGrantedPermissionMatchPatterns:(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)grantedPermissionMatchPatterns
 {
-    NSParameterAssert(grantedPermissionMatchPatterns);
+    NSParameterAssert([grantedPermissionMatchPatterns isKindOfClass:NSDictionary.class]);
 
     _webExtensionContext->setGrantedPermissionMatchPatterns(toImpl(grantedPermissionMatchPatterns));
 }
@@ -219,7 +224,7 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
 
 - (void)setDeniedPermissions:(NSDictionary<_WKWebExtensionPermission, NSDate *> *)deniedPermissions
 {
-    NSParameterAssert(deniedPermissions);
+    NSParameterAssert([deniedPermissions isKindOfClass:NSDictionary.class]);
 
     _webExtensionContext->setDeniedPermissions(toImpl(deniedPermissions));
 }
@@ -231,7 +236,7 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
 
 - (void)setDeniedPermissionMatchPatterns:(NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *)deniedPermissionMatchPatterns
 {
-    NSParameterAssert(deniedPermissionMatchPatterns);
+    NSParameterAssert([deniedPermissionMatchPatterns isKindOfClass:NSDictionary.class]);
 
     _webExtensionContext->setDeniedPermissionMatchPatterns(toImpl(deniedPermissionMatchPatterns));
 }
@@ -284,28 +289,28 @@ static inline NSSet<_WKWebExtensionMatchPattern *> *toAPI(const WebKit::WebExten
 
 - (BOOL)hasPermission:(_WKWebExtensionPermission)permission
 {
-    NSParameterAssert(permission);
+    NSParameterAssert([permission isKindOfClass:NSString.class]);
 
     return [self hasPermission:permission inTab:nil];
 }
 
 - (BOOL)hasPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
 {
-    NSParameterAssert(permission);
+    NSParameterAssert([permission isKindOfClass:NSString.class]);
 
     return _webExtensionContext->hasPermission(permission, tab);
 }
 
 - (BOOL)hasAccessToURL:(NSURL *)url
 {
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     return [self hasAccessToURL:url inTab:nil];
 }
 
 - (BOOL)hasAccessToURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
 {
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     return _webExtensionContext->hasPermission(url, tab);
 }
@@ -355,14 +360,14 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 
 - (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission
 {
-    NSParameterAssert(permission);
+    NSParameterAssert([permission isKindOfClass:NSString.class]);
 
     return [self permissionStatusForPermission:permission inTab:nil];
 }
 
 - (_WKWebExtensionContextPermissionStatus)permissionStatusForPermission:(_WKWebExtensionPermission)permission inTab:(id<_WKWebExtensionTab>)tab
 {
-    NSParameterAssert(permission);
+    NSParameterAssert([permission isKindOfClass:NSString.class]);
 
     return toAPI(_webExtensionContext->permissionState(permission, tab));
 }
@@ -370,7 +375,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission
 {
     NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
-    NSParameterAssert(permission);
+    NSParameterAssert([permission isKindOfClass:NSString.class]);
 
     [self setPermissionStatus:status forPermission:permission expirationDate:nil];
 }
@@ -378,21 +383,21 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forPermission:(_WKWebExtensionPermission)permission expirationDate:(NSDate *)expirationDate
 {
     NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
-    NSParameterAssert(permission);
+    NSParameterAssert([permission isKindOfClass:NSString.class]);
 
     _webExtensionContext->setPermissionState(toImpl(status), permission, toImpl(expirationDate));
 }
 
 - (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url
 {
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     return [self permissionStatusForURL:url inTab:nil];
 }
 
 - (_WKWebExtensionContextPermissionStatus)permissionStatusForURL:(NSURL *)url inTab:(id<_WKWebExtensionTab>)tab
 {
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     return toAPI(_webExtensionContext->permissionState(url, tab));
 }
@@ -400,7 +405,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url
 {
     NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     [self setPermissionStatus:status forURL:url expirationDate:nil];
 }
@@ -408,21 +413,21 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
 {
     NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
-    NSParameterAssert(url);
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
 
     _webExtensionContext->setPermissionState(toImpl(status), url, toImpl(expirationDate));
 }
 
 - (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern
 {
-    NSParameterAssert(pattern);
+    NSParameterAssert([pattern isKindOfClass:_WKWebExtensionMatchPattern.class]);
 
     return [self permissionStatusForMatchPattern:pattern inTab:nil];
 }
 
 - (_WKWebExtensionContextPermissionStatus)permissionStatusForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(id<_WKWebExtensionTab>)tab
 {
-    NSParameterAssert(pattern);
+    NSParameterAssert([pattern isKindOfClass:_WKWebExtensionMatchPattern.class]);
 
     return toAPI(_webExtensionContext->permissionState(pattern._webExtensionMatchPattern, tab));
 }
@@ -430,7 +435,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern
 {
     NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
-    NSParameterAssert(pattern);
+    NSParameterAssert([pattern isKindOfClass:_WKWebExtensionMatchPattern.class]);
 
     [self setPermissionStatus:status forMatchPattern:pattern expirationDate:nil];
 }
@@ -438,7 +443,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(NSDate *)expirationDate
 {
     NSParameterAssert(status == _WKWebExtensionContextPermissionStatusDeniedExplicitly || status == _WKWebExtensionContextPermissionStatusUnknown || status == _WKWebExtensionContextPermissionStatusGrantedExplicitly);
-    NSParameterAssert(pattern);
+    NSParameterAssert([pattern isKindOfClass:_WKWebExtensionMatchPattern.class]);
 
     _webExtensionContext->setPermissionState(toImpl(status), pattern._webExtensionMatchPattern, toImpl(expirationDate));
 }
@@ -455,12 +460,14 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 
 - (BOOL)hasInjectedContentForURL:(NSURL *)url
 {
+    NSParameterAssert([url isKindOfClass:NSURL.class]);
+
     return _webExtensionContext->hasInjectedContentForURL(url);
 }
 
 - (BOOL)hasActiveUserGestureInTab:(id<_WKWebExtensionTab>)tab
 {
-    NSParameterAssert(tab);
+    NSParameterAssert([tab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
 
     return _webExtensionContext->hasActiveUserGesture(tab);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -53,7 +53,7 @@
 
 - (instancetype)initWithConfiguration:(_WKWebExtensionControllerConfiguration *)configuration
 {
-    NSParameterAssert(configuration);
+    NSParameterAssert([configuration isKindOfClass:_WKWebExtensionControllerConfiguration.class]);
 
     if (!(self = [super init]))
         return nil;
@@ -78,21 +78,21 @@
 
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
-    NSParameterAssert(extensionContext);
+    NSParameterAssert([extensionContext isKindOfClass:_WKWebExtensionContext.class]);
 
     return _webExtensionController->load(extensionContext._webExtensionContext, outError);
 }
 
 - (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
-    NSParameterAssert(extensionContext);
+    NSParameterAssert([extensionContext isKindOfClass:_WKWebExtensionContext.class]);
 
     return _webExtensionController->unload(extensionContext._webExtensionContext, outError);
 }
 
 - (_WKWebExtensionContext *)extensionContextForExtension:(_WKWebExtension *)extension
 {
-    NSParameterAssert(extension);
+    NSParameterAssert([extension isKindOfClass:_WKWebExtension.class]);
 
     if (auto extensionContext = _webExtensionController->extensionContext(extension._webExtension))
         return extensionContext->wrapper();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -57,7 +57,7 @@ static constexpr NSString *identifierCodingKey = @"identifier";
 
 + (instancetype)configurationWithIdentifier:(NSUUID *)identifier
 {
-    NSParameterAssert(identifier);
+    NSParameterAssert([identifier isKindOfClass:NSUUID.class]);
 
     auto uuid = WTF::UUID::fromNSUUID(identifier);
     RELEASE_ASSERT(uuid);
@@ -66,7 +66,7 @@ static constexpr NSString *identifierCodingKey = @"identifier";
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    NSParameterAssert(coder);
+    NSParameterAssert([coder isKindOfClass:NSCoder.class]);
 
     [coder encodeObject:self.identifier forKey:identifierCodingKey];
     [coder encodeBool:self.persistent forKey:persistentCodingKey];
@@ -74,7 +74,7 @@ static constexpr NSString *identifierCodingKey = @"identifier";
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    NSParameterAssert(coder);
+    NSParameterAssert([coder isKindOfClass:NSCoder.class]);
 
     if (!(self = [super init]))
         return nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -47,14 +47,14 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    NSParameterAssert(coder);
+    NSParameterAssert([coder isKindOfClass:NSCoder.class]);
 
     return [self initWithString:[coder decodeObjectOfClass:[NSString class] forKey:stringCodingKey] error:nullptr];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    NSParameterAssert(coder);
+    NSParameterAssert([coder isKindOfClass:NSCoder.class]);
 
     [coder encodeObject:self.string forKey:stringCodingKey];
 }
@@ -69,6 +69,7 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 + (void)registerCustomURLScheme:(NSString *)urlScheme
 {
+    NSParameterAssert([urlScheme isKindOfClass:NSString.class]);
     NSAssert1(WTF::URLParser::maybeCanonicalizeScheme(String(urlScheme)), @"Invalid parameter: '%@' is not a valid URL scheme", urlScheme);
 
     WebKit::WebExtensionMatchPattern::registerCustomURLScheme(urlScheme);
@@ -86,23 +87,23 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 + (instancetype)matchPatternWithString:(NSString *)patternString
 {
-    NSParameterAssert(patternString);
+    NSParameterAssert([patternString isKindOfClass:NSString.class]);
 
     return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(patternString));
 }
 
 + (instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path
 {
-    NSParameterAssert(scheme);
-    NSParameterAssert(host);
-    NSParameterAssert(path);
+    NSParameterAssert([scheme isKindOfClass:NSString.class]);
+    NSParameterAssert([host isKindOfClass:NSString.class]);
+    NSParameterAssert([path isKindOfClass:NSString.class]);
 
     return WebKit::wrapper(WebKit::WebExtensionMatchPattern::getOrCreate(scheme, host, path));
 }
 
 - (instancetype)initWithString:(NSString *)string error:(NSError **)error
 {
-    NSParameterAssert(string);
+    NSParameterAssert([string isKindOfClass:NSString.class]);
 
     if (!error) {
         // Balance the destructor in dealloc with the empty constructor.
@@ -119,9 +120,9 @@ NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain = @"_WKWebExtensionMa
 
 - (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error
 {
-    NSParameterAssert(scheme);
-    NSParameterAssert(host);
-    NSParameterAssert(path);
+    NSParameterAssert([scheme isKindOfClass:NSString.class]);
+    NSParameterAssert([host isKindOfClass:NSString.class]);
+    NSParameterAssert([path isKindOfClass:NSString.class]);
 
     if (!error) {
         // Balance the destructor in dealloc with the empty constructor.
@@ -232,6 +233,7 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensi
 
 - (BOOL)matchesURL:(NSURL *)urlToMatch options:(_WKWebExtensionMatchPatternOptions)options
 {
+    NSParameterAssert([urlToMatch isKindOfClass:NSURL.class]);
     NSAssert(!(options & _WKWebExtensionMatchPatternOptionsMatchBidirectionally), @"Invalid parameter: WKWebExtensionMatchPatternOptionsMatchBidirectionally is not valid when matching a URL");
 
     return _webExtensionMatchPattern->matchesURL(urlToMatch, toImpl(options));
@@ -246,6 +248,9 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensi
 {
     if (!patternToMatch)
         return NO;
+
+    NSParameterAssert([patternToMatch isKindOfClass:_WKWebExtensionMatchPattern.class]);
+
     return _webExtensionMatchPattern->matchesPattern(patternToMatch._webExtensionMatchPattern, toImpl(options));
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm
@@ -32,6 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "Logging.h"
 #import "WebExtensionController.h"
 #import "_WKWebExtensionControllerDelegatePrivate.h"
 #import "_WKWebExtensionControllerInternal.h"
@@ -49,13 +50,15 @@ void WebExtensionContext::testResult(bool result, String message, String sourceU
         return;
     }
 
-    if (result)
-        return;
-
     if (message.isEmpty())
         message = "(no message)"_s;
 
-    NSLog(@"EXTENSION TEST ASSERTION FAILED: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    if (result) {
+        RELEASE_LOG_INFO(Extensions, "Test assertion passed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+        return;
+    }
+
+    RELEASE_LOG_ERROR(Extensions, "Test assertion failed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
 void WebExtensionContext::testEqual(bool result, String expectedValue, String actualValue, String message, String sourceURL, unsigned lineNumber)
@@ -69,13 +72,15 @@ void WebExtensionContext::testEqual(bool result, String expectedValue, String ac
         return;
     }
 
-    if (result)
-        return;
-
     if (message.isEmpty())
         message = "Expected equality of these values"_s;
 
-    NSLog(@"EXTENSION TEST EQUALITY FAILED: %@: %@ !== %@ (%@:%u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
+    if (result) {
+        RELEASE_LOG_INFO(Extensions, "Test equality passed: %{public}@: %{public}@ === %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
+        return;
+    }
+
+    RELEASE_LOG_ERROR(Extensions, "Test equality failed: %{public}@: %{public}@ !== %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
 }
 
 void WebExtensionContext::testMessage(String message, String sourceURL, unsigned lineNumber)
@@ -92,7 +97,7 @@ void WebExtensionContext::testMessage(String message, String sourceURL, unsigned
     if (message.isEmpty())
         message = "(no message)"_s;
 
-    NSLog(@"EXTENSION TEST MESSAGE: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test message: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
 void WebExtensionContext::testYielded(String message, String sourceURL, unsigned lineNumber)
@@ -109,7 +114,7 @@ void WebExtensionContext::testYielded(String message, String sourceURL, unsigned
     if (message.isEmpty())
         message = "(no message)"_s;
 
-    NSLog(@"EXTENSION TEST YIELDED: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_INFO(Extensions, "Test yielded: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
 void WebExtensionContext::testFinished(bool result, String message, String sourceURL, unsigned lineNumber)
@@ -123,13 +128,15 @@ void WebExtensionContext::testFinished(bool result, String message, String sourc
         return;
     }
 
-    if (result)
-        return;
-
     if (message.isEmpty())
         message = "(no message)"_s;
 
-    NSLog(@"EXTENSION TEST FAILED: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    if (result) {
+        RELEASE_LOG_INFO(Extensions, "Test passed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+        return;
+    }
+
+    RELEASE_LOG_ERROR(Extensions, "Test failed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -35,6 +35,7 @@
 #import "APIData.h"
 #import "CocoaHelpers.h"
 #import "FoundationSPI.h"
+#import "Logging.h"
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionPermission.h"
 #import <CoreFoundation/CFBundle.h>
@@ -281,8 +282,10 @@ NSURL *WebExtension::resourceFileURLForPath(NSString *path)
     NSURL *resourceURL = [NSURL fileURLWithPath:path.stringByRemovingPercentEncoding isDirectory:NO relativeToURL:m_resourceBaseURL.get()].URLByStandardizingPath;
 
     // Don't allow escaping the base URL with "../".
-    if (![resourceURL.absoluteString hasPrefix:m_resourceBaseURL.get().absoluteString])
+    if (![resourceURL.absoluteString hasPrefix:m_resourceBaseURL.get().absoluteString]) {
+        RELEASE_LOG_ERROR(Extensions, "Resource URL path escape attempt: %{private}@", resourceURL);
         return nil;
+    }
 
     return resourceURL;
 }
@@ -554,6 +557,8 @@ void WebExtension::recordError(NSError *error, SuppressNotification suppressNoti
 
     if (!m_errors)
         m_errors = [NSMutableArray array];
+
+    RELEASE_LOG_ERROR(Extensions, "Error recorded: %{private}@", error);
 
     [m_errors addObject:error];
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -34,6 +34,7 @@
 
 #import "CocoaHelpers.h"
 #import "InjectUserScriptImmediately.h"
+#import "Logging.h"
 #import "WKNavigationActionPrivate.h"
 #import "WKNavigationDelegatePrivate.h"
 #import "WKPreferencesPrivate.h"
@@ -192,6 +193,7 @@ bool WebExtensionContext::load(WebExtensionController& controller, String storag
         *outError = nil;
 
     if (isLoaded()) {
+        RELEASE_LOG_ERROR(Extensions, "Extension context already loaded");
         if (outError)
             *outError = createError(Error::AlreadyLoaded);
         return false;
@@ -225,6 +227,7 @@ bool WebExtensionContext::unload(NSError **outError)
         *outError = nil;
 
     if (!isLoaded()) {
+        RELEASE_LOG_ERROR(Extensions, "Extension context not loaded");
         if (outError)
             *outError = createError(Error::NotLoaded);
         return false;
@@ -274,7 +277,7 @@ NSDictionary *WebExtensionContext::readStateFromStorage()
     }];
 
     if (coordinatorError)
-        RELEASE_LOG(Extensions, "Failed to coordinate reading extension state %{public}@", coordinatorError.debugDescription);
+        RELEASE_LOG_ERROR(Extensions, "Failed to coordinate reading extension state: %{private}@", coordinatorError);
 
     m_state = savedState;
 
@@ -292,11 +295,11 @@ void WebExtensionContext::writeStateToStorage() const
     [fileCoordinator coordinateWritingItemAtURL:[NSURL fileURLWithPath:stateFilePath()] options:NSFileCoordinatorWritingForReplacing error:&coordinatorError byAccessor:^(NSURL *fileURL) {
         NSError *error;
         if (![currentState() writeToURL:fileURL error:&error])
-            RELEASE_LOG(Extensions, "Unable to save extension state: %{public}@", error.debugDescription);
+            RELEASE_LOG_ERROR(Extensions, "Unable to save extension state: %{private}@", error);
     }];
 
     if (coordinatorError)
-        RELEASE_LOG(Extensions, "Failed to coordinate writing extension state %{public}@", coordinatorError.debugDescription);
+        RELEASE_LOG_ERROR(Extensions, "Failed to coordinate writing extension state: %{private}@", coordinatorError);
 }
 
 void WebExtensionContext::setBaseURL(URL&& url)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm
@@ -55,6 +55,8 @@ String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::opti
 
         String appDirectoryName = [NSBundle mainBundle].bundleIdentifier ?: [NSProcessInfo processInfo].processName;
         defaultStoragePath.get() = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identifierPath });
+
+        RELEASE_ASSERT(!defaultStoragePath->isEmpty());
     });
 
     return defaultStoragePath.get();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp
@@ -36,7 +36,7 @@ void WebExtensionAlarm::schedule()
 {
     m_parameters.nextScheduledTime = MonotonicTime::now() + initialInterval();
 
-    RELEASE_LOG_INFO(Extensions, "Scheduled alarm; initial = %f seconds; repeat = %f seconds", initialInterval().seconds(), repeatInterval().seconds());
+    RELEASE_LOG_DEBUG(Extensions, "Scheduled alarm; initial = %{public}f seconds; repeat = %{public}f seconds", initialInterval().seconds(), repeatInterval().seconds());
 
     m_timer = makeUnique<Timer>(*this, &WebExtensionAlarm::fire);
     m_timer->start(initialInterval(), repeatInterval());

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -147,7 +147,7 @@ public:
 
     NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
 
-    bool storageIsPersistent() const { return hasCustomUniqueIdentifier(); }
+    bool storageIsPersistent() const { return hasCustomUniqueIdentifier() && !m_storageDirectory.isEmpty(); }
 
     bool load(WebExtensionController&, String storageDirectory, NSError ** = nullptr);
     bool unload(NSError ** = nullptr);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -85,8 +85,6 @@ void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo,
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create
 
-    RELEASE_LOG_INFO(Extensions, "alarms.create()");
-
     static NSArray<NSString *> *optionalKeys = @[
         whenKey,
         delayInMinutesKey,
@@ -135,8 +133,6 @@ void WebExtensionAPIAlarms::get(NSString *name, Ref<WebExtensionCallbackHandler>
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/get
 
-    RELEASE_LOG_INFO(Extensions, "alarms.get()");
-
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGet(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionAlarmParameters> alarm) {
         callback->call(toAPI(alarm));
     }, extensionContext().identifier().toUInt64());
@@ -145,8 +141,6 @@ void WebExtensionAPIAlarms::get(NSString *name, Ref<WebExtensionCallbackHandler>
 void WebExtensionAPIAlarms::getAll(Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll
-
-    RELEASE_LOG_INFO(Extensions, "alarms.getAll()");
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionAlarmParameters> alarms) {
         callback->call(toAPI(alarms));
@@ -157,8 +151,6 @@ void WebExtensionAPIAlarms::clear(NSString *name, Ref<WebExtensionCallbackHandle
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clear
 
-    RELEASE_LOG_INFO(Extensions, "alarms.clear()");
-
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClear(name ?: emptyAlarmName), [protectedThis = Ref { *this }, callback = WTFMove(callback)]() {
         callback->call();
     }, extensionContext().identifier().toUInt64());
@@ -167,8 +159,6 @@ void WebExtensionAPIAlarms::clear(NSString *name, Ref<WebExtensionCallbackHandle
 void WebExtensionAPIAlarms::clearAll(Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll
-
-    RELEASE_LOG_INFO(Extensions, "alarms.clearAll()");
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::AlarmsClearAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)]() {
         callback->call();
@@ -188,8 +178,6 @@ WebExtensionAPIEvent& WebExtensionAPIAlarms::onAlarm()
 void WebExtensionContextProxy::dispatchAlarmEvent(const WebExtensionAlarmParameters& alarm)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/onAlarm
-
-    RELEASE_LOG_INFO(Extensions, "alarms.onAlarm dispatched");
 
     NSDictionary *alarmDictionary = toAPI(alarm);
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -46,8 +46,6 @@ static NSString *originsKey = @"origins";
 
 void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callback)
 {
-    RELEASE_LOG(Extensions, "permissions.getAll()");
-
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<String> permissions, Vector<String> origins) {
         callback->call(@{
             permissionsKey: createNSArray(permissions).get(),
@@ -58,8 +56,6 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
 
 void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    RELEASE_LOG(Extensions, "permissions.contains()");
-
     HashSet<String> permissions, origins;
     WebExtension::MatchPatternSet matchPatterns;
     parseDetailsDictionary(details, permissions, origins);
@@ -74,8 +70,6 @@ void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensio
 
 void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
 {
-    RELEASE_LOG(Extensions, "permissions.request()");
-
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);
 
@@ -108,8 +102,6 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
 
 void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
 {
-    RELEASE_LOG(Extensions, "permissions.remove()");
-
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -32,12 +32,16 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "Logging.h"
+
 namespace WebKit {
 
 void WebExtensionAPIRuntimeBase::reportErrorForCallbackHandler(WebExtensionCallbackHandler& callback, NSString *errorMessage, JSGlobalContextRef contextRef)
 {
     ASSERT(errorMessage.length);
     ASSERT(contextRef);
+
+    RELEASE_LOG_ERROR(Extensions, "Callback error reported: %{public}@", errorMessage);
 
     JSContext *context = [JSContext contextWithJSGlobalContextRef:contextRef];
 
@@ -50,6 +54,8 @@ void WebExtensionAPIRuntimeBase::reportErrorForCallbackHandler(WebExtensionCallb
         // Log the error to the console if it wasn't checked in the callback.
         JSValue *consoleErrorFunction = context.globalObject[@"console"][@"error"];
         [consoleErrorFunction callWithArguments:@[ [JSValue valueWithNewErrorFromMessage:[NSString stringWithFormat:@"Unchecked runtime.lastError: %@", errorMessage] inContext:context] ]];
+
+        RELEASE_LOG_DEBUG(Extensions, "Unchecked runtime.lastError");
     }
 
     m_lastErrorAccessed = false;

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -34,6 +34,7 @@
 
 #import "CocoaHelpers.h"
 #import "JSWebExtensionWrappable.h"
+#import "Logging.h"
 #import "WebExtensionAPIRuntime.h"
 #import <JavaScriptCore/JSObjectRef.h>
 
@@ -107,6 +108,8 @@ void WebExtensionCallbackHandler::reportError(NSString *message)
 
     if (!m_rejectFunction)
         return;
+
+    RELEASE_LOG_ERROR(Extensions, "Promise rejected: %{public}@", message);
 
     JSValue *error = [JSValue valueWithNewErrorFromMessage:message inContext:[JSContext contextWithJSGlobalContextRef:m_globalContext.get()]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -59,7 +59,7 @@ TEST(WKWebExtensionController, Configuration)
 
 TEST(WKWebExtensionController, LoadingAndUnloadingContexts)
 {
-    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];
+    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     EXPECT_EQ(testController.extensions.count, 0ul);
     EXPECT_EQ(testController.extensionContexts.count, 0ul);
@@ -146,7 +146,7 @@ TEST(WKWebExtensionController, BackgroundPageLoading)
 
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
     _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
-    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];
+    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     EXPECT_EQ(testExtension.errors.count, 0ul);;
 
@@ -214,7 +214,7 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
 
     _WKWebExtension *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources];
     _WKWebExtensionContext *testContext = [[_WKWebExtensionContext alloc] initForExtension:testExtension];
-    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] init];
+    _WKWebExtensionController *testController = [[_WKWebExtensionController alloc] initWithConfiguration:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration];
 
     EXPECT_EQ(testExtension.errors.count, 0ul);;
 


### PR DESCRIPTION
#### 71338e8db0ce777a17016df4b4367a61f9261449
<pre>
Clean up Web Extension logging and add some more logs.
<a href="https://webkit.org/b/260416">https://webkit.org/b/260416</a>

Reviewed by Brian Weinstein.

Improve a bunch of NSParameterAsserts to check object class not just nil. Added some missing NSParameterAsserts.
Changed some plain RELEASE_LOGs to use a more specific level like DEBUG, INFO or ERROR. Moved API logging to the
code generator and removed the manual logs from the API implementations.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(+[_WKWebExtension extensionWithAppExtensionBundle:]):
(+[_WKWebExtension extensionWithResourceBaseURL:]):
(-[_WKWebExtension initWithAppExtensionBundle:error:]):
(-[_WKWebExtension initWithResourceBaseURL:error:]):
(-[_WKWebExtension _initWithManifestDictionary:]):
(-[_WKWebExtension _initWithManifestDictionary:resources:]):
(-[_WKWebExtension _initWithResources:]):
(-[_WKWebExtension _hasStaticInjectedContentForURL:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(+[_WKWebExtensionContext contextForExtension:]):
(-[_WKWebExtensionContext initForExtension:]):
(-[_WKWebExtensionContext setBaseURL:]):
(-[_WKWebExtensionContext setUniqueIdentifier:]):
(toImpl):
(-[_WKWebExtensionContext setGrantedPermissions:]):
(-[_WKWebExtensionContext setGrantedPermissionMatchPatterns:]):
(-[_WKWebExtensionContext setDeniedPermissions:]):
(-[_WKWebExtensionContext setDeniedPermissionMatchPatterns:]):
(-[_WKWebExtensionContext hasPermission:]):
(-[_WKWebExtensionContext hasPermission:inTab:]):
(-[_WKWebExtensionContext hasAccessToURL:]):
(-[_WKWebExtensionContext hasAccessToURL:inTab:]):
(-[_WKWebExtensionContext permissionStatusForPermission:]):
(-[_WKWebExtensionContext permissionStatusForPermission:inTab:]):
(-[_WKWebExtensionContext setPermissionStatus:forPermission:]):
(-[_WKWebExtensionContext setPermissionStatus:forPermission:expirationDate:]):
(-[_WKWebExtensionContext permissionStatusForURL:]):
(-[_WKWebExtensionContext permissionStatusForURL:inTab:]):
(-[_WKWebExtensionContext setPermissionStatus:forURL:]):
(-[_WKWebExtensionContext setPermissionStatus:forURL:expirationDate:]):
(-[_WKWebExtensionContext permissionStatusForMatchPattern:]):
(-[_WKWebExtensionContext permissionStatusForMatchPattern:inTab:]):
(-[_WKWebExtensionContext setPermissionStatus:forMatchPattern:]):
(-[_WKWebExtensionContext setPermissionStatus:forMatchPattern:expirationDate:]):
(-[_WKWebExtensionContext hasInjectedContentForURL:]):
(-[_WKWebExtensionContext hasActiveUserGestureInTab:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController initWithConfiguration:]):
(-[_WKWebExtensionController loadExtensionContext:error:]):
(-[_WKWebExtensionController unloadExtensionContext:error:]):
(-[_WKWebExtensionController extensionContextForExtension:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm:
(+[_WKWebExtensionControllerConfiguration configurationWithIdentifier:]):
(-[_WKWebExtensionControllerConfiguration encodeWithCoder:]):
(-[_WKWebExtensionControllerConfiguration initWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(-[_WKWebExtensionMatchPattern initWithCoder:]):
(-[_WKWebExtensionMatchPattern encodeWithCoder:]):
(+[_WKWebExtensionMatchPattern registerCustomURLScheme:]):
(+[_WKWebExtensionMatchPattern matchPatternWithString:]):
(+[_WKWebExtensionMatchPattern matchPatternWithScheme:host:path:]):
(-[_WKWebExtensionMatchPattern initWithString:error:]):
(-[_WKWebExtensionMatchPattern initWithScheme:host:path:error:]):
(-[_WKWebExtensionMatchPattern matchesURL:options:]):
(-[_WKWebExtensionMatchPattern matchesPattern:options:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm:
(WebKit::WebExtensionContext::testResult):
(WebKit::WebExtensionContext::testEqual):
(WebKit::WebExtensionContext::testMessage):
(WebKit::WebExtensionContext::testYielded):
(WebKit::WebExtensionContext::testFinished):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceFileURLForPath):
(WebKit::WebExtension::recordError):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::unload):
(WebKit::WebExtensionContext::readStateFromStorage):
(WebKit::WebExtensionContext::writeStateToStorage const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfiguration.mm:
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath):
* Source/WebKit/UIProcess/Extensions/WebExtensionAlarm.cpp:
(WebKit::WebExtensionAlarm::schedule):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::storageIsPersistent const): Also check m_storageDirectory.isEmpty().
This resolves an error that was being logged during tests.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::createAlarm):
(WebKit::WebExtensionAPIAlarms::get):
(WebKit::WebExtensionAPIAlarms::getAll):
(WebKit::WebExtensionAPIAlarms::clear):
(WebKit::WebExtensionAPIAlarms::clearAll):
(WebKit::WebExtensionContextProxy::dispatchAlarmEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::getAll):
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntimeBase::reportErrorForCallbackHandler):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::WebExtensionCallbackHandler::reportError):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_callString):
(_installAutomaticExceptions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST): Drive-by to use non-persistent storage to resolve an error being logged during tests.

Canonical link: <a href="https://commits.webkit.org/267111@main">https://commits.webkit.org/267111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8699e2d4146d0a94a21e4975e3ac553107d9fbab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14707 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18175 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21068 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17574 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12639 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18522 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1916 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->