### PR TITLE
In-place interpreter: fix clobbered register in call and reduce memory usage for if and br

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -642,8 +642,9 @@ instructionLabel(_if)
     nextIPIntInstruction()
 .ipint_if_taken:
     # Skip LEB128
-    loadq 8[PM, MC], PC
-    advanceMC(16)
+    loadb 8[PM, MC], t0
+    advanceMC(9)
+    advancePCByReg(t0)
     nextIPIntInstruction()
 
 instructionLabel(_else)
@@ -742,8 +743,9 @@ instructionLabel(_br_if)
     # pop i32
     popInt32(t0, t2)
     bineq t0, 0, _ipint_br
-    loadi 12[PM, MC], PC
-    advanceMC(16)
+    loadb 12[PM, MC], t0
+    advanceMC(13)
+    advancePCByReg(t0)
     nextIPIntInstruction()
 
 instructionLabel(_br_table)
@@ -3490,7 +3492,7 @@ _ipint_call_impl:
     # Get function data
     move t0, a1
     move wasmInstance, a0
-    cCall2(_ipint_extern_call)
+    operationCall(macro() cCall2(_ipint_extern_call) end)
 
 # FIXME: switch offlineasm unalignedglobal to take alignment and optionally pad with breakpoint instructions (rdar://113594783)
 macro mintAlign()


### PR DESCRIPTION
#### fcf3ca83171a536e886f5db868de709d1cafcd39
<pre>
In-place interpreter: fix clobbered register in call and reduce memory usage for if and br
<a href="https://bugs.webkit.org/show_bug.cgi?id=260471">https://bugs.webkit.org/show_bug.cgi?id=260471</a>
rdar://114218539

Reviewed by Yusuke Suzuki.

Updated `call` instruction to save caller save registers around the operation call.
Reduce memory usage for if and br by 3B by saving the size of the instruction instead of the next PC.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addBranch):
(JSC::Wasm::IPIntGenerator::addSwitch):

Canonical link: <a href="https://commits.webkit.org/267142@main">https://commits.webkit.org/267142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9fbe41feeee79d1694b5e734e6697a828127777

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14729 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17257 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18201 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21098 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13490 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17598 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14940 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12668 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15888 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14180 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3992 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18547 "Built successfully") | | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/16504 "Failed to compile JSC") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14746 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/16504 "Failed to compile JSC") | 
<!--EWS-Status-Bubble-End-->