### PR TITLE
ScrollingStateNode::m_children should be a Vector instead of a unique_ptr<Vector>

### DIFF
--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
@@ -16,8 +16,6 @@
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)
       (viewport rect at last layout at (0,0) size 800x600)
       (layer position at last layout (8,10))
-      (children 0
-      )
     )
   )
 )

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
@@ -17,8 +17,6 @@
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)
       (viewport rect at last layout at (0,0) size 785x600)
       (layer position at last layout (8,10))
-      (children 0
-      )
     )
   )
 )

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/remove-coordinated-frame-expected.txt
@@ -17,8 +17,6 @@
       (anchor edges: AnchorEdgeLeft AnchorEdgeTop)
       (viewport rect at last layout at (0,0) size 785x600)
       (layer position at last layout (8,10))
-      (children 0
-      )
     )
   )
 )

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -837,11 +837,7 @@ Vector<ScrollingNodeID> AsyncScrollingCoordinator::childrenOfNode(ScrollingNodeI
     if (!scrollingNode)
         return { };
 
-    auto children = scrollingNode->children();
-    if (!children || children->isEmpty())
-        return { };
-
-    return children->map([](auto& child) {
+    return scrollingNode->children().map([](auto& child) {
         return child->scrollingNodeID();
     });
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -312,8 +312,9 @@ public:
     void setParent(RefPtr<ScrollingStateNode>&& parent) { m_parent = parent; }
     ScrollingNodeID parentNodeID() const;
 
-    Vector<RefPtr<ScrollingStateNode>>* children() const { return m_children.get(); }
-    std::unique_ptr<Vector<RefPtr<ScrollingStateNode>>> takeChildren() { return WTFMove(m_children); }
+    Vector<Ref<ScrollingStateNode>>& children() { return m_children; }
+    const Vector<Ref<ScrollingStateNode>>& children() const { return m_children; }
+    Vector<Ref<ScrollingStateNode>> takeChildren() { return std::exchange(m_children, { }); }
 
     void appendChild(Ref<ScrollingStateNode>&&);
     void insertChild(Ref<ScrollingStateNode>&&, size_t index);
@@ -347,7 +348,7 @@ private:
     ScrollingStateTree& m_scrollingStateTree;
 
     ThreadSafeWeakPtr<ScrollingStateNode> m_parent;
-    std::unique_ptr<Vector<RefPtr<ScrollingStateNode>>> m_children;
+    Vector<Ref<ScrollingStateNode>> m_children;
 
     LayerRepresentation m_layer;
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -441,11 +441,9 @@ bool ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
     node->removeAllChildren();
 
     // Now update the children if we have any.
-    if (auto children = stateNode->children()) {
-        for (auto& child : *children) {
-            if (!updateTreeFromStateNodeRecursive(child.get(), state))
-                return false;
-        }
+    for (auto& child : stateNode->children()) {
+        if (!updateTreeFromStateNodeRecursive(child.ptr(), state))
+            return false;
     }
 
     if (!node->commitStateAfterChildren(*stateNode))

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp.orig
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp.orig
@@ -501,21 +501,7 @@ bool ArgumentCoder<ScrollingStatePositionedNode>::decode(Decoder& decoder, Scrol
     return true;
 }
 
-namespace WebKit {
-
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
-
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching)
-    : m_scrollingStateTree(WTFMove(scrollingStateTree))
-    , m_clearScrollLatching(clearScrollLatching) { }
-
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&) = default;
-
-RemoteScrollingCoordinatorTransaction& RemoteScrollingCoordinatorTransaction::operator=(RemoteScrollingCoordinatorTransaction&&) = default;
-
-RemoteScrollingCoordinatorTransaction::~RemoteScrollingCoordinatorTransaction() = default;
-
-static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingStateNode& stateNode, int& encodedNodeCount)
+static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingStateNode& stateNode, unsigned& encodedNodeCount)
 {
     ++encodedNodeCount;
 
@@ -548,51 +534,36 @@ static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingState
         encodeNodeAndDescendants(encoder, child.get(), encodedNodeCount);
 }
 
-void RemoteScrollingCoordinatorTransaction::encode(IPC::Encoder& encoder) const
+void ArgumentCoder<WebCore::ScrollingStateTree>::encode(Encoder& encoder, const WebCore::ScrollingStateTree& tree)
 {
-    encoder << m_clearScrollLatching;
-
-    int numNodes = m_scrollingStateTree ? m_scrollingStateTree->nodeCount() : 0;
-    encoder << numNodes;
-    
-    bool hasNewRootNode = m_scrollingStateTree ? m_scrollingStateTree->hasNewRootStateNode() : false;
-    encoder << hasNewRootNode;
-
-    if (m_scrollingStateTree) {
-        encoder << m_scrollingStateTree->hasChangedProperties();
-
-        int numNodesEncoded = 0;
-        if (const ScrollingStateNode* rootNode = m_scrollingStateTree->rootStateNode())
-            encodeNodeAndDescendants(encoder, *rootNode, numNodesEncoded);
-
-        ASSERT_UNUSED(numNodesEncoded, numNodesEncoded == numNodes);
-    } else
-        encoder << Vector<ScrollingNodeID>();
+    encoder << tree.hasNewRootStateNode();
+    encoder << tree.hasChangedProperties();
+    encoder << tree.nodeCount();
+    unsigned numNodesEncoded = 0;
+    if (const ScrollingStateNode* rootNode = tree.rootStateNode())
+        encodeNodeAndDescendants(encoder, *rootNode, numNodesEncoded);
+    ASSERT_UNUSED(numNodesEncoded, numNodesEncoded == tree.nodeCount());
 }
 
-auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std::optional<RemoteScrollingCoordinatorTransaction>
+std::optional<WebCore::ScrollingStateTree> ArgumentCoder<WebCore::ScrollingStateTree>::decode(Decoder& decoder)
 {
-    bool clearScrollLatching;
-    if (!decoder.decode(clearScrollLatching))
-        return std::nullopt;
-
-    int numNodes;
-    if (!decoder.decode(numNodes))
-        return std::nullopt;
-
     bool hasNewRootNode;
     if (!decoder.decode(hasNewRootNode))
         return std::nullopt;
-    
-    auto scrollingStateTree = makeUnique<ScrollingStateTree>();
 
     bool hasChangedProperties;
     if (!decoder.decode(hasChangedProperties))
         return std::nullopt;
 
-    scrollingStateTree->setHasChangedProperties(hasChangedProperties);
+    unsigned numNodes;
+    if (!decoder.decode(numNodes))
+        return std::nullopt;
 
-    for (int i = 0; i < numNodes; ++i) {
+    ScrollingStateTree scrollingStateTree;
+
+    scrollingStateTree.setHasChangedProperties(hasChangedProperties);
+
+    for (unsigned i = 0; i < numNodes; ++i) {
         ScrollingNodeType nodeType;
         if (!decoder.decode(nodeType))
             return std::nullopt;
@@ -605,11 +576,11 @@ auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std
         if (!decoder.decode(parentNodeID))
             return std::nullopt;
 
-        auto createdNodeID = scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
+        auto createdNodeID = scrollingStateTree.insertNode(nodeType, nodeID, parentNodeID, notFound);
         if (createdNodeID != nodeID)
             return std::nullopt;
 
-        auto newNode = scrollingStateTree->stateNodeForID(nodeID);
+        auto newNode = scrollingStateTree.stateNodeForID(nodeID);
         ASSERT(newNode);
         if (newNode->nodeType() != nodeType)
             return std::nullopt;
@@ -649,10 +620,24 @@ auto RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder) -> std
         }
     }
 
-    scrollingStateTree->setHasNewRootStateNode(hasNewRootNode);
+    scrollingStateTree.setHasNewRootStateNode(hasNewRootNode);
 
-    return { RemoteScrollingCoordinatorTransaction { WTFMove(scrollingStateTree), clearScrollLatching } };
+    return { WTFMove(scrollingStateTree) };
 }
+
+namespace WebKit {
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching)
+    : m_scrollingStateTree(WTFMove(scrollingStateTree))
+    , m_clearScrollLatching(clearScrollLatching) { }
+
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&) = default;
+
+RemoteScrollingCoordinatorTransaction& RemoteScrollingCoordinatorTransaction::operator=(RemoteScrollingCoordinatorTransaction&&) = default;
+
+RemoteScrollingCoordinatorTransaction::~RemoteScrollingCoordinatorTransaction() = default;
 
 #if !defined(NDEBUG) || !LOG_DISABLED
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp.rej
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp.rej
@@ -1,0 +1,155 @@
+@@ -409,143 +377,89 @@
+ {
+     if (!decoder.decode(static_cast<ScrollingStateScrollingNode&>(node)))
+         return false;
+-
++    
+     return true;
+ }
+ 
+ bool ArgumentCoder<ScrollingStateOverflowScrollProxyNode>::decode(Decoder& decoder, ScrollingStateOverflowScrollProxyNode& node)
+ {
+-    if (!decoder.decode(static_cast<ScrollingStateNode&>(node)))
+-        return false;
+-
+     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::OverflowScrollingNode, ScrollingNodeID, setOverflowScrollingNode);
+     return true;
+ }
+ 
+ void ArgumentCoder<ScrollingStateFixedNode>::encode(Encoder& encoder, const ScrollingStateFixedNode& node)
+ {
+-    encoder << static_cast<const ScrollingStateNode&>(node);
+-    
+     if (node.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints))
+         encoder << node.viewportConstraints();
+ }
+ 
+ bool ArgumentCoder<ScrollingStateFixedNode>::decode(Decoder& decoder, ScrollingStateFixedNode& node)
+ {
+-    if (!decoder.decode(static_cast<ScrollingStateNode&>(node)))
+-        return false;
+-
+     if (node.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints)) {
+         FixedPositionViewportConstraints decodedValue;
+         if (!decoder.decode(decodedValue))
+             return false;
+         node.updateConstraints(decodedValue);
+     }
+-
++    
+     return true;
+ }
+ 
+ void ArgumentCoder<ScrollingStateStickyNode>::encode(Encoder& encoder, const ScrollingStateStickyNode& node)
+ {
+-    encoder << static_cast<const ScrollingStateNode&>(node);
+-    
+     if (node.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints))
+         encoder << node.viewportConstraints();
+ }
+ 
+ bool ArgumentCoder<ScrollingStateStickyNode>::decode(Decoder& decoder, ScrollingStateStickyNode& node)
+ {
+-    if (!decoder.decode(static_cast<ScrollingStateNode&>(node)))
+-        return false;
+-
+     if (node.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints)) {
+         StickyPositionViewportConstraints decodedValue;
+         if (!decoder.decode(decodedValue))
+             return false;
+         node.updateConstraints(decodedValue);
+     }
+-
++    
+     return true;
+ }
+ 
+ void ArgumentCoder<ScrollingStatePositionedNode>::encode(Encoder& encoder, const ScrollingStatePositionedNode& node)
+ {
+-    encoder << static_cast<const ScrollingStateNode&>(node);
+-
+     if (node.hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
+         encoder << node.relatedOverflowScrollingNodes();
+-
++    
+     if (node.hasChangedProperty(ScrollingStateNode::Property::LayoutConstraintData))
+         encoder << node.layoutConstraints();
+ }
+ 
+ bool ArgumentCoder<ScrollingStatePositionedNode>::decode(Decoder& decoder, ScrollingStatePositionedNode& node)
+ {
+-    if (!decoder.decode(static_cast<ScrollingStateNode&>(node)))
+-        return false;
+-
+     if (node.hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes)) {
+         Vector<ScrollingNodeID> decodedValue;
+         if (!decoder.decode(decodedValue))
+             return false;
+         node.setRelatedOverflowScrollingNodes(WTFMove(decodedValue));
+     }
+-
++    
+     if (node.hasChangedProperty(ScrollingStateNode::Property::LayoutConstraintData)) {
+         AbsolutePositionConstraints decodedValue;
+         if (!decoder.decode(decodedValue))
+             return false;
+         node.updateConstraints(decodedValue);
+     }
+-
++    
+     return true;
+ }
+ 
+-static void encodeNodeAndDescendants(IPC::Encoder& encoder, const ScrollingStateNode& stateNode, unsigned& encodedNodeCount)
+-{
+-    ++encodedNodeCount;
+-
+-    switch (stateNode.nodeType()) {
+-    case ScrollingNodeType::MainFrame:
+-    case ScrollingNodeType::Subframe:
+-        encoder << downcast<ScrollingStateFrameScrollingNode>(stateNode);
+-        break;
+-    case ScrollingNodeType::FrameHosting:
+-        encoder << downcast<ScrollingStateFrameHostingNode>(stateNode);
+-        break;
+-    case ScrollingNodeType::Overflow:
+-        encoder << downcast<ScrollingStateOverflowScrollingNode>(stateNode);
+-        break;
+-    case ScrollingNodeType::OverflowProxy:
+-        encoder << downcast<ScrollingStateOverflowScrollProxyNode>(stateNode);
+-        break;
+-    case ScrollingNodeType::Fixed:
+-        encoder << downcast<ScrollingStateFixedNode>(stateNode);
+-        break;
+-    case ScrollingNodeType::Sticky:
+-        encoder << downcast<ScrollingStateStickyNode>(stateNode);
+-        break;
+-    case ScrollingNodeType::Positioned:
+-        encoder << downcast<ScrollingStatePositionedNode>(stateNode);
+-        break;
+-    }
+-
+-    if (!stateNode.children())
+-        return;
+-
+-    for (const auto& child : *stateNode.children())
+-        encodeNodeAndDescendants(encoder, *child.get(), encodedNodeCount);
+-}
+-
+ void ArgumentCoder<WebCore::ScrollingStateTree>::encode(Encoder& encoder, const WebCore::ScrollingStateTree& tree)
+ {
+     encoder << tree.hasNewRootStateNode();
+     encoder << tree.hasChangedProperties();
+-    encoder << tree.nodeCount();
+-    unsigned numNodesEncoded = 0;
+-    if (const ScrollingStateNode* rootNode = tree.rootStateNode())
+-        encodeNodeAndDescendants(encoder, *rootNode, numNodesEncoded);
+-    ASSERT_UNUSED(numNodesEncoded, numNodesEncoded == tree.nodeCount());
++    if (const ScrollingStateNode* rootNode = tree.rootStateNode()) {
++        encoder << true;
++        encoder << *rootNode;
++    } else
++        encoder << false;
+ }
+ 
+ std::optional<WebCore::ScrollingStateTree> ArgumentCoder<WebCore::ScrollingStateTree>::decode(Decoder& decoder)


### PR DESCRIPTION
#### c32407025177e9f14ae61fb833c0811c4bfe95ac
<pre>
ScrollingStateNode::m_children should be a Vector instead of a unique_ptr&lt;Vector&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=260500">https://bugs.webkit.org/show_bug.cgi?id=260500</a>
rdar://114229385

Reviewed by Simon Fraser.

This removes double allocation and double pointer dereferencing.  It adds a pointer size to the node.

There was one layout test that printed that it had 0 children in the scroll tree and that is no longer printed.
This is of no consequence.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::childrenOfNode const):
* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::cloneAndResetChildren):
(WebCore::ScrollingStateNode::appendChild):
(WebCore::ScrollingStateNode::insertChild):
(WebCore::ScrollingStateNode::removeChildAtIndex):
(WebCore::ScrollingStateNode::indexOfChild const):
(WebCore::ScrollingStateNode::dump const):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::children):
(WebCore::ScrollingStateNode::children const):
(WebCore::ScrollingStateNode::takeChildren):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::nodeWasReattachedRecursive):
(WebCore::ScrollingStateTree::unparentChildrenAndDestroyNode):
(WebCore::ScrollingStateTree::traverse const):
(WebCore::ScrollingStateTree::removeNodeAndAllDescendants):
(WebCore::ScrollingStateTree::recursiveNodeWillBeRemoved):
(WebCore::reconcileLayerPositionsRecursive):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(encodeNodeAndDescendants):
(WebKit::recursiveDumpNodes):

Canonical link: <a href="https://commits.webkit.org/267174@main">https://commits.webkit.org/267174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38c568c1458ca0d8d1cdedb4e08fc15a92f0606

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17562 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14830 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17321 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18318 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21171 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17694 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18645 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1947 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->