### PR TITLE
[GStreamer] Harness: Basic segment handling

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -85,7 +85,7 @@ public:
     }
     ~GStreamerElementHarness();
 
-    void start(GRefPtr<GstCaps>&&);
+    void start(GRefPtr<GstCaps>&&, std::optional<const GstSegment*>&& = { });
     bool isStarted() const { return m_playing.loadRelaxed(); }
 
     bool pushSample(GRefPtr<GstSample>&&);
@@ -112,7 +112,8 @@ private:
     bool srcQuery(GstPad*, GstObject*, GstQuery*);
     bool srcEvent(GstEvent*);
 
-    void pushStickyEvents(GRefPtr<GstCaps>&&);
+    void pushStickyEvents(GRefPtr<GstCaps>&&, std::optional<const GstSegment*>&& = { });
+    void pushSegmentEvent(std::optional<const GstSegment*>&& = { });
 
     GRefPtr<GstElement> m_element;
     ProcessBufferCallback m_processOutputBufferCallback;
@@ -127,7 +128,8 @@ private:
     Deque<GRefPtr<GstEvent>> m_srcEventQueue WTF_GUARDED_BY_LOCK(m_srcEventQueueLock);
 
     Atomic<bool> m_playing { false };
-    Atomic<bool> m_stickyEventsSent { false };
+    Atomic<bool> m_capsEventSent { false };
+    Atomic<bool> m_segmentEventSent { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2cf98196e729c6217a83c7ded6be8801eddf517a
<pre>
[GStreamer] Harness: Basic segment handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=260424">https://bugs.webkit.org/show_bug.cgi?id=260424</a>

Reviewed by Xabier Rodriguez-Calvar.

The pushSample API is now able to use the segment information from the sample, if it&apos;s available.
The corresponding sticky segment event is then coherent.

Flush handling also needed a change, after flush-stop we should re-push a segment event, but we were
not doing it, leading to runtime GStreamer warnings.

* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::start):
(WebCore::GStreamerElementHarness::pushStickyEvents):
(WebCore::GStreamerElementHarness::pushSegmentEvent):
(WebCore::GStreamerElementHarness::pushSample):
(WebCore::GStreamerElementHarness::pushBuffer):
(WebCore::GStreamerElementHarness::flush):
(WebCore::GStreamerElementHarness::flushBuffers):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
(WebCore::GStreamerElementHarness::start):
(WebCore::GStreamerElementHarness::pushStickyEvents):
(WebCore::GStreamerElementHarness::pushSegmentEvent):

Canonical link: <a href="https://commits.webkit.org/267083@main">https://commits.webkit.org/267083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a94365884c9ab81e1e172946856c3bee2c0dc01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14579 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17138 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18044 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20955 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17461 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12518 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14031 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3738 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->