### PR TITLE
AutoInstaller should name directory based on ABI

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py
@@ -28,7 +28,7 @@ from flask_cors import CORS
 autoinstall_path = os.environ.get('AUTOINSTALL_PATH')
 if autoinstall_path:
     from webkitcorepy import AutoInstall
-    AutoInstall.set_directory(autoinstall_path)
+    AutoInstall.set_directory(autoinstall_path, create_platform_subdirectory=False)
 
 from flask import Flask, current_app, json as fjson
 from reporelaypy import Checkout, CheckoutRoute, Redirector, HookReceiver

--- a/Tools/Scripts/libraries/resultsdbpy/container
+++ b/Tools/Scripts/libraries/resultsdbpy/container
@@ -35,7 +35,7 @@ if sys.platform == 'darwin':
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 from resultsdbpy.model.docker import Docker
 

--- a/Tools/Scripts/libraries/resultsdbpy/run
+++ b/Tools/Scripts/libraries/resultsdbpy/run
@@ -38,7 +38,7 @@ if sys.platform == 'darwin':
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 from resultsdbpy.model.docker import Docker
 from multiprocessing import Process

--- a/Tools/Scripts/libraries/resultsdbpy/run-tests
+++ b/Tools/Scripts/libraries/resultsdbpy/run-tests
@@ -39,7 +39,7 @@ if sys.platform == 'darwin':
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 from cassandra.cqlengine.management import CQLENG_ALLOW_SCHEMA_MANAGEMENT
 

--- a/Tools/Scripts/libraries/webkitbugspy/run-tests
+++ b/Tools/Scripts/libraries/webkitbugspy/run-tests
@@ -33,7 +33,7 @@ from webkitcorepy.testing import PythonTestRunner
 
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)

--- a/Tools/Scripts/libraries/webkitcorepy/run-tests
+++ b/Tools/Scripts/libraries/webkitcorepy/run-tests
@@ -32,7 +32,7 @@ from webkitcorepy.testing import PythonTestRunner
 
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -30,6 +30,7 @@ import shutil
 import ssl
 import subprocess
 import sys
+import sysconfig
 import tarfile
 import tempfile
 import time
@@ -492,7 +493,61 @@ class AutoInstall(object):
                 os.chown(os.path.join(root, file), uid, gid)
 
     @classmethod
-    def set_directory(cls, directory):
+    def _platform_compatibility_tag(cls):
+        try:
+            impl = sys.implementation.name
+        except AttributeError:
+            # Python 2
+            impl = platform.python_implementation().lower()
+
+        INTERPRETER_SHORT_NAMES = {
+            "python": "py",
+            "cpython": "cp",
+            "pypy": "pp",
+            "ironpython": "ip",
+            "jython": "jy",
+        }
+
+        impl = INTERPRETER_SHORT_NAMES.get(impl, impl)
+
+        version = "".join(map(str, sys.version_info[:2]))
+
+        try:
+            abi = sys.abiflags
+        except AttributeError:
+            # Python 2
+            abi = ""
+
+        if platform.system() == "Darwin":
+            mac_version_str, _, mac_arch = platform.mac_ver()
+            mac_version = tuple(map(int, mac_version_str.split(".")))
+            tag_platform = "macosx_{}_{}_{}".format(
+                mac_version[0], 0 if mac_version[0] >= 11 else mac_version[1], mac_arch
+            )
+        else:
+            tag_platform = (
+                sysconfig.get_platform()
+                .replace(".", "_")
+                .replace("-", "_")
+                .replace(" ", "_")
+            )
+            if platform.system() == "Linux" and sys.maxsize <= 2**32:
+                if tag_platform == "linux_x86_64":
+                    tag_platform = "linux_i686"
+                elif tag_platform == "linux_aarch64":
+                    tag_platform = "linux_armv7l"
+
+        if impl == "cp":
+            return "{impl}{version}-{impl}{version}{abi}-{platform}".format(
+                impl=impl, version=version, abi=abi, platform=tag_platform
+            )
+        else:
+            return "{impl}{version}-{abi}-{platform}".format(
+                impl=impl, version=version, abi=abi, platform=tag_platform
+            )
+
+    @classmethod
+    def set_directory(cls, directory, create_platform_subdirectory=True):
         if not directory or not isinstance(directory, str):
             raise ValueError('{} is an invalid autoinstall directory'.format(directory))
 
@@ -503,6 +558,9 @@ class AutoInstall(object):
                 os.environ.get(cls.DISABLE_ENV_VAR),
             ))
             return
+
+        if create_platform_subdirectory:
+            directory = os.path.join(directory, cls._platform_compatibility_tag())
 
         directory = os.path.abspath(directory)
         if not os.path.isdir(directory):

--- a/Tools/Scripts/libraries/webkitscmpy/run-tests
+++ b/Tools/Scripts/libraries/webkitscmpy/run-tests
@@ -34,7 +34,7 @@ from webkitcorepy.testing import PythonTestRunner
 
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -32,7 +32,7 @@ if sys.platform == 'darwin':
         libraries = os.path.expanduser('~/Library/webkitpy')
 
 from webkitcorepy import AutoInstall, Package, Version
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
 
 if sys.version_info >= (3, 7):
     AutoInstall.register(Package('pylint', Version(2, 6, 0)))
@@ -57,10 +57,10 @@ else:
     sys.stderr.write("pytest, pylint and websockets do not support Python version! (%s)\n" % sys.version)
 
 if sys.version_info >= (3, 6):
-    AutoInstall.register(Package('importlib_metadata', Version(4, 8, 1)))
+    AutoInstall.register(Package('importlib_metadata', Version(4, 8, 1), implicit_deps=['zipp', 'typing_extensions']))
     AutoInstall.register(Package('typing_extensions', Version(3, 10, 0)))
 else:
-    AutoInstall.register(Package('importlib_metadata', Version(1, 7, 0)))
+    AutoInstall.register(Package('importlib_metadata', Version(1, 7, 0), implicit_deps=['zipp']))
 
 AutoInstall.register(Package('atomicwrites', Version(1, 1, 5)))
 AutoInstall.register(Package('attr', Version(20, 3, 0), pypi_name='attrs'))


### PR DESCRIPTION
#### 17ed495179235a185b77e1ef4d02778d9fb1dda0
<pre>
AutoInstaller should name directory based on ABI
<a href="https://bugs.webkit.org/show_bug.cgi?id=224669">https://bugs.webkit.org/show_bug.cgi?id=224669</a>

Reviewed by Jonathan Bedard.

While the autoinstaller currently (mostly!) puts autoinstalled libraries
into a directory such as `python-3-arm64`, this doesn&apos;t suffice to
uniquely identify the ABI of the interpreter.

In practice, this mostly works because since Python 3.2 distutils will
compile extensions into files with suffixes such as
`cpython-39-darwin.so`, and most extension modules we compile are
optional &quot;speedup&quot; modules where failing to have an appropriate
extension module will simply degrade performance but not prevent
operation.

This replaces our current tags with a string that should match
`str(list(packaging.tags.sys_tags())[0])`.

It doesn&apos;t, however, use packaging directly, because we can&apos;t install
packaging until we know what directory we&apos;re using. If we do in future
move to vendoring packaging we should be able to migrate to this without
invalidating everyone&apos;s local autoinstall directories.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py:
* Tools/Scripts/libraries/resultsdbpy/container:
* Tools/Scripts/libraries/resultsdbpy/run:
* Tools/Scripts/libraries/resultsdbpy/run-tests:
* Tools/Scripts/libraries/webkitbugspy/run-tests:
* Tools/Scripts/libraries/webkitcorepy/run-tests:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(AutoInstall._platform_compatibility_tag):
(AutoInstall):
(AutoInstall.set_directory):
* Tools/Scripts/libraries/webkitscmpy/run-tests:
* Tools/Scripts/webkitpy/__init__.py:

Canonical link: <a href="https://commits.webkit.org/268205@main">https://commits.webkit.org/268205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16994e0bf21d4967ba8575fef7b6a0ea8f3ee252

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17827 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19057 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/16626 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21753 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13345 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/16384 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19285 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->