### PR TITLE
Go back to using the default bounds for password and search fields' InteractionRegions

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -110,13 +110,13 @@
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 800 height: 32])
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
           (layer position [x: 400 y: 400])
           (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 96 height: 32])
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
               (layer position [x: 400 y: 400]))
             (
               (layer bounds [x: 0 y: 0 width: 800 height: 12])
@@ -223,17 +223,17 @@
                       (layer opacity 0.15)
                       (layer cornerRadius 3))))))))
         (
-          (layer bounds [x: 0 y: 0 width: 32 height: 600])
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
           (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 32 height: 96])
-              (layer position [x: 16 y: 16]))
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
             (
               (layer bounds [x: 0 y: 0 width: 12 height: 600])
-              (layer position [x: 16 y: 16])
+              (layer position [x: 6 y: 6])
               (sublayers
                 (
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -122,13 +122,13 @@
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 800 height: 32])
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
           (layer position [x: 400 y: 400])
           (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 96 height: 32])
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
               (layer position [x: 400 y: 400]))
             (
               (layer bounds [x: 0 y: 0 width: 800 height: 12])
@@ -235,17 +235,17 @@
                       (layer opacity 0.15)
                       (layer cornerRadius 3))))))))
         (
-          (layer bounds [x: 0 y: 0 width: 32 height: 600])
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
           (layer zPosition 1000)
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 32 height: 96])
-              (layer position [x: 16 y: 16]))
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
             (
               (layer bounds [x: 0 y: 0 width: 12 height: 600])
-              (layer position [x: 16 y: 16])
+              (layer position [x: 6 y: 6])
               (sublayers
                 (
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])

--- a/LayoutTests/interaction-region/text-input-expected.txt
+++ b/LayoutTests/interaction-region/text-input-expected.txt
@@ -1,0 +1,31 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 644.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 644.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=644)
+
+      (interaction regions [
+        (interaction (161,126) width=98 height=38)
+        (borderRadius 5.00),
+        (interaction (344,120) width=110 height=50)
+        (borderRadius 5.00),
+        (interaction (160,250) width=110 height=50)
+        (borderRadius 5.00),
+        (interaction (161,381) width=98 height=38)
+        (borderRadius 0.00),
+        (interaction (161,461) width=110 height=50)
+        (borderRadius 0.00),
+        (interaction (161,553) width=110 height=50)
+        (borderRadius 0.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/text-input.html
+++ b/LayoutTests/interaction-region/text-input.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<style>
+    * {
+        margin: 40px;
+    }
+    input {
+        width: 100px;
+        height: 40px;
+        padding: 5px;
+    }
+    .styled {
+        display: block;
+        border-radius: 0;
+        border: 1px gray solid;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<form>
+    <input placeholder="Search" type="search">
+    <input placeholder="Password" type="password">
+    <input type="text">
+
+    <input class="styled" placeholder="Search" type="search">
+    <input class="styled" placeholder="Password" type="password">
+    <input class="styled" type="text">
+</form>
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = async function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -293,7 +293,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     float borderRadius = 0;
     OptionSet<InteractionRegion::CornerMask> maskedCorners;
 
-    if (auto* renderBox = dynamicDowncast<RenderBox>(regionRenderer)) {
+    if (const auto& renderBox = dynamicDowncast<RenderBox>(regionRenderer)) {
         auto borderRadii = renderBox->borderRadii();
         auto minRadius = borderRadii.minimumRadius();
         auto maxRadius = borderRadii.maximumRadius();
@@ -312,14 +312,6 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         } else {
             // We default to the minimum radius applied uniformly to all corners.
             borderRadius = minRadius;
-        }
-
-        auto* input = dynamicDowncast<HTMLInputElement>(matchedElement);
-        if (input && input->containerElement()) {
-            auto borderBoxRect = renderBox->borderBoxRect();
-            auto contentBoxRect = renderBox->contentBoxRect();
-            bounds.move(IntSize(borderBoxRect.location() - contentBoxRect.location()));
-            bounds.expand(IntSize(borderBoxRect.size() - contentBoxRect.size()));
         }
     }
 


### PR DESCRIPTION
#### c8e296339bfdcd99ebbe0242cfc7b25443c3d8e9
<pre>
Go back to using the default bounds for password and search fields&apos; InteractionRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260466">https://bugs.webkit.org/show_bug.cgi?id=260466</a>
&lt;rdar://112718594&gt;

Reviewed by Tim Horton.

Remove the old workaround and add a new test so we can do more surgical
tweaks in the future if needed.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Remove the bounds extension for HTMLInputElements.

* LayoutTests/interaction-region/text-input-expected.txt: Added.
* LayoutTests/interaction-region/text-input.html: Added.
Add new test.
* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
Test update, unrelated.

Canonical link: <a href="https://commits.webkit.org/267230@main">https://commits.webkit.org/267230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60161f361d8e1e996f82592ec40afea32e472829

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17397 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17208 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18142 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21039 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17545 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13965 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3825 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->