### PR TITLE
[WebCrypto] Implement a key pair check for Ed25519.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
@@ -183,10 +183,10 @@ PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify])
 PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify])
 PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
 PASS Bad key length: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign, sign])
 PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign])
 PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, false, [sign])
 PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
@@ -195,6 +195,6 @@ PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
@@ -195,6 +195,6 @@ PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
-PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign])
-PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
@@ -195,6 +195,6 @@ PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
-PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign])
-PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
 

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -116,20 +116,20 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
         break;
     }
 
-    if (!keyData.d.isNull()) {
-        // FIXME: Validate keyData.x is paired with keyData.d
-        auto d = base64URLDecode(keyData.d);
-        if (!d)
-            return nullptr;
-        return create(identifier, namedCurve, CryptoKeyType::Private, WTFMove(*d), extractable, usages);
-    }
-
     if (keyData.x.isNull())
         return nullptr;
 
     auto x = base64URLDecode(keyData.x);
     if (!x)
         return nullptr;
+
+    if (!keyData.d.isNull()) {
+        auto d = base64URLDecode(keyData.d);
+        if (!d || !platformCheckPairedKeys(identifier, namedCurve, WTFMove(*d), WTFMove(*x)))
+            return nullptr;
+        return create(identifier, namedCurve, CryptoKeyType::Private, WTFMove(*d), extractable, usages);
+    }
+
     return create(identifier, namedCurve, CryptoKeyType::Public, WTFMove(*x), extractable, usages);
 }
 
@@ -198,7 +198,14 @@ auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
     return CryptoKeyAlgorithm { CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier()) };
 }
 
-#if !PLATFORM(COCOA) && !USE(GCRYPT)
+#if !PLATFORM(COCOA)
+
+bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&&, Vector<uint8_t>&&)
+{
+    return true;
+}
+
+#if !USE(GCRYPT)
 bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve)
 {
     return false;
@@ -246,6 +253,7 @@ Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const
     return { };
 }
 
+#endif
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -77,6 +77,7 @@ private:
 
     static bool isPlatformSupportedCurve(NamedCurve);
     static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
+    static bool platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&&, Vector<uint8_t>&&);
     Vector<uint8_t> platformExportRaw() const;
     Vector<uint8_t> platformExportSpki() const;
     Vector<uint8_t> platformExportPkcs8() const;

--- a/Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp
@@ -74,6 +74,23 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
     return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
 }
 
+bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve namedCurve, Vector<uint8_t>&& privateKey, Vector<uint8_t>&& publicKey)
+{
+    // FIXME: Implement the same check for X25519
+    if (namedCurve != NamedCurve::Ed25519)
+        return true;
+
+    if (privateKey.size() != 32 || publicKey.size() != 32)
+        return false;
+
+    ccec25519pubkey ccPublicKey;
+    static_assert(sizeof(ccPublicKey) == 32);
+
+    auto* di = ccsha512_di();
+    cced25519_make_pub(di, ccPublicKey, privateKey.data());
+    return !std::memcmp(ccPublicKey, publicKey.data(), sizeof(ccPublicKey));
+}
+
 // Per https://www.ietf.org/rfc/rfc5280.txt
 // SubjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
 // AlgorithmIdentifier  ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY DEFINED BY algorithm OPTIONAL }


### PR DESCRIPTION
#### 8c9a448b18a44fda10a8b6de16db52e7582cefa9
<pre>
[WebCrypto] Implement a key pair check for Ed25519.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260469">https://bugs.webkit.org/show_bug.cgi?id=260469</a>

Reviewed by Youenn Fablet.

When importing an Ed25519 key-pair in JWK format we extract
different values from the &apos;x&apos; and &apos;d&apos; dict properties, which
correspond to the public and private keys respectively.

The new platformCheckPairedKeys ensures that the public key
imported matches the one generated from the private one, using
the Ed25519 key-pair generation operation.

There are several WPT that pass thanks to this change, so no
new tests are needed.
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
* Source/WebCore/crypto/keys/CryptoKeyOKP.h:
* Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):

Canonical link: <a href="https://commits.webkit.org/267184@main">https://commits.webkit.org/267184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a371268e2f116b80ceb12fa23f438ebf3703b70f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14905 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17371 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18400 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21227 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17764 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12804 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14348 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3795 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->