### PR TITLE
Fix Speedometer 3 patch for run-benchmark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/Speedometer3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/Speedometer3.patch
@@ -1,10 +1,12 @@
-diff --git a/resources/benchmark-report.mjs b/resources/benchmark-report.mjs
-index 4a71c5a..b85d066 100644
---- a/resources/benchmark-report.mjs
-+++ b/resources/benchmark-report.mjs
-@@ -1,5 +1,56 @@
- // This file can be customized to report results as needed.
- 
+diff --git a/resources/benchmark-runner.mjs b/resources/benchmark-runner.mjs
+index 1ad7104..22809a0 100644
+--- a/resources/benchmark-runner.mjs
++++ b/resources/benchmark-runner.mjs
+@@ -595,3 +595,54 @@ export class BenchmarkRunner {
+             metric.computeAggregatedMetrics();
+     }
+ }
++
 +window.onload = function () {
 +    const originalDidFinishLastIteration = benchmarkClient.didFinishLastIteration;
 +    benchmarkClient.didFinishLastIteration = function (...args) {
@@ -55,7 +57,3 @@ index 4a71c5a..b85d066 100644
 +    }
 +    document.querySelector(".start-tests-button").click();
 +};
-+
- (function () {
-     if (!window.testRunner && location.search !== "?webkit" && location.hash !== "#webkit")
-         return;


### PR DESCRIPTION
#### 1003bbe8e3c859f0bf579964d8b8876125116153
<pre>
Fix Speedometer 3 patch for run-benchmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=260476">https://bugs.webkit.org/show_bug.cgi?id=260476</a>

Reviewed by Dewei Zhu.

Fixed the patch.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/Speedometer3.patch:

Canonical link: <a href="https://commits.webkit.org/267101@main">https://commits.webkit.org/267101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b118db7cba32096cc933169c2a6eb573053a6f11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17431 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16083 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15859 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18177 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/15784 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/14600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/18524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1908 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/14725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->