### PR TITLE
Keep SpeechSynthesisUtterance wrapper alive when utterance is spoken multiple times

### DIFF
--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-utterance-gc-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-utterance-gc-expected.txt
@@ -1,0 +1,9 @@
+This tests speaking an utterance multiple times will not crash due to garbage collection.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-utterance-gc.html
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-utterance-gc.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    description("This tests speaking an utterance multiple times will not crash due to garbage collection.");
+
+    if (window.internals)
+        window.internals.enableMockSpeechSynthesizer();
+
+    window.jsTestIsAsync = true;
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    var utterance = new SpeechSynthesisUtterance("this is a test");
+    count = 10;
+    utterance.onend = function(event) {
+        if (--count == 0) 
+            finishJSTest();
+    }
+
+    for (let i = 0; i < count; ++i)
+        speechSynthesis.speak(utterance);
+
+    utterance = null;
+    gc();
+    // For mock speech synthesizer, speaking each utterance takes 100ms to complete,
+    // so we make gc happen after first speaking.
+    setTimeout(() => { gc(); }, 150);
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.h
@@ -77,7 +77,7 @@ public:
 
 private:
     SpeechSynthesis(ScriptExecutionContext&);
-    void clearUtteranceQueue();
+    RefPtr<SpeechSynthesisUtterance> protectedCurrentSpeechUtterance();
 
     // PlatformSpeechSynthesizerClient override methods.
     void voicesDidChange() override;
@@ -109,7 +109,7 @@ private:
     
     RefPtr<PlatformSpeechSynthesizer> m_platformSpeechSynthesizer;
     Vector<Ref<SpeechSynthesisVoice>> m_voiceList;
-    RefPtr<SpeechSynthesisUtterance> m_currentSpeechUtterance;
+    std::unique_ptr<SpeechSynthesisUtteranceActivity> m_currentSpeechUtterance;
     Deque<Ref<SpeechSynthesisUtterance>> m_utteranceQueue;
     bool m_isPaused;
     BehaviorRestrictions m_restrictions;


### PR DESCRIPTION
#### 75a01d7e9d12969c5a2b878a6c4c572c9e6fbf27
<pre>
Keep SpeechSynthesisUtterance wrapper alive when utterance is spoken multiple times
<a href="https://bugs.webkit.org/show_bug.cgi?id=260474">https://bugs.webkit.org/show_bug.cgi?id=260474</a>
rdar://114203537

Reviewed by Ryosuke Niwa.

In 266959@main and 266990@main, we make sure wrapper of SpeechSynthesisUtterance is kept alive when it is being
processed. The &quot;alive&quot; period starts from when SpeechSynthesisUtterance is handed to SpeechSynthesis via speak(), and
ends when SpeechSynthesisUtterance receives end events or SpeechSynthesisUtterance is removed from SpeechSynthesis.
According to existing wpt test SpeechSynthesis-speak-twice.html, it is valid to speak an utterance multiple times, i.e.
same utterance can be handed to SpeechSynthesis multiple times, so we should make sure SpeechSynthesisUtterance is kept
alive until the last speaking is finished.

* LayoutTests/fast/speechsynthesis/speech-synthesis-utterance-gc-expected.txt: Added.
* LayoutTests/fast/speechsynthesis/speech-synthesis-utterance-gc.html: Added.
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::setPlatformSynthesizer):
(WebCore::SpeechSynthesis::speaking const):
(WebCore::SpeechSynthesis::startSpeakingImmediately):
(WebCore::SpeechSynthesis::speak):
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::didStartSpeaking):
(WebCore::SpeechSynthesis::didFinishSpeaking):
(WebCore::SpeechSynthesis::didPauseSpeaking):
(WebCore::SpeechSynthesis::didResumeSpeaking):
(WebCore::SpeechSynthesis::speakingErrorOccurred):
(WebCore::SpeechSynthesis::boundaryEventOccurred):
(WebCore::SpeechSynthesis::protectedCurrentSpeechUtterance):
(WebCore::SpeechSynthesis::clearUtteranceQueue): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesis.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::eventOccurred):
(WebCore::SpeechSynthesisUtterance::errorEventOccurred):
(WebCore::SpeechSynthesisUtterance::incrementActivityCountForEventDispatch):
(WebCore::SpeechSynthesisUtterance::decrementActivityCountForEventDispatch):
(WebCore::SpeechSynthesisUtterance::virtualHasPendingActivity const):
(WebCore::SpeechSynthesisUtterance::dispatchEventAndUpdateState): Deleted.
(WebCore::SpeechSynthesisUtterance::setIsActiveForEventDispatch): Deleted.
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
(WebCore::SpeechSynthesisUtteranceActivity::SpeechSynthesisUtteranceActivity):
(WebCore::SpeechSynthesisUtteranceActivity::~SpeechSynthesisUtteranceActivity):
(WebCore::SpeechSynthesisUtteranceActivity::utterance):

Canonical link: <a href="https://commits.webkit.org/267161@main">https://commits.webkit.org/267161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0805d5a21b00a85fa42d8c18114e5f83ae994a6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16498 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18352 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21191 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17720 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12771 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14141 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->