### PR TITLE
When adding image support for "com.adobe.photoshop-image", also add MIME type "application/x-photoshop"

### DIFF
--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -112,9 +112,8 @@ void setAdditionalSupportedImageTypes(const Vector<String>& imageTypes)
     MIMETypeRegistry::additionalSupportedImageMIMETypes().clear();
     for (const auto& imageType : imageTypes) {
         additionalSupportedImageTypes().add(imageType);
-        auto mimeType = MIMETypeForImageType(imageType);
-        if (!mimeType.isEmpty())
-            MIMETypeRegistry::additionalSupportedImageMIMETypes().add(mimeType);
+        auto mimeTypes = RequiredMIMETypesFromUTI(imageType);
+        MIMETypeRegistry::additionalSupportedImageMIMETypes().add(mimeTypes.begin(), mimeTypes.end());
     }
 }
 

--- a/Source/WebCore/platform/network/mac/UTIUtilities.h
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.h
@@ -30,6 +30,7 @@
 namespace WebCore {
 
 WEBCORE_EXPORT String MIMETypeFromUTI(const String&);
+WEBCORE_EXPORT HashSet<String> RequiredMIMETypesFromUTI(const String&);
 RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef);
 WEBCORE_EXPORT String UTIFromMIMEType(const String&);
 bool isDeclaredUTI(const String&);

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -46,6 +46,20 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
+HashSet<String> RequiredMIMETypesFromUTI(const String& uti)
+{
+    HashSet<String> mimeTypes;
+
+    auto mainMIMEType = MIMETypeFromUTI(uti);
+    if (!mainMIMEType.isEmpty())
+        mimeTypes.add(mainMIMEType);
+
+    if (equalLettersIgnoringASCIICase(uti, "com.adobe.photoshop-image"_s))
+        mimeTypes.add("application/x-photoshop"_s);
+
+    return mimeTypes;
+}
+
 RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef uti)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -541,6 +541,8 @@
 		71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
 		725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
 		7283A9D222FB1E0600B21C7D /* exif-orientation-8-llo.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */; };
+		7498C3D72A94435F009A387E /* TestUTIUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7498C3CF2A94435F009A387E /* TestUTIUtilities.cpp */; };
+		74DEF2252A946FD800E034A3 /* TestUTIRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74DEF21D2A946FD700E034A3 /* TestUTIRegistry.cpp */; };
 		751B05D61F8EAC410028A09E /* DatabaseTrackerTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */; };
 		754CEC811F6722F200D0039A /* AutoFillAvailable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */; };
 		7673499D1930C5BB00E44DF9 /* StopLoadingDuringDidFailProvisionalLoad_bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7673499A1930182E00E44DF9 /* StopLoadingDuringDidFailProvisionalLoad_bundle.cpp */; };
@@ -2753,6 +2755,8 @@
 		725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = AdditionalSupportedImageTypes.html; sourceTree = "<group>"; };
 		7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "exif-orientation-8-llo.jpg"; sourceTree = "<group>"; };
 		73BD731723A846500020F450 /* DisplayName.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DisplayName.mm; sourceTree = "<group>"; };
+		7498C3CF2A94435F009A387E /* TestUTIUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestUTIUtilities.cpp; sourceTree = "<group>"; };
+		74DEF21D2A946FD700E034A3 /* TestUTIRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestUTIRegistry.cpp; sourceTree = "<group>"; };
 		751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DatabaseTrackerTest.mm; sourceTree = "<group>"; };
 		754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AutoFillAvailable.mm; sourceTree = "<group>"; };
 		75F3133F18C171B70041CAEC /* EphemeralSessionPushStateNoHistoryCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EphemeralSessionPushStateNoHistoryCallback.cpp; sourceTree = "<group>"; };
@@ -5666,6 +5670,8 @@
 				5769C50A1D9B0001000847FB /* SerializedCryptoKeyWrap.mm */,
 				A17991861E1C994E00A505ED /* SharedBuffer.mm */,
 				7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */,
+				74DEF21D2A946FD700E034A3 /* TestUTIRegistry.cpp */,
+				7498C3CF2A94435F009A387E /* TestUTIUtilities.cpp */,
 				CD89D0381C4EDB2A00040A04 /* WebCoreNSURLSession.mm */,
 			);
 			path = cocoa;
@@ -6614,6 +6620,8 @@
 				F4CB8A7D2856462B0017ECD3 /* TestPDFHostViewController.mm in Sources */,
 				7B774906267CCE72009873B4 /* TestRunnerTests.cpp in Sources */,
 				F4D5C55827C6FF4800ED1C23 /* TestUIMenuBuilder.mm in Sources */,
+				74DEF2252A946FD800E034A3 /* TestUTIRegistry.cpp in Sources */,
+				7498C3D72A94435F009A387E /* TestUTIUtilities.cpp in Sources */,
 				F4517B672054C49500C26721 /* TestWKWebViewController.mm in Sources */,
 				F472E00327D966F200F3A172 /* TextAlternatives.mm in Sources */,
 				F45033F5206BEC95009351CE /* TextAutosizingBoost.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIRegistry.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIRegistry.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCore/UTIRegistry.h"
+
+#include "WebCore/MIMETypeRegistry.h"
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(UTIRegistry, AdditionalSupportedImageTypesForMailPsd)
+{
+    EXPECT_FALSE(isSupportedImageType("com.adobe.photoshop-image"_s));
+    EXPECT_FALSE(MIMETypeRegistry::isSupportedImageMIMEType("image/vnd.adobe.photoshop"_s));
+    EXPECT_FALSE(MIMETypeRegistry::isSupportedImageMIMEType("application/x-photoshop"_s));
+
+    setAdditionalSupportedImageTypes(Vector { String { "com.adobe.photoshop-image"_s } });
+    EXPECT_TRUE(isSupportedImageType("com.adobe.photoshop-image"_s));
+    EXPECT_TRUE(MIMETypeRegistry::isSupportedImageMIMEType("image/vnd.adobe.photoshop"_s));
+    // If this fails, Mail may not be able to display psd images when editing.
+    EXPECT_TRUE(MIMETypeRegistry::isSupportedImageMIMEType("application/x-photoshop"_s));
+    // If this fails, the special case of "application/x-photoshop" introduced in
+    // https://bugs.webkit.org/show_bug.cgi?id=260464 should be removed or reworked.
+    EXPECT_EQ(MIMETypeRegistry::mimeTypeForExtension("psd"_s), "application/x-photoshop"_s);
+}
+
+}; // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIUtilities.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCore/UTIUtilities.h"
+
+#include <wtf/HashSet.h>
+#include <wtf/text/StringHash.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(UTIUtilities, MIMETypeFromUTIForMailPsd)
+{
+    EXPECT_EQ(MIMETypeFromUTI("com.adobe.photoshop-image"_s), "image/vnd.adobe.photoshop"_s);
+}
+
+TEST(UTIUtilities, RequiredMIMETypesFromUTIForMailPsd)
+{
+    auto mimeTypes = RequiredMIMETypesFromUTI("com.adobe.photoshop-image"_s);
+    EXPECT_EQ(mimeTypes.size(), 2u);
+    EXPECT_TRUE(mimeTypes.contains("image/vnd.adobe.photoshop"_s));
+    // If this fails, Mail may not be able to display psd images when editing.
+    EXPECT_TRUE(mimeTypes.contains("application/x-photoshop"_s));
+}
+
+}; // namespace TestWebKitAPI


### PR DESCRIPTION
#### b2fab9cbd1d1baf5a80ac164ed4bf46179aabb19
<pre>
When adding image support for &quot;com.adobe.photoshop-image&quot;, also add MIME type &quot;application/x-photoshop&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=260464">https://bugs.webkit.org/show_bug.cgi?id=260464</a>
rdar://103614570

Reviewed by Said Abou-Hallawa.

Mail adds &quot;com.adobe.photoshop-image&quot; as supported type, so that Photoshop images may be viewed as images
in emails. At that time, the associated MIME type &quot;image/vnd.adobe.photoshop&quot; also gets added.
However when inserting an attachment with file extension &quot;psd&quot;, the system infers its MIME type as
&quot;application/x-photoshop&quot; instead, which is not supported by default, this prevents psd&apos;s from appearing
in the Mail editor.

So when adding &quot;com.adobe.photoshop-image&quot;, the MIME type &quot;application/x-photoshop&quot; gets added as well to
correctly show attached psd images.

* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::setAdditionalSupportedImageTypes):
* Source/WebCore/platform/network/mac/UTIUtilities.h:

* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::RequiredMIMETypesFromUTI):
Note: This 1:M UTI-&gt;MIME mapping should be exceedingly rare, so a simple `if` test here is enough.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIRegistry.cpp: Added.
(TestWebKitAPI::TEST):
Relevant tests for this fix, but also a check to know if one day this fix is not needed anymore or needs
an update (e.g., if the platform starts to associate *.psd files with &quot;image/vnd.adobe.photoshop&quot; or
another MIME type).

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIUtilities.cpp: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267153@main">https://commits.webkit.org/267153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60638f3c7224112cb164cd13419364cbff3255bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17292 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18277 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21131 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17651 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14238 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3773 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->