### PR TITLE
[MQ5] Ensure that media “scripting: initial-only” never matches

### DIFF
--- a/LayoutTests/fast/css/media-query-scripting-initial-only-expected.html
+++ b/LayoutTests/fast/css/media-query-scripting-initial-only-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html style="color: green;"><p>This text should be green when printing.</p></html>

--- a/LayoutTests/fast/css/media-query-scripting-initial-only.html
+++ b/LayoutTests/fast/css/media-query-scripting-initial-only.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<style>
+    :root {
+        color: green;
+    }
+    @media (scripting: initial-only) {
+        :root {
+            color: red;
+        }
+    }
+</style>
+<p>This text should be green when printing.</p>
+<script>
+if (window.internals)
+    internals.settings.setMediaTypeOverride("print");
+</script>
+</html>

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -607,11 +607,6 @@ const FeatureSchema& scripting()
 
             if (!frame.script().canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
                 return MatchingIdentifiers { CSSValueNone };
-
-            auto* frameView = frame.view();
-            if (frameView && frameView->mediaType() == printAtom())
-                return MatchingIdentifiers { CSSValueInitialOnly };
-
             return MatchingIdentifiers { CSSValueEnabled };
         }
     };


### PR DESCRIPTION
#### 706e894119545882666bdaef16156905f323d364
<pre>
[MQ5] Ensure that media “scripting: initial-only” never matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=260432">https://bugs.webkit.org/show_bug.cgi?id=260432</a>

Reviewed by Tim Nguyen.

<a href="https://github.com/w3c/csswg-drafts/issues/8621">https://github.com/w3c/csswg-drafts/issues/8621</a>

* LayoutTests/fast/css/media-query-scripting-initial-only-expected.html: Added.
* LayoutTests/fast/css/media-query-scripting-initial-only.html: Added.
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::scripting):

Canonical link: <a href="https://commits.webkit.org/267198@main">https://commits.webkit.org/267198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4670c232c9ebb9890273779a140642d405b8df78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17701 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16358 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13587 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/18474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14404 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21281 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12859 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3804 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->