### PR TITLE
[GStreamer][WebCodecs] Circular references in video decoder leading to memory leaks

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
@@ -37,9 +37,9 @@ class IntSize;
 
 class ImageGStreamer : public RefCounted<ImageGStreamer> {
 public:
-    static RefPtr<ImageGStreamer> createImage(GRefPtr<GstSample>&& sample)
+    static Ref<ImageGStreamer> createImage(GRefPtr<GstSample>&& sample)
     {
-        return adoptRef(new ImageGStreamer(WTFMove(sample)));
+        return adoptRef(*new ImageGStreamer(WTFMove(sample)));
     }
     ~ImageGStreamer();
 

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
@@ -171,6 +171,8 @@ ImageGStreamer::~ImageGStreamer()
     // cairo_surface_t was created using cairo_image_surface_create_for_data().
     if (m_frameMapped)
         gst_video_frame_unmap(&m_videoFrame);
+
+    m_sample.clear();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### dfa421425d517ac2b7822c9b758cacb9d52743b2
<pre>
[GStreamer][WebCodecs] Circular references in video decoder leading to memory leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=260423">https://bugs.webkit.org/show_bug.cgi?id=260423</a>

Reviewed by Xabier Rodriguez-Calvar.

Circular references between the GStreamerInternalVideoDecoder and its harness through captured
references in lambdas was preventing proper cleanup of the harness when closing the decoder. Using
WeakPtrs instead of strong Refs in captured variables fixes the issue.

Also, driving-by, fixing the ImageGStreamer API to fit with our style guidelines and making sure the
sample is cleared *after* the associated video frame is un-mapped.

* Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h:
(WebCore::ImageGStreamer::createImage):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp:
(WebCore::ImageGStreamer::~ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::harnessedElement const):
(WebCore::GStreamerVideoDecoder::create):
(WebCore::GStreamerVideoDecoder::~GStreamerVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::decode):

Canonical link: <a href="https://commits.webkit.org/267132@main">https://commits.webkit.org/267132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a38c5a768ba2fece01dc1ef6acf22ad15e464b88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16197 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18300 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21153 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17674 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12725 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14259 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3763 "layout-tests (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18628 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1926 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->