### PR TITLE
Set <details> ToggleEvent oldState correctly for coalesced tasks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Adding open to 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
-PASS Removing open from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'
+PASS Adding open to 'details' and then removing open from that 'details' should fire only one toggle event at the 'details' element, with 'oldState: closed' and 'newState: closed'
 PASS Adding open to 'details' (display:none) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
 PASS Adding open to 'details' (no children) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
-PASS Calling open twice on 'details' fires only one toggle event, with 'oldState: closed' and 'newState: open'
-PASS Calling setAttribute('open', '') from 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
-PASS Calling removeAttribute('open') from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'
-PASS Setting open=true to opened 'details' element should not fire a toggle event at the 'details' element
-PASS Setting open=false to closed 'details' element should not fire a toggle event at the 'details' element
+PASS Adding open to 'details' and then removing open from that 'details' and then again adding open to that 'details' should fire only one toggle event at the 'details' element, with 'oldState: closed' and 'newState: closed'
+PASS Adding open to 'details' using setAttribute('open', '') should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
+PASS Adding open to 'details' and then calling removeAttribute('open') should fire only one toggle event at the 'details' element, with 'oldState: closed' and 'newState: closed'
+PASS Setting open=true on an opened 'details' element should not fire a toggle event at the 'details' element
+PASS Setting open=false on a closed 'details' element should not fire a toggle event at the 'details' element
 PASS Adding open to 'details' (not in the document) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'
 Lorem ipsum
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html
@@ -47,14 +47,14 @@
 </details>
 <script>
   var t1 = async_test("Adding open to 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
-  t2 = async_test("Removing open from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'"),
+  t2 = async_test("Adding open to 'details' and then removing open from that 'details' should fire only one toggle event at the 'details' element, with 'oldState: closed' and 'newState: closed'"),
   t3 = async_test("Adding open to 'details' (display:none) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
   t4 = async_test("Adding open to 'details' (no children) should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
-  t6 = async_test("Calling open twice on 'details' fires only one toggle event, with 'oldState: closed' and 'newState: open'"),
-  t7 = async_test("Calling setAttribute('open', '') from 'details' should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
-  t8 = async_test("Calling removeAttribute('open') from 'details' should fire a toggle event at the 'details' element, with 'oldState: open' and 'newState: closed'"),
-  t9 = async_test("Setting open=true to opened 'details' element should not fire a toggle event at the 'details' element"),
-  t10 = async_test("Setting open=false to closed 'details' element should not fire a toggle event at the 'details' element"),
+  t6 = async_test("Adding open to 'details' and then removing open from that 'details' and then again adding open to that 'details' should fire only one toggle event at the 'details' element, with 'oldState: closed' and 'newState: closed'"),
+  t7 = async_test("Adding open to 'details' using setAttribute('open', '') should fire a toggle event at the 'details' element, with 'oldState: closed' and 'newState: open'"),
+  t8 = async_test("Adding open to 'details' and then calling removeAttribute('open') should fire only one toggle event at the 'details' element, with 'oldState: closed' and 'newState: closed'"),
+  t9 = async_test("Setting open=true on an opened 'details' element should not fire a toggle event at the 'details' element"),
+  t10 = async_test("Setting open=false on a closed 'details' element should not fire a toggle event at the 'details' element"),
 
   details1 = document.getElementById('details1'),
   details2 = document.getElementById('details2'),
@@ -76,13 +76,15 @@
 
   details1.ontoggle = t1.step_func_done(function(evt) {
     assert_equals(evt.oldState, "closed");
-    assert_equals(evt.newState, "open");+
+    assert_equals(evt.newState, "open");
     assert_true(details1.open);
     testEvent(evt)
   });
   details1.open = true; // opens details1
 
   details2.ontoggle = t2.step_func_done(function(evt) {
+    assert_equals(evt.oldState, "closed");
+    assert_equals(evt.newState, "closed");
     assert_false(details2.open);
     testEvent(evt);
   });
@@ -90,7 +92,7 @@
 
   details3.ontoggle = t3.step_func_done(function(evt) {
     assert_equals(evt.oldState, "closed");
-    assert_equals(evt.newState, "open");+
+    assert_equals(evt.newState, "open");
     assert_true(details3.open);
     testEvent(evt);
   });
@@ -107,6 +109,8 @@
   async_test(function(t) {
     var details5 = document.createElement("details");
     details5.ontoggle = t.step_func_done(function(evt) {
+      assert_equals(evt.oldState, "closed");
+      assert_equals(evt.newState, "open");
       assert_true(details5.open);
       testEvent(evt);
     })
@@ -119,6 +123,8 @@
     if (loop) {
       assert_unreached("toggle event fired twice");
     } else {
+      assert_equals(evt.oldState, "closed");
+      assert_equals(evt.newState, "closed");
       loop = true;
     }
   });
@@ -136,6 +142,8 @@
   details7.setAttribute('open', ''); // opens details7
 
   details8.ontoggle = t8.step_func_done(function(evt) {
+    assert_equals(evt.oldState, "closed");
+    assert_equals(evt.newState, "closed");
     assert_false(details8.open);
     testEvent(evt)
   });

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -133,6 +133,8 @@ bool HTMLDetailsElement::isActiveSummary(const HTMLSummaryElement& summary) cons
 
 void HTMLDetailsElement::queueDetailsToggleEventTask(DetailsState oldState, DetailsState newState)
 {
+    if (auto queuedEventData = queuedToggleEventData())
+        oldState = queuedEventData->oldState;
     setQueuedToggleEventData({ oldState, newState });
     queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [this, newState] {
         auto queuedEventData = queuedToggleEventData();


### PR DESCRIPTION
#### 06b30c68edf91408b614dbd577f4c211b4b3f000
<pre>
Set &lt;details&gt; ToggleEvent oldState correctly for coalesced tasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=260463">https://bugs.webkit.org/show_bug.cgi?id=260463</a>

Reviewed by Tim Nguyen.

Set the ToggleEvent oldState value correctly in the case where a
&lt;details&gt; element is open and closed multiple times (toggled back and
forth) — which <a href="https://commits.webkit.org/267076@main">https://commits.webkit.org/267076@main</a> didn’t get right.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::queueDetailsToggleEventTask):

Canonical link: <a href="https://commits.webkit.org/267089@main">https://commits.webkit.org/267089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a417ff7fcae05bf89d7157a3d571c8d3789c7ecd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17194 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18126 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21026 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12598 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18474 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->