### PR TITLE
[JSC] Update Intl.NumberFormat / Intl.PluralRules roundingIncrement handling

### DIFF
--- a/JSTests/stress/intl-numberformat-rounding-increment-value.js
+++ b/JSTests/stress/intl-numberformat-rounding-increment-value.js
@@ -2,8 +2,28 @@ function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual + " " + expected);
 }
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
 shouldBe(new Intl.NumberFormat("en", { minimumFractionDigits: 3, maximumFractionDigits: 3, roundingIncrement: 10 }).format(55555555555.555555), `55,555,555,555.560`);
 shouldBe(new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 2, roundingIncrement: 100 }).format(55555555555.555555), `55,555,555,556.00`);
-shouldBe(new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 4, roundingIncrement: 1000 }).format(55555555555.555555), `55,555,555,555.6000`);
+
+shouldThrow(() => {
+    new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 4, roundingIncrement: 1000 }).format(55555555555.555555);
+},`RangeError: maximumFractionDigits and minimumFractionDigits are different while roundingIncrement is specified`);
+shouldBe(new Intl.NumberFormat("en", { minimumFractionDigits: 4, maximumFractionDigits: 4, roundingIncrement: 1000 }).format(55555555555.555555), `55,555,555,555.6000`);
 shouldBe(new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 2, roundingIncrement: 1000 }).format(55555555555.555555), `55,555,555,560.00`);
 shouldBe(new Intl.NumberFormat("en", { minimumFractionDigits: 1, maximumFractionDigits: 1, roundingIncrement: 1000 }).format(55555555555.555555), `55,555,555,600.0`);

--- a/JSTests/stress/intl-numberformat-rounding-mode-v3.js
+++ b/JSTests/stress/intl-numberformat-rounding-mode-v3.js
@@ -98,4 +98,4 @@ let options = {
 };
 
 new Intl.NumberFormat(undefined, options);
-shouldBe("signDisplay,roundingMode", read.join(","));
+shouldBe("roundingMode,signDisplay", read.join(","));

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -64,7 +64,6 @@ skip:
     # Slightly different formatting. We should update test262 side.
     - test/intl402/DateTimeFormat/prototype/formatRangeToParts/en-US.js
     - test/intl402/DateTimeFormat/prototype/formatRangeToParts/fractionalSecondDigits.js
-    - test/intl402/NumberFormat/test-option-roundingPriority-mixed-options.js
     - test/intl402/NumberFormat/prototype/format/unit-ja-JP.js
     - test/intl402/NumberFormat/prototype/format/unit-zh-TW.js
     - test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1726,15 +1726,6 @@ test/intl402/Locale/likely-subtags-grandfathered.js:
 test/intl402/Locale/prototype/minimize/removing-likely-subtags-first-adds-likely-subtags.js:
   default: 'Test262Error: "und".minimize() should be "en" Expected SameValue(«en-u-va-posix», «en») to be true'
   strict mode: 'Test262Error: "und".minimize() should be "en" Expected SameValue(«en-u-va-posix», «en») to be true'
-test/intl402/NumberFormat/constructor-roundingIncrement-invalid.js:
-  default: 'Test262Error: "maximumFractionDigits" is not equal to "minimumFractionDigits" Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: "maximumFractionDigits" is not equal to "minimumFractionDigits" Expected a RangeError to be thrown but no exception was thrown at all'
-test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js:
-  default: 'Test262Error: Formatted value for 1, en-US-u-nu-arab and options {"useGrouping":false,"roundingPriority":"lessPrecision","minimumSignificantDigits":3,"minimumFractionDigits":1} is ١٫٠٠; expected ١٫٠.'
-  strict mode: 'Test262Error: Formatted value for 1, en-US-u-nu-arab and options {"useGrouping":false,"roundingPriority":"lessPrecision","minimumSignificantDigits":3,"minimumFractionDigits":1} is ١٫٠٠; expected ١٫٠.'
-test/intl402/NumberFormat/prototype/format/format-rounding-priority-more-precision.js:
-  default: 'Test262Error: Formatted value for 1, en-US-u-nu-arab and options {"useGrouping":false,"roundingPriority":"morePrecision","minimumSignificantDigits":2,"minimumFractionDigits":2} is ١٫٠٠; expected ١٫٠.'
-  strict mode: 'Test262Error: Formatted value for 1, en-US-u-nu-arab and options {"useGrouping":false,"roundingPriority":"morePrecision","minimumSignificantDigits":2,"minimumFractionDigits":2} is ١٫٠٠; expected ١٫٠.'
 test/intl402/NumberFormat/prototype/format/numbering-systems.js:
   default: 'Test262Error: numberingSystem: kawi, digit: 0 Expected SameValue(«0», «𑽐») to be true'
   strict mode: 'Test262Error: numberingSystem: kawi, digit: 0 Expected SameValue(«0», «𑽐») to be true'

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -64,6 +64,7 @@ enum class RelevantExtensionKey : uint8_t;
 
 enum class IntlRoundingType : uint8_t { FractionDigits, SignificantDigits, MorePrecision, LessPrecision };
 enum class IntlRoundingPriority : uint8_t { Auto, MorePrecision, LessPrecision };
+enum class IntlTrailingZeroDisplay : uint8_t { Auto, StripIfInteger };
 enum class IntlNotation : uint8_t { Standard, Scientific, Engineering, Compact };
 template<typename IntlType> void setNumberFormatDigitOptions(JSGlobalObject*, IntlType*, JSObject*, unsigned minimumFractionDigitsDefault, unsigned maximumFractionDigitsDefault, IntlNotation);
 template<typename IntlType> void appendNumberFormatDigitOptionsToSkeleton(IntlType*, StringBuilder&);
@@ -210,6 +211,7 @@ public:
 
     static IntlNumberFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);
 
+    static ASCIILiteral roundingModeString(RoundingMode);
     static ASCIILiteral roundingPriorityString(IntlRoundingType);
 
 private:
@@ -224,7 +226,6 @@ private:
     enum class UnitDisplay : uint8_t { Short, Narrow, Long };
     enum class CompactDisplay : uint8_t { Short, Long };
     enum class SignDisplay : uint8_t { Auto, Never, Always, ExceptZero, Negative };
-    enum class TrailingZeroDisplay : uint8_t { Auto, StripIfInteger };
     enum class UseGrouping : uint8_t { False, Min2, Auto, Always };
 
     static ASCIILiteral styleString(Style);
@@ -233,8 +234,7 @@ private:
     static ASCIILiteral unitDisplayString(UnitDisplay);
     static ASCIILiteral compactDisplayString(CompactDisplay);
     static ASCIILiteral signDisplayString(SignDisplay);
-    static ASCIILiteral roundingModeString(RoundingMode);
-    static ASCIILiteral trailingZeroDisplayString(TrailingZeroDisplay);
+    static ASCIILiteral trailingZeroDisplayString(IntlTrailingZeroDisplay);
     static JSValue useGroupingValue(VM&, UseGrouping);
 
     WriteBarrier<JSBoundFunction> m_boundFormat;
@@ -264,7 +264,7 @@ private:
     CompactDisplay m_compactDisplay;
     IntlNotation m_notation { IntlNotation::Standard };
     SignDisplay m_signDisplay;
-    TrailingZeroDisplay m_trailingZeroDisplay { TrailingZeroDisplay::Auto };
+    IntlTrailingZeroDisplay m_trailingZeroDisplay { IntlTrailingZeroDisplay::Auto };
     UseGrouping m_useGrouping { UseGrouping::Always };
     RoundingMode m_roundingMode { RoundingMode::HalfExpand };
     IntlRoundingType m_roundingType { IntlRoundingType::FractionDigits };

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -65,6 +65,42 @@ void setNumberFormatDigitOptions(JSGlobalObject* globalObject, IntlType* intlIns
     IntlRoundingPriority roundingPriority = intlOption<IntlRoundingPriority>(globalObject, options, vm.propertyNames->roundingPriority, { { "auto"_s, IntlRoundingPriority::Auto }, { "morePrecision"_s, IntlRoundingPriority::MorePrecision }, { "lessPrecision"_s, IntlRoundingPriority::LessPrecision } }, "roundingPriority must be either \"auto\", \"morePrecision\", or \"lessPrecision\""_s, IntlRoundingPriority::Auto);
     RETURN_IF_EXCEPTION(scope, void());
 
+    unsigned roundingIncrement = intlNumberOption(globalObject, options, vm.propertyNames->roundingIncrement, 1, 5000, 1);
+    RETURN_IF_EXCEPTION(scope, void());
+    static constexpr const unsigned roundingIncrementCandidates[] = {
+        1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000
+    };
+    if (std::none_of(roundingIncrementCandidates, roundingIncrementCandidates + std::size(roundingIncrementCandidates),
+        [&](unsigned candidate) {
+            return candidate == roundingIncrement;
+        })) {
+        throwRangeError(globalObject, scope, "roundingIncrement must be one of 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000"_s);
+        return;
+    }
+
+    RoundingMode roundingMode = intlOption<RoundingMode>(globalObject, options, vm.propertyNames->roundingMode, {
+            { "ceil"_s, RoundingMode::Ceil },
+            { "floor"_s, RoundingMode::Floor },
+            { "expand"_s, RoundingMode::Expand },
+            { "trunc"_s, RoundingMode::Trunc },
+            { "halfCeil"_s, RoundingMode::HalfCeil },
+            { "halfFloor"_s, RoundingMode::HalfFloor },
+            { "halfExpand"_s, RoundingMode::HalfExpand },
+            { "halfTrunc"_s, RoundingMode::HalfTrunc },
+            { "halfEven"_s, RoundingMode::HalfEven }
+        }, "roundingMode must be either \"ceil\", \"floor\", \"expand\", \"trunc\", \"halfCeil\", \"halfFloor\", \"halfExpand\", \"halfTrunc\", or \"halfEven\""_s, RoundingMode::HalfExpand);
+    RETURN_IF_EXCEPTION(scope, void());
+
+    IntlTrailingZeroDisplay trailingZeroDisplay = intlOption<IntlTrailingZeroDisplay>(globalObject, options, vm.propertyNames->trailingZeroDisplay, { { "auto"_s, IntlTrailingZeroDisplay::Auto }, { "stripIfInteger"_s, IntlTrailingZeroDisplay::StripIfInteger } }, "trailingZeroDisplay must be either \"auto\" or \"stripIfInteger\""_s, IntlTrailingZeroDisplay::Auto);
+    RETURN_IF_EXCEPTION(scope, void());
+
+    if (roundingIncrement != 1)
+        maximumFractionDigitsDefault = minimumFractionDigitsDefault;
+
+    intlInstance->m_roundingIncrement = roundingIncrement;
+    intlInstance->m_roundingMode = roundingMode;
+    intlInstance->m_trailingZeroDisplay = trailingZeroDisplay;
+
     bool hasSd = !minimumSignificantDigitsValue.isUndefined() || !maximumSignificantDigitsValue.isUndefined();
     bool hasFd = !minimumFractionDigitsValue.isUndefined() || !maximumFractionDigitsValue.isUndefined();
 
@@ -132,11 +168,64 @@ void setNumberFormatDigitOptions(JSGlobalObject* globalObject, IntlType* intlIns
         intlInstance->m_minimumSignificantDigits = 1;
         intlInstance->m_maximumSignificantDigits = 2;
     }
+
+    if (roundingIncrement != 1) {
+        if (intlInstance->m_roundingType != IntlRoundingType::FractionDigits) {
+            throwTypeError(globalObject, scope, "rounding type is not fraction-digits while roundingIncrement is specified"_s);
+            return;
+        }
+        if (intlInstance->m_maximumFractionDigits != intlInstance->m_minimumFractionDigits) {
+            throwRangeError(globalObject, scope, "maximumFractionDigits and minimumFractionDigits are different while roundingIncrement is specified"_s);
+            return;
+        }
+    }
 }
 
 template<typename IntlType>
 void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuilder& skeletonBuilder)
 {
+    switch (intlInstance->m_roundingMode) {
+    case RoundingMode::Ceil:
+        skeletonBuilder.append(" rounding-mode-ceiling");
+        break;
+    case RoundingMode::Floor:
+        skeletonBuilder.append(" rounding-mode-floor");
+        break;
+    case RoundingMode::Expand:
+        skeletonBuilder.append(" rounding-mode-up");
+        break;
+    case RoundingMode::Trunc:
+        skeletonBuilder.append(" rounding-mode-down");
+        break;
+    case RoundingMode::HalfCeil: {
+        // Only ICU69~ supports half-ceiling. Ignore this option if linked ICU does not support it.
+        // https://github.com/unicode-org/icu/commit/e8dfea9bb6bb27596731173b352759e44ad06b21
+        if (WTF::ICU::majorVersion() >= 69)
+            skeletonBuilder.append(" rounding-mode-half-ceiling");
+        else
+            skeletonBuilder.append(" rounding-mode-half-up"); // Default option.
+        break;
+    }
+    case RoundingMode::HalfFloor: {
+        // Only ICU69~ supports half-flooring. Ignore this option if linked ICU does not support it.
+        // https://github.com/unicode-org/icu/commit/e8dfea9bb6bb27596731173b352759e44ad06b21
+        if (WTF::ICU::majorVersion() >= 69)
+            skeletonBuilder.append(" rounding-mode-half-floor");
+        else
+            skeletonBuilder.append(" rounding-mode-half-up"); // Default option.
+        break;
+    }
+    case RoundingMode::HalfExpand:
+        skeletonBuilder.append(" rounding-mode-half-up");
+        break;
+    case RoundingMode::HalfTrunc:
+        skeletonBuilder.append(" rounding-mode-half-down");
+        break;
+    case RoundingMode::HalfEven:
+        skeletonBuilder.append(" rounding-mode-half-even");
+        break;
+    }
+
     // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#integer-width
     skeletonBuilder.append(" integer-width/", WTF::ICU::majorVersion() >= 67 ? '*' : '+'); // Prior to ICU 67, use the symbol + instead of *.
     for (unsigned i = 0; i < intlInstance->m_minimumIntegerDigits; ++i)
@@ -197,6 +286,19 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
             }
             break;
         }
+    }
+
+    // Configure this just after precision.
+    // https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#trailing-zero-display
+    switch (intlInstance->m_trailingZeroDisplay) {
+    case IntlTrailingZeroDisplay::Auto:
+        break;
+    case IntlTrailingZeroDisplay::StripIfInteger:
+        // Only ICU69~ supports trailing zero display. Ignore this option if linked ICU does not support it.
+        // https://github.com/unicode-org/icu/commit/b79c299f90d4023ac237db3d0335d568bf21cd36
+        if (WTF::ICU::majorVersion() >= 69)
+            skeletonBuilder.append("/w");
+        break;
     }
 }
 

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -124,7 +124,6 @@ void IntlPluralRules::initializePluralRules(JSGlobalObject* globalObject, JSValu
 
 #if HAVE(ICU_U_NUMBER_FORMATTER)
     StringBuilder skeletonBuilder;
-    skeletonBuilder.append("rounding-mode-half-up");
 
     appendNumberFormatDigitOptionsToSkeleton(this, skeletonBuilder);
 
@@ -205,6 +204,9 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
         options->putDirect(vm, vm.propertyNames->maximumSignificantDigits, jsNumber(m_maximumSignificantDigits));
         break;
     }
+    options->putDirect(vm, vm.propertyNames->roundingMode, jsNontrivialString(vm, IntlNumberFormat::roundingModeString(m_roundingMode)));
+    options->putDirect(vm, vm.propertyNames->roundingIncrement, jsNumber(m_roundingIncrement));
+    options->putDirect(vm, vm.propertyNames->trailingZeroDisplay, jsNontrivialString(vm, IntlNumberFormat::trailingZeroDisplayString(m_trailingZeroDisplay)));
 
     JSArray* categories = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), 0);
     if (UNLIKELY(!categories)) {
@@ -225,7 +227,7 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
         RETURN_IF_EXCEPTION(scope, { });
     }
     options->putDirect(vm, Identifier::fromString(vm, "pluralCategories"_s), categories);
-    options->putDirect(vm, vm.propertyNames->roundingMode, jsNontrivialString(vm, IntlNumberFormat::roundingPriorityString(m_roundingType)));
+    options->putDirect(vm, vm.propertyNames->roundingPriority, jsNontrivialString(vm, IntlNumberFormat::roundingPriorityString(m_roundingType)));
 
     return options;
 }

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.h
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.h
@@ -102,6 +102,8 @@ private:
     unsigned m_minimumSignificantDigits { 0 };
     unsigned m_maximumSignificantDigits { 0 };
     unsigned m_roundingIncrement { 1 };
+    IntlTrailingZeroDisplay m_trailingZeroDisplay { IntlTrailingZeroDisplay::Auto };
+    RoundingMode m_roundingMode { RoundingMode::HalfExpand };
     IntlRoundingType m_roundingType { IntlRoundingType::FractionDigits };
     Type m_type { Type::Cardinal };
 };


### PR DESCRIPTION
#### 22cfa17515c153b0a2041985879138bc68f9a260
<pre>
[JSC] Update Intl.NumberFormat / Intl.PluralRules roundingIncrement handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=260489">https://bugs.webkit.org/show_bug.cgi?id=260489</a>
rdar://114219889

Reviewed by Ross Kirsling.

This patch updates Intl.NumberFormat / Intl.PluralRules to the latest spec.
In particular, roundingIncrement / roundingMode / roundingPriority handlings are updated.

* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
(JSC::IntlNumberFormat::trailingZeroDisplayString):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::setNumberFormatDigitOptions):
(JSC::appendNumberFormatDigitOptionsToSkeleton):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::initializePluralRules):
(JSC::IntlPluralRules::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlPluralRules.h:

Canonical link: <a href="https://commits.webkit.org/267123@main">https://commits.webkit.org/267123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8495d51bf34c173533cdd291fd79751e236cf3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15768 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18284 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13554 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/14678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15014 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/14997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/15966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/15966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18613 "Built successfully") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/17047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1922 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/14819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/17047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->