### PR TITLE
Deploy more smart pointers in Source/WebKit/Shared/

### DIFF
--- a/Source/WebKit/Shared/APIWebArchive.mm
+++ b/Source/WebKit/Shared/APIWebArchive.mm
@@ -67,7 +67,7 @@ WebArchive::WebArchive(WebArchiveResource* mainResource, RefPtr<API::Array>&& su
     Vector<Ref<ArchiveResource>> coreArchiveResources;
     coreArchiveResources.reserveInitialCapacity(m_cachedSubresources->size());
     for (size_t i = 0; i < m_cachedSubresources->size(); ++i) {
-        auto resource = m_cachedSubresources->at<WebArchiveResource>(i);
+        RefPtr resource = m_cachedSubresources->at<WebArchiveResource>(i);
         ASSERT(resource);
         ASSERT(resource->coreArchiveResource());
         coreArchiveResources.uncheckedAppend(*resource->coreArchiveResource());
@@ -76,7 +76,7 @@ WebArchive::WebArchive(WebArchiveResource* mainResource, RefPtr<API::Array>&& su
     Vector<Ref<LegacyWebArchive>> coreSubframeLegacyWebArchives;
     coreSubframeLegacyWebArchives.reserveInitialCapacity(m_cachedSubframeArchives->size());
     for (size_t i = 0; i < m_cachedSubframeArchives->size(); ++i) {
-        auto subframeWebArchive = m_cachedSubframeArchives->at<WebArchive>(i);
+        RefPtr subframeWebArchive = m_cachedSubframeArchives->at<WebArchive>(i);
         ASSERT(subframeWebArchive);
         ASSERT(subframeWebArchive->coreLegacyWebArchive());
         coreSubframeLegacyWebArchives.uncheckedAppend(*subframeWebArchive->coreLegacyWebArchive());

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
@@ -57,7 +57,14 @@ const char* AuthenticationManager::supplementName()
 AuthenticationManager::AuthenticationManager(NetworkProcess& process)
     : m_process(process)
 {
-    m_process.addMessageReceiver(Messages::AuthenticationManager::messageReceiverName(), *this);
+    process.addMessageReceiver(Messages::AuthenticationManager::messageReceiverName(), *this);
+}
+
+AuthenticationManager::~AuthenticationManager() = default;
+
+inline CheckedRef<NetworkProcess> AuthenticationManager::checkedProcess() const
+{
+    return m_process;
 }
 
 AuthenticationChallengeIdentifier AuthenticationManager::addChallengeToChallengeMap(UniqueRef<Challenge>&& challenge)
@@ -117,7 +124,7 @@ void AuthenticationManager::didReceiveAuthenticationChallenge(PAL::SessionID ses
     std::optional<SecurityOriginData> topOriginData;
     if (topOrigin)
         topOriginData = *topOrigin;
-    m_process.send(Messages::NetworkProcessProxy::DidReceiveAuthenticationChallenge(sessionID, pageID, topOriginData, authenticationChallenge, negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes, challengeID));
+    checkedProcess()->send(Messages::NetworkProcessProxy::DidReceiveAuthenticationChallenge(sessionID, pageID, topOriginData, authenticationChallenge, negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes, challengeID));
 }
 
 void AuthenticationManager::didReceiveAuthenticationChallenge(IPC::MessageSender& download, const WebCore::AuthenticationChallenge& authenticationChallenge, ChallengeCompletionHandler&& completionHandler)
@@ -145,7 +152,7 @@ void AuthenticationManager::completeAuthenticationChallenge(AuthenticationChalle
 
 void AuthenticationManager::negotiatedLegacyTLS(WebPageProxyIdentifier pageID) const
 {
-    m_process.send(Messages::NetworkProcessProxy::NegotiatedLegacyTLS(pageID));
+    checkedProcess()->send(Messages::NetworkProcessProxy::NegotiatedLegacyTLS(pageID));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.h
@@ -34,6 +34,7 @@
 #include <WebCore/AuthenticationChallenge.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -68,6 +69,7 @@ class AuthenticationManager : public NetworkProcessSupplement, public IPC::Messa
     WTF_MAKE_NONCOPYABLE(AuthenticationManager);
 public:
     explicit AuthenticationManager(NetworkProcess&);
+    ~AuthenticationManager();
 
     static const char* supplementName();
 
@@ -79,6 +81,7 @@ public:
     void negotiatedLegacyTLS(WebPageProxyIdentifier) const;
 
 private:
+    CheckedRef<NetworkProcess> checkedProcess() const;
     struct Challenge {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         Challenge(WebPageProxyIdentifier pageID, const WebCore::AuthenticationChallenge& challenge, ChallengeCompletionHandler&& completionHandler)
@@ -104,7 +107,7 @@ private:
 
     Vector<AuthenticationChallengeIdentifier> coalesceChallengesMatching(AuthenticationChallengeIdentifier) const;
 
-    NetworkProcess& m_process;
+    CheckedRef<NetworkProcess> m_process;
 
     HashMap<AuthenticationChallengeIdentifier, UniqueRef<Challenge>> m_challenges;
 };

--- a/Source/WebKit/Shared/Cocoa/WKNSArray.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSArray.mm
@@ -51,7 +51,7 @@
 
 - (id)objectAtIndex:(NSUInteger)i
 {
-    API::Object* object = _array->at(i);
+    RefPtr object = _array->at(i);
     return object ? (id)object->wrapper() : [NSNull null];
 }
 

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -65,7 +65,7 @@ using namespace WebKit;
         return nil;
 
     bool exists;
-    API::Object* value = _dictionary->get((NSString *)key, exists);
+    RefPtr value = _dictionary->get((NSString *)key, exists);
     if (!exists)
         return nil;
 

--- a/Source/WebKit/Shared/EditingRange.cpp
+++ b/Source/WebKit/Shared/EditingRange.cpp
@@ -45,7 +45,7 @@ std::optional<WebCore::SimpleRange> EditingRange::toRange(WebCore::LocalFrame& f
         // directly in the document DOM, so serialization is problematic. Our solution is
         // to use the root editable element of the selection start as the positional base.
         // That fits with AppKit's idea of an input context.
-        auto* element = frame.selection().rootEditableElementOrDocumentElement();
+        RefPtr element = frame.selection().rootEditableElementOrDocumentElement();
         if (!element)
             return std::nullopt;
         return resolveCharacterRange(makeRangeSelectingNodeContents(*element), range);
@@ -57,7 +57,7 @@ std::optional<WebCore::SimpleRange> EditingRange::toRange(WebCore::LocalFrame& f
     if (!paragraphStart)
         return std::nullopt;
 
-    auto scopeEnd = makeBoundaryPointAfterNodeContents(paragraphStart->container->treeScope().rootNode());
+    auto scopeEnd = makeBoundaryPointAfterNodeContents(Ref { paragraphStart->container->treeScope().rootNode() });
     return WebCore::resolveCharacterRange({ WTFMove(*paragraphStart), WTFMove(scopeEnd) }, range);
 }
 
@@ -68,7 +68,7 @@ EditingRange EditingRange::fromRange(WebCore::LocalFrame& frame, const std::opti
     if (!range)
         return { };
 
-    auto* element = frame.selection().rootEditableElementOrDocumentElement();
+    RefPtr element = frame.selection().rootEditableElementOrDocumentElement();
     if (!element)
         return { };
 

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -75,13 +75,13 @@ static int sendTestMessage(const uint8_t* data, size_t size, void* context)
     auto messageContext = reinterpret_cast<SendMessageContext*>(context);
     if (messageContext->shouldStop)
         return 1;
-    auto& testedConnection = messageContext->connection;
-    if (!testedConnection.isValid())
+    Ref testedConnection = messageContext->connection;
+    if (!testedConnection->isValid())
         return 1;
     BinarySemaphore semaphore;
     auto decoder = IPC::Decoder::create(data, size, [&semaphore] (const uint8_t*, size_t) { semaphore.signal(); }, { }); // NOLINT
     if (decoder) {
-        testedConnection.dispatchIncomingMessageForTesting(WTFMove(decoder));
+        testedConnection->dispatchIncomingMessageForTesting(WTFMove(decoder));
         semaphore.wait();
     }
     return 0;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -873,7 +873,7 @@ static void dump(TextStream& ts, const ScrollingStateTree& stateTree, bool chang
     ts.dumpProperty("has new root node", stateTree.hasNewRootStateNode());
 
     if (stateTree.rootStateNode())
-        recursiveDumpNodes(ts, *stateTree.rootStateNode(), changedPropertiesOnly);
+        recursiveDumpNodes(ts, Ref { *stateTree.rootStateNode() }, changedPropertiesOnly);
 }
 
 String RemoteScrollingCoordinatorTransaction::description() const

--- a/Source/WebKit/Shared/UserData.cpp
+++ b/Source/WebKit/Shared/UserData.cpp
@@ -87,7 +87,7 @@ static bool shouldTransform(const API::Object& object, const UserData::Transform
             if (!keyValuePair.value)
                 continue;
 
-            if (shouldTransform(*keyValuePair.value, transformer))
+            if (shouldTransform(Ref { *keyValuePair.value }, transformer))
                 return true;
         }
     }
@@ -113,10 +113,11 @@ static RefPtr<API::Object> transformGraph(API::Object& object, const UserData::T
 
         API::Dictionary::MapType map;
         for (const auto& keyValuePair : dictionary.map()) {
-            if (!keyValuePair.value)
+            RefPtr value = keyValuePair.value;
+            if (!value)
                 map.add(keyValuePair.key, nullptr);
             else
-                map.add(keyValuePair.key, transformGraph(*keyValuePair.value, transformer));
+                map.add(keyValuePair.key, transformGraph(*value, transformer));
         }
         return API::Dictionary::create(WTFMove(map));
     }
@@ -165,7 +166,7 @@ void UserData::encode(IPC::Encoder& encoder, const API::Object& object)
         auto& array = static_cast<const API::Array&>(object);
         encoder << static_cast<uint64_t>(array.size());
         for (size_t i = 0; i < array.size(); ++i)
-            encode(encoder, array.at(i));
+            encode(encoder, RefPtr { array.at(i) }.get());
         break;
     }
 

--- a/Source/WebKit/Shared/WebConnection.cpp
+++ b/Source/WebKit/Shared/WebConnection.cpp
@@ -63,7 +63,8 @@ void WebConnection::didClose()
 
 void WebConnection::handleMessage(const String& messageName, const UserData& messageBody)
 {
-    m_client.didReceiveMessage(this, messageName, transformHandlesToObjects(messageBody.object()).get());
+    RefPtr protectedObject = messageBody.object();
+    m_client.didReceiveMessage(this, messageName, transformHandlesToObjects(protectedObject.get()).get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebContextMenuItem.cpp
+++ b/Source/WebKit/Shared/WebContextMenuItem.cpp
@@ -31,6 +31,7 @@
 
 #include "APIArray.h"
 #include <WebCore/ContextMenuItem.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
 
@@ -56,8 +57,8 @@ Ref<WebContextMenuItem> WebContextMenuItem::create(const String& title, bool ena
 
 WebContextMenuItem* WebContextMenuItem::separatorItem()
 {
-    static WebContextMenuItem* separatorItem = new WebContextMenuItem(WebContextMenuItemData(WebCore::SeparatorType, WebCore::ContextMenuItemTagNoAction, String(), true, false));
-    return separatorItem;
+    static NeverDestroyed<Ref<WebContextMenuItem>> separatorItem = adoptRef(*new WebContextMenuItem(WebContextMenuItemData(WebCore::SeparatorType, WebCore::ContextMenuItemTagNoAction, String(), true, false)));
+    return separatorItem->ptr();
 }
 
 Ref<API::Array> WebContextMenuItem::submenuItemsAsAPIArray() const

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -100,7 +100,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
             }
 
             imageText = [&]() -> String {
-                if (auto* element = dynamicDowncast<Element>(target.get())) {
+                if (RefPtr element = dynamicDowncast<Element>(target.get())) {
                     auto& title = element->attributeWithoutSynchronization(HTMLNames::titleAttr);
                     if (!title.isEmpty())
                         return title;
@@ -152,15 +152,15 @@ WebHitTestResultData::~WebHitTestResultData()
 
 IntRect WebHitTestResultData::elementBoundingBoxInWindowCoordinates(const WebCore::HitTestResult& hitTestResult)
 {
-    Node* node = hitTestResult.innerNonSharedNode();
+    RefPtr node = hitTestResult.innerNonSharedNode();
     if (!node)
         return IntRect();
 
-    auto* frame = node->document().frame();
+    RefPtr frame = node->document().frame();
     if (!frame)
         return IntRect();
 
-    auto* view = frame->view();
+    RefPtr view = frame->view();
     if (!view)
         return IntRect();
 


### PR DESCRIPTION
#### cc21d6f48180ca2d26d5f5db4809001a3b28dd5c
<pre>
Deploy more smart pointers in Source/WebKit/Shared/
<a href="https://bugs.webkit.org/show_bug.cgi?id=260440">https://bugs.webkit.org/show_bug.cgi?id=260440</a>

Reviewed by Wenson Hsieh.

Deployed more smart pointers.

* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::WebArchive):
* Source/WebKit/Shared/Authentication/AuthenticationManager.cpp:
(WebKit::AuthenticationManager::processChecked const): Added.
(WebKit::AuthenticationManager::AuthenticationManager):
(WebKit::AuthenticationManager::~AuthenticationManager):
(WebKit::AuthenticationManager::didReceiveAuthenticationChallenge):
(WebKit::AuthenticationManager::negotiatedLegacyTLS const):
* Source/WebKit/Shared/Authentication/AuthenticationManager.h:
* Source/WebKit/Shared/Cocoa/WKNSArray.mm:
(-[WKNSArray objectAtIndex:]):
* Source/WebKit/Shared/Cocoa/WKNSDictionary.mm:
(-[WKNSDictionary objectForKey:]):
* Source/WebKit/Shared/EditingRange.cpp:
(WebKit::EditingRange::toRange):
(WebKit::EditingRange::fromRange):
* Source/WebKit/Shared/IPCTester.cpp:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::dump):
* Source/WebKit/Shared/UserData.cpp:
(WebKit::shouldTransform):
(WebKit::transformGraph):
(WebKit::UserData::encode):
* Source/WebKit/Shared/WebConnection.cpp:
(WebKit::WebConnection::handleMessage):
* Source/WebKit/Shared/WebContextMenuItem.cpp:
(WebKit::WebContextMenuItem::separatorItem):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
(WebKit::WebHitTestResultData::elementBoundingBoxInWindowCoordinates):

Canonical link: <a href="https://commits.webkit.org/267232@main">https://commits.webkit.org/267232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccd55a3667a705eb8c099ab072457b98279b3a89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17440 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18487 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13874 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21298 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12878 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18799 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1964 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->