### PR TITLE
Investigate the possibility of replacing twisted http server in run-benchmark with python3 http.server

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/README.md
+++ b/Tools/Scripts/webkitpy/benchmark_runner/README.md
@@ -40,7 +40,8 @@ benchmark_runner
 ├── http_server_driver
 │   ├── __init__.py
 │   ├── http_server
-│   │   └── twisted_http_server.py
+│   │   ├── twisted_http_server.py
+│   │   └── builtin_http_server.py
 │   ├── http_server_driver.py
 │   ├── http_server_driver_factory.py
 │   └── simple_http_server_driver.py

--- a/Tools/Scripts/webkitpy/benchmark_runner/generic_factory.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/generic_factory.py
@@ -9,8 +9,8 @@ class GenericFactory(object):
     products = None
 
     @classmethod
-    def create(cls, description):
-        return cls.products[description]()
+    def create(cls, description, *args, **kwargs):
+        return cls.products[description](*args, **kwargs)
 
     @classmethod
     def add(cls, description, product):

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+import argparse
+import logging
+import sys
+import threading
+
+
+_log = logging.getLogger(__name__)
+
+
+class Handler(SimpleHTTPRequestHandler):
+    web_root = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, directory=self.web_root)
+
+    def server_shutdown(self):
+        try:
+            shutdown_thread = threading.Thread(target=self.server.shutdown)
+            shutdown_thread.start()
+        except Exception as e:
+            _log.error(f'Error shutting down HTTP server: {e}')
+            sys.exit(1)
+
+    def log_message(self, format, *args):
+        _log.info(format % args)
+
+    def do_GET(self):
+        shutdown_path = self.web_root + '/shutdown'
+        if not self.translate_path(self.path).startswith(shutdown_path):
+            super().do_GET()
+            return
+        self.send_response(200)
+        self.end_headers()
+        self.server_shutdown()
+
+    def do_POST(self):
+        report_path = self.web_root + '/report'
+        if not self.translate_path(self.path).startswith(report_path):
+            super().do_POST()
+            return
+        length = int(self.headers['content-length'])
+        try:
+            content = self.rfile.read(length)
+            sys.stdout.write(content.decode('utf-8'))
+            sys.stdout.flush()
+            self.send_response(200)
+        except Exception as e:
+            _log.error(f'Error reading and writing report: {e}')
+            self.send_response(500)
+        self.end_headers()
+        self.server_shutdown()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='python py3_builtin_http_server.py web_root')
+    parser.add_argument('web_root')
+    parser.add_argument('--port', type=int, default=0)
+    parser.add_argument('--interface', default='')
+    parser.add_argument('--log-path', default='/tmp/run-benchmark-http.log')
+    args = parser.parse_args()
+
+    logging.basicConfig(datefmt='%Y-%m-%d %H:%M:%S',
+                        format='%(asctime)s [%(levelname)s]: %(message)s', filename=args.log_path, level=logging.INFO)
+    port = args.port
+    Handler.web_root = args.web_root
+    httpd = HTTPServer((args.interface, port), Handler)
+    httpd.serve_forever()

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
@@ -19,16 +19,19 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
 
     platforms = ['osx', 'linux']
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._server_process = None
         self._server_port = 0
         self._ip = '127.0.0.1'
         self._http_log_path = None
+        self._server_type = kwargs.get('server_type', 'twisted')
+        self.set_device_id(kwargs.get('device_id'))
         self._ensure_http_server_dependencies()
 
     def serve(self, web_root):
         _log.info('Launching an http server')
-        http_server_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "http_server/twisted_http_server.py")
+        http_server_file = 'http_server/{}_http_server.py'.format(self._server_type)
+        http_server_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), http_server_file)
         extra_args = []
         if self._ip:
             extra_args.extend(['--interface', self._ip])
@@ -113,6 +116,10 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
     def set_http_log(self, log_path):
         self._http_log_path = log_path
 
+    def set_http_server_type(self, server_type):
+        self._server_type = server_type
+
     def _ensure_http_server_dependencies(self):
         _log.info('Ensure dependencies of http server is satisfied')
-        from webkitpy.autoinstalled import twisted
+        if(self._server_type == 'twisted'):
+            from webkitpy.autoinstalled import twisted

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -69,6 +69,8 @@ def config_argument_parser():
 
     parser.add_argument('browser_args', nargs='*', help='Additional arguments to pass to the browser process. These are positional arguments and must follow all other arguments. If the pass through arguments begin with a dash, use `--` before the argument list begins.')
 
+    parser.add_argument('--http-server-type', default="twisted", choices=["twisted", "builtin"], help="Specify the http server to use for the webserver benchmark runner.")
+
     return parser
 
 
@@ -103,7 +105,7 @@ def run_benchmark_plan(args, plan):
                                     WEBKIT_PGO_DIR if args.generate_pgo_profiles else None,
                                     args.diagnose_dir if args.trace_type else None,
                                     args.trace_type, args.profiling_interval,
-                                    args.browser_args)
+                                    args.browser_args, args.http_server_type)
     runner.execute()
 
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -23,9 +23,8 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None):
-        self._http_server_driver = HTTPServerDriverFactory.create(platform)
-        self._http_server_driver.set_device_id(device_id)
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None, http_server_type='twisted'):
+        self._http_server_driver = HTTPServerDriverFactory.create(platform, server_type=http_server_type, device_id=device_id)
         super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, trace_type, profiling_interval, browser_args)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
@@ -67,5 +66,4 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         finally:
             self._browser_driver.close_browsers()
             self._http_server_driver.kill_server()
-
         return json.loads(result)


### PR DESCRIPTION
#### 1e3555d85962434a8f26aae28cd16815ab5412b8
<pre>
Investigate the possibility of replacing twisted http server in run-benchmark with python3 http.server
<a href="https://bugs.webkit.org/show_bug.cgi?id=259835">https://bugs.webkit.org/show_bug.cgi?id=259835</a>

Reviewed by Stephanie Lewis.

This is an implementation of the python 3 http.server library as the server hosting benchmark requests. This would possibly replace the implementation where the http server is being run through the externl library, twisted.
Running the http server is behind the new optional flag &quot;--http-server-type&quot; which takes in arguments &quot;twisted&quot; or &quot;base&quot; and will launch the http server when you put in as the argument. If the flag is not used it will default to using the twisted http server.
Requirements for if twisted is installed will only be checked for when running the twisted http server.

* Tools/Scripts/webkitpy/benchmark_runner/README.md:
* Tools/Scripts/webkitpy/benchmark_runner/generic_factory.py:
(GenericFactory.create):
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py: Added.
(Handler):
(Handler.__init__):
(Handler.server_shutdown):
(Handler.log_message):
(Handler.do_GET):
(Handler.do_POST):
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py:
(SimpleHTTPServerDriver.__init__):
(SimpleHTTPServerDriver.serve):
(SimpleHTTPServerDriver.set_http_server_type):
(SimpleHTTPServerDriver._ensure_http_server_dependencies):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):
(run_benchmark_plan):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):
(WebServerBenchmarkRunner):

Canonical link: <a href="https://commits.webkit.org/271176@main">https://commits.webkit.org/271176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1b599ffeeee8b669a4058e7987a99a61da0c52b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/28795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/29771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3582 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/27812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/4966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4320 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/27706 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/30410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30615 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2647 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/28582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5983 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6631 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/4966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/4905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->