### PR TITLE
Deploy more smart pointers in WebsiteDataStore.cpp

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -492,6 +492,7 @@ private:
 
     WebsiteDataStore();
     static WorkQueue& websiteDataStoreIOQueue();
+    Ref<NetworkProcessProxy> protectedNetworkProcess() const;
 
     // FIXME: Only Cocoa ports respect ShouldCreateDirectory, so you cannot rely on it to create
     // directories. This is confusing.


### PR DESCRIPTION
#### c25e2794cc5efd55ee34156ebe6cfe62b1890c33
<pre>
Deploy more smart pointers in WebsiteDataStore.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=260441">https://bugs.webkit.org/show_bug.cgi?id=260441</a>

Reviewed by Sihui Liu.

Make more use of smart pointers in this file. Most notably, store NetworkProcessProxy
in a local Ref before calling any non-trivial member functions on it.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::protectedNetworkProcess const): Added.
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::setServiceWorkerTimeoutForTesting):
(WebKit::WebsiteDataStore::resetServiceWorkerTimeoutForTesting):
(WebKit::WebsiteDataStore::setMaxStatisticsEntries):
(WebKit::WebsiteDataStore::setPruneEntriesDownTo):
(WebKit::WebsiteDataStore::setGrandfatheringTime):
(WebKit::WebsiteDataStore::setMinimumTimeBetweenDataRecordsRemoval):
(WebKit::WebsiteDataStore::dumpResourceLoadStatistics):
(WebKit::WebsiteDataStore::isPrevalentResource):
(WebKit::WebsiteDataStore::isGrandfathered):
(WebKit::WebsiteDataStore::setPrevalentResource):
(WebKit::WebsiteDataStore::setPrevalentResourceForDebugMode):
(WebKit::WebsiteDataStore::isVeryPrevalentResource):
(WebKit::WebsiteDataStore::setVeryPrevalentResource):
(WebKit::WebsiteDataStore::setShouldClassifyResourcesBeforeDataRecordsRemoval):
(WebKit::WebsiteDataStore::setSubframeUnderTopFrameDomain):
(WebKit::WebsiteDataStore::isRegisteredAsSubFrameUnder):
(WebKit::WebsiteDataStore::setSubresourceUnderTopFrameDomain):
(WebKit::WebsiteDataStore::isRegisteredAsSubresourceUnder):
(WebKit::WebsiteDataStore::setSubresourceUniqueRedirectTo):
(WebKit::WebsiteDataStore::setSubresourceUniqueRedirectFrom):
(WebKit::WebsiteDataStore::setTopFrameUniqueRedirectTo):
(WebKit::WebsiteDataStore::setTopFrameUniqueRedirectFrom):
(WebKit::WebsiteDataStore::isRegisteredAsRedirectingTo):
(WebKit::WebsiteDataStore::clearPrevalentResource):
(WebKit::WebsiteDataStore::resetParametersToDefaultValues):
(WebKit::WebsiteDataStore::scheduleClearInMemoryAndPersistent):
(WebKit::WebsiteDataStore::getResourceLoadStatisticsDataSummary):
(WebKit::WebsiteDataStore::scheduleCookieBlockingUpdate):
(WebKit::WebsiteDataStore::scheduleStatisticsAndDataRecordsProcessing):
(WebKit::WebsiteDataStore::statisticsDatabaseHasAllTables):
(WebKit::WebsiteDataStore::setLastSeen):
(WebKit::WebsiteDataStore::domainIDExistsInDatabase):
(WebKit::WebsiteDataStore::mergeStatisticForTesting):
(WebKit::WebsiteDataStore::insertExpiredStatisticForTesting):
(WebKit::WebsiteDataStore::setNotifyPagesWhenDataRecordsWereScanned):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsTimeAdvanceForTesting):
(WebKit::WebsiteDataStore::setIsRunningResourceLoadStatisticsTest):
(WebKit::WebsiteDataStore::getAllStorageAccessEntries):
(WebKit::WebsiteDataStore::setTimeToLiveUserInteraction):
(WebKit::WebsiteDataStore::logUserInteraction):
(WebKit::WebsiteDataStore::hasHadUserInteraction):
(WebKit::WebsiteDataStore::isRelationshipOnlyInDatabaseOnce):
(WebKit::WebsiteDataStore::clearUserInteraction):
(WebKit::WebsiteDataStore::setGrandfathered):
(WebKit::WebsiteDataStore::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebsiteDataStore::resetCrossSiteLoadsWithLinkDecorationForTesting):
(WebKit::WebsiteDataStore::deleteCookiesForTesting):
(WebKit::WebsiteDataStore::hasLocalStorageForTesting const):
(WebKit::WebsiteDataStore::hasIsolatedSessionForTesting const):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldDowngradeReferrerForTesting):
(WebKit::WebsiteDataStore::setThirdPartyCookieBlockingMode):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldEnbleSameSiteStrictEnforcementForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsToSameSiteStrictCookiesForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting):
(WebKit::WebsiteDataStore::syncLocalStorage):
(WebKit::WebsiteDataStore::storeServiceWorkerRegistrations):
(WebKit::WebsiteDataStore::setCacheMaxAgeCapForPrevalentResources):
(WebKit::WebsiteDataStore::resetCacheMaxAgeCapForPrevalentResources):
(WebKit::WebsiteDataStore::allowSpecificHTTPSCertificateForHost):
(WebKit::WebsiteDataStore::allowTLSCertificateChainForLocalPCMTesting):
(WebKit::WebsiteDataStore::getNetworkProcessConnection):
(WebKit::WebsiteDataStore::sendNetworkProcessPrepareToSuspendForTesting):
(WebKit::WebsiteDataStore::sendNetworkProcessWillSuspendImminentlyForTesting):
(WebKit::WebsiteDataStore::sendNetworkProcessDidResume):
(WebKit::WebsiteDataStore::setTrackingPreventionEnabled):
(WebKit::WebsiteDataStore::setStatisticsTestingCallback):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsDebugMode):
(WebKit::WebsiteDataStore::isResourceLoadStatisticsEphemeral const):
(WebKit::WebsiteDataStore::setPrivateClickMeasurementDebugMode):
(WebKit::WebsiteDataStore::storePrivateClickMeasurement):
(WebKit::WebsiteDataStore::closeDatabases):
(WebKit::WebsiteDataStore::setAllowsAnySSLCertificateForWebSocket):
(WebKit::WebsiteDataStore::resetQuota):
(WebKit::WebsiteDataStore::resetStoragePersistedState):
(WebKit::WebsiteDataStore::renameOriginInWebsiteData):
(WebKit::WebsiteDataStore::originDirectoryForTesting):
(WebKit::WebsiteDataStore::hasAppBoundSession const):
(WebKit::WebsiteDataStore::clearAppBoundSession):
(WebKit::WebsiteDataStore::setAppBoundDomainsForITP):
(WebKit::WebsiteDataStore::setManagedDomainsForITP):
(WebKit::WebsiteDataStore::updateBundleIdentifierInNetworkProcess):
(WebKit::WebsiteDataStore::clearBundleIdentifierInNetworkProcess):
(WebKit::WebsiteDataStore::countNonDefaultSessionSets):
(WebKit::WebsiteDataStore::setEmulatedConditions):
(WebKit::WebsiteDataStore::createDownloadProxy):
(WebKit::WebsiteDataStore::download):
(WebKit::WebsiteDataStore::resumeDownload):
(WebKit::WebsiteDataStore::clearProxyConfigData):
(WebKit::WebsiteDataStore::setProxyConfigData):

Canonical link: <a href="https://commits.webkit.org/267150@main">https://commits.webkit.org/267150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99402ee118cd6f1483d80e75b434d77b6d698d27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14774 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17278 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18257 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13654 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21118 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17632 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12693 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18591 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1938 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->