### PR TITLE
Add ScopedName type

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2399,6 +2399,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     storage/StorageType.h
     storage/StorageUtilities.h
 
+    style/ScopedName.h
     style/StyleAppearance.h
     style/StyleChange.h
     style/StyleScope.h

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -49,7 +49,7 @@ Ref<CSSAnimation> CSSAnimation::create(const Styleable& owningElement, const Ani
 
 CSSAnimation::CSSAnimation(const Styleable& element, const Animation& backingAnimation)
     : DeclarativeAnimation(element, backingAnimation)
-    , m_animationName(backingAnimation.name().string)
+    , m_animationName(backingAnimation.name().name)
 {
 }
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -680,7 +680,7 @@ auto KeyframeEffect::getKeyframes(Document& document) -> Vector<ComputedKeyframe
             return { };
 
         auto& backingAnimation = downcast<CSSAnimation>(*animation()).backingAnimation();
-        auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.nameStyleScopeOrdinal());
+        auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.name().scopeOrdinal);
         if (!styleScope)
             return { };
 
@@ -1072,8 +1072,8 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
 
     auto& backingAnimation = downcast<CSSAnimation>(*animation()).backingAnimation();
 
-    KeyframeList keyframeList(AtomString { backingAnimation.name().string });
-    if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.nameStyleScopeOrdinal()))
+    KeyframeList keyframeList(AtomString { backingAnimation.name().name });
+    if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.name().scopeOrdinal))
         styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, keyframeList);
 
     // Ensure resource loads for all the frames.

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -396,7 +396,7 @@ void CSSToStyleMap::mapAnimationName(Animation& layer, const CSSValue& value)
     if (primitiveValue.valueID() == CSSValueNone)
         layer.setIsNoneAnimation(true);
     else
-        layer.setName({ primitiveValue.stringValue(), primitiveValue.isCustomIdent() }, m_builderState.styleScopeOrdinal());
+        layer.setName({ AtomString { primitiveValue.stringValue() }, primitiveValue.isCustomIdent(), m_builderState.styleScopeOrdinal() });
 }
 
 void CSSToStyleMap::mapAnimationPlayState(Animation& layer, const CSSValue& value)

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1532,11 +1532,11 @@ static Ref<CSSPrimitiveValue> valueForAnimationPlayState(AnimationPlayState play
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static Ref<CSSPrimitiveValue> valueForAnimationName(const Animation::Name& name)
+static Ref<CSSPrimitiveValue> valueForScopedName(const Style::ScopedName& scopedName)
 {
-    if (name.isIdentifier)
-        return CSSPrimitiveValue::createCustomIdent(name.string);
-    return CSSPrimitiveValue::create(name.string);
+    if (scopedName.isIdentifier)
+        return CSSPrimitiveValue::createCustomIdent(scopedName.name);
+    return CSSPrimitiveValue::create(scopedName.name);
 }
 
 static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timingFunction)
@@ -1605,7 +1605,7 @@ void ComputedStyleExtractor::addValueForAnimationPropertyToList(CSSValueListBuil
         if (!animation || !animation->isPlayStateFilled())
             list.append(valueForAnimationPlayState(animation ? animation->playState() : Animation::initialPlayState()));
     } else if (property == CSSPropertyAnimationName)
-        list.append(valueForAnimationName(animation ? animation->name() : Animation::initialName()));
+        list.append(valueForScopedName(animation ? animation->name() : Animation::initialName()));
     else if (property == CSSPropertyAnimationComposition) {
         if (!animation || !animation->isCompositeOperationFilled())
             list.append(valueForAnimationComposition(animation ? animation->compositeOperation() : Animation::initialCompositeOperation()));

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -70,7 +70,6 @@ Animation::Animation(const Animation& o)
     , m_delay(o.m_delay)
     , m_duration(o.m_duration)
     , m_timingFunction(o.m_timingFunction)
-    , m_nameStyleScopeOrdinal(o.m_nameStyleScopeOrdinal)
     , m_direction(o.m_direction)
     , m_fillMode(o.m_fillMode)
     , m_playState(o.m_playState)
@@ -102,7 +101,7 @@ Animation::~Animation() = default;
 
 bool Animation::animationsMatch(const Animation& other, bool matchProperties) const
 {
-    bool result = m_name.string == other.m_name.string
+    bool result = m_name == other.m_name
         && m_playState == other.m_playState
         && m_compositeOperation == other.m_compositeOperation
         && m_playStateSet == other.m_playStateSet
@@ -110,7 +109,6 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_delay == other.m_delay
         && m_duration == other.m_duration
         && *(m_timingFunction.get()) == *(other.m_timingFunction.get())
-        && m_nameStyleScopeOrdinal == other.m_nameStyleScopeOrdinal
         && m_direction == other.m_direction
         && m_fillMode == other.m_fillMode
         && m_delaySet == other.m_delaySet
@@ -129,9 +127,9 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
     return !matchProperties || (m_property.mode == other.m_property.mode && m_property.animatableProperty == other.m_property.animatableProperty && m_propertySet == other.m_propertySet);
 }
 
-auto Animation::initialName() -> const Name&
+auto Animation::initialName() -> const Style::ScopedName&
 {
-    static NeverDestroyed<Name> initialValue { Name { noneAtom(), true } };
+    static NeverDestroyed<Style::ScopedName> initialValue { Style::ScopedName { noneAtom() } };
     return initialValue;
 }
 
@@ -160,7 +158,7 @@ TextStream& operator<<(TextStream& ts, Animation::Direction direction)
 TextStream& operator<<(TextStream& ts, const Animation& animation)
 {
     ts.dumpProperty("property", animation.property());
-    ts.dumpProperty("name", animation.name().string);
+    ts.dumpProperty("name", animation.name().name);
     ts.dumpProperty("iteration count", animation.iterationCount());
     ts.dumpProperty("delay", animation.iterationCount());
     ts.dumpProperty("duration", animation.duration());

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -27,7 +27,7 @@
 #include "CSSPropertyNames.h"
 #include "CompositeOperation.h"
 #include "RenderStyleConstants.h"
-#include "StyleScopeOrdinal.h"
+#include "ScopedName.h"
 #include "TimingFunction.h"
 #include "WebAnimationTypes.h"
 
@@ -56,7 +56,7 @@ public:
 
     // We can make placeholder Animation objects to keep the comma-separated lists
     // of properties in sync. isValidAnimation means this is not a placeholder.
-    bool isValidAnimation() const { return !m_isNone && !m_name.string.isEmpty(); }
+    bool isValidAnimation() const { return !m_isNone && !m_name.name.isEmpty(); }
 
     bool isEmpty() const
     {
@@ -125,15 +125,9 @@ public:
     double duration() const { return m_duration; }
     double playbackRate() const { return m_playbackRate; }
 
-    struct Name {
-        String string;
-        bool isIdentifier { false };
-    };
-
     static constexpr double IterationCountInfinite = -1;
     double iterationCount() const { return m_iterationCount; }
-    const Name& name() const { return m_name; }
-    Style::ScopeOrdinal nameStyleScopeOrdinal() const { return m_nameStyleScopeOrdinal; }
+    const Style::ScopedName& name() const { return m_name; }
     AnimationPlayState playState() const { return static_cast<AnimationPlayState>(m_playState); }
     TransitionProperty property() const { return m_property; }
     TimingFunction* timingFunction() const { return m_timingFunction.get(); }
@@ -145,10 +139,9 @@ public:
     void setPlaybackRate(double d) { m_playbackRate = d; }
     void setFillMode(AnimationFillMode f) { m_fillMode = static_cast<unsigned>(f); m_fillModeSet = true; }
     void setIterationCount(double c) { m_iterationCount = c; m_iterationCountSet = true; }
-    void setName(const Name& name, Style::ScopeOrdinal scope = Style::ScopeOrdinal::Element)
+    void setName(const Style::ScopedName& name)
     {
         m_name = name;
-        m_nameStyleScopeOrdinal = scope;
         m_nameSet = true;
     }
     void setPlayState(AnimationPlayState d) { m_playState = static_cast<unsigned>(d); m_playStateSet = true; }
@@ -197,15 +190,13 @@ private:
     // Packs with m_refCount from the base class.
     TransitionProperty m_property { TransitionMode::All, CSSPropertyInvalid };
 
-    Name m_name;
+    Style::ScopedName m_name;
     double m_iterationCount;
     double m_delay;
     double m_duration;
     double m_playbackRate { 1 };
     RefPtr<TimingFunction> m_timingFunction;
     RefPtr<TimingFunction> m_defaultTimingFunctionForKeyframes;
-
-    Style::ScopeOrdinal m_nameStyleScopeOrdinal { Style::ScopeOrdinal::Element };
 
     unsigned m_direction : 2; // Direction
     unsigned m_fillMode : 2; // AnimationFillMode
@@ -241,7 +232,7 @@ public:
     static double initialDuration() { return 0; }
     static AnimationFillMode initialFillMode() { return AnimationFillMode::None; }
     static double initialIterationCount() { return 1.0; }
-    static const Name& initialName();
+    static const Style::ScopedName& initialName();
     static AnimationPlayState initialPlayState() { return AnimationPlayState::Playing; }
     static CompositeOperation initialCompositeOperation() { return CompositeOperation::Replace; }
     static TransitionProperty initialProperty() { return { TransitionMode::All, CSSPropertyInvalid }; }

--- a/Source/WebCore/style/ScopedName.h
+++ b/Source/WebCore/style/ScopedName.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleScopeOrdinal.h"
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+namespace Style {
+
+struct ScopedName {
+    AtomString name;
+    bool isIdentifier { true };
+    ScopeOrdinal scopeOrdinal { ScopeOrdinal::Element };
+
+    bool operator==(const ScopedName&) const = default;
+};
+
+}
+}
+

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -271,7 +271,7 @@ void Styleable::cancelDeclarativeAnimations() const
 
 static bool keyframesRuleExistsForAnimation(Element& element, const Animation& animation, const String& animationName)
 {
-    auto* styleScope = Style::Scope::forOrdinal(element, animation.nameStyleScopeOrdinal());
+    auto* styleScope = Style::Scope::forOrdinal(element, animation.name().scopeOrdinal);
     return styleScope && styleScope->resolver().isAnimationNameValid(animationName);
 }
 
@@ -282,7 +282,7 @@ bool Styleable::animationListContainsNewlyValidAnimation(const AnimationList& an
         return false;
 
     for (auto& animation : animations) {
-        auto& name = animation->name().string;
+        auto& name = animation->name().name;
         if (name != noneAtom() && !name.isEmpty() && keyframeEffectStack.containsInvalidCSSAnimationName(name) && keyframesRuleExistsForAnimation(element, animation.get(), name))
             return true;
     }
@@ -327,7 +327,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
             if (!currentAnimation->isValidAnimation())
                 continue;
 
-            auto& animationName = currentAnimation->name().string;
+            auto& animationName = currentAnimation->name().name;
             if (animationName == noneAtom() || animationName.isEmpty())
                 continue;
 


### PR DESCRIPTION
#### 25f43abc6e10e195a41db5db0b383bef04a208ac
<pre>
Add ScopedName type
<a href="https://bugs.webkit.org/show_bug.cgi?id=260493">https://bugs.webkit.org/show_bug.cgi?id=260493</a>
rdar://114224001

Reviewed by Alan Baradlay.

Refactor animation name type to a generic struct. There are some other things in CSS
that need scoped names too.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::CSSAnimation):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationName):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForScopedName):
(WebCore::ComputedStyleExtractor::addValueForAnimationPropertyToList):
(WebCore::valueForAnimationName): Deleted.
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
(WebCore::Animation::initialName const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isValidAnimation const):
(WebCore::Animation::name const):
(WebCore::Animation::setName):
(WebCore::Animation::nameStyleScopeOrdinal const): Deleted.
* Source/WebCore/style/ScopedName.h: Added.
* Source/WebCore/style/Styleable.cpp:
(WebCore::keyframesRuleExistsForAnimation):
(WebCore::Styleable::animationListContainsNewlyValidAnimation const):
(WebCore::Styleable::updateCSSAnimations const):

Canonical link: <a href="https://commits.webkit.org/267135@main">https://commits.webkit.org/267135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17b230a87064509d1e10d0a21ef5bf3045983d3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17284 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18267 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21125 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17644 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12699 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14228 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3765 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->