### PR TITLE
Change navigable target names to _blank if they have dangling markup

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -229,6 +229,7 @@
     "web-platform-tests/html/browsers/origin/cross-origin-objects/cross-origin-objects.sub.html": "skip",
     "web-platform-tests/html/browsers/sandboxing": "skip",
     "web-platform-tests/html/browsers/the-window-object": "import",
+    "web-platform-tests/html/browsers/windows": "import",
     "web-platform-tests/html/browsers/windows/auxiliary-browsing-contexts": "import",
     "web-platform-tests/html/browsers/windows/browsing-context-first-created.xhtml": "skip",
     "web-platform-tests/html/browsers/windows/browsing-context-names": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Dangling Markup in target is not reset when set by window.open
+PASS Dangling Markup with "\n" in target is reset when set by <a> tag
+PASS Dangling Markup with "\r" in target is reset when set by <a> tag
+PASS Dangling Markup with "\t" in target is reset when set by <a> tag
+PASS Dangling Markup in target is reset when set by <form> tag
+PASS Dangling Markup in target is reset when set by <base> tag
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html>
+<head>
+  <title>Dangling Markup in target</title>
+  <meta name="timeout" content="long">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/utils.js"></script>
+</head>
+<body>
+  <script>
+    function anchorClick(target, id) {
+      const hyperlink = document.body.appendChild(document.createElement('a'));
+      if (target) {
+        hyperlink.target = target;
+      }
+      hyperlink.href = `resources/window-name.sub.html?report=${id}|close`;
+      hyperlink.click();
+    }
+
+    async function pollResultAndCheck(t, id, expected) {
+      const stashURL = new URL('resources/window-name-stash.py', location);
+      stashURL.searchParams.set('id', id);
+
+      let res = 'NONE';
+      while (res == 'NONE') {
+        await new Promise(resolve => { t.step_timeout(resolve, 100); });
+
+        const response = await fetch(stashURL);
+        res = await response.text();
+      }
+      if (res !== expected) {
+        assert_unreached('Stash result does not equal expected result.')
+      }
+    }
+
+    promise_test(async t => {
+      const id = token();
+      const value = '\n<' + id;
+
+      window.open(`resources/window-name.sub.html?report=${id}|close`, value);
+      await pollResultAndCheck(t, id, value);
+    }, 'Dangling Markup in target is not reset when set by window.open');
+
+    promise_test(async t => {
+      const id = token();
+      const value = '\n<' + id;
+
+      anchorClick(value, id)
+      await pollResultAndCheck(t, id, '');
+    }, 'Dangling Markup with "\\n" in target is reset when set by <a> tag');
+
+    promise_test(async t => {
+      const id = token();
+      const value = '\r<' + id;
+
+      anchorClick(value, id)
+      await pollResultAndCheck(t, id, '');
+    }, 'Dangling Markup with "\\r" in target is reset when set by <a> tag');
+
+    promise_test(async t => {
+      const id = token();
+      const value = '\t<' + id;
+
+      anchorClick(value, id)
+      await pollResultAndCheck(t, id, '');
+    }, 'Dangling Markup with "\\t" in target is reset when set by <a> tag');
+
+    promise_test(async t => {
+      const id = token();
+      const value = '\n<' + id;
+
+      const form = document.body.appendChild(document.createElement('form'));
+      form.target = value;
+      form.method = 'GET';
+      form.action = 'resources/window-name.sub.html';
+      const input = form.appendChild(document.createElement('input'));
+      input.type = 'hidden';
+      input.name = 'report';
+      input.value = `${id}|close`;
+      form.submit();
+
+      await pollResultAndCheck(t, id, '');
+    }, 'Dangling Markup in target is reset when set by <form> tag');
+
+    promise_test(async t => {
+      const id = token();
+      const value = '\n<' + id;
+      const base = document.head.appendChild(document.createElement('base'));
+      base.target = value;
+
+      anchorClick(null, id)
+      await pollResultAndCheck(t, id, '');
+    }, 'Dangling Markup in target is reset when set by <base> tag');
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/resources/window-name.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/resources/window-name.sub.html
@@ -2,7 +2,7 @@
 <title>popup helper</title>
 <script>
 
-const search = window.location.search.replace("?", "");
+const search = decodeURIComponent(window.location.search.replace("?", ""));
 const steps = search.split("|");
 
 async function proceedTest() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-window.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/clear-window-name.https.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/document-domain-nested-navigate.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/document-domain-nested-set.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/document-domain-nested.window.js

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -3383,6 +3383,9 @@
     "imported/w3c/web-platform-tests/html/browsers/windows/clear-window-name.https.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/browsers/windows/noreferrer-window-name.html": [
         "slow"
     ],

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5399,4 +5399,11 @@ void Element::contentVisibilityViewportChange(bool)
     document().scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
 }
 
+AtomString Element::makeTargetBlankIfHasDanglingMarkup(const AtomString& target)
+{
+    if ((target.contains('\n') || target.contains('\r') || target.contains('\t')) && target.contains('<'))
+        return "_blank"_s;
+    return target;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -768,6 +768,8 @@ protected:
 
     void updateLabel(TreeScope&, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue);
 
+    static AtomString makeTargetBlankIfHasDanglingMarkup(const AtomString& target);
+
 private:
     LocalFrame* documentFrameWithNonNullView() const;
     void hideNonceSlow();

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -649,7 +649,7 @@ AtomString HTMLAnchorElement::effectiveTarget() const
     auto effectiveTarget = target();
     if (effectiveTarget.isEmpty())
         effectiveTarget = document().baseTarget();
-    return effectiveTarget;
+    return makeTargetBlankIfHasDanglingMarkup(effectiveTarget);
 }
 
 HTMLAnchorElement::EventType HTMLAnchorElement::eventType(Event& event)

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -735,12 +735,12 @@ AtomString HTMLFormElement::effectiveTarget(const Event* event, HTMLFormControlE
     if (RefPtr submitter = overrideSubmitter ? overrideSubmitter : findSubmitter(event)) {
         auto& targetValue = submitter->attributeWithoutSynchronization(formtargetAttr);
         if (!targetValue.isNull())
-            return targetValue;
+            return makeTargetBlankIfHasDanglingMarkup(targetValue);
     }
 
     auto targetValue = target();
     if (!targetValue.isNull())
-        return targetValue;
+        return makeTargetBlankIfHasDanglingMarkup(targetValue);
 
     return document().baseTarget();
 }


### PR DESCRIPTION
#### 6752480fe44bb56f5e1306e81bf45a6eeef245cc
<pre>
Change navigable target names to _blank if they have dangling markup
<a href="https://bugs.webkit.org/show_bug.cgi?id=257349">https://bugs.webkit.org/show_bug.cgi?id=257349</a>

Reviewed by Chris Dumez.

<a href="https://github.com/whatwg/html/pull/9309">https://github.com/whatwg/html/pull/9309</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/dangling-markup-window-name.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/resources/window-name.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/w3c-import.log:
* LayoutTests/tests-options.json:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::makeTargetBlankIfHasDanglingMarkup const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::effectiveTarget const):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::effectiveTarget const):

Canonical link: <a href="https://commits.webkit.org/267154@main">https://commits.webkit.org/267154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ca711446efa35ad368f696b07c135bff96e5d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17305 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18298 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21149 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12724 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14089 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->