### PR TITLE
Directly check values of grid-template-rows and grid-template-columns when serializing grid-template with grid areas

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-areas-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-areas-valid-expected.txt
@@ -1,7 +1,7 @@
 
 PASS grid-template: none / 1px and "grid-template-areas: "a";" should be valid.
 PASS grid-template: none / none and "grid-template-areas: "a";" should be valid.
-FAIL grid-template: auto / 1px and "grid-template-areas: "a a a";" should be valid. assert_equals: expected "\"a a a\" / 1px" but got ""
-FAIL grid-template: auto / auto and "grid-template-areas: "a a a";" should be valid. assert_equals: expected "\"a a a\" / auto" but got ""
-FAIL grid-template: 10px 20px 30px / 40px 50px 60px 70px and "grid-template-areas: "a . b ." "c d . e" "f g h .";" should be valid. assert_equals: expected "\"a . b .\" 10px \"c d . e\" 20px \"f g h .\" 30px / 40px 50px 60px 70px" but got ""
+PASS grid-template: auto / 1px and "grid-template-areas: "a a a";" should be valid.
+PASS grid-template: auto / auto and "grid-template-areas: "a a a";" should be valid.
+PASS grid-template: 10px 20px 30px / 40px 50px 60px 70px and "grid-template-areas: "a . b ." "c d . e" "f g h .";" should be valid.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-valid-expected.txt
@@ -27,6 +27,7 @@ PASS e.style['grid-template'] = "\"a\" [a] [b] \"b\"" should set the property va
 PASS e.style['grid-template'] = "\"a\" [a] \"b\"" should set the property value
 PASS e.style['grid-template'] = "\"a\" / 0" should set the property value
 PASS e.style['grid-template'] = "\"a\" 10px / 10px" should set the property value
+PASS e.style['grid-template'] = "\"a\" calc(100% - 10px) / calc(10px)" should set the property value
 PASS e.style['grid-template'] = "\"a\" [a] \"b\" 10px" should set the property value
 PASS e.style['grid-template'] = "\"a\" [a] \"b\" 10px [a]" should set the property value
 PASS e.style['grid-template'] = "\"a\" [a] [a] \"b\" 10px" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-valid.html
@@ -41,6 +41,7 @@ test_valid_value("grid-template", '"a" [a] [b] "b"', '"a" [a b] "b"');
 test_valid_value("grid-template", '"a" [a] "b"');
 test_valid_value("grid-template", '"a" / 0', '"a" / 0px');
 test_valid_value("grid-template", '"a" 10px / 10px');
+test_valid_value("grid-template", '"a" calc(100% - 10px) / calc(10px)');
 test_valid_value("grid-template", '"a" [a] "b" 10px');
 test_valid_value("grid-template", '"a" [a] "b" 10px [a]');
 test_valid_value("grid-template", '"a" [a] [a] "b" 10px', '"a" [a a] "b" 10px');

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -7522,6 +7522,11 @@ bool isSelfPositionOrLeftOrRightKeyword(CSSValueID id)
     return isSelfPositionKeyword(id) || isLeftOrRightKeyword(id);
 }
 
+bool isGridBreadthIdent(CSSValueID id)
+{
+    return identMatches<CSSValueMinContent, CSSValueWebkitMinContent, CSSValueMaxContent, CSSValueWebkitMaxContent, CSSValueAuto>(id);
+}
+
 RefPtr<CSSValue> consumeSelfPositionOverflowPosition(CSSParserTokenRange& range, IsPositionKeyword isPositionKeyword)
 {
     ASSERT(isPositionKeyword);
@@ -7747,7 +7752,7 @@ bool parseGridTemplateAreasRow(StringView gridRowNames, NamedGridAreaMap& gridAr
 static RefPtr<CSSPrimitiveValue> consumeGridBreadth(CSSParserTokenRange& range, CSSParserMode mode)
 {
     const CSSParserToken& token = range.peek();
-    if (identMatches<CSSValueMinContent, CSSValueWebkitMinContent, CSSValueMaxContent, CSSValueWebkitMaxContent, CSSValueAuto>(token.id()))
+    if (isGridBreadthIdent(token.id()))
         return consumeIdent(range);
     if (token.type() == DimensionToken && token.unitType() == CSSUnitType::CSS_FR) {
         if (range.peek().numericValue() < 0)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -214,6 +214,7 @@ bool isContentPositionKeyword(CSSValueID);
 bool isContentPositionOrLeftOrRightKeyword(CSSValueID);
 bool isSelfPositionKeyword(CSSValueID);
 bool isSelfPositionOrLeftOrRightKeyword(CSSValueID);
+bool isGridBreadthIdent(CSSValueID);
 
 RefPtr<CSSValueList> consumeAlignTracks(CSSParserTokenRange&);
 RefPtr<CSSValueList> consumeJustifyTracks(CSSParserTokenRange&);


### PR DESCRIPTION
#### 74849b01b11986fbd6aec530fa9a90e283cf8db3
<pre>
Directly check values of grid-template-rows and grid-template-columns when serializing grid-template with grid areas
<a href="https://bugs.webkit.org/show_bug.cgi?id=260494">https://bugs.webkit.org/show_bug.cgi?id=260494</a>
rdar://114224504

Reviewed by Tim Nguyen.

The grid-template shorthand has two different options for its syntax:
- [ &lt;&apos;grid-template-rows&apos;&gt; / &lt;&apos;grid-template-columns&apos;&gt; ]
- [ &lt;line-names&gt;? &lt;string&gt; &lt;track-size&gt;? &lt;line-names&gt;? ]+ [ / &lt;explicit-track-list&gt; ]?

In the latter version of the syntax, ShorthandSerializer would bail out
early (and not serialize any values) if grid-template-areas (the &lt;string&gt;
portion of the syntax) was not set by the grid-template shorthand. We
should instead check the values of grid-template-rows and grid-template-columns
directly to see if they can be expressed inside of this shorthand.

For the rows portion we build up the shorthand iteratively, so we can
just check if the value is a valid &lt;track-size&gt; and return an empty
string if it is not since that would mean the value could not be
expressed in the shorthand. A value being a valid &lt;track-size&gt; means that
it must be one of: minmax(), fit-content(), length-percentage, flex,
min-content, max-content, or auto. If it is not one of these then the
value is not a &lt;track-size&gt;.

For the columns portion we have to check the entire value of grid-template-columns
beforehand since we will end up appending the whole value to the end
of the shorthand. To check to see if a value is a valid &lt;explicit-track-list&gt;,
we need to make sure the value contains only &lt;line-names&gt;s and &lt;track-size&gt;s
with at least one &lt;track-size&gt; in the value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-areas-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-shorthand-valid.html:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::commonSerializationChecks):
(WebCore::ShorthandSerializer::serializeGridTemplate const):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::isGridBreadthIdent):
(WebCore::CSSPropertyParserHelpers::consumeGridBreadth):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:

Canonical link: <a href="https://commits.webkit.org/267155@main">https://commits.webkit.org/267155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6333aa032d3cda714b1f05dfb7d452a9efe73bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17325 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16469 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13460 "1 api test failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18322 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21172 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17705 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12747 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14112 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3778 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->