### PR TITLE
Begin generating serialization code for RemoteScrollingCoordinatorTransaction

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -214,6 +214,7 @@ $(PROJECT_DIR)/Shared/PlatformPopupMenuData.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/PolicyDecision.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+$(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerType.serialization.in
 $(PROJECT_DIR)/Shared/SameDocumentNavigationType.serialization.in
 $(PROJECT_DIR)/Shared/SessionState.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -535,6 +535,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/ApplePay/PaymentSetupConfiguration.serialization.in \
 	Shared/Databases/IndexedDB/WebIDBResult.serialization.in \
 	Shared/RemoteLayerTree/RemoteLayerTree.serialization.in \
+	Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in \
 	Shared/mac/PDFContextMenuItem.serialization.in \
 	Shared/mac/SecItemRequestData.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -501,21 +501,7 @@ bool ArgumentCoder<ScrollingStatePositionedNode>::decode(Decoder& decoder, Scrol
     return true;
 }
 
-namespace WebKit {
-
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
-
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching)
-    : m_scrollingStateTree(WTFMove(scrollingStateTree))
-    , m_clearScrollLatching(clearScrollLatching) { }
-
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&) = default;
-
-RemoteScrollingCoordinatorTransaction& RemoteScrollingCoordinatorTransaction::operator=(RemoteScrollingCoordinatorTransaction&&) = default;
-
-RemoteScrollingCoordinatorTransaction::~RemoteScrollingCoordinatorTransaction() = default;
-
-static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingStateNode& stateNode, int& encodedNodeCount)
+static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingStateNode& stateNode, unsigned& encodedNodeCount)
 {
     ++encodedNodeCount;
 
@@ -551,51 +537,36 @@ static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingState
         encodeNodeAndDescendants(encoder, *child.get(), encodedNodeCount);
 }
 
-void RemoteScrollingCoordinatorTransaction::encode(IPC::Encoder& encoder) const
+void ArgumentCoder<WebCore::ScrollingStateTree>::encode(Encoder& encoder, const WebCore::ScrollingStateTree& tree)
 {
-    encoder << m_clearScrollLatching;
-
-    int numNodes = m_scrollingStateTree ? m_scrollingStateTree->nodeCount() : 0;
-    encoder << numNodes;
-    
-    bool hasNewRootNode = m_scrollingStateTree ? m_scrollingStateTree->hasNewRootStateNode() : false;
-    encoder << hasNewRootNode;
-
-    if (m_scrollingStateTree) {
-        encoder << m_scrollingStateTree->hasChangedProperties();
-
-        int numNodesEncoded = 0;
-        if (const ScrollingStateNode* rootNode = m_scrollingStateTree->rootStateNode())
-            encodeNodeAndDescendants(encoder, *rootNode, numNodesEncoded);
-
-        ASSERT_UNUSED(numNodesEncoded, numNodesEncoded == numNodes);
-    } else
-        encoder << Vector<ScrollingNodeID>();
+    encoder << tree.hasNewRootStateNode();
+    encoder << tree.hasChangedProperties();
+    encoder << tree.nodeCount();
+    unsigned numNodesEncoded = 0;
+    if (const ScrollingStateNode* rootNode = tree.rootStateNode())
+        encodeNodeAndDescendants(encoder, *rootNode, numNodesEncoded);
+    ASSERT_UNUSED(numNodesEncoded, numNodesEncoded == tree.nodeCount());
 }
 
-auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std::optional<RemoteScrollingCoordinatorTransaction>
+std::optional<WebCore::ScrollingStateTree> ArgumentCoder<WebCore::ScrollingStateTree>::decode(Decoder& decoder)
 {
-    bool clearScrollLatching;
-    if (!decoder.decode(clearScrollLatching))
-        return std::nullopt;
-
-    int numNodes;
-    if (!decoder.decode(numNodes))
-        return std::nullopt;
-
     bool hasNewRootNode;
     if (!decoder.decode(hasNewRootNode))
         return std::nullopt;
-    
-    auto scrollingStateTree = makeUnique<ScrollingStateTree>();
 
     bool hasChangedProperties;
     if (!decoder.decode(hasChangedProperties))
         return std::nullopt;
 
-    scrollingStateTree->setHasChangedProperties(hasChangedProperties);
+    unsigned numNodes;
+    if (!decoder.decode(numNodes))
+        return std::nullopt;
 
-    for (int i = 0; i < numNodes; ++i) {
+    ScrollingStateTree scrollingStateTree;
+
+    scrollingStateTree.setHasChangedProperties(hasChangedProperties);
+
+    for (unsigned i = 0; i < numNodes; ++i) {
         ScrollingNodeType nodeType;
         if (!decoder.decode(nodeType))
             return std::nullopt;
@@ -608,11 +579,11 @@ auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std
         if (!decoder.decode(parentNodeID))
             return std::nullopt;
 
-        auto createdNodeID = scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
+        auto createdNodeID = scrollingStateTree.insertNode(nodeType, nodeID, parentNodeID, notFound);
         if (createdNodeID != nodeID)
             return std::nullopt;
 
-        auto newNode = scrollingStateTree->stateNodeForID(nodeID);
+        auto newNode = scrollingStateTree.stateNodeForID(nodeID);
         ASSERT(newNode);
         if (newNode->nodeType() != nodeType)
             return std::nullopt;
@@ -652,10 +623,24 @@ auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std
         }
     }
 
-    scrollingStateTree->setHasNewRootStateNode(hasNewRootNode);
+    scrollingStateTree.setHasNewRootStateNode(hasNewRootNode);
 
-    return { RemoteScrollingCoordinatorTransaction { WTFMove(scrollingStateTree), clearScrollLatching } };
+    return { WTFMove(scrollingStateTree) };
 }
+
+namespace WebKit {
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching)
+    : m_scrollingStateTree(WTFMove(scrollingStateTree))
+    , m_clearScrollLatching(clearScrollLatching) { }
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&) = default;
+
+RemoteScrollingCoordinatorTransaction& RemoteScrollingCoordinatorTransaction::operator=(RemoteScrollingCoordinatorTransaction&&) = default;
+
+RemoteScrollingCoordinatorTransaction::~RemoteScrollingCoordinatorTransaction() = default;
 
 #if !defined(NDEBUG) || !LOG_DISABLED
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 
+#include <wtf/ArgumentCoder.h>
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -47,9 +49,7 @@ public:
     ~RemoteScrollingCoordinatorTransaction();
 
     std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() { return m_scrollingStateTree; }
-
-    void encode(IPC::Encoder&) const;
-    static std::optional<RemoteScrollingCoordinatorTransaction> decode(IPC::Decoder&);
+    const std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() const { return m_scrollingStateTree; }
 
     bool clearScrollLatching() const { return m_clearScrollLatching; }
 
@@ -67,5 +67,12 @@ private:
 };
 
 } // namespace WebKit
+
+namespace IPC {
+template<> struct ArgumentCoder<WebCore::ScrollingStateTree> {
+    static void encode(Encoder&, const WebCore::ScrollingStateTree&);
+    static std::optional<WebCore::ScrollingStateTree> decode(Decoder&);
+};
+}
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -1,0 +1,28 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+headers: <WebCore/ScrollingStateTree.h> <WebCore/ScrollingStateFrameScrollingNode.h>
+
+class WebKit::RemoteScrollingCoordinatorTransaction {
+    std::unique_ptr<WebCore::ScrollingStateTree> scrollingStateTree()
+    bool clearScrollLatching()
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7281,6 +7281,7 @@
 		FA9CD6342A01B21700EA5CAC /* NetworkOriginAccessPatterns.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkOriginAccessPatterns.h; sourceTree = "<group>"; };
 		FAA4E2FE2A1575A3003F5E50 /* WebFrameLoaderClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameLoaderClient.cpp; sourceTree = "<group>"; };
 		FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebFrameLoaderClient.h; sourceTree = "<group>"; };
+		FAC3C3BA2A93E561001E2EB8 /* RemoteScrollingCoordinatorTransaction.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteScrollingCoordinatorTransaction.serialization.in; sourceTree = "<group>"; };
 		FED3C1DA1B447AE800E0EB7F /* APISerializedScriptValueCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = APISerializedScriptValueCocoa.mm; sourceTree = "<group>"; };
 		FEDBDCD41E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorInterruptDispatcherMessageReceiver.cpp; sourceTree = "<group>"; };
 		FEDBDCD51E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorInterruptDispatcherMessages.h; sourceTree = "<group>"; };
@@ -9232,6 +9233,7 @@
 				0F80264627AB4AEF00EC6ED7 /* RemoteLayerWithRemoteRenderingBackingStoreCollection.mm */,
 				0F5947A1187B3B7D00437857 /* RemoteScrollingCoordinatorTransaction.cpp */,
 				0F5947A2187B3B7D00437857 /* RemoteScrollingCoordinatorTransaction.h */,
+				FAC3C3BA2A93E561001E2EB8 /* RemoteScrollingCoordinatorTransaction.serialization.in */,
 				0FCD094E24C79F5B000C6D39 /* RemoteScrollingUIState.cpp */,
 				0FCD094F24C79F5B000C6D39 /* RemoteScrollingUIState.h */,
 				0F65956727DB1D5800EE874B /* SwapBuffersDisplayRequirement.h */,


### PR DESCRIPTION
#### df4b7bc6ed9077c54aa81e455a78cd471892594d
<pre>
Begin generating serialization code for RemoteScrollingCoordinatorTransaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=260479">https://bugs.webkit.org/show_bug.cgi?id=260479</a>
rdar://114210492

Reviewed by Simon Fraser.

I begin by generating the serialization of the tree container, then I&apos;ll
slowly move things around in ways that don&apos;t change behavior until everything&apos;s generated.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(encodeNodeAndDescendants):
(ArgumentCoder&lt;WebCore::ScrollingStateTree&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateTree&gt;::decode):
(WebKit::RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction):
(WebKit::encodeNodeAndDescendants): Deleted.
(WebKit::RemoteScrollingCoordinatorTransaction::encode const): Deleted.
(WebKit::RemoteScrollingCoordinatorTransaction::decode): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
(WebKit::RemoteScrollingCoordinatorTransaction::scrollingStateTree const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/267109@main">https://commits.webkit.org/267109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4cef354874ef31edd157e20af2d650d9e96c7dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14716 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18186 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13605 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17583 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14914 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18532 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1914 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->