### PR TITLE
REGRESSION (Safari 16.3): Passing "noopener" as third argument opens tabs into new window

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4420,7 +4420,7 @@ RefPtr<LocalFrame> createWindow(LocalFrame& openerFrame, LocalFrame& lookupFrame
 
     ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy = shouldOpenExternalURLsPolicyToApply(openerFrame, request);
     NavigationAction action { request.requester(), request.resourceRequest(), request.initiatedByMainFrame(), NavigationType::Other, shouldOpenExternalURLsPolicy };
-    action.setNewFrameOpenerPolicy(features.noopener || features.noreferrer ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
+    action.setNewFrameOpenerPolicy(features.wantsNoOpener() ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
     Page* page = oldPage->chrome().createWindow(openerFrame, features, action);
     if (!page)
         return nullptr;
@@ -4439,19 +4439,23 @@ RefPtr<LocalFrame> createWindow(LocalFrame& openerFrame, LocalFrame& lookupFrame
 
     if (!frame->page())
         return nullptr;
-    page->chrome().setStatusbarVisible(features.statusBarVisible);
+    if (features.statusBarVisible)
+        page->chrome().setStatusbarVisible(*features.statusBarVisible);
 
     if (!frame->page())
         return nullptr;
-    page->chrome().setScrollbarsVisible(features.scrollbarsVisible);
+    if (features.scrollbarsVisible)
+        page->chrome().setScrollbarsVisible(*features.scrollbarsVisible);
 
     if (!frame->page())
         return nullptr;
-    page->chrome().setMenubarVisible(features.menuBarVisible);
+    if (features.menuBarVisible)
+        page->chrome().setMenubarVisible(*features.menuBarVisible);
 
     if (!frame->page())
         return nullptr;
-    page->chrome().setResizable(features.resizable);
+    if (features.resizable)
+        page->chrome().setResizable(*features.resizable);
 
     // 'x' and 'y' specify the location of the window, while 'width' and 'height'
     // specify the size of the viewport. We can only resize the window, so adjust

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -198,7 +198,7 @@ Page* Chrome::createWindow(LocalFrame& frame, const WindowFeatures& features, co
     if (!newPage)
         return nullptr;
 
-    if (!features.noopener && !features.noreferrer)
+    if (!features.wantsNoOpener())
         m_page.storageNamespaceProvider().copySessionStorageNamespace(m_page, *newPage);
 
     return newPage;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2607,7 +2607,7 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
     WindowFeatures windowFeatures = initialWindowFeatures;
 
     // For whatever reason, Firefox uses the first frame to determine the outgoingReferrer. We replicate that behavior here.
-    String referrer = windowFeatures.noreferrer ? String() : SecurityPolicy::generateReferrerHeader(firstFrame.document()->referrerPolicy(), completedURL, firstFrame.loader().outgoingReferrer(), OriginAccessPatternsForWebProcess::singleton());
+    String referrer = windowFeatures.wantsNoReferrer() ? String() : SecurityPolicy::generateReferrerHeader(firstFrame.document()->referrerPolicy(), completedURL, firstFrame.loader().outgoingReferrer(), OriginAccessPatternsForWebProcess::singleton());
     auto initiatedByMainFrame = activeFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
     ResourceRequest resourceRequest { completedURL, referrer };
@@ -2624,7 +2624,7 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
     if (!newFrame)
         return RefPtr<LocalFrame> { nullptr };
 
-    bool noopener = windowFeatures.noopener || windowFeatures.noreferrer;
+    bool noopener = windowFeatures.wantsNoOpener();
     if (!noopener)
         newFrame->loader().setOpener(&openerFrame);
 

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -53,24 +53,10 @@ static bool isSeparator(UChar character, FeatureMode mode)
 
 WindowFeatures parseWindowFeatures(StringView featuresString)
 {
-    // The IE rule is: all features except for channelmode and fullscreen default to YES, but
-    // if the user specifies a feature string, all features default to NO. (There is no public
-    // standard that applies to this method.)
-    //
-    // <http://msdn.microsoft.com/workshop/author/dhtml/reference/methods/open_0.asp>
-    // We always allow a window to be resized, which is consistent with Firefox.
-
     WindowFeatures features;
 
     if (featuresString.isEmpty())
         return features;
-
-    features.menuBarVisible = false;
-    features.statusBarVisible = false;
-    features.toolBarVisible = false;
-    features.locationBarVisible = false;
-    features.scrollbarsVisible = false;
-    features.noopener = false;
 
     processFeaturesString(featuresString, FeatureMode::Window, [&features](StringView key, StringView value) {
         setWindowFeature(features, key, value);
@@ -147,6 +133,8 @@ static void setWindowFeature(WindowFeatures& features, StringView key, StringVie
         features.width = numericValue;
     else if (equalLettersIgnoringASCIICase(key, "height"_s) || equalLettersIgnoringASCIICase(key, "innerheight"_s))
         features.height = numericValue;
+    else if (equalLettersIgnoringASCIICase(key, "popup"_s))
+        features.popup = numericValue;
     else if (equalLettersIgnoringASCIICase(key, "menubar"_s))
         features.menuBarVisible = numericValue;
     else if (equalLettersIgnoringASCIICase(key, "toolbar"_s))
@@ -159,12 +147,17 @@ static void setWindowFeature(WindowFeatures& features, StringView key, StringVie
         features.fullscreen = numericValue;
     else if (equalLettersIgnoringASCIICase(key, "scrollbars"_s))
         features.scrollbarsVisible = numericValue;
+    else if (equalLettersIgnoringASCIICase(key, "resizable"_s))
+        features.resizable = numericValue;
     else if (equalLettersIgnoringASCIICase(key, "noopener"_s))
         features.noopener = numericValue;
     else if (equalLettersIgnoringASCIICase(key, "noreferrer"_s))
         features.noreferrer = numericValue;
-    else if (numericValue == 1)
-        features.additionalFeatures.append(key.toString());
+    else if (key.length() || value.length()) {
+        features.hasAdditionalFeatures = true;
+        if (numericValue == 1)
+            features.additionalFeatures.append(key.toString());
+    }
 }
 
 WindowFeatures parseDialogFeatures(StringView dialogFeaturesString, const FloatRect& screenAvailableRect)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1858,22 +1858,25 @@ enum class WebCore::DiagnosticLoggingDomain : uint8_t {
 };
 
 struct WebCore::WindowFeatures {
+    bool hasAdditionalFeatures;
+
     std::optional<float> x;
     std::optional<float> y;
     std::optional<float> width;
     std::optional<float> height;
 
-    bool menuBarVisible;
-    bool statusBarVisible;
-    bool toolBarVisible;
-    bool locationBarVisible;
-    bool scrollbarsVisible;
-    bool resizable;
+    std::optional<bool> popup;
+    std::optional<bool> menuBarVisible;
+    std::optional<bool> statusBarVisible;
+    std::optional<bool> toolBarVisible;
+    std::optional<bool> locationBarVisible;
+    std::optional<bool> scrollbarsVisible;
+    std::optional<bool> resizable;
 
-    bool fullscreen;
-    bool dialog;
-    [NotSerialized] bool noopener;
-    [NotSerialized] bool noreferrer;
+    std::optional<bool> fullscreen;
+    std::optional<bool> dialog;
+    [NotSerialized] std::optional<bool> noopener;
+    [NotSerialized] std::optional<bool> noreferrer;
 
     [NotSerialized] Vector<String> additionalFeatures;
 };

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1599,6 +1599,8 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         
             if (m_client.createNewPage_deprecatedForUseWithV1 || m_client.createNewPage_deprecatedForUseWithV0) {
                 API::Dictionary::MapType map;
+                map.set("wantsPopup"_s, API::Boolean::create(windowFeatures.wantsPopup()));
+                map.set("hasAdditionalFeatures"_s, API::Boolean::create(windowFeatures.hasAdditionalFeatures));
                 if (windowFeatures.x)
                     map.set("x"_s, API::Double::create(*windowFeatures.x));
                 if (windowFeatures.y)
@@ -1607,14 +1609,24 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                     map.set("width"_s, API::Double::create(*windowFeatures.width));
                 if (windowFeatures.height)
                     map.set("height"_s, API::Double::create(*windowFeatures.height));
-                map.set("menuBarVisible"_s, API::Boolean::create(windowFeatures.menuBarVisible));
-                map.set("statusBarVisible"_s, API::Boolean::create(windowFeatures.statusBarVisible));
-                map.set("toolBarVisible"_s, API::Boolean::create(windowFeatures.toolBarVisible));
-                map.set("locationBarVisible"_s, API::Boolean::create(windowFeatures.locationBarVisible));
-                map.set("scrollbarsVisible"_s, API::Boolean::create(windowFeatures.scrollbarsVisible));
-                map.set("resizable"_s, API::Boolean::create(windowFeatures.resizable));
-                map.set("fullscreen"_s, API::Boolean::create(windowFeatures.fullscreen));
-                map.set("dialog"_s, API::Boolean::create(windowFeatures.dialog));
+                if (windowFeatures.popup)
+                    map.set("popup"_s, API::Boolean::create(*windowFeatures.popup));
+                if (windowFeatures.menuBarVisible)
+                    map.set("menuBarVisible"_s, API::Boolean::create(*windowFeatures.menuBarVisible));
+                if (windowFeatures.statusBarVisible)
+                    map.set("statusBarVisible"_s, API::Boolean::create(*windowFeatures.statusBarVisible));
+                if (windowFeatures.toolBarVisible)
+                    map.set("toolBarVisible"_s, API::Boolean::create(*windowFeatures.toolBarVisible));
+                if (windowFeatures.locationBarVisible)
+                    map.set("locationBarVisible"_s, API::Boolean::create(*windowFeatures.locationBarVisible));
+                if (windowFeatures.scrollbarsVisible)
+                    map.set("scrollbarsVisible"_s, API::Boolean::create(*windowFeatures.scrollbarsVisible));
+                if (windowFeatures.resizable)
+                    map.set("resizable"_s, API::Boolean::create(*windowFeatures.resizable));
+                if (windowFeatures.fullscreen)
+                    map.set("fullscreen"_s, API::Boolean::create(*windowFeatures.fullscreen));
+                if (windowFeatures.dialog)
+                    map.set("dialog"_s, API::Boolean::create(*windowFeatures.dialog));
                 Ref<API::Dictionary> featuresMap = API::Dictionary::create(WTFMove(map));
 
                 if (m_client.createNewPage_deprecatedForUseWithV1) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.mm
@@ -44,22 +44,34 @@
 
 - (NSNumber *)menuBarVisibility
 {
-    return @(_windowFeatures->windowFeatures().menuBarVisible);
+    if (auto menuBarVisible = _windowFeatures->windowFeatures().menuBarVisible)
+        return @(*menuBarVisible);
+
+    return nil;
 }
 
 - (NSNumber *)statusBarVisibility
 {
-    return @(_windowFeatures->windowFeatures().statusBarVisible);
+    if (auto statusBarVisible = _windowFeatures->windowFeatures().statusBarVisible)
+        return @(*statusBarVisible);
+
+    return nil;
 }
 
 - (NSNumber *)toolbarsVisibility
 {
-    return @(_windowFeatures->windowFeatures().toolBarVisible);
+    if (auto toolBarVisible = _windowFeatures->windowFeatures().toolBarVisible)
+        return @(*toolBarVisible);
+
+    return nil;
 }
 
 - (NSNumber *)allowsResizing
 {
-    return @(_windowFeatures->windowFeatures().resizable);
+    if (auto resizable = _windowFeatures->windowFeatures().resizable)
+        return @(*resizable);
+
+    return nil;
 }
 
 - (NSNumber *)x
@@ -105,24 +117,54 @@
 
 @implementation WKWindowFeatures (WKPrivate)
 
+- (BOOL)_wantsPopup
+{
+    return _windowFeatures->windowFeatures().wantsPopup();
+}
+
+- (BOOL)_hasAdditionalFeatures
+{
+    return _windowFeatures->windowFeatures().hasAdditionalFeatures;
+}
+
+- (NSNumber *)_popup
+{
+    if (auto popup = _windowFeatures->windowFeatures().popup)
+        return @(*popup);
+
+    return nil;
+}
+
 - (NSNumber *)_locationBarVisibility
 {
-    return @(_windowFeatures->windowFeatures().locationBarVisible);
+    if (auto locationBarVisible = _windowFeatures->windowFeatures().locationBarVisible)
+        return @(*locationBarVisible);
+
+    return nil;
 }
 
 - (NSNumber *)_scrollbarsVisibility
 {
-    return @(_windowFeatures->windowFeatures().scrollbarsVisible);
+    if (auto scrollbarsVisible = _windowFeatures->windowFeatures().scrollbarsVisible)
+        return @(*scrollbarsVisible);
+
+    return nil;
 }
 
 - (NSNumber *)_fullscreenDisplay
 {
-    return @(_windowFeatures->windowFeatures().fullscreen);
+    if (auto fullscreen = _windowFeatures->windowFeatures().fullscreen)
+        return @(*fullscreen);
+
+    return nil;
 }
 
 - (NSNumber *)_dialogDisplay
 {
-    return @(_windowFeatures->windowFeatures().dialog);
+    if (auto dialog = _windowFeatures->windowFeatures().dialog)
+        return @(*dialog);
+
+    return nil;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeaturesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeaturesPrivate.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WKWindowFeatures (WKPrivate)
 
+@property (nonatomic, readonly) BOOL _wantsPopup WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly) BOOL _hasAdditionalFeatures WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nullable, nonatomic, readonly) NSNumber *_popup WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nullable, nonatomic, readonly) NSNumber *_locationBarVisibility WK_API_AVAILABLE(macos(10.13), ios(11.0));
 @property (nullable, nonatomic, readonly) NSNumber *_scrollbarsVisibility WK_API_AVAILABLE(macos(10.13), ios(11.0));
 @property (nullable, nonatomic, readonly) NSNumber *_fullscreenDisplay WK_API_AVAILABLE(macos(10.13), ios(11.0));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp
@@ -395,13 +395,20 @@ void webkitWindowPropertiesUpdateFromWebWindowFeatures(WebKitWindowProperties* w
     webkitWindowPropertiesSetGeometry(windowProperties, &geometry);
 #endif
 
-    webkitWindowPropertiesSetMenubarVisible(windowProperties, windowFeatures.menuBarVisible);
-    webkitWindowPropertiesSetStatusbarVisible(windowProperties, windowFeatures.statusBarVisible);
-    webkitWindowPropertiesSetToolbarVisible(windowProperties, windowFeatures.toolBarVisible);
-    webkitWindowPropertiesSetLocationbarVisible(windowProperties, windowFeatures.locationBarVisible);
-    webkitWindowPropertiesSetScrollbarsVisible(windowProperties, windowFeatures.scrollbarsVisible);
-    webkitWindowPropertiesSetResizable(windowProperties, windowFeatures.resizable);
-    webkitWindowPropertiesSetFullscreen(windowProperties, windowFeatures.fullscreen);
+    if (windowFeatures.menuBarVisible)
+        webkitWindowPropertiesSetMenubarVisible(windowProperties, *windowFeatures.menuBarVisible);
+    if (windowFeatures.statusBarVisible)
+        webkitWindowPropertiesSetStatusbarVisible(windowProperties, *windowFeatures.statusBarVisible);
+    if (windowFeatures.toolBarVisible)
+        webkitWindowPropertiesSetToolbarVisible(windowProperties, *windowFeatures.toolBarVisible);
+    if (windowFeatures.locationBarVisible)
+        webkitWindowPropertiesSetLocationbarVisible(windowProperties, *windowFeatures.locationBarVisible);
+    if (windowFeatures.scrollbarsVisible)
+        webkitWindowPropertiesSetScrollbarsVisible(windowProperties, *windowFeatures.scrollbarsVisible);
+    if (windowFeatures.resizable)
+        webkitWindowPropertiesSetResizable(windowProperties, *windowFeatures.resizable);
+    if (windowFeatures.fullscreen)
+        webkitWindowPropertiesSetFullscreen(windowProperties, *windowFeatures.fullscreen);
 }
 
 #if PLATFORM(GTK)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -260,14 +260,9 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& fea
     
     if ([delegate respondsToSelector:@selector(webView:createWebViewWithRequest:windowFeatures:)]) {
         auto dictFeatures = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                                             @(features.menuBarVisible), @"menuBarVisible",
-                                             @(features.statusBarVisible), @"statusBarVisible",
-                                             @(features.toolBarVisible), @"toolBarVisible",
-                                             @(features.scrollbarsVisible), @"scrollbarsVisible",
-                                             @(features.resizable), @"resizable",
-                                             @(features.fullscreen), @"fullscreen",
-                                             @(features.dialog), @"dialog",
-                                             nil]);
+            @(features.wantsPopup()), @"wantsPopup",
+            @(features.hasAdditionalFeatures), @"hasAdditionalFeatures",
+            nil]);
         
         if (features.x)
             [dictFeatures setObject:@(*features.x) forKey:@"x"];
@@ -277,7 +272,23 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& fea
             [dictFeatures setObject:@(*features.width) forKey:@"width"];
         if (features.height)
             [dictFeatures setObject:@(*features.height) forKey:@"height"];
-        
+        if (features.popup)
+            [dictFeatures setObject:@(*features.dialog) forKey:@"popup"];
+        if (features.menuBarVisible)
+            [dictFeatures setObject:@(*features.menuBarVisible) forKey:@"menuBarVisible"];
+        if (features.statusBarVisible)
+            [dictFeatures setObject:@(*features.statusBarVisible) forKey:@"statusBarVisible"];
+        if (features.toolBarVisible)
+            [dictFeatures setObject:@(*features.toolBarVisible) forKey:@"toolBarVisible"];
+        if (features.scrollbarsVisible)
+            [dictFeatures setObject:@(*features.scrollbarsVisible) forKey:@"scrollbarsVisible"];
+        if (features.resizable)
+            [dictFeatures setObject:@(*features.resizable) forKey:@"resizable"];
+        if (features.fullscreen)
+            [dictFeatures setObject:@(*features.fullscreen) forKey:@"fullscreen"];
+        if (features.dialog)
+            [dictFeatures setObject:@(*features.dialog) forKey:@"dialog"];
+
         newWebView = CallUIDelegate(m_webView, @selector(webView:createWebViewWithRequest:windowFeatures:), nil, dictFeatures.get());
     } else if (features.dialog && [delegate respondsToSelector:@selector(webView:createWebViewModalDialogWithRequest:)])
         newWebView = CallUIDelegate(m_webView, @selector(webView:createWebViewModalDialogWithRequest:), nil);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm
@@ -245,45 +245,143 @@ TEST(WebKit, OpenWindowFeatures)
     TestWebKitAPI::Util::run(&isDone);
     isDone = false;
 
-//  https://bugs.webkit.org/show_bug.cgi?id=174271 - WebCore currently doesn't distinguish between unspecified (nil) and false
-//  for the following window features.
-//  EXPECT_TRUE([openWindowFeatures menuBarVisibility] == nil);
-//  EXPECT_TRUE([openWindowFeatures statusBarVisibility] == nil);
-//  EXPECT_TRUE([openWindowFeatures toolbarsVisibility] == nil);
-//  EXPECT_TRUE([openWindowFeatures allowsResizing] == nil);
-//  EXPECT_TRUE([openWindowFeatures _locationBarVisibility] == nil);
-//  EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility] == nil);
-//  EXPECT_TRUE([openWindowFeatures _fullscreenDisplay] == nil);
-//  EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
+    EXPECT_FALSE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
+    EXPECT_TRUE([openWindowFeatures menuBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures statusBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures toolbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures allowsResizing] == nil);
+    EXPECT_TRUE([openWindowFeatures _popup] == nil);
+    EXPECT_TRUE([openWindowFeatures _locationBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _fullscreenDisplay] == nil);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
     openWindowFeatures = nullptr;
 
-    NSString *featuresStringAllSpecifiedAndTrue = @"menubar=yes,status=yes,toolbar=yes,resizable=yes,location=yes,scrollbars=yes,fullscreen=yes";
+    NSString *featuresStringOnlyNonPopupSpecifiedAndTrue = @"noopener=true,noreferrer=true";
+    [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringOnlyNonPopupSpecifiedAndTrue] completionHandler:nil];
+    TestWebKitAPI::Util::run(&isDone);
+    isDone = false;
+
+    EXPECT_FALSE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
+    EXPECT_TRUE([openWindowFeatures menuBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures statusBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures toolbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures allowsResizing] == nil);
+    EXPECT_TRUE([openWindowFeatures _popup] == nil);
+    EXPECT_TRUE([openWindowFeatures _locationBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _fullscreenDisplay] == nil);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
+    openWindowFeatures = nullptr;
+
+    NSString *featuresStringOnlyNonPopupSpecifiedAndFalse = @"noopener=false,noreferrer=false";
+    [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringOnlyNonPopupSpecifiedAndFalse] completionHandler:nil];
+    TestWebKitAPI::Util::run(&isDone);
+    isDone = false;
+
+    EXPECT_FALSE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
+    EXPECT_TRUE([openWindowFeatures menuBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures statusBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures toolbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures allowsResizing] == nil);
+    EXPECT_TRUE([openWindowFeatures _popup] == nil);
+    EXPECT_TRUE([openWindowFeatures _locationBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _fullscreenDisplay] == nil);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
+    openWindowFeatures = nullptr;
+
+    NSString *featuresStringAllSpecifiedAndTrue = @"popup=yes,menubar=yes,status=yes,toolbar=yes,resizable=yes,location=yes,scrollbars=yes,fullscreen=yes";
     [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringAllSpecifiedAndTrue] completionHandler:nil];
     TestWebKitAPI::Util::run(&isDone);
     isDone = false;
 
+    EXPECT_TRUE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
     EXPECT_TRUE([openWindowFeatures menuBarVisibility].boolValue);
     EXPECT_TRUE([openWindowFeatures statusBarVisibility].boolValue);
     EXPECT_TRUE([openWindowFeatures toolbarsVisibility].boolValue);
     EXPECT_TRUE([openWindowFeatures allowsResizing].boolValue);
+    EXPECT_TRUE([openWindowFeatures _popup].boolValue);
     EXPECT_TRUE([openWindowFeatures _locationBarVisibility].boolValue);
     EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility].boolValue);
     EXPECT_TRUE([openWindowFeatures _fullscreenDisplay].boolValue);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
     openWindowFeatures = nullptr;
 
-    NSString *featuresStringAllSpecifiedAndFalse = @"menubar=no,status=no,toolbar=no,resizable=no,location=no,scrollbars=no,fullscreen=no";
+    NSString *featuresStringAllSpecifiedAndFalse = @"popup=no,menubar=no,status=no,toolbar=no,resizable=no,location=no,scrollbars=no,fullscreen=no";
     [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringAllSpecifiedAndFalse] completionHandler:nil];
     TestWebKitAPI::Util::run(&isDone);
     isDone = false;
 
+    EXPECT_FALSE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
     EXPECT_FALSE([openWindowFeatures menuBarVisibility].boolValue);
     EXPECT_FALSE([openWindowFeatures statusBarVisibility ].boolValue);
     EXPECT_FALSE([openWindowFeatures toolbarsVisibility].boolValue);
-//  https://bugs.webkit.org/show_bug.cgi?id=174388 - This property doesn't accurately reflect the parameters passed by the webpage.
-//  EXPECT_FALSE([openWindowFeatures allowsResizing].boolValue);
+    EXPECT_FALSE([openWindowFeatures allowsResizing].boolValue);
+    EXPECT_FALSE([openWindowFeatures _popup].boolValue);
     EXPECT_FALSE([openWindowFeatures _locationBarVisibility].boolValue);
     EXPECT_FALSE([openWindowFeatures _scrollbarsVisibility].boolValue);
     EXPECT_FALSE([openWindowFeatures _fullscreenDisplay].boolValue);
+    EXPECT_FALSE([openWindowFeatures _dialogDisplay].boolValue);
+    openWindowFeatures = nullptr;
+
+    NSString *featuresStringAllSpecifiedWithoutValues = @"popup,menubar,status,toolbar,resizable,location,scrollbars,fullscreen";
+    [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringAllSpecifiedWithoutValues] completionHandler:nil];
+    TestWebKitAPI::Util::run(&isDone);
+    isDone = false;
+
+    EXPECT_TRUE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
+    EXPECT_TRUE([openWindowFeatures menuBarVisibility].boolValue);
+    EXPECT_TRUE([openWindowFeatures statusBarVisibility ].boolValue);
+    EXPECT_TRUE([openWindowFeatures toolbarsVisibility].boolValue);
+    EXPECT_TRUE([openWindowFeatures allowsResizing].boolValue);
+    EXPECT_TRUE([openWindowFeatures _popup].boolValue);
+    EXPECT_TRUE([openWindowFeatures _locationBarVisibility].boolValue);
+    EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility].boolValue);
+    EXPECT_TRUE([openWindowFeatures _fullscreenDisplay].boolValue);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
+    openWindowFeatures = nullptr;
+
+    NSString *featuresStringWithUnknownFeatures = @"foo=bar";
+    [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringWithUnknownFeatures] completionHandler:nil];
+    TestWebKitAPI::Util::run(&isDone);
+    isDone = false;
+
+    EXPECT_TRUE([openWindowFeatures _wantsPopup]);
+    EXPECT_TRUE([openWindowFeatures _hasAdditionalFeatures]);
+    EXPECT_TRUE([openWindowFeatures menuBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures statusBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures toolbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures allowsResizing] == nil);
+    EXPECT_TRUE([openWindowFeatures _popup] == nil);
+    EXPECT_TRUE([openWindowFeatures _locationBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _fullscreenDisplay] == nil);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
+    openWindowFeatures = nullptr;
+
+    NSString *featuresStringGarbage = @",,   =   ,   ";
+    [webView evaluateJavaScript:[NSString stringWithFormat:windowOpenFormatString, featuresStringGarbage] completionHandler:nil];
+    TestWebKitAPI::Util::run(&isDone);
+    isDone = false;
+
+    EXPECT_FALSE([openWindowFeatures _wantsPopup]);
+    EXPECT_FALSE([openWindowFeatures _hasAdditionalFeatures]);
+    EXPECT_TRUE([openWindowFeatures menuBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures statusBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures toolbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures allowsResizing] == nil);
+    EXPECT_TRUE([openWindowFeatures _popup] == nil);
+    EXPECT_TRUE([openWindowFeatures _locationBarVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _scrollbarsVisibility] == nil);
+    EXPECT_TRUE([openWindowFeatures _fullscreenDisplay] == nil);
+    EXPECT_TRUE([openWindowFeatures _dialogDisplay] == nil);
     openWindowFeatures = nullptr;
 }
 


### PR DESCRIPTION
#### 301fe8a7cb268ab64cc6c4debd43ba3e66c35e59
<pre>
REGRESSION (Safari 16.3): Passing &quot;noopener&quot; as third argument opens tabs into new window
<a href="https://bugs.webkit.org/show_bug.cgi?id=259093">https://bugs.webkit.org/show_bug.cgi?id=259093</a>
rdar://112086061

Reviewed by BJ Burg and Chris Dumez.

The changes herein bring WebKit up to the HTML specs for window.open().

First, this commit now parses the popup field which is specified in the specs but
was missing in our parser. We also start parsing the resizable field which is defined
in our API but was never parsed. Finally, we mark all other member fields of optional
rather than setting a default value for each of them.

Second, this adds the member fields wantsPopup and hasAdditionalFeatures:
hasAdditionalFeatures is serialized and sent to the UI Process to indicate that we
detected other strings than the ones we normally parse.

The field wantsPopup implements the algorithm described here:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#apis-for-creating-and-navigating-browsing-contexts-by-name">https://html.spec.whatwg.org/multipage/nav-history-apis.html#apis-for-creating-and-navigating-browsing-contexts-by-name</a>
aimed at determining whether we should display a popup or not. Its value is determined
in the following way:
  - features noopener and noreferrer do not count towards the tested feature string.
  - empty features (two commas in a row), strings made of spaces only do not towards
    the tested feature string. So spaces and commas don&apos;t make the string not empty.
  - every other words or characters are counted.

As such the first test to determine the value of wantsPopup is to check whether any
feature is defined or if the string contains additional features, the latter flag is
only set if the string contains anything but spaces and commas. This matches the
behavior from other browsers and prescribed by the specs.

Finally, despite being declared as nullable, the corresponding properties in WKWindowFeatures
could never be in fact nil; changing all member fields in WindowFeatures to std::optional
allows us to return nil in the corresponding properties when those features are missing.
We also add private properties for the corresponding WindowFeatures member fields.

These changes ostensibly fixes the issue in question since we needed the ability to check
for the absence of the window features. However, to be correct a browser should adopt the
new properties as well.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::createWindow):

* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::createWindow):

* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):

* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::WindowFeatures::wantsPopup const):
  Implements the specs algorithm to check if we need to get a popup. No features declared
  besides noopener and noreferrer means we do not want a popup.

(WebCore::parseWindowFeatures):
  Stop setting default values for the window features to avoid indicating that those features
  were declared in the string. Compute wantsPopup after we are done parsing the string.

(WebCore::setWindowFeature):
  Add a parse step for the popup feature and set the additional features when they are not empty
  strings or strings made of spaces.

(WebCore::parseDialogFeatures):
  Dialogs are always popups.

* Source/WebCore/page/WindowFeatures.h:
  Make all potential features optional. Add convenience member functions to use instead of
  using noopener and noreferrer directly.

(WebCore::WindowFeatures::wantsNoOpener const):
(WebCore::WindowFeatures::wantsNoReferrer const):

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
  Match the declaration above. Serialize the three new fields.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
  Save the new fields in the window feature dictionary for legacy clients.

* Source/WebKit/UIProcess/API/Cocoa/WKWindowFeatures.mm:
(-[WKWindowFeatures menuBarVisibility]):
(-[WKWindowFeatures statusBarVisibility]):
(-[WKWindowFeatures toolbarsVisibility]):
(-[WKWindowFeatures allowsResizing]):
(-[WKWindowFeatures _wantsPopup]):
(-[WKWindowFeatures _hasAdditionalFeatures]):
(-[WKWindowFeatures _popup]):
(-[WKWindowFeatures _locationBarVisibility]):
(-[WKWindowFeatures _scrollbarsVisibility]):
(-[WKWindowFeatures _fullscreenDisplay]):
(-[WKWindowFeatures _dialogDisplay]):

* Source/WebKit/UIProcess/API/Cocoa/WKWindowFeaturesPrivate.h:
  Check if the value is defined and return it as a boolean otherwise return nil.

* Source/WebKit/UIProcess/API/glib/WebKitWindowProperties.cpp:
  Convert optional features into glib API.

(webkitWindowPropertiesSetGeometry):
(webkitWindowPropertiesSetWantsPopup):

* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):
  Write the new fields in the window feature dictionary for legacy clients.
  Only write optional fields if they are not null.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/OpenAndCloseWindow.mm:
(TEST(WebKit, OpenWindowFeatures)):
  - Reenable the tests checking for the nil case when the string is empty.
  - Add checks for the new fields in the API.
  - Add tests for noopener and noreferrer features.
  - Add test for hasAdditionalFeatures.
  - Add test for a string containing only separators.

Canonical link: <a href="https://commits.webkit.org/267354@main">https://commits.webkit.org/267354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0205dfc4e8d32d18b178c0bfed179e65a6070e0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17551 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18662 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14599 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17995 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13020 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14582 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3919 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->