### PR TITLE
WebGL "is resource" checking and object validation contains repeated code

### DIFF
--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -94,13 +94,8 @@ GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
     if (isContextLost())
         return false;
     auto& context = this->context();
-
-    if (!query || !query->validate(context))
+    if (!context.validateIsWebGLObject(query))
         return false;
-
-    if (query->isDeleted())
-        return false;
-
     return context.graphicsContextGL()->isQueryEXT(query->object());
 }
 
@@ -112,7 +107,7 @@ void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& q
 
     Locker locker { context.objectGraphLock() };
 
-    if (!context.validateWebGLObject("beginQueryEXT", &query))
+    if (!context.validateWebGLObject("beginQueryEXT", query))
         return;
 
     // The WebGL extension requires ending time elapsed queries when they are deleted.
@@ -134,7 +129,6 @@ void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& q
         return;
     }
 
-    query.setTarget(target);
     context.m_activeQuery = &query;
 
     context.graphicsContextGL()->beginQueryEXT(target, query.object());
@@ -176,7 +170,7 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
     if (!context.scriptExecutionContext())
         return;
 
-    if (!context.validateWebGLObject("queryCounterEXT", &query))
+    if (!context.validateWebGLObject("queryCounterEXT", query))
         return;
 
     if (target != GraphicsContextGL::TIMESTAMP_EXT) {
@@ -228,7 +222,7 @@ WebGLAny EXTDisjointTimerQuery::getQueryObjectEXT(WebGLTimerQueryEXT& query, GCG
         return nullptr;
     auto& context = this->context();
 
-    if (!context.validateWebGLObject("getQueryObjectEXT", &query))
+    if (!context.validateWebGLObject("getQueryObjectEXT", query))
         return nullptr;
 
     if (!query.target()) {

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -58,7 +58,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
     if (!context.scriptExecutionContext())
         return;
 
-    if (!context.validateWebGLObject("queryCounterEXT", &query))
+    if (!context.validateWebGLObject("queryCounterEXT", query))
         return;
 
     if (target != GraphicsContextGL::TIMESTAMP_EXT) {

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
@@ -87,14 +87,8 @@ GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* ar
     if (isContextLost())
         return false;
     auto& context = this->context();
-    if (!arrayObject || !arrayObject->validate(context))
+    if (!context.validateIsWebGLObject(arrayObject))
         return false;
-
-    if (!arrayObject->hasEverBeenBound())
-        return false;
-    if (arrayObject->isDeleted())
-        return false;
-
     return context.graphicsContextGL()->isVertexArray(arrayObject->object());
 }
 
@@ -112,7 +106,6 @@ void OESVertexArrayObject::bindVertexArrayOES(WebGLVertexArrayObjectOES* arrayOb
     auto* contextGL = context.graphicsContextGL();
     if (arrayObject && !arrayObject->isDefaultObject() && arrayObject->object()) {
         contextGL->bindVertexArray(arrayObject->object());
-        arrayObject->setHasEverBeenBound();
         context.setBoundVertexArrayObject(locker, arrayObject);
     } else {
         contextGL->bindVertexArray(0);

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -305,9 +305,6 @@ bool WebGL2RenderingContext::validateAndCacheBufferBinding(const AbstractLocker&
         ASSERT_NOT_REACHED();
         break;
     }
-
-    if (buffer && !buffer->getTarget())
-        buffer->setTarget(target);
     return true;
 }
 
@@ -601,8 +598,9 @@ void WebGL2RenderingContext::getBufferSubData(GCGLenum target, long long srcByte
 
 void WebGL2RenderingContext::bindFramebuffer(GCGLenum target, WebGLFramebuffer* buffer)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindFramebuffer", buffer))
         return;
 
@@ -660,7 +658,7 @@ void WebGL2RenderingContext::framebufferTextureLayer(GCGLenum target, GCGLenum a
     if (isContextLost() || !validateFramebufferFuncParameters("framebufferTextureLayer", target, attachment))
         return;
 
-    if (texture && !validateWebGLObject("framebufferTextureLayer", texture))
+    if (texture && !validateWebGLObject("framebufferTextureLayer", *texture))
         return;
 
     GCGLenum texTarget = texture ? texture->getTarget() : 0;
@@ -1245,7 +1243,9 @@ void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint le
 
 GCGLint WebGL2RenderingContext::getFragDataLocation(WebGLProgram& program, const String& name)
 {
-    if (!validateWebGLProgramOrShader("getFragDataLocation", &program))
+    if (isContextLost())
+        return -1;
+    if (!validateWebGLObject("getFragDataLocation", program))
         return -1;
     return m_context->getFragDataLocation(program.object(), name);
 }
@@ -1676,7 +1676,7 @@ void WebGL2RenderingContext::deleteQuery(WebGLQuery* query)
 {
     Locker locker { objectGraphLock() };
 
-    if (isContextLost() || !query || !query->object() || !validateWebGLObject("deleteQuery", query))
+    if (isContextLost() || !query || !query->object() || !validateWebGLObject("deleteQuery", *query))
         return;
     if (query->target()) {
         for (auto& activeQuery : m_activeQueries) {
@@ -1692,12 +1692,10 @@ void WebGL2RenderingContext::deleteQuery(WebGLQuery* query)
 
 GCGLboolean WebGL2RenderingContext::isQuery(WebGLQuery* query)
 {
-    if (isContextLost() || !query || !query->validate(*this))
+    if (isContextLost())
         return false;
-
-    if (query->isDeleted())
+    if (!validateIsWebGLObject(query))
         return false;
-
     return m_context->isQuery(query->object());
 }
 
@@ -1721,8 +1719,10 @@ std::optional<WebGL2RenderingContext::ActiveQueryKey> WebGL2RenderingContext::va
 
 void WebGL2RenderingContext::beginQuery(GCGLenum target, WebGLQuery& query)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-    if (!validateWebGLObject("beginQuery", &query))
+    if (!validateWebGLObject("beginQuery", query))
         return;
     auto activeQueryKey = validateQueryTarget("beginQuery", target);
     if (!activeQueryKey)
@@ -1801,7 +1801,9 @@ WebGLAny WebGL2RenderingContext::getQuery(GCGLenum target, GCGLenum pname)
 
 WebGLAny WebGL2RenderingContext::getQueryParameter(WebGLQuery& query, GCGLenum pname)
 {
-    if (!validateWebGLObject("getQueryParameter", &query))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getQueryParameter", query))
         return nullptr;
     if (!query.target()) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getQueryParameter", "query has not been used by beginQuery");
@@ -1852,16 +1854,18 @@ void WebGL2RenderingContext::deleteSampler(WebGLSampler* sampler)
 
 GCGLboolean WebGL2RenderingContext::isSampler(WebGLSampler* sampler)
 {
-    if (isContextLost() || !sampler || !sampler->validate(*this) || sampler->isDeleted())
+    if (isContextLost())
         return false;
-
+    if (!validateIsWebGLObject(sampler))
+        return false;
     return m_context->isSampler(sampler->object());
 }
 
 void WebGL2RenderingContext::bindSampler(GCGLuint unit, WebGLSampler* sampler)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindSampler", sampler))
         return;
     
@@ -1878,7 +1882,9 @@ void WebGL2RenderingContext::bindSampler(GCGLuint unit, WebGLSampler* sampler)
 
 void WebGL2RenderingContext::samplerParameteri(WebGLSampler& sampler, GCGLenum pname, GCGLint value)
 {
-    if (!validateWebGLObject("samplerParameteri", &sampler))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("samplerParameteri", sampler))
         return;
 
     m_context->samplerParameteri(sampler.object(), pname, value);
@@ -1886,7 +1892,9 @@ void WebGL2RenderingContext::samplerParameteri(WebGLSampler& sampler, GCGLenum p
 
 void WebGL2RenderingContext::samplerParameterf(WebGLSampler& sampler, GCGLenum pname, GCGLfloat value)
 {
-    if (!validateWebGLObject("samplerParameterf", &sampler))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("samplerParameterf", sampler))
         return;
 
     m_context->samplerParameterf(sampler.object(), pname, value);
@@ -1894,7 +1902,9 @@ void WebGL2RenderingContext::samplerParameterf(WebGLSampler& sampler, GCGLenum p
 
 WebGLAny WebGL2RenderingContext::getSamplerParameter(WebGLSampler& sampler, GCGLenum pname)
 {
-    if (!validateWebGLObject("getSamplerParameter", &sampler))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getSamplerParameter", sampler))
         return nullptr;
 
     switch (pname) {
@@ -1942,12 +1952,10 @@ RefPtr<WebGLSync> WebGL2RenderingContext::fenceSync(GCGLenum condition, GCGLbitf
 
 GCGLboolean WebGL2RenderingContext::isSync(WebGLSync* sync)
 {
-    if (isContextLost() || !sync || !sync->validate(*this))
+    if (isContextLost())
         return false;
-
-    if (sync->isDeleted())
+    if (!validateIsWebGLObject(sync))
         return false;
-
     return !!sync->object();
 }
 
@@ -1960,7 +1968,9 @@ void WebGL2RenderingContext::deleteSync(WebGLSync* sync)
 
 GCGLenum WebGL2RenderingContext::clientWaitSync(WebGLSync& sync, GCGLbitfield flags, GCGLuint64 timeout)
 {
-    if (!validateWebGLObject("clientWaitSync", &sync))
+    if (isContextLost())
+        return GraphicsContextGL::WAIT_FAILED_WEBGL;
+    if (!validateWebGLObject("clientWaitSync", sync))
         return GraphicsContextGL::WAIT_FAILED_WEBGL;
 
     if (timeout > MaxClientWaitTimeout) {
@@ -1985,7 +1995,9 @@ GCGLenum WebGL2RenderingContext::clientWaitSync(WebGLSync& sync, GCGLbitfield fl
 
 void WebGL2RenderingContext::waitSync(WebGLSync& sync, GCGLbitfield flags, GCGLint64 timeout)
 {
-    if (!validateWebGLObject("waitSync", &sync))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("waitSync", sync))
         return;
 
     if (flags)
@@ -1998,7 +2010,9 @@ void WebGL2RenderingContext::waitSync(WebGLSync& sync, GCGLbitfield flags, GCGLi
 
 WebGLAny WebGL2RenderingContext::getSyncParameter(WebGLSync& sync, GCGLenum pname)
 {
-    if (!validateWebGLObject("getSyncParameter", &sync))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getSyncParameter", sync))
         return nullptr;
 
     switch (pname) {
@@ -2055,21 +2069,18 @@ void WebGL2RenderingContext::deleteTransformFeedback(WebGLTransformFeedback* fee
 
 GCGLboolean WebGL2RenderingContext::isTransformFeedback(WebGLTransformFeedback* feedbackObject)
 {
-    if (isContextLost() || !feedbackObject || !feedbackObject->validate(*this))
+    if (isContextLost())
         return false;
-
-    if (!feedbackObject->hasEverBeenBound())
+    if (!validateIsWebGLObject(feedbackObject))
         return false;
-    if (feedbackObject->isDeleted())
-        return false;
-
     return m_context->isTransformFeedback(feedbackObject->object());
 }
 
 void WebGL2RenderingContext::bindTransformFeedback(GCGLenum target, WebGLTransformFeedback* feedbackObject)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindTransformFeedback", feedbackObject))
         return;
 
@@ -2083,7 +2094,6 @@ void WebGL2RenderingContext::bindTransformFeedback(GCGLenum target, WebGLTransfo
     }
 
     auto toBeBound = feedbackObject ? feedbackObject : m_defaultTransformFeedback.get();
-    toBeBound->setHasEverBeenBound();
     m_context->bindTransformFeedback(target, toBeBound->object());
     m_boundTransformFeedback = toBeBound;
 }
@@ -2153,7 +2163,9 @@ void WebGL2RenderingContext::endTransformFeedback()
 
 void WebGL2RenderingContext::transformFeedbackVaryings(WebGLProgram& program, const Vector<String>& varyings, GCGLenum bufferMode)
 {
-    if (!validateWebGLProgramOrShader("transformFeedbackVaryings", &program))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("transformFeedbackVaryings", program))
         return;
     
     switch (bufferMode) {
@@ -2176,7 +2188,9 @@ void WebGL2RenderingContext::transformFeedbackVaryings(WebGLProgram& program, co
 
 RefPtr<WebGLActiveInfo> WebGL2RenderingContext::getTransformFeedbackVarying(WebGLProgram& program, GCGLuint index)
 {
-    if (!validateWebGLProgramOrShader("getTransformFeedbackVarying", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getTransformFeedbackVarying", program))
         return nullptr;
     if (!program.getLinkStatus()) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getTransformFeedbackVarying", "program not linked");
@@ -2235,8 +2249,9 @@ bool WebGL2RenderingContext::isTransformFeedbackActiveAndNotPaused()
 
 bool WebGL2RenderingContext::setIndexedBufferBinding(const char *functionName, GCGLenum target, GCGLuint index, WebGLBuffer* buffer)
 {
+    if (isContextLost())
+        return false;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject(functionName, buffer))
         return false;
 
@@ -2355,14 +2370,18 @@ Vector<bool> WebGL2RenderingContext::getIndexedBooleanArrayParameter(GCGLenum pn
 
 std::optional<Vector<GCGLuint>> WebGL2RenderingContext::getUniformIndices(WebGLProgram& program, const Vector<String>& names)
 {
-    if (!validateWebGLProgramOrShader("getUniformIndices", &program))
+    if (isContextLost())
+        return std::nullopt;
+    if (!validateWebGLObject("getUniformIndices", program))
         return std::nullopt;
     return m_context->getUniformIndices(program.object(), names);
 }
 
 WebGLAny WebGL2RenderingContext::getActiveUniforms(WebGLProgram& program, const Vector<GCGLuint>& uniformIndices, GCGLenum pname)
 {
-    if (!validateWebGLProgramOrShader("getActiveUniforms", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getActiveUniforms", program))
         return nullptr;
 
     switch (pname) {
@@ -2391,14 +2410,18 @@ WebGLAny WebGL2RenderingContext::getActiveUniforms(WebGLProgram& program, const 
 
 GCGLuint WebGL2RenderingContext::getUniformBlockIndex(WebGLProgram& program, const String& uniformBlockName)
 {
-    if (!validateWebGLProgramOrShader("getUniformBlockIndex", &program))
+    if (isContextLost())
+        return 0;
+    if (!validateWebGLObject("getUniformBlockIndex", program))
         return 0;
     return m_context->getUniformBlockIndex(program.object(), uniformBlockName);
 }
 
 WebGLAny WebGL2RenderingContext::getActiveUniformBlockParameter(WebGLProgram& program, GCGLuint uniformBlockIndex, GCGLenum pname)
 {
-    if (!validateWebGLProgramOrShader("getActiveUniformBlockParameter", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getActiveUniformBlockParameter", program))
         return nullptr;
     switch (pname) {
     case GraphicsContextGL::UNIFORM_BLOCK_BINDING:
@@ -2422,7 +2445,9 @@ WebGLAny WebGL2RenderingContext::getActiveUniformBlockParameter(WebGLProgram& pr
 
 WebGLAny WebGL2RenderingContext::getActiveUniformBlockName(WebGLProgram& program, GCGLuint index)
 {
-    if (!validateWebGLProgramOrShader("getActiveUniformBlockName", &program))
+    if (isContextLost())
+        return String { };
+    if (!validateWebGLObject("getActiveUniformBlockName", program))
         return String();
     if (!program.getLinkStatus()) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getActiveUniformBlockName", "program not linked");
@@ -2436,7 +2461,9 @@ WebGLAny WebGL2RenderingContext::getActiveUniformBlockName(WebGLProgram& program
 
 void WebGL2RenderingContext::uniformBlockBinding(WebGLProgram& program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding)
 {
-    if (!validateWebGLProgramOrShader("uniformBlockBinding", &program))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("uniformBlockBinding", program))
         return;
     m_context->uniformBlockBinding(program.object(), uniformBlockIndex, uniformBlockBinding);
 }
@@ -2477,28 +2504,23 @@ void WebGL2RenderingContext::deleteVertexArray(WebGLVertexArrayObject* arrayObje
 
 GCGLboolean WebGL2RenderingContext::isVertexArray(WebGLVertexArrayObject* arrayObject)
 {
-    if (isContextLost() || !arrayObject || !arrayObject->validate(*this))
+    if (isContextLost())
         return false;
-
-    if (!arrayObject->hasEverBeenBound())
+    if (!validateIsWebGLObject(arrayObject))
         return false;
-    if (arrayObject->isDeleted())
-        return false;
-
     return m_context->isVertexArray(arrayObject->object());
 }
 
 void WebGL2RenderingContext::bindVertexArray(WebGLVertexArrayObject* arrayObject)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindVertexArray", arrayObject))
         return;
 
     if (arrayObject && !arrayObject->isDefaultObject() && arrayObject->object()) {
         m_context->bindVertexArray(arrayObject->object());
-
-        arrayObject->setHasEverBeenBound();
         setBoundVertexArrayObject(locker, arrayObject);
     } else {
         m_context->bindVertexArray(m_defaultVertexArrayObject->object());
@@ -2643,7 +2665,7 @@ WebGLAny WebGL2RenderingContext::getFramebufferAttachmentParameter(GCGLenum targ
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid target");
         return nullptr;
     }
-    auto targetFramebuffer = (target == GraphicsContextGL::READ_FRAMEBUFFER) ? m_readFramebufferBinding : m_framebufferBinding;
+    RefPtr<WebGLFramebuffer> targetFramebuffer = (target == GraphicsContextGL::READ_FRAMEBUFFER) ? m_readFramebufferBinding : m_framebufferBinding;
 
     if (!targetFramebuffer) {
         if (!validateDefaultFramebufferAttachment(attachment)) {
@@ -3111,7 +3133,7 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER_BINDING:
         return m_boundTransformFeedbackBuffer;
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BINDING:
-        return m_boundTransformFeedback == m_defaultTransformFeedback ? nullptr : m_boundTransformFeedback;
+        return m_boundTransformFeedback == m_defaultTransformFeedback ? nullptr : RefPtr { m_boundTransformFeedback.get() };
     case GraphicsContextGL::TRANSFORM_FEEDBACK_PAUSED:
         return getBooleanParameter(pname);
     case GraphicsContextGL::UNIFORM_BUFFER_BINDING:
@@ -3131,7 +3153,7 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     case GraphicsContextGL::VERTEX_ARRAY_BINDING:
         if (m_boundVertexArrayObject->isDefaultObject())
             return nullptr;
-        return static_pointer_cast<WebGLVertexArrayObject>(m_boundVertexArrayObject);
+        return RefPtr { static_cast<WebGLVertexArrayObject*>(m_boundVertexArrayObject.get()) };
     case GraphicsContextGL::MAX_CLIP_DISTANCES_ANGLE:
     case GraphicsContextGL::MAX_CULL_DISTANCES_ANGLE:
     case GraphicsContextGL::MAX_COMBINED_CLIP_AND_CULL_DISTANCES_ANGLE:

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -335,17 +335,17 @@ private:
     };
     void updateBuffersToAutoClear(ClearBufferCaller, GCGLenum buffer, GCGLint drawbuffer);
 
-    RefPtr<WebGLFramebuffer> m_readFramebufferBinding;
-    RefPtr<WebGLTransformFeedback> m_boundTransformFeedback;
+    WebGLBindingPoint<WebGLFramebuffer> m_readFramebufferBinding;
+    WebGLBindingPoint<WebGLTransformFeedback> m_boundTransformFeedback;
     RefPtr<WebGLTransformFeedback> m_defaultTransformFeedback;
 
-    RefPtr<WebGLBuffer> m_boundCopyReadBuffer;
-    RefPtr<WebGLBuffer> m_boundCopyWriteBuffer;
-    RefPtr<WebGLBuffer> m_boundPixelPackBuffer;
-    RefPtr<WebGLBuffer> m_boundPixelUnpackBuffer;
-    RefPtr<WebGLBuffer> m_boundTransformFeedbackBuffer;
-    RefPtr<WebGLBuffer> m_boundUniformBuffer;
-    Vector<RefPtr<WebGLBuffer>> m_boundIndexedUniformBuffers;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::COPY_READ_BUFFER> m_boundCopyReadBuffer;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::COPY_WRITE_BUFFER> m_boundCopyWriteBuffer;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::PIXEL_PACK_BUFFER> m_boundPixelPackBuffer;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::PIXEL_UNPACK_BUFFER> m_boundPixelUnpackBuffer;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER> m_boundTransformFeedbackBuffer;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::UNIFORM_BUFFER> m_boundUniformBuffer;
+    Vector<WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::UNIFORM_BUFFER>> m_boundIndexedUniformBuffers;
 
     RefPtr<WebGLQuery> m_activeQueries[ActiveQueryKey::NumKeys];
 

--- a/Source/WebCore/html/canvas/WebGLBuffer.h
+++ b/Source/WebCore/html/canvas/WebGLBuffer.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -43,9 +43,9 @@ public:
     virtual ~WebGLBuffer();
 
     GCGLenum getTarget() const { return m_target; }
-    void setTarget(GCGLenum target) { m_target = target; }
-    bool hasEverBeenBound() const { return object() && m_target; }
-
+    void didBind(GCGLenum target);
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return m_target; }
 private:
     WebGLBuffer(WebGLRenderingContextBase&);
 
@@ -53,6 +53,13 @@ private:
 
     GCGLenum m_target { 0 };
 };
+
+inline void WebGLBuffer::didBind(GCGLenum target)
+{
+    if (m_target)
+        return;
+    m_target = target;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
+++ b/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
@@ -54,7 +54,7 @@ String WebGLDebugShaders::getTranslatedShaderSource(WebGLShader& shader)
     if (isContextLost())
         return String();
     auto& context = this->context();
-    if (!context.validateWebGLObject("getTranslatedShaderSource", &shader))
+    if (!context.validateWebGLObject("getTranslatedShaderSource", shader))
         return emptyString();
     return context.graphicsContextGL()->getTranslatedShaderSourceANGLE(shader.object());
 }

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.cpp
@@ -49,8 +49,6 @@ namespace {
         WebGLObject* getObject() const override;
         bool isSharedObject(WebGLObject*) const override;
         bool isValid() const override;
-        bool isInitialized() const override;
-        void setInitialized() override;
         void onDetached(const AbstractLocker&, GraphicsContextGL*) override;
         void attach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) override;
         void unattach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) override;
@@ -87,17 +85,6 @@ namespace {
         return m_renderbuffer->object();
     }
 
-    bool WebGLRenderbufferAttachment::isInitialized() const
-    {
-        return m_renderbuffer->object() && m_renderbuffer->isInitialized();
-    }
-
-    void WebGLRenderbufferAttachment::setInitialized()
-    {
-        if (m_renderbuffer->object())
-            m_renderbuffer->setInitialized();
-    }
-
     void WebGLRenderbufferAttachment::onDetached(const AbstractLocker& locker, GraphicsContextGL* context)
     {
         m_renderbuffer->onDetached(locker, context);
@@ -128,8 +115,6 @@ namespace {
         WebGLObject* getObject() const override;
         bool isSharedObject(WebGLObject*) const override;
         bool isValid() const override;
-        bool isInitialized() const override;
-        void setInitialized() override;
         void onDetached(const AbstractLocker&, GraphicsContextGL*) override;
         void attach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) override;
         void unattach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) override;
@@ -169,17 +154,6 @@ namespace {
     bool WebGLTextureAttachment::isValid() const
     {
         return m_texture->object();
-    }
-
-    bool WebGLTextureAttachment::isInitialized() const
-    {
-        // Textures are assumed to be initialized.
-        return true;
-    }
-
-    void WebGLTextureAttachment::setInitialized()
-    {
-        // Textures are assumed to be initialized.
     }
 
     void WebGLTextureAttachment::onDetached(const AbstractLocker& locker, GraphicsContextGL* context)
@@ -234,7 +208,6 @@ Ref<WebGLFramebuffer> WebGLFramebuffer::createOpaque(WebGLRenderingContextBase& 
 
 WebGLFramebuffer::WebGLFramebuffer(WebGLRenderingContextBase& ctx)
     : WebGLObject(ctx)
-    , m_hasEverBeenBound(false)
 {
     setObject(ctx.graphicsContextGL()->createFramebuffer());
 }

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -54,8 +54,6 @@ public:
         virtual WebGLObject* getObject() const = 0;
         virtual bool isSharedObject(WebGLObject*) const = 0;
         virtual bool isValid() const = 0;
-        virtual bool isInitialized() const = 0;
-        virtual void setInitialized() = 0;
         virtual void onDetached(const AbstractLocker&, GraphicsContextGL*) = 0;
         virtual void attach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) = 0;
         virtual void unattach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) = 0;
@@ -80,10 +78,7 @@ public:
     void removeAttachmentFromBoundFramebuffer(const AbstractLocker&, GCGLenum target, GCGLenum attachment);
     WebGLObject* getAttachmentObject(GCGLenum) const;
 
-    bool hasEverBeenBound() const { return object() && m_hasEverBeenBound; }
-
-    void setHasEverBeenBound() { m_hasEverBeenBound = true; }
-
+    void didBind() { m_hasEverBeenBound = true; }
     bool hasStencilBuffer() const;
 
     // Wrapper for drawBuffersEXT/drawBuffersARB to work around a driver bug.
@@ -97,6 +92,9 @@ public:
     bool isOpaque() const { return m_opaque; }
     void setOpaqueActive(bool active) { m_opaqueActive = active; }
 #endif
+
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
     WebGLFramebuffer(WebGLRenderingContextBase&);
@@ -124,7 +122,7 @@ private:
 
     AttachmentMap m_attachments;
 
-    bool m_hasEverBeenBound;
+    bool m_hasEverBeenBound { false };
 
     Vector<GCGLenum> m_drawBuffers;
     Vector<GCGLenum> m_filteredDrawBuffers;

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -90,6 +90,9 @@ public:
 
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
 
+    bool isUsable() const { return object(); }
+    bool isInitialized() const { return true; }
+
 private:
     WebGLProgram(WebGLRenderingContextBase&);
 

--- a/Source/WebCore/html/canvas/WebGLQuery.h
+++ b/Source/WebCore/html/canvas/WebGLQuery.h
@@ -46,7 +46,8 @@ public:
 
     void setTarget(GCGLenum target) { m_target = target; }
     GCGLenum target() const { return m_target; }
-
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return true; }
 private:
     explicit WebGLQuery(WebGLRenderingContextBase&);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
@@ -50,12 +50,6 @@ WebGLRenderbuffer::~WebGLRenderbuffer()
 
 WebGLRenderbuffer::WebGLRenderbuffer(WebGLRenderingContextBase& ctx)
     : WebGLObject(ctx)
-    , m_internalFormat(GraphicsContextGL::RGBA4)
-    , m_initialized(false)
-    , m_width(0)
-    , m_height(0)
-    , m_isValid(true)
-    , m_hasEverBeenBound(false)
 {
     setObject(ctx.graphicsContextGL()->createRenderbuffer());
 }

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.h
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.h
@@ -40,7 +40,6 @@ public:
     void setInternalFormat(GCGLenum internalformat)
     {
         m_internalFormat = internalformat;
-        m_initialized = false;
     }
     GCGLenum getInternalFormat() const { return m_internalFormat; }
 
@@ -55,12 +54,11 @@ public:
     void setIsValid(bool isValid) { m_isValid = isValid; }
     bool isValid() const { return m_isValid; }
 
-    bool isInitialized() const { return m_initialized; }
-    void setInitialized() { m_initialized = true; }
+    void didBind() { m_hasEverBeenBound = true; }
+    bool hasEverBeenBound() const { return m_hasEverBeenBound; }
 
-    bool hasEverBeenBound() const { return object() && m_hasEverBeenBound; }
-
-    void setHasEverBeenBound() { m_hasEverBeenBound = true; }
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
     WebGLRenderbuffer(WebGLRenderingContextBase&);
@@ -69,12 +67,11 @@ private:
 
     bool isRenderbuffer() const override { return true; }
 
-    GCGLenum m_internalFormat;
-    bool m_initialized;
-    GCGLsizei m_width, m_height;
-    bool m_isValid; // This is only false if internalFormat is DEPTH_STENCIL and packed_depth_stencil is not supported.
-
-    bool m_hasEverBeenBound;
+    GCGLenum m_internalFormat { GraphicsContextGL::RGBA4 };
+    GCGLsizei m_width { 0 };
+    GCGLsizei m_height { 0 };
+    bool m_isValid { true }; // This is only false if internalFormat is DEPTH_STENCIL and packed_depth_stencil is not supported.
+    bool m_hasEverBeenBound { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -58,7 +58,7 @@ public:
 protected:
     friend class EXTDisjointTimerQuery;
 
-    RefPtr<WebGLTimerQueryEXT> m_activeQuery;
+    WebGLBindingPoint<WebGLTimerQueryEXT, GraphicsContextGL::TIME_ELAPSED_EXT> m_activeQuery;
 
 private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -997,7 +997,7 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cal
 
     restoreStateAfterClear();
     if (m_framebufferBinding)
-        m_context->bindFramebuffer(bindingPoint, objectOrZero(m_framebufferBinding.get()));
+        m_context->bindFramebuffer(bindingPoint, m_framebufferBinding->object());
     m_layerCleared = true;
 
     return combinedClear;
@@ -1115,7 +1115,7 @@ void WebGLRenderingContextBase::reshape(int width, int height)
     m_context->bindTexture(GraphicsContextGL::TEXTURE_2D, objectOrZero(textureUnit.texture2DBinding.get()));
     m_context->bindRenderbuffer(GraphicsContextGL::RENDERBUFFER, objectOrZero(m_renderbufferBinding.get()));
     if (m_framebufferBinding)
-        m_context->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, objectOrZero(m_framebufferBinding.get()));
+        m_context->bindFramebuffer(GraphicsContextGL::FRAMEBUFFER, m_framebufferBinding->object());
 }
 
 int WebGLRenderingContextBase::drawingBufferWidth() const
@@ -1188,9 +1188,10 @@ void WebGLRenderingContextBase::activeTexture(GCGLenum texture)
 
 void WebGLRenderingContextBase::attachShader(WebGLProgram& program, WebGLShader& shader)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
-    if (!validateWebGLProgramOrShader("attachShader", &program) || !validateWebGLProgramOrShader("attachShader", &shader))
+    if (!validateWebGLObject("attachShader", program) || !validateWebGLObject("attachShader", shader))
         return;
     if (!program.attachShader(locker, &shader)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "attachShader", "shader attachment already has shader");
@@ -1202,7 +1203,9 @@ void WebGLRenderingContextBase::attachShader(WebGLProgram& program, WebGLShader&
 
 void WebGLRenderingContextBase::bindAttribLocation(WebGLProgram& program, GCGLuint index, const String& name)
 {
-    if (!validateWebGLProgramOrShader("bindAttribLocation", &program))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("bindAttribLocation", program))
         return;
     if (!validateLocationLength("bindAttribLocation", name))
         return;
@@ -1217,18 +1220,6 @@ void WebGLRenderingContextBase::bindAttribLocation(WebGLProgram& program, GCGLui
         return;
     }
     m_context->bindAttribLocation(program.object(), index, name);
-}
-
-bool WebGLRenderingContextBase::validateNullableWebGLObject(const char* functionName, WebGLObject* object)
-{
-    if (isContextLost())
-        return false;
-    if (!object) {
-        // This differs in behavior to ValidateWebGLObject; null objects are allowed
-        // in these entry points.
-        return true;
-    }
-    return validateWebGLObject(functionName, object);
 }
 
 bool WebGLRenderingContextBase::validateBufferTarget(const char* functionName, GCGLenum target)
@@ -1281,15 +1272,14 @@ bool WebGLRenderingContextBase::validateAndCacheBufferBinding(const AbstractLock
         m_boundVertexArrayObject->setElementArrayBuffer(locker, buffer);
     }
 
-    if (buffer && !buffer->getTarget())
-        buffer->setTarget(target);
     return true;
 }
 
 void WebGLRenderingContextBase::bindBuffer(GCGLenum target, WebGLBuffer* buffer)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindBuffer", buffer))
         return;
 
@@ -1301,8 +1291,9 @@ void WebGLRenderingContextBase::bindBuffer(GCGLenum target, WebGLBuffer* buffer)
 
 void WebGLRenderingContextBase::bindFramebuffer(GCGLenum target, WebGLFramebuffer* buffer)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindFramebuffer", buffer))
         return;
 
@@ -1316,8 +1307,9 @@ void WebGLRenderingContextBase::bindFramebuffer(GCGLenum target, WebGLFramebuffe
 
 void WebGLRenderingContextBase::bindRenderbuffer(GCGLenum target, WebGLRenderbuffer* renderBuffer)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindRenderbuffer", renderBuffer))
         return;
     if (target != GraphicsContextGL::RENDERBUFFER) {
@@ -1326,14 +1318,13 @@ void WebGLRenderingContextBase::bindRenderbuffer(GCGLenum target, WebGLRenderbuf
     }
     m_renderbufferBinding = renderBuffer;
     m_context->bindRenderbuffer(target, objectOrZero(renderBuffer));
-    if (renderBuffer)
-        renderBuffer->setHasEverBeenBound();
 }
 
 void WebGLRenderingContextBase::bindTexture(GCGLenum target, WebGLTexture* texture)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("bindTexture", texture))
         return;
     if (texture && texture->getTarget() && texture->getTarget() != target) {
@@ -1354,8 +1345,6 @@ void WebGLRenderingContextBase::bindTexture(GCGLenum target, WebGLTexture* textu
         return;
     }
     m_context->bindTexture(target, objectOrZero(texture));
-    if (texture)
-        texture->setTarget(target);
 
     // Note: previously we used to automatically set the TEXTURE_WRAP_R
     // repeat mode to CLAMP_TO_EDGE for cube map textures, because OpenGL
@@ -1525,7 +1514,9 @@ void WebGLRenderingContextBase::colorMask(GCGLboolean red, GCGLboolean green, GC
 
 void WebGLRenderingContextBase::compileShader(WebGLShader& shader)
 {
-    if (!validateWebGLProgramOrShader("compileShader", &shader))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("compileShader", shader))
         return;
     m_context->compileShader(shader.object());
 }
@@ -1792,9 +1783,10 @@ void WebGLRenderingContextBase::depthRange(GCGLfloat zNear, GCGLfloat zFar)
 
 void WebGLRenderingContextBase::detachShader(WebGLProgram& program, WebGLShader& shader)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
-    if (!validateWebGLProgramOrShader("detachShader", &program) || !validateWebGLProgramOrShader("detachShader", &shader))
+    if (!validateWebGLObject("detachShader", program) || !validateWebGLObject("detachShader", shader))
         return;
     if (!program.detachShader(locker, &shader)) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "detachShader", "shader not attached");
@@ -1833,53 +1825,6 @@ bool WebGLRenderingContextBase::validateVertexArrayObject(const char* functionNa
 {
     if (!m_boundVertexArrayObject->areAllEnabledAttribBuffersBound()) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "no buffer is bound to enabled attribute");
-        return false;
-    }
-    return true;
-}
-
-bool WebGLRenderingContextBase::validateWebGLObject(const char* functionName, WebGLObject* object)
-{
-    if (isContextLost())
-        return false;
-    if (!object) {
-        synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "object is null");
-        return false;
-    }
-    if (object->isDeleted()) {
-        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "attempt to use a deleted object");
-        return false;
-    }
-    if (!object->validate(*this)) {
-        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "object does not belong to this context");
-        return false;
-    }
-    return true;
-}
-
-bool WebGLRenderingContextBase::validateWebGLProgramOrShader(const char* functionName, WebGLObject* object)
-{
-    if (isContextLost())
-        return false;
-    if (!object) {
-        synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "program or shader is null");
-        return false;
-    }
-    // OpenGL ES 3.0.5 p. 45:
-    // "Commands that accept shader or program object names will generate the
-    // error INVALID_VALUE if the provided name is not the name of either a shader
-    // or program object and INVALID_OPERATION if the provided name identifies an
-    // object that is not the expected type."
-    //
-    // Programs and shaders also have slightly different lifetime rules than other
-    // objects in the API; they continue to be usable after being marked for
-    // deletion.
-    if (!object->object()) {
-        synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "attempt to use a deleted program or shader");
-        return false;
-    }
-    if (!object->validate(*this)) {
-        synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "object does not belong to this context");
         return false;
     }
     return true;
@@ -2046,7 +1991,9 @@ void WebGLRenderingContextBase::generateMipmap(GCGLenum target)
 
 RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveAttrib(WebGLProgram& program, GCGLuint index)
 {
-    if (!validateWebGLProgramOrShader("getActiveAttrib", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getActiveAttrib", program))
         return nullptr;
     GraphicsContextGLActiveInfo info;
     if (!m_context->getActiveAttrib(program.object(), index, info))
@@ -2056,7 +2003,9 @@ RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveAttrib(WebGLProgram&
 
 RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveUniform(WebGLProgram& program, GCGLuint index)
 {
-    if (!validateWebGLProgramOrShader("getActiveUniform", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getActiveUniform", program))
         return nullptr;
     GraphicsContextGLActiveInfo info;
     if (!m_context->getActiveUniform(program.object(), index, info))
@@ -2071,7 +2020,9 @@ RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveUniform(WebGLProgram
 
 std::optional<Vector<RefPtr<WebGLShader>>> WebGLRenderingContextBase::getAttachedShaders(WebGLProgram& program)
 {
-    if (!validateWebGLProgramOrShader("getAttachedShaders", &program))
+    if (isContextLost())
+        return std::nullopt;
+    if (!validateWebGLObject("getAttachedShaders", program))
         return std::nullopt;
 
     const GCGLenum shaderTypes[] = {
@@ -2088,7 +2039,9 @@ std::optional<Vector<RefPtr<WebGLShader>>> WebGLRenderingContextBase::getAttache
 
 GCGLint WebGLRenderingContextBase::getAttribLocation(WebGLProgram& program, const String& name)
 {
-    if (!validateWebGLProgramOrShader("getAttribLocation", &program))
+    if (isContextLost())
+        return -1;
+    if (!validateWebGLObject("getAttribLocation", program))
         return -1;
     if (!validateLocationLength("getAttribLocation", name))
         return -1;
@@ -2418,7 +2371,7 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
         if (m_oesVertexArrayObject) {
             if (m_boundVertexArrayObject->isDefaultObject())
                 return nullptr;
-            return static_pointer_cast<WebGLVertexArrayObjectOES>(m_boundVertexArrayObject);
+            return RefPtr { static_cast<WebGLVertexArrayObjectOES*>(m_boundVertexArrayObject.get()) };
         }
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, OES_vertex_array_object not enabled");
         return nullptr;
@@ -2496,7 +2449,7 @@ WebGLAny WebGLRenderingContextBase::getProgramParameter(WebGLProgram& program, G
             return true;
         return nullptr;
     }
-    if (!validateWebGLProgramOrShader("getProgramParameter", &program))
+    if (!validateWebGLObject("getProgramParameter", program))
         return nullptr;
 
     switch (pname) {
@@ -2534,7 +2487,9 @@ WebGLAny WebGLRenderingContextBase::getProgramParameter(WebGLProgram& program, G
 
 String WebGLRenderingContextBase::getProgramInfoLog(WebGLProgram& program)
 {
-    if (!validateWebGLProgramOrShader("getProgramInfoLog", &program))
+    if (isContextLost())
+        return String { };
+    if (!validateWebGLObject("getProgramInfoLog", program))
         return String();
     return ensureNotNull(m_context->getProgramInfoLog(program.object()));
 }
@@ -2617,7 +2572,7 @@ WebGLAny WebGLRenderingContextBase::getShaderParameter(WebGLShader& shader, GCGL
             return true;
         return nullptr;
     }
-    if (!validateWebGLProgramOrShader("getShaderParameter", &shader))
+    if (!validateWebGLObject("getShaderParameter", shader))
         return nullptr;
 
     switch (pname) {
@@ -2640,7 +2595,9 @@ WebGLAny WebGLRenderingContextBase::getShaderParameter(WebGLShader& shader, GCGL
 
 String WebGLRenderingContextBase::getShaderInfoLog(WebGLShader& shader)
 {
-    if (!validateWebGLProgramOrShader("getShaderInfoLog", &shader))
+    if (isContextLost())
+        return String { };
+    if (!validateWebGLObject("getShaderInfoLog", shader))
         return String();
     return ensureNotNull(m_context->getShaderInfoLog(shader.object()));
 }
@@ -2678,7 +2635,9 @@ RefPtr<WebGLShaderPrecisionFormat> WebGLRenderingContextBase::getShaderPrecision
 
 String WebGLRenderingContextBase::getShaderSource(WebGLShader& shader)
 {
-    if (!validateWebGLProgramOrShader("getShaderSource", &shader))
+    if (isContextLost())
+        return String { };
+    if (!validateWebGLObject("getShaderSource", shader))
         return String();
     return ensureNotNull(shader.getSource());
 }
@@ -2709,7 +2668,9 @@ WebGLAny WebGLRenderingContextBase::getTexParameter(GCGLenum target, GCGLenum pn
 
 WebGLAny WebGLRenderingContextBase::getUniform(WebGLProgram& program, const WebGLUniformLocation& uniformLocation)
 {
-    if (!validateWebGLProgramOrShader("getUniform", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getUniform", program))
         return nullptr;
     if (uniformLocation.program() != &program) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "getUniform", "no uniformlocation or not valid for this program");
@@ -2898,7 +2859,9 @@ WebGLAny WebGLRenderingContextBase::getUniform(WebGLProgram& program, const WebG
 
 RefPtr<WebGLUniformLocation> WebGLRenderingContextBase::getUniformLocation(WebGLProgram& program, const String& name)
 {
-    if (!validateWebGLProgramOrShader("getUniformLocation", &program))
+    if (isContextLost())
+        return nullptr;
+    if (!validateWebGLObject("getUniformLocation", program))
         return nullptr;
     if (!validateLocationLength("getUniformLocation", name))
         return nullptr;
@@ -3078,14 +3041,10 @@ void WebGLRenderingContextBase::hint(GCGLenum target, GCGLenum mode)
 
 GCGLboolean WebGLRenderingContextBase::isBuffer(WebGLBuffer* buffer)
 {
-    if (!buffer || isContextLost() || !buffer->validate(*this))
-        return 0;
-
-    if (!buffer->hasEverBeenBound())
-        return 0;
-    if (buffer->isDeleted())
-        return 0;
-
+    if (isContextLost())
+        return false;
+    if (!validateIsWebGLObject(buffer))
+        return false;
     return m_context->isBuffer(buffer->object());
 }
 
@@ -3105,64 +3064,46 @@ GCGLboolean WebGLRenderingContextBase::isEnabled(GCGLenum cap)
 
 GCGLboolean WebGLRenderingContextBase::isFramebuffer(WebGLFramebuffer* framebuffer)
 {
-    if (!framebuffer || isContextLost() || !framebuffer->validate(*this))
-        return 0;
-
-    if (!framebuffer->hasEverBeenBound())
-        return 0;
-    if (framebuffer->isDeleted())
-        return 0;
-
+    if (isContextLost())
+        return false;
+    if (!validateIsWebGLObject(framebuffer))
+        return false;
     return m_context->isFramebuffer(framebuffer->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isProgram(WebGLProgram* program)
 {
-    if (!program || isContextLost() || !program->validate(*this))
-        return 0;
-
-    // OpenGL ES special-cases the behavior of program objects; if they're deleted
-    // while attached to the current context state, glIsProgram is supposed to
-    // still return true. For this reason, isDeleted is not checked here.
-
+    if (isContextLost())
+        return false;
+    if (!validateIsWebGLObject(program))
+        return false;
     return m_context->isProgram(program->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isRenderbuffer(WebGLRenderbuffer* renderbuffer)
 {
-    if (!renderbuffer || isContextLost() || !renderbuffer->validate(*this))
-        return 0;
-
-    if (!renderbuffer->hasEverBeenBound())
-        return 0;
-    if (renderbuffer->isDeleted())
-        return 0;
-
+    if (isContextLost())
+        return false;
+    if (!validateIsWebGLObject(renderbuffer))
+        return false;
     return m_context->isRenderbuffer(renderbuffer->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isShader(WebGLShader* shader)
 {
-    if (!shader || isContextLost() || !shader->validate(*this))
+    if (isContextLost())
         return 0;
-
-    // OpenGL ES special-cases the behavior of shader objects; if they're deleted
-    // while attached to a program, glIsShader is supposed to still return true.
-    // For this reason, isDeleted is not checked here.
-
+    if (!validateIsWebGLObject(shader))
+        return false;
     return m_context->isShader(shader->object());
 }
 
 GCGLboolean WebGLRenderingContextBase::isTexture(WebGLTexture* texture)
 {
-    if (!texture || isContextLost() || !texture->validate(*this))
-        return 0;
-
-    if (!texture->hasEverBeenBound())
-        return 0;
-    if (texture->isDeleted())
-        return 0;
-
+    if (isContextLost())
+        return false;
+    if (!validateIsWebGLObject(texture))
+        return false;
     return m_context->isTexture(texture->object());
 }
 
@@ -3175,17 +3116,19 @@ void WebGLRenderingContextBase::lineWidth(GCGLfloat width)
 
 void WebGLRenderingContextBase::linkProgram(WebGLProgram& program)
 {
-    if (!linkProgramWithoutInvalidatingAttribLocations(&program))
+    if (!linkProgramWithoutInvalidatingAttribLocations(program))
         return;
 
     program.increaseLinkCount();
 }
 
-bool WebGLRenderingContextBase::linkProgramWithoutInvalidatingAttribLocations(WebGLProgram* program)
+bool WebGLRenderingContextBase::linkProgramWithoutInvalidatingAttribLocations(WebGLProgram& program)
 {
-    if (!validateWebGLProgramOrShader("linkProgram", program))
+    if (isContextLost())
         return false;
-    m_context->linkProgram(objectOrZero(program));
+    if (!validateWebGLObject("linkProgram", program))
+        return false;
+    m_context->linkProgram(program.object());
     return true;
 }
 
@@ -3420,7 +3363,9 @@ void WebGLRenderingContextBase::scissor(GCGLint x, GCGLint y, GCGLsizei width, G
 
 void WebGLRenderingContextBase::shaderSource(WebGLShader& shader, const String& string)
 {
-    if (!validateWebGLProgramOrShader("shaderSource", &shader))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("shaderSource", shader))
         return;
     m_context->shaderSource(shader.object(), string);
     shader.setSource(string);
@@ -4845,8 +4790,9 @@ void WebGLRenderingContextBase::uniformMatrix4fv(const WebGLUniformLocation* loc
 
 void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
 {
+    if (isContextLost())
+        return;
     Locker locker { objectGraphLock() };
-
     if (!validateNullableWebGLObject("useProgram", program))
         return;
     if (program && !program->getLinkStatus()) {
@@ -4876,7 +4822,9 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
 
 void WebGLRenderingContextBase::validateProgram(WebGLProgram& program)
 {
-    if (!validateWebGLProgramOrShader("validateProgram", &program))
+    if (isContextLost())
+        return;
+    if (!validateWebGLObject("validateProgram", program))
         return;
     m_context->validateProgram(program.object());
 }
@@ -5841,9 +5789,6 @@ void WebGLRenderingContextBase::setBackDrawBuffer(GCGLenum buf)
 
 void WebGLRenderingContextBase::setFramebuffer(const AbstractLocker&, GCGLenum target, WebGLFramebuffer* buffer)
 {
-    if (buffer)
-        buffer->setHasEverBeenBound();
-
     if (target == GraphicsContextGL::FRAMEBUFFER || target == GraphicsContextGL::DRAW_FRAMEBUFFER)
         m_framebufferBinding = buffer;
     m_context->bindFramebuffer(target, objectOrZero(buffer));

--- a/Source/WebCore/html/canvas/WebGLSampler.h
+++ b/Source/WebCore/html/canvas/WebGLSampler.h
@@ -39,7 +39,9 @@ class WebGLSampler final : public WebGLObject {
 public:
     static Ref<WebGLSampler> create(WebGLRenderingContextBase&);
     virtual ~WebGLSampler();
-
+    void didBind() { }
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return true; }
 private:
     explicit WebGLSampler(WebGLRenderingContextBase&);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;

--- a/Source/WebCore/html/canvas/WebGLShader.h
+++ b/Source/WebCore/html/canvas/WebGLShader.h
@@ -42,6 +42,8 @@ public:
 
     void setSource(const String& source) { m_source = source; }
 
+    bool isUsable() const { return object(); }
+    bool isInitialized() const { return true; }
 private:
     WebGLShader(WebGLRenderingContextBase&, GCGLenum);
 

--- a/Source/WebCore/html/canvas/WebGLSync.h
+++ b/Source/WebCore/html/canvas/WebGLSync.h
@@ -43,6 +43,8 @@ public:
     bool isSignaled() const;
     void scheduleAllowCacheUpdate(WebGLRenderingContextBase&);
 
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return true; }
 private:
     WebGLSync(WebGLRenderingContextBase&);
 

--- a/Source/WebCore/html/canvas/WebGLTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLTexture.cpp
@@ -41,7 +41,6 @@ Ref<WebGLTexture> WebGLTexture::create(WebGLRenderingContextBase& ctx)
 
 WebGLTexture::WebGLTexture(WebGLRenderingContextBase& ctx)
     : WebGLObject(ctx)
-    , m_target(0)
 {
     setObject(ctx.graphicsContextGL()->createTexture());
 }
@@ -54,7 +53,7 @@ WebGLTexture::~WebGLTexture()
     runDestructor();
 }
 
-void WebGLTexture::setTarget(GCGLenum target)
+void WebGLTexture::didBind(GCGLenum target)
 {
     if (!object())
         return;

--- a/Source/WebCore/html/canvas/WebGLTexture.h
+++ b/Source/WebCore/html/canvas/WebGLTexture.h
@@ -45,12 +45,13 @@ public:
 
     static Ref<WebGLTexture> create(WebGLRenderingContextBase&);
 
-    void setTarget(GCGLenum);
+    void didBind(GCGLenum);
     GCGLenum getTarget() const { return m_target; }
 
-    bool hasEverBeenBound() const { return object() && m_target; }
-
     static GCGLint computeLevelCount(GCGLsizei width, GCGLsizei height);
+
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return m_target; }
 
 private:
     WebGLTexture(WebGLRenderingContextBase&);
@@ -60,7 +61,7 @@ private:
     bool isTexture() const override { return true; }
 
     int mapTargetToIndex(GCGLenum) const;
-    GCGLenum m_target;
+    GCGLenum m_target { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
@@ -45,6 +45,9 @@ public:
 
     void setTarget(GCGLenum target) { m_target = target; }
     GCGLenum target() const { return m_target; }
+    void didBind(GCGLenum target) { setTarget(target); }
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return true; }
 
 private:
     explicit WebGLTimerQueryEXT(WebGLRenderingContextBase&);

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.h
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -50,44 +50,46 @@ public:
     virtual ~WebGLTransformFeedback();
 
     static RefPtr<WebGLTransformFeedback> create(WebGL2RenderingContext&);
-    
+
     bool isActive() const { return m_active; }
     bool isPaused() const { return m_paused; }
-    
+
     void setActive(bool active) { m_active = active; }
     void setPaused(bool paused) { m_paused = paused; }
-    
+
     // These are the indexed bind points for transform feedback buffers.
     // Returns false if index is out of range and the caller should
     // synthesize a GL error.
     void setBoundIndexedTransformFeedbackBuffer(const AbstractLocker&, GCGLuint index, WebGLBuffer*);
     bool getBoundIndexedTransformFeedbackBuffer(GCGLuint index, WebGLBuffer** outBuffer);
     bool hasBoundIndexedTransformFeedbackBuffer(const WebGLBuffer* buffer) { return m_boundIndexedTransformFeedbackBuffers.contains(buffer); }
-    
+
     bool validateProgramForResume(WebGLProgram*) const;
 
-    bool hasEverBeenBound() const { return object() && m_hasEverBeenBound; }
-    void setHasEverBeenBound() { m_hasEverBeenBound = true; }
-    
+    void didBind() { m_hasEverBeenBound = true; }
+
     WebGLProgram* program() const { return m_program.get(); }
     void setProgram(const AbstractLocker&, WebGLProgram&);
-    
+
     void unbindBuffer(const AbstractLocker&, WebGLBuffer&);
-    
+
     bool hasEnoughBuffers(GCGLuint numRequired) const;
 
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
+
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
     WebGLTransformFeedback(WebGL2RenderingContext&);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
-    
+
     bool m_active { false };
     bool m_paused { false };
     bool m_hasEverBeenBound { false };
     unsigned m_programLinkCount { 0 };
-    Vector<RefPtr<WebGLBuffer>> m_boundIndexedTransformFeedbackBuffers;
+    Vector<WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER>> m_boundIndexedTransformFeedbackBuffers;
     RefPtr<WebGLProgram> m_program;
 };
 

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
@@ -54,7 +54,7 @@ public:
         bool validateBinding() const { return !enabled || isBound(); }
 
         bool enabled { false };
-        RefPtr<WebGLBuffer> bufferBinding;
+        WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::ARRAY_BUFFER> bufferBinding;
         GCGLsizei bytesPerElement { 0 };
         GCGLint size { 4 };
         GCGLenum type { GraphicsContextGL::FLOAT };
@@ -68,8 +68,7 @@ public:
 
     bool isDefaultObject() const { return m_type == Type::Default; }
 
-    bool hasEverBeenBound() const { return object() && m_hasEverBeenBound; }
-    void setHasEverBeenBound() { m_hasEverBeenBound = true; }
+    void didBind() { m_hasEverBeenBound = true; }
 
     WebGLBuffer* getElementArrayBuffer() const { return m_boundElementArrayBuffer.get(); }
     void setElementArrayBuffer(const AbstractLocker&, WebGLBuffer*);
@@ -85,13 +84,17 @@ public:
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
 
     bool areAllEnabledAttribBuffersBound();
+
+    bool isUsable() const { return object() && !isDeleted(); }
+    bool isInitialized() const { return m_hasEverBeenBound; }
+
 protected:
     WebGLVertexArrayObjectBase(WebGLRenderingContextBase&, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override = 0;
 
     Type m_type;
     bool m_hasEverBeenBound { false };
-    RefPtr<WebGLBuffer> m_boundElementArrayBuffer;
+    WebGLBindingPoint<WebGLBuffer, GraphicsContextGL::ELEMENT_ARRAY_BUFFER> m_boundElementArrayBuffer;
     Vector<VertexAttribState> m_vertexAttribState;
     std::optional<bool> m_allEnabledAttribBuffersBoundCache;
 };

--- a/Source/WebCore/inspector/InspectorShaderProgram.cpp
+++ b/Source/WebCore/inspector/InspectorShaderProgram.cpp
@@ -97,7 +97,7 @@ bool InspectorShaderProgram::updateShader(Inspector::Protocol::Canvas::ShaderTyp
     if (!std::holds_alternative<bool>(compileStatus))
         return false;
     if (std::get<bool>(compileStatus))
-        context->linkProgramWithoutInvalidatingAttribLocations(&m_program);
+        context->linkProgramWithoutInvalidatingAttribLocations(m_program);
     else {
         auto errors = context->getShaderInfoLog(*shader);
         auto* scriptContext = m_canvas.scriptExecutionContext();


### PR DESCRIPTION
#### f13b4beff03458f7ee54332a23507cd35e22ad35
<pre>
WebGL &quot;is resource&quot; checking and object validation contains repeated code
<a href="https://bugs.webkit.org/show_bug.cgi?id=260475">https://bugs.webkit.org/show_bug.cgi?id=260475</a>
rdar://114207432

Reviewed by Dan Glastonbury.

Checks of &quot;isTexture()&quot; and others, and webgl object validation has
following problems:
 - Uses inheritance for customizing behavior, forcing the base class
   have state which is not common to all subclasses
 - Has custom but similar code for each resource, with varying level
   of consistency (slight checking differences)
 - Has duplicated isContextLost() checks inside validation functions

Fix these by:
 - Using templates to implement the common logic for validation
   instead of using WebGLObject base class. This allows future changes
   to remove the virtualization, further simplifying the code.
 - Expose the differences in resource behavior in the `isUsable()`,
   `isInitialized()` methods in the resources.
 - Implement WebGLBindingPoint&lt;T&gt; template to implement &quot;this object
   was bound&quot; marker in a consistent, &quot;provably&quot; not missing any cases
   kind of way.
 - Removes unused WebGLRenderbuffer::isInitialized() and related
   WebGLFramebuffer::WebGLAttachment::isInitialized() code.
   The code was unused and appropriate to remove here due to the name
   clash with the added isInitialized().
 - Change validateWebGLObject object argument from pointer to object
   since it was always called with an existing object.

* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::isQueryEXT):
(WebCore::EXTDisjointTimerQuery::beginQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
(WebCore::EXTDisjointTimerQuery::getQueryObjectEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/OESVertexArrayObject.cpp:
(WebCore::OESVertexArrayObject::isVertexArrayOES):
(WebCore::OESVertexArrayObject::bindVertexArrayOES):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateAndCacheBufferBinding):
(WebCore::WebGL2RenderingContext::bindFramebuffer):
(WebCore::WebGL2RenderingContext::framebufferTextureLayer):
(WebCore::WebGL2RenderingContext::getFragDataLocation):
(WebCore::WebGL2RenderingContext::deleteQuery):
(WebCore::WebGL2RenderingContext::isQuery):
(WebCore::WebGL2RenderingContext::beginQuery):
(WebCore::WebGL2RenderingContext::getQueryParameter):
(WebCore::WebGL2RenderingContext::isSampler):
(WebCore::WebGL2RenderingContext::bindSampler):
(WebCore::WebGL2RenderingContext::samplerParameteri):
(WebCore::WebGL2RenderingContext::samplerParameterf):
(WebCore::WebGL2RenderingContext::getSamplerParameter):
(WebCore::WebGL2RenderingContext::isSync):
(WebCore::WebGL2RenderingContext::clientWaitSync):
(WebCore::WebGL2RenderingContext::waitSync):
(WebCore::WebGL2RenderingContext::getSyncParameter):
(WebCore::WebGL2RenderingContext::isTransformFeedback):
(WebCore::WebGL2RenderingContext::bindTransformFeedback):
(WebCore::WebGL2RenderingContext::transformFeedbackVaryings):
(WebCore::WebGL2RenderingContext::getTransformFeedbackVarying):
(WebCore::WebGL2RenderingContext::setIndexedBufferBinding):
(WebCore::WebGL2RenderingContext::getUniformIndices):
(WebCore::WebGL2RenderingContext::getActiveUniforms):
(WebCore::WebGL2RenderingContext::getUniformBlockIndex):
(WebCore::WebGL2RenderingContext::getActiveUniformBlockParameter):
(WebCore::WebGL2RenderingContext::getActiveUniformBlockName):
(WebCore::WebGL2RenderingContext::uniformBlockBinding):
(WebCore::WebGL2RenderingContext::isVertexArray):
(WebCore::WebGL2RenderingContext::bindVertexArray):
(WebCore::WebGL2RenderingContext::getFramebufferAttachmentParameter):
(WebCore::WebGL2RenderingContext::getParameter):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLBuffer.h:
(WebCore::WebGLBuffer::didBind):
* Source/WebCore/html/canvas/WebGLDebugShaders.cpp:
(WebCore::WebGLDebugShaders::getTranslatedShaderSource):
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::WebGLFramebuffer):
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLObject.h:
(WebCore::WebGLBindingPoint::WebGLBindingPoint):
(WebCore::WebGLBindingPoint::operator=):
(WebCore::WebGLBindingPoint::operator== const):
(WebCore::WebGLBindingPoint::operator bool const):
(WebCore::WebGLBindingPoint::get const):
(WebCore::WebGLBindingPoint::operator-&gt; const):
(WebCore::WebGLBindingPoint::operator* const):
(WebCore::WebGLBindingPoint::operator RefPtr&lt;T&gt; const):
(WebCore::WebGLBindingPoint::didBind):
(WebCore::WebGLObject::isDeleted const):
(WebCore::objectOrZero):
(WebCore::WebGLObject::isDeleted): Deleted.
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/canvas/WebGLQuery.h:
* Source/WebCore/html/canvas/WebGLRenderbuffer.cpp:
(WebCore::WebGLRenderbuffer::WebGLRenderbuffer):
* Source/WebCore/html/canvas/WebGLRenderbuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::reshape):
(WebCore::WebGLRenderingContextBase::attachShader):
(WebCore::WebGLRenderingContextBase::bindAttribLocation):
(WebCore::WebGLRenderingContextBase::validateAndCacheBufferBinding):
(WebCore::WebGLRenderingContextBase::bindBuffer):
(WebCore::WebGLRenderingContextBase::bindFramebuffer):
(WebCore::WebGLRenderingContextBase::bindRenderbuffer):
(WebCore::WebGLRenderingContextBase::bindTexture):
(WebCore::WebGLRenderingContextBase::compileShader):
(WebCore::WebGLRenderingContextBase::detachShader):
(WebCore::WebGLRenderingContextBase::getActiveAttrib):
(WebCore::WebGLRenderingContextBase::getActiveUniform):
(WebCore::WebGLRenderingContextBase::getAttachedShaders):
(WebCore::WebGLRenderingContextBase::getAttribLocation):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::getProgramParameter):
(WebCore::WebGLRenderingContextBase::getProgramInfoLog):
(WebCore::WebGLRenderingContextBase::getShaderParameter):
(WebCore::WebGLRenderingContextBase::getShaderInfoLog):
(WebCore::WebGLRenderingContextBase::getShaderSource):
(WebCore::WebGLRenderingContextBase::getUniform):
(WebCore::WebGLRenderingContextBase::getUniformLocation):
(WebCore::WebGLRenderingContextBase::isBuffer):
(WebCore::WebGLRenderingContextBase::isFramebuffer):
(WebCore::WebGLRenderingContextBase::isProgram):
(WebCore::WebGLRenderingContextBase::isRenderbuffer):
(WebCore::WebGLRenderingContextBase::isShader):
(WebCore::WebGLRenderingContextBase::isTexture):
(WebCore::WebGLRenderingContextBase::linkProgram):
(WebCore::WebGLRenderingContextBase::linkProgramWithoutInvalidatingAttribLocations):
(WebCore::WebGLRenderingContextBase::shaderSource):
(WebCore::WebGLRenderingContextBase::useProgram):
(WebCore::WebGLRenderingContextBase::validateProgram):
(WebCore::WebGLRenderingContextBase::setFramebuffer):
(WebCore::WebGLRenderingContextBase::validateNullableWebGLObject): Deleted.
(WebCore::WebGLRenderingContextBase::validateWebGLObject): Deleted.
(WebCore::WebGLRenderingContextBase::validateWebGLProgramOrShader): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::validateWebGLObject):
(WebCore::WebGLRenderingContextBase::validateNullableWebGLObject):
(WebCore::WebGLRenderingContextBase::validateIsWebGLObject const):
* Source/WebCore/html/canvas/WebGLSampler.h:
* Source/WebCore/html/canvas/WebGLShader.h:
* Source/WebCore/html/canvas/WebGLSync.h:
* Source/WebCore/html/canvas/WebGLTexture.cpp:
(WebCore::WebGLTexture::WebGLTexture):
(WebCore::WebGLTexture::didBind):
(WebCore::WebGLTexture::setTarget): Deleted.
* Source/WebCore/html/canvas/WebGLTexture.h:
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.h:
* Source/WebCore/html/canvas/WebGLTransformFeedback.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h:
(WebCore::WebGLVertexArrayObjectBase::didBind):
(WebCore::WebGLVertexArrayObjectBase::isUsable const):
(WebCore::WebGLVertexArrayObjectBase::isInitialized const):
(WebCore::WebGLVertexArrayObjectBase::hasEverBeenBound const): Deleted.
(WebCore::WebGLVertexArrayObjectBase::setHasEverBeenBound): Deleted.
* Source/WebCore/inspector/InspectorShaderProgram.cpp:
(WebCore::InspectorShaderProgram::updateShader):

Canonical link: <a href="https://commits.webkit.org/267121@main">https://commits.webkit.org/267121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec66d2a8e729f2f91e2a573013e67d5f80e929f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17243 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18181 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14154 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12645 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14163 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3757 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->