### PR TITLE
Move off of UIKit SPI: `UIURLDragPreviewView`

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -125,8 +125,6 @@
 #import <UIKit/UIDragPreview_Private.h>
 #import <UIKit/UIDragSession.h>
 #import <UIKit/UIDropInteraction.h>
-#import <UIKit/UIPreviewInteraction.h>
-#import <UIKit/UIURLDragPreviewView.h>
 #import <UIKit/_UITextDragCaretView.h>
 #endif
 
@@ -1101,10 +1099,6 @@ WTF_EXTERN_C_END
 -(void)insertAtPosition:(UITextPosition *)position;
 -(void)updateToPosition:(UITextPosition *)position;
 -(void)remove;
-@end
-
-@interface UIURLDragPreviewView : UIView
-+ (instancetype)viewWithTitle:(NSString *)title URL:(NSURL *)url;
 @end
 
 @interface _UIParallaxTransitionPanGestureRecognizer : UIScreenEdgePanGestureRecognizer

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
@@ -47,7 +47,6 @@ namespace WebKit {
 
 struct DragSourceState {
     OptionSet<WebCore::DragSourceAction> action;
-    CGPoint adjustedOrigin { CGPointZero };
     CGRect dragPreviewFrameInRootViewCoordinates { CGRectZero };
     RetainPtr<UIImage> image;
     std::optional<WebCore::TextIndicatorData> indicatorData;


### PR DESCRIPTION
#### 9a057d296f1ea27ce5cfea7db29905082a7fb3f6
<pre>
Move off of UIKit SPI: `UIURLDragPreviewView`
<a href="https://bugs.webkit.org/show_bug.cgi?id=260448">https://bugs.webkit.org/show_bug.cgi?id=260448</a>
rdar://114165890

Reviewed by Aditya Keerthi and Tim Horton.

Replace usages of `UIURLDragPreviewView` in WebKit with `+[UIDragPreview previewForURL:title:]`.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove the (now-unused) SPI declaration and header include.

* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::stageDragItem):

We no longer need to plumb the `center` point into the preview provider block, so we can also remove
the `adjustedOrigin` member while we&apos;re here.

(WebKit::DragDropInteractionState::updatePreviewsForActiveDragSources):

Use `+[UIDragPreview previewForURL:title:]` instead of directly creating a `UIURLDragPreviewView`.
There is a caveat here, which is that on visionOS (where we need to override the background color of
the preview by setting `-backgroundColor` on the preview parameters), we need to first use
`+previewForURL:title:` to make UIKit instantiate a `UIURLDragPreviewView`, which we can then use to
initialize a `UIDragPreview`.

Canonical link: <a href="https://commits.webkit.org/267102@main">https://commits.webkit.org/267102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a99588279f83ea147015bd0bb8c2f53ee6d8f75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14701 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16075 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18168 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14587 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12631 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14152 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->