### PR TITLE
LocalFrameView::frame() should return a LocalFrame

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -572,10 +572,7 @@ static void appendAccessibilityObject(RefPtr<AXCoreObject> object, Accessibility
         auto* frameView = dynamicDowncast<LocalFrameView>(widget);
         if (!frameView)
             return;
-        auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-        if (!localFrame)
-            return;
-        auto* document = localFrame->document();
+        auto* document = frameView->frame().document();
         if (!document || !document->hasLivingRenderTree())
             return;
         
@@ -1410,10 +1407,7 @@ VisiblePosition AccessibilityObject::visiblePositionForPoint(const IntPoint& poi
         auto* frameView = dynamicDowncast<LocalFrameView>(widget);
         if (!frameView)
             break;
-        auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-        if (!localFrame)
-            break;
-        auto* document = localFrame->document();
+        auto* document = frameView->frame().document();
         if (!document)
             break;
 
@@ -2044,11 +2038,7 @@ Document* AccessibilityObject::document() const
     if (!frameView)
         return nullptr;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-    if (!localFrame)
-        return nullptr;
-
-    return localFrame->document();
+    return frameView->frame().document();
 }
     
 Page* AccessibilityObject::page() const

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2222,11 +2222,7 @@ AccessibilitySVGRoot* AccessibilityRenderObject::remoteSVGRootElement(CreationCh
     if (!frameView)
         return nullptr;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-    if (!localFrame)
-        return nullptr;
-
-    auto* document = localFrame->document();
+    auto* document = frameView->frame().document();
     if (!is<SVGDocument>(document))
         return nullptr;
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -235,8 +235,7 @@ LayoutRect AccessibilityScrollView::elementRect() const
 Document* AccessibilityScrollView::document() const
 {
     if (auto* frameView = dynamicDowncast<LocalFrameView>(m_scrollView.get())) {
-        if (auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame()))
-            return localFrame->document();
+        return frameView->frame().document();
     }
     return AccessibilityObject::document();
 }

--- a/Source/WebCore/display/DisplayView.cpp
+++ b/Source/WebCore/display/DisplayView.cpp
@@ -52,7 +52,7 @@ View::~View()
 
 LocalFrame& View::frame() const
 {
-    return downcast<LocalFrame>(m_frameView.frame());
+    return m_frameView.frame();
 }
 
 Page* View::page() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2187,9 +2187,10 @@ void Document::resolveStyle(ResolveStyleType type)
         // As a result of the style recalculation, the currently hovered element might have been
         // detached (for example, by setting display:none in the :hover style), schedule another mouseMove event
         // to check if any other elements ended up under the mouse pointer due to re-layout.
-        if (m_hoveredElement && !m_hoveredElement->renderer() && is<LocalFrame>(frameView.frame()))
-            if (auto* localMainFrame = dynamicDowncast<LocalFrame>(downcast<LocalFrame>(frameView.frame()).mainFrame()))
+        if (m_hoveredElement && !m_hoveredElement->renderer()) {
+            if (auto* localMainFrame = dynamicDowncast<LocalFrame>(frameView.frame().mainFrame()))
                 localMainFrame->eventHandler().dispatchFakeMouseMoveEventSoon();
+        }
 
         ++m_styleRecalcCount;
         // FIXME: Assert ASSERT(!needsStyleRecalc()) here. fast/events/media-element-focus-tab.html hits this assertion.
@@ -2627,7 +2628,7 @@ void Document::attachToCachedFrame(CachedFrameBase& cachedFrame)
     RELEASE_ASSERT(cachedFrame.document() == this);
     ASSERT(cachedFrame.view());
     ASSERT(m_backForwardCacheState == Document::InBackForwardCache);
-    observeFrame(dynamicDowncast<LocalFrame>(cachedFrame.view()->frame()));
+    observeFrame(&cachedFrame.view()->frame());
 }
 
 void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1855,8 +1855,7 @@ bool FrameSelection::recomputeCaretRect()
 bool CaretBase::shouldRepaintCaret(const RenderView* view, bool isContentEditable) const
 {
     ASSERT(view);
-    auto* frame = dynamicDowncast<LocalFrame>(view->frameView().frame()); // The frame where the selection started.
-    bool caretBrowsing = frame && frame->settings().caretBrowsingEnabled();
+    bool caretBrowsing = view->frameView().frame().settings().caretBrowsingEnabled(); // The frame where the selection started.
     return (caretBrowsing || isContentEditable);
 }
 

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -92,15 +92,13 @@ void CachedFrameBase::restore()
     if (m_isMainFrame)
         m_view->setParentVisible(true);
 
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_view->frame());
-    if (!frame)
-        return;
+    Ref frame = m_view->frame();
     {
         Style::PostResolutionCallbackDisabler disabler(*m_document);
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         NavigationDisabler disableNavigation { nullptr }; // Disable navigation globally.
 
-        m_cachedFrameScriptData->restore(*frame);
+        m_cachedFrameScriptData->restore(frame);
 
         if (m_document->svgExtensions())
             m_document->accessSVGExtensions().unpauseAnimations();
@@ -131,7 +129,7 @@ void CachedFrameBase::restore()
         if (auto* domWindow = m_document->domWindow()) {
             // FIXME: Use Document::hasListenerType(). See <rdar://problem/9615482>.
             if (domWindow->scrollEventListenerCount() && frame->page())
-                frame->page()->chrome().client().setNeedsScrollNotifications(*frame, true);
+                frame->page()->chrome().client().setNeedsScrollNotifications(frame, true);
         }
     }
 #endif
@@ -217,8 +215,7 @@ void CachedFrame::open()
     ASSERT(m_view);
     ASSERT(m_document);
 
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(m_view->frame()))
-        localFrame->loader().open(*this);
+    m_view->frame().loader().open(*this);
 }
 
 void CachedFrame::clear()
@@ -257,8 +254,8 @@ void CachedFrame::destroy()
 
     m_document->domWindow()->willDestroyCachedFrame();
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_view->frame());
-    if (!m_isMainFrame && m_view->frame().page() && localFrame) {
+    Ref localFrame = m_view->frame();
+    if (!m_isMainFrame && m_view->frame().page()) {
         localFrame->loader().detachViewsAndDocumentLoader();
         localFrame->detachFromPage();
     }

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -128,10 +128,7 @@ void CachedPage::restore(Page& page)
 {
     ASSERT(m_cachedMainFrame);
     ASSERT(m_cachedMainFrame->view());
-#if ASSERT_ENABLED
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_cachedMainFrame->view()->frame());
-#endif
-    ASSERT(localFrame && localFrame->isMainFrame());
+    ASSERT(m_cachedMainFrame->view()->frame().isMainFrame());
     ASSERT(!page.subframeCount());
 
     auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -187,13 +187,10 @@ void InspectorInstrumentation::didChangeRendererForDOMNodeImpl(InstrumentingAgen
 
 void InspectorInstrumentation::didAddOrRemoveScrollbarsImpl(InstrumentingAgents& instrumentingAgents, LocalFrameView& frameView)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (!localFrame)
-        return;
     auto* cssAgent = instrumentingAgents.enabledCSSAgent();
     if (!cssAgent)
         return;
-    auto* document = localFrame->document();
+    auto* document = frameView.frame().document();
     if (!document)
         return;
     auto* documentElement = document->documentElement();

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -621,8 +621,7 @@ inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
 inline void InspectorInstrumentation::didAddOrRemoveScrollbars(LocalFrameView& frameView)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* agents = localFrame ? instrumentingAgents(localFrame->document()) : nullptr)
+    if (auto* agents = instrumentingAgents(frameView.frame().document()))
         didAddOrRemoveScrollbarsImpl(*agents, frameView);
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1957,7 +1957,7 @@ Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int d
     auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
     if (pageAgent) {
         if (auto* frameView = node->document().view())
-            value->setFrameId(pageAgent->frameId(dynamicDowncast<LocalFrame>(frameView->frame())));
+            value->setFrameId(pageAgent->frameId(&frameView->frame()));
     }
 
     if (is<Element>(*node)) {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -1050,8 +1050,8 @@ void InspectorPageAgent::didPaint(RenderObject& renderer, const LayoutRect& rect
     auto* view = renderer.document().view();
 
     LayoutRect rootRect = absoluteRect;
-    auto* localFrame = dynamicDowncast<LocalFrame>(view->frame());
-    if (localFrame && !localFrame->isMainFrame()) {
+    Ref localFrame = view->frame();
+    if (!localFrame->isMainFrame()) {
         IntRect rootViewRect = view->contentsToRootView(snappedIntRect(absoluteRect));
         auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame());
         if (!localMainFrame)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1405,7 +1405,7 @@ RefPtr<LocalFrame> EventHandler::subframeForTargetNode(Node* node)
     if (!is<LocalFrameView>(widget))
         return nullptr;
 
-    return dynamicDowncast<LocalFrame>(downcast<LocalFrameView>(*widget).frame());
+    return &downcast<LocalFrameView>(*widget).frame();
 }
 
 static bool isSubmitImage(Node* node)
@@ -5074,11 +5074,8 @@ bool EventHandler::passWheelEventToWidget(const PlatformWheelEvent& event, Widge
     auto* frameView = dynamicDowncast<LocalFrameView>(widget);
     if (!frameView)
         return false;
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-    if (!localFrame)
-        return false;
 
-    return localFrame->eventHandler().handleWheelEvent(event, processingSteps);
+    return frameView->frame().eventHandler().handleWheelEvent(event, processingSteps);
 }
 
 bool EventHandler::tabsToAllFormControls(KeyboardEvent*) const

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -347,7 +347,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
             return;
         }
 
-        ASSERT(is<LocalFrame>(frameView.frame()) && downcast<LocalFrame>(frameView.frame()).isMainFrame());
+        ASSERT(frameView.frame().isMainFrame());
         // FIXME: Handle the case of an implicit-root observer that has a target in a different frame tree.
         if (dynamicDowncast<LocalFrame>(targetRenderer->frame().mainFrame()) != &frameView.frame())
             return;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -749,7 +749,7 @@ LocalFrame* LocalFrame::frameForWidget(const Widget& widget)
 
     // Assume all widgets are either a FrameView or owned by a RenderWidget.
     // FIXME: That assumption is not right for scroll bars!
-    return dynamicDowncast<LocalFrame>(downcast<LocalFrameView>(widget).frame());
+    return &downcast<LocalFrameView>(widget).frame();
 }
 
 void LocalFrame::clearTimers(LocalFrameView *view, Document *document)
@@ -759,8 +759,7 @@ void LocalFrame::clearTimers(LocalFrameView *view, Document *document)
     view->layoutContext().unscheduleLayout();
     if (auto* timelines = document->timelinesController())
         timelines->suspendAnimations();
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(view->frame()))
-        localFrame->eventHandler().stopAutoscrollTimer();
+    view->frame().eventHandler().stopAutoscrollTimer();
 }
 
 void LocalFrame::clearTimers()

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2664,8 +2664,7 @@ bool LocalFrameView::scrollRectToVisible(const LayoutRect& absoluteRect, const R
 static ScrollPositionChangeOptions scrollPositionChangeOptionsForElement(const LocalFrameView& frameView, Element* element, const ScrollRectToVisibleOptions& options)
 {
     auto scrollPositionOptions = ScrollPositionChangeOptions::createProgrammatic();
-    if (is<LocalFrame>(frameView.frame())
-        && !downcast<LocalFrame>(frameView.frame()).eventHandler().autoscrollInProgress()
+    if (!frameView.frame().eventHandler().autoscrollInProgress()
         && element
         && useSmoothScrolling(options.behavior, element))
         scrollPositionOptions.animated = ScrollIsAnimated::Yes;
@@ -3319,8 +3318,7 @@ void LocalFrameView::adjustTiledBackingCoverage()
 
 static bool shouldEnableSpeculativeTilingDuringLoading(const LocalFrameView& view)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(view.frame());
-    auto* page = localFrame ? localFrame->page() : nullptr;
+    auto* page = view.frame().page();
     return page && view.isVisuallyNonEmpty() && !page->progress().isMainLoadProgressing();
 }
 
@@ -5966,7 +5964,7 @@ ScrollBehaviorForFixedElements LocalFrameView::scrollBehaviorForFixedElements() 
     return m_frame->settings().backgroundShouldExtendBeyondPage() ? StickToViewportBounds : StickToDocumentBounds;
 }
 
-Frame& LocalFrameView::frame() const
+LocalFrame& LocalFrameView::frame() const
 {
     return m_frame;
 }
@@ -6383,10 +6381,7 @@ float LocalFrameView::deviceScaleFactor() const
 
 void LocalFrameView::writeRenderTreeAsText(TextStream& ts, OptionSet<RenderAsTextFlag> behavior)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame());
-    if (!localFrame)
-        return;
-    externalRepresentationForLocalFrame(ts, *localFrame, behavior);
+    externalRepresentationForLocalFrame(ts, frame(), behavior);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -109,8 +109,7 @@ public:
     Type viewType() const final { return Type::Local; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 
-    // FIXME: This should return Frame. If it were a RemoteFrame, we would have a RemoteFrameView.
-    WEBCORE_EXPORT Frame& frame() const;
+    WEBCORE_EXPORT LocalFrame& frame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -184,7 +184,7 @@ void LocalFrameViewLayoutContext::performLayout()
     LayoutScope layoutScope(*this);
     TraceScope tracingScope(PerformLayoutStart, PerformLayoutEnd);
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    InspectorInstrumentation::willLayout(downcast<LocalFrame>(view().frame()));
+    InspectorInstrumentation::willLayout(view().frame());
     WeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
@@ -269,8 +269,8 @@ void LocalFrameViewLayoutContext::performLayout()
         view().didLayout(layoutRoot);
         runOrScheduleAsynchronousTasks();
     }
-    InspectorInstrumentation::didLayout(downcast<LocalFrame>(view().frame()), *layoutRoot);
-    DebugPageOverlays::didLayout(downcast<LocalFrame>(view().frame()));
+    InspectorInstrumentation::didLayout(view().frame(), *layoutRoot);
+    DebugPageOverlays::didLayout(view().frame());
 }
 
 void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks()
@@ -637,7 +637,7 @@ void LocalFrameViewLayoutContext::checkLayoutState()
 
 LocalFrame& LocalFrameViewLayoutContext::frame() const
 {
-    return downcast<LocalFrame>(view().frame());
+    return view().frame();
 }
 
 LocalFrameView& LocalFrameViewLayoutContext::view() const

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -118,11 +118,7 @@ static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& loca
     auto colorSpace = DestinationColorSpace::SRGB();
 
     ASSERT(document.view());
-    auto* localFrame = dynamicDowncast<LocalFrame>(document.view()->frame());
-    if (!localFrame)
-        return std::nullopt;
-
-    auto snapshot = snapshotFrameRect(*localFrame, IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
+    auto snapshot = snapshotFrameRect(document.view()->frame(), IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
     if (!snapshot)
         return std::nullopt;
 

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -486,10 +486,7 @@ bool EventHandler::passWheelEventToWidget(const PlatformWheelEvent& wheelEvent, 
         auto* frameView = dynamicDowncast<LocalFrameView>(widget);
         if (!frameView)
             return false;
-        auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-        if (!localFrame)
-            return false;
-        return localFrame->eventHandler().handleWheelEvent(wheelEvent, processingSteps);
+        return frameView->frame().eventHandler().handleWheelEvent(wheelEvent, processingSteps);
     }
 
     if ([currentNSEvent() type] != NSEventTypeScrollWheel || m_sendingEventToSubview)

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -228,8 +228,7 @@ void AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged(LocalFrameV
         return;
 
     setEventTrackingRegionsDirty();
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame()))
-        DebugPageOverlays::didChangeEventHandlers(*localFrame);
+    DebugPageOverlays::didChangeEventHandlers(frameView.frame());
 }
 
 void AsyncScrollingCoordinator::frameViewRootLayerDidChange(LocalFrameView& frameView)
@@ -320,8 +319,7 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
 
     setScrollingNodeScrollableAreaGeometry(scrollingNodeID, scrollableArea);
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView->frame());
-    bool inBackForwardCache = localFrame && localFrame->document()->backForwardCacheState() != Document::NotInBackForwardCache;
+    bool inBackForwardCache = frameView->frame().document()->backForwardCacheState() != Document::NotInBackForwardCache;
     bool isSnapshotting = m_page->isTakingSnapshotsForApplicationSuspension();
     bool inProgrammaticScroll = scrollableArea.currentScrollType() == ScrollType::Programmatic;
 
@@ -628,8 +626,7 @@ void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNo
 
     auto& frameView = *frameViewPtr;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameViewPtr->frame());
-    if (localFrame && !localFrame->isMainFrame()) {
+    if (!frameViewPtr->frame().isMainFrame()) {
         if (scrollingLayerPositionAction == ScrollingLayerPositionAction::Set)
             m_page->editorClient().subFrameScrollPositionChanged();
     }
@@ -864,7 +861,7 @@ void AsyncScrollingCoordinator::ensureRootStateNodeForFrameView(LocalFrameView& 
 
     // For non-main frames, it is only possible to arrive in this function from
     // RenderLayerCompositor::updateBacking where the node has already been created.
-    ASSERT(is<LocalFrame>(frameView.frame()) && downcast<LocalFrame>(frameView.frame()).isMainFrame());
+    ASSERT(frameView.frame().isMainFrame());
     insertNode(ScrollingNodeType::MainFrame, frameView.scrollingNodeID(), 0, 0);
 }
 
@@ -907,8 +904,7 @@ void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeI
     auto& settings = localMainFrame->settings();
     auto& frameScrollingNode = downcast<ScrollingStateFrameScrollingNode>(*stateNode);
 
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame()))
-        frameScrollingNode.setFrameScaleFactor(localFrame->frameScaleFactor());
+    frameScrollingNode.setFrameScaleFactor(frameView.frame().frameScaleFactor());
     frameScrollingNode.setHeaderHeight(frameView.headerHeight());
     frameScrollingNode.setFooterHeight(frameView.footerHeight());
     frameScrollingNode.setTopContentInset(frameView.topContentInset());

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -74,10 +74,7 @@ bool ScrollingCoordinator::coordinatesScrollingForFrameView(const LocalFrameView
     ASSERT(isMainThread());
     ASSERT(m_page);
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (!localFrame)
-        return false;
-
+    Ref localFrame = frameView.frame();
     if (!localFrame->isMainFrame() && !m_page->settings().scrollingTreeIncludesFrames()
 #if PLATFORM(MAC) || USE(NICOSIA)
         && !m_page->settings().asyncFrameScrollingEnabled()
@@ -214,16 +211,14 @@ void ScrollingCoordinator::frameViewFixedObjectsDidChange(LocalFrameView& frameV
 
 GraphicsLayer* ScrollingCoordinator::scrollContainerLayerForFrameView(LocalFrameView& frameView)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().scrollContainerLayer();
     return nullptr;
 }
 
 GraphicsLayer* ScrollingCoordinator::scrolledContentsLayerForFrameView(LocalFrameView& frameView)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().scrolledContentsLayer();
     return nullptr;
 }
@@ -231,8 +226,7 @@ GraphicsLayer* ScrollingCoordinator::scrolledContentsLayerForFrameView(LocalFram
 GraphicsLayer* ScrollingCoordinator::headerLayerForFrameView(LocalFrameView& frameView)
 {
 #if HAVE(RUBBER_BANDING)
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().headerLayer();
     return nullptr;
 #else
@@ -244,8 +238,7 @@ GraphicsLayer* ScrollingCoordinator::headerLayerForFrameView(LocalFrameView& fra
 GraphicsLayer* ScrollingCoordinator::footerLayerForFrameView(LocalFrameView& frameView)
 {
 #if HAVE(RUBBER_BANDING)
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().footerLayer();
     return nullptr;
 #else
@@ -256,16 +249,14 @@ GraphicsLayer* ScrollingCoordinator::footerLayerForFrameView(LocalFrameView& fra
 
 GraphicsLayer* ScrollingCoordinator::counterScrollingLayerForFrameView(LocalFrameView& frameView)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().fixedRootBackgroundLayer();
     return nullptr;
 }
 
 GraphicsLayer* ScrollingCoordinator::insetClipLayerForFrameView(LocalFrameView& frameView)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().clipLayer();
     return nullptr;
 }
@@ -273,10 +264,8 @@ GraphicsLayer* ScrollingCoordinator::insetClipLayerForFrameView(LocalFrameView& 
 GraphicsLayer* ScrollingCoordinator::contentShadowLayerForFrameView(LocalFrameView& frameView)
 {
 #if HAVE(RUBBER_BANDING)
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().layerForContentShadow();
-    
     return nullptr;
 #else
     UNUSED_PARAM(frameView);
@@ -286,8 +275,7 @@ GraphicsLayer* ScrollingCoordinator::contentShadowLayerForFrameView(LocalFrameVi
 
 GraphicsLayer* ScrollingCoordinator::rootContentsLayerForFrameView(LocalFrameView& frameView)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (auto* renderView = localFrame ? localFrame->contentRenderer() : nullptr)
+    if (auto* renderView = frameView.frame().contentRenderer())
         return renderView->compositor().rootContentsLayer();
     return nullptr;
 }
@@ -337,10 +325,9 @@ void ScrollingCoordinator::updateSynchronousScrollingReasons(LocalFrameView& fra
     if (hasVisibleSlowRepaintViewportConstrainedObjects(frameView))
         newSynchronousScrollingReasons.add(SynchronousScrollingReason::HasNonLayerViewportConstrainedObjects);
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
+    Ref localFrame = frameView.frame();
     auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame()); 
-    if (localFrame
-        && localMainFrame
+    if (localMainFrame
         && localMainFrame->document()
         && localFrame->document()->isImageDocument())
         newSynchronousScrollingReasons.add(SynchronousScrollingReason::IsImageDocument);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2081,8 +2081,7 @@ static RenderObject::BlockContentHeightType includeNonFixedHeight(const RenderOb
 
 void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWidth)
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(view().frameView().frame());
-    auto* document = localFrame ? localFrame->document() : nullptr;
+    auto* document = view().frameView().frame().document();
     if (!document)
         return;
 
@@ -2112,8 +2111,7 @@ void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWid
 
 void RenderElement::resetTextAutosizing()
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(view().frameView().frame());
-    auto* document = localFrame ? localFrame->document() : nullptr;
+    auto* document = view().frameView().frame().document();
     if (!document)
         return;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3908,8 +3908,7 @@ bool RenderLayer::hitTest(const HitTestRequest& request, const HitTestLocation& 
         if (settings.visualViewportEnabled() && settings.clientCoordinatesRelativeToLayoutViewport()) {
             auto& frameView = renderer().view().frameView();
             LayoutRect absoluteLayoutViewportRect = frameView.layoutViewportRect();
-            auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-            auto scaleFactor = localFrame ? localFrame->frameScaleFactor() : 1.0f;
+            auto scaleFactor = frameView.frame().frameScaleFactor();
             if (scaleFactor > 1)
                 absoluteLayoutViewportRect.scale(scaleFactor);
             hitTestArea.intersect(absoluteLayoutViewportRect);

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4362,8 +4362,7 @@ void RenderLayerCompositor::ensureRootLayer()
 
 #if PLATFORM(IOS_FAMILY)
         // Page scale is applied above this on iOS, so we'll just say that our root layer applies it.
-        auto* frame = dynamicDowncast<LocalFrame>(m_renderView.frameView().frame());
-        if (frame && frame->isMainFrame())
+        if (m_renderView.frameView().frame().isMainFrame())
             m_rootContentsLayer->setAppliesPageScale();
 #endif
 
@@ -4488,8 +4487,7 @@ void RenderLayerCompositor::attachRootLayer(RootLayerAttachment attachment)
             ASSERT_NOT_REACHED();
             break;
         case RootLayerAttachedViaChromeClient: {
-            if (auto* frame = dynamicDowncast<LocalFrame>(m_renderView.frameView().frame()))
-                page().chrome().client().attachRootGraphicsLayer(*frame, rootGraphicsLayer());
+            page().chrome().client().attachRootGraphicsLayer(m_renderView.frameView().frame(), rootGraphicsLayer());
             break;
         }
         case RootLayerAttachedViaEnclosingFrame: {
@@ -4539,11 +4537,9 @@ void RenderLayerCompositor::detachRootLayer()
         break;
     }
     case RootLayerAttachedViaChromeClient: {
-        if (auto* frame = dynamicDowncast<LocalFrame>(m_renderView.frameView().frame())) {
-            if (auto* scrollingCoordinator = this->scrollingCoordinator())
-                scrollingCoordinator->frameViewWillBeDetached(m_renderView.frameView());
-            page().chrome().client().attachRootGraphicsLayer(*frame, nullptr);
-        }
+        if (auto* scrollingCoordinator = this->scrollingCoordinator())
+            scrollingCoordinator->frameViewWillBeDetached(m_renderView.frameView());
+        page().chrome().client().attachRootGraphicsLayer(m_renderView.frameView().frame(), nullptr);
     }
     break;
     case RootLayerUnattached:
@@ -4573,7 +4569,7 @@ void RenderLayerCompositor::rootLayerAttachmentChanged()
     if (auto* backing = layer ? layer->backing() : nullptr)
         backing->updateDrawsContent();
 
-    if (auto* frame = dynamicDowncast<LocalFrame>(m_renderView.frameView().frame()); !frame || !frame->isMainFrame())
+    if (!m_renderView.frameView().frame().isMainFrame())
         return;
 
     Ref<GraphicsLayer> overlayHost = page().pageOverlayController().layerWithDocumentOverlays();

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -259,9 +259,8 @@ LayoutUnit RenderView::pageOrViewLogicalHeight() const
 LayoutUnit RenderView::clientLogicalWidthForFixedPosition() const
 {
     // FIXME: If the FrameView's fixedVisibleContentRect() is not empty, perhaps it should be consulted here too?
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView().frame());
-    if (localFrame && frameView().fixedElementsLayoutRelativeToFrame())
-        return LayoutUnit((isHorizontalWritingMode() ? frameView().visibleWidth() : frameView().visibleHeight()) / localFrame->frameScaleFactor());
+    if (frameView().fixedElementsLayoutRelativeToFrame())
+        return LayoutUnit((isHorizontalWritingMode() ? frameView().visibleWidth() : frameView().visibleHeight()) / frameView().frame().frameScaleFactor());
 
 #if PLATFORM(IOS_FAMILY)
     if (frameView().useCustomFixedPositionLayoutRect())
@@ -277,9 +276,8 @@ LayoutUnit RenderView::clientLogicalWidthForFixedPosition() const
 LayoutUnit RenderView::clientLogicalHeightForFixedPosition() const
 {
     // FIXME: If the FrameView's fixedVisibleContentRect() is not empty, perhaps it should be consulted here too?
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView().frame());
-    if (localFrame && frameView().fixedElementsLayoutRelativeToFrame())
-        return LayoutUnit((isHorizontalWritingMode() ? frameView().visibleHeight() : frameView().visibleWidth()) / localFrame->frameScaleFactor());
+    if (frameView().fixedElementsLayoutRelativeToFrame())
+        return LayoutUnit((isHorizontalWritingMode() ? frameView().visibleHeight() : frameView().visibleWidth()) / frameView().frame().frameScaleFactor());
 
 #if PLATFORM(IOS_FAMILY)
     if (frameView().useCustomFixedPositionLayoutRect())
@@ -632,10 +630,7 @@ bool RenderView::shouldUsePrintingLayout() const
 {
     if (!printing())
         return false;
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView().frame());
-    if (!localFrame)
-        return false;
-    return localFrame->shouldUsePrintingLayout();
+    return frameView().frame().shouldUsePrintingLayout();
 }
 
 LayoutRect RenderView::viewRect() const
@@ -758,10 +753,7 @@ void RenderView::setPageLogicalSize(LayoutSize size)
 
 float RenderView::zoomFactor() const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView().frame());
-    if (!localFrame)
-        return 1.0f;
-    return localFrame->pageZoomFactor();
+    return frameView().frame().pageZoomFactor();
 }
 
 FloatSize RenderView::sizeForCSSSmallViewportUnits() const

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -374,9 +374,8 @@ RenderWidget::ChildWidgetState RenderWidget::updateWidgetPosition()
     if (is<LocalFrameView>(*m_widget)) {
         LocalFrameView& frameView = downcast<LocalFrameView>(*m_widget);
         // Check the frame's page to make sure that the frame isn't in the process of being destroyed.
-        auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
+        Ref localFrame = frameView.frame();
         if ((widgetSizeChanged || frameView.needsLayout())
-            && localFrame
             && localFrame->page()
             && localFrame->document())
             frameView.layoutContext().layout();
@@ -416,10 +415,7 @@ bool RenderWidget::nodeAtPoint(const HitTestRequest& request, HitTestResult& res
         HitTestRequest newHitTestRequest(request.type() | HitTestRequest::Type::ChildFrameHitTest);
         HitTestResult childFrameResult(newHitTestLocation);
 
-        auto* localFrame = dynamicDowncast<LocalFrame>(childFrameView.frame());
-        if (!localFrame)
-            return false;
-        auto* document = localFrame->document();
+        auto* document = childFrameView.frame().document();
         if (!document)
             return false;
         bool isInsideChildFrame = document->hitTest(newHitTestRequest, newHitTestLocation, childFrameResult);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -640,9 +640,7 @@ static WebCore::FloatRect convertRectFromFrameClientToRootView(WebCore::LocalFra
         return frameView->contentsToRootView(frameView->clientToDocumentRect(clientRect));
 
     // If the frame delegates scrolling, contentsToRootView doesn't take into account scroll/zoom/scale.
-    auto* frame = dynamicDowncast<LocalFrame>(frameView->frame());
-    if (!frame)
-        return { };
+    Ref frame = frameView->frame();
     clientRect.scale(frame->pageZoomFactor() * frame->frameScaleFactor());
     clientRect.moveBy(frameView->contentsScrollPosition());
     return clientRect;
@@ -654,9 +652,7 @@ static WebCore::FloatPoint convertPointFromFrameClientToRootView(WebCore::LocalF
         return frameView->contentsToRootView(frameView->clientToDocumentPoint(clientPoint));
 
     // If the frame delegates scrolling, contentsToRootView doesn't take into account scroll/zoom/scale.
-    auto* frame = dynamicDowncast<LocalFrame>(frameView->frame());
-    if (!frame)
-        return { };
+    Ref frame = frameView->frame();
     clientPoint.scale(frame->pageZoomFactor() * frame->frameScaleFactor());
     clientPoint.moveBy(frameView->contentsScrollPosition());
     return clientPoint;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3831,8 +3831,7 @@ void WebPage::dynamicViewportSizeUpdate(const DynamicViewportSizeUpdate& target)
 
         HitTestResult hitTestResult = HitTestResult(unobscuredContentRectCenter);
 
-        auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frameView.frame());
-        if (auto* document = localFrame ? localFrame->document() : nullptr)
+        if (auto* document = frameView.frame().document())
             document->hitTest(HitTestRequest(), hitTestResult);
 
         if (Node* node = hitTestResult.innerNode()) {
@@ -3984,10 +3983,7 @@ void WebPage::dynamicViewportSizeUpdate(const DynamicViewportSizeUpdate& target)
     frameView.updateLayoutAndStyleIfNeededRecursive();
 
     // FIXME: Move settings from Frame to Frame and remove this check.
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    if (!localFrame)
-        return;
-    auto& settings = localFrame->settings();
+    auto& settings = frameView.frame().settings();
     LayoutRect documentRect = IntRect(frameView.scrollOrigin(), frameView.contentsSize());
     auto layoutViewportSize = LocalFrameView::expandedLayoutViewportSize(frameView.baseLayoutViewportSize(), LayoutSize(documentRect.size()), settings.layoutViewportHeightExpansionFactor());
     LayoutRect layoutViewportRect = LocalFrameView::computeUpdatedLayoutViewportRect(frameView.layoutViewportRect(), documentRect, LayoutSize(newUnobscuredContentRect.size()), LayoutRect(newUnobscuredContentRect), layoutViewportSize, frameView.minStableLayoutViewportOrigin(), frameView.maxStableLayoutViewportOrigin(), LayoutViewportConstraint::ConstrainedToDocumentRect);
@@ -4486,8 +4482,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
         frameView.setLayoutViewportOverrideRect(LayoutRect(visibleContentRectUpdateInfo.layoutViewportRect()));
         if (selectionIsInsideFixedPositionContainer(*localMainFrame)) {
             // Ensure that the next layer tree commit contains up-to-date caret/selection rects.
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame()))
-                localFrame->selection().setCaretRectNeedsUpdate();
+            frameView.frame().selection().setCaretRectNeedsUpdate();
             scheduleFullEditorStateUpdate();
         }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -646,9 +646,7 @@ void TiledCoreAnimationDrawingArea::updateDebugInfoLayer(bool showLayer)
 
 bool TiledCoreAnimationDrawingArea::shouldUseTiledBackingForFrameView(const LocalFrameView& frameView) const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    return (localFrame && localFrame->isMainFrame())
-        || m_webPage.corePage()->settings().asyncFrameScrollingEnabled();
+    return frameView.frame().isMainFrame() || m_webPage.corePage()->settings().asyncFrameScrollingEnabled();
 }
 
 PlatformCALayer* TiledCoreAnimationDrawingArea::layerForTransientZoom() const

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -124,8 +124,7 @@ void DrawingAreaWC::updatePreferences(const WebPreferencesStore& store)
 
 bool DrawingAreaWC::shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView& frameView) const
 {
-    auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frameView.frame());
-    return localFrame && localFrame->isRootFrame();
+    return frameView.frame().isRootFrame();
 }
 
 void DrawingAreaWC::setLayerTreeStateIsFrozen(bool isFrozen)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -180,9 +180,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView* v, int selectedIndex)
     }
     // Save the current event that triggered the popup, so we can clean up our event
     // state after the NSMenu goes away.
-    RefPtr frame { dynamicDowncast<LocalFrame>(v->frame()) };
-    if (!frame)
-        return;
+    Ref frame { v->frame() };
     RetainPtr<NSEvent> event = frame->eventHandler().currentNSEvent();
     
     Ref<PopupMenuMac> protector(*this);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -212,9 +212,7 @@ RetainPtr<NSImage> WebContextMenuClient::imageForCurrentSharingServicePickerItem
     if (!buffer)
         return nil;
 
-    auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frameView->frame());
-    if (!localFrame)
-        return nil;
+    Ref localFrame = frameView->frame();
 
     auto oldSelection = localFrame->selection().selection();
     localFrame->selection().setSelection(*makeRangeSelectingNode(*node), FrameSelection::SetSelectionOption::DoNotSetFocus);


### PR DESCRIPTION
#### 9f014099462e13f310e80507604a71a0db7787ff
<pre>
LocalFrameView::frame() should return a LocalFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=260437">https://bugs.webkit.org/show_bug.cgi?id=260437</a>
rdar://114145180

Reviewed by Tim Nguyen.

Make LocalFrameView::frame() return a LocalFrame instead of Frame.

The FIXME comment was made when Frame was named AbstractFrame and LocalFrame was named Frame, so the
FIXME on LocalFrameView::frame() is referring to LocalFrame, not Frame.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::appendAccessibilityObject):
(WebCore::AccessibilityObject::visiblePositionForPoint const):
(WebCore::AccessibilityObject::document const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::remoteSVGRootElement const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::document const):
* Source/WebCore/display/DisplayView.cpp:
(WebCore::Display::View::frame const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
(WebCore::Document::attachToCachedFrame):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::shouldRepaintCaret const):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore):
(WebCore::CachedFrame::open):
(WebCore::CachedFrame::destroy):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbarsImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbars):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForNode):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::didPaint):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::subframeForTargetNode):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::frameForWidget):
(WebCore::LocalFrame::clearTimers):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::scrollPositionChangeOptionsForElement):
(WebCore::shouldEnableSpeculativeTilingDuringLoading):
(WebCore::LocalFrameView::frame const):
(WebCore::LocalFrameView::writeRenderTreeAsText):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::frame const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::sampleColor):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passWheelEventToWidget):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged):
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
(WebCore::AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll):
(WebCore::AsyncScrollingCoordinator::ensureRootStateNodeForFrameView):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::coordinatesScrollingForFrameView const):
(WebCore::ScrollingCoordinator::scrollContainerLayerForFrameView):
(WebCore::ScrollingCoordinator::scrolledContentsLayerForFrameView):
(WebCore::ScrollingCoordinator::headerLayerForFrameView):
(WebCore::ScrollingCoordinator::footerLayerForFrameView):
(WebCore::ScrollingCoordinator::counterScrollingLayerForFrameView):
(WebCore::ScrollingCoordinator::insetClipLayerForFrameView):
(WebCore::ScrollingCoordinator::contentShadowLayerForFrameView):
(WebCore::ScrollingCoordinator::rootContentsLayerForFrameView):
(WebCore::ScrollingCoordinator::updateSynchronousScrollingReasons):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::adjustComputedFontSizesOnBlocks):
(WebCore::RenderElement::resetTextAutosizing):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTest):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::ensureRootLayer):
(WebCore::RenderLayerCompositor::attachRootLayer):
(WebCore::RenderLayerCompositor::detachRootLayer):
(WebCore::RenderLayerCompositor::rootLayerAttachmentChanged):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::clientLogicalWidthForFixedPosition const):
(WebCore::RenderView::clientLogicalHeightForFixedPosition const):
(WebCore::RenderView::shouldUsePrintingLayout const):
(WebCore::RenderView::zoomFactor const):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::updateWidgetPosition):
(WebCore::RenderWidget::nodeAtPoint):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::convertRectFromFrameClientToRootView):
(WebKit::convertPointFromFrameClientToRootView):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::dynamicViewportSizeUpdate):
(WebKit::WebPage::updateVisibleContentRects):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::shouldUseTiledBackingForFrameView const):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::shouldUseTiledBackingForFrameView const):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::show):
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::imageForCurrentSharingServicePickerItem):

Canonical link: <a href="https://commits.webkit.org/267074@main">https://commits.webkit.org/267074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/156c1e374d20c5dc33e6832214a3b8bd95b1e3c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15756 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18074 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20977 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17483 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12543 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14061 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3732 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18423 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1899 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14625 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->