### PR TITLE
Rename WebPushD::Daemon to WebPushD::WebPushDaemon

### DIFF
--- a/Source/WebKit/webpushd/ICAppBundle.mm
+++ b/Source/WebKit/webpushd/ICAppBundle.mm
@@ -81,7 +81,7 @@ namespace WebPushD {
 
 static void broadcastDebugMessage(const String& message)
 {
-    Daemon::singleton().broadcastDebugMessage(makeString("ICAppBundle: ", message));
+    WebPushDaemon::singleton().broadcastDebugMessage(makeString("ICAppBundle: ", message));
 }
 
 ICAppBundle::ICAppBundle(ClientConnection& clientConnection, const String& originString, PushAppBundleClient& client)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -85,7 +85,7 @@ void ClientConnection::setHostAppAuditTokenData(const Vector<uint8_t>& tokenData
     }
 
     m_hostAppAuditToken = WTFMove(token);
-    Daemon::singleton().broadcastAllConnectionIdentities();
+    WebPushDaemon::singleton().broadcastAllConnectionIdentities();
 }
 
 WebCore::PushSubscriptionSetIdentifier ClientConnection::subscriptionSetIdentifier()
@@ -175,7 +175,7 @@ void ClientConnection::broadcastDebugMessage(const String& message)
     else
         messageIdentifier = makeString("[", signingIdentifier, " (", String::number(identifier()), ")] ");
 
-    Daemon::singleton().broadcastDebugMessage(makeString(messageIdentifier, message));
+    WebPushDaemon::singleton().broadcastDebugMessage(makeString(messageIdentifier, message));
 }
 
 void ClientConnection::sendDebugMessage(const String& message)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -58,10 +58,10 @@ namespace WebPushD {
 
 using EncodedMessage = Vector<uint8_t>;
 
-class Daemon {
-    friend class WTF::NeverDestroyed<Daemon>;
+class WebPushDaemon {
+    friend class WTF::NeverDestroyed<WebPushDaemon>;
 public:
-    static Daemon& singleton();
+    static WebPushDaemon& singleton();
 
     void connectionEventHandler(xpc_object_t);
     void connectionAdded(xpc_connection_t);
@@ -96,7 +96,7 @@ public:
     void broadcastAllConnectionIdentities();
 
 private:
-    Daemon();
+    WebPushDaemon();
 
     CompletionHandler<void(EncodedMessage&&)> createReplySender(WebKit::WebPushD::MessageType, OSObjectPtr<xpc_object_t>&& request);
     void decodeAndHandleRawXPCMessage(WebKit::WebPushD::RawXPCMessageType, OSObjectPtr<xpc_object_t>&&);

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -44,7 +44,7 @@
 #import <wtf/spi/darwin/XPCSPI.h>
 
 using WebKit::Daemon::EncodedMessage;
-using WebPushD::Daemon;
+using WebPushD::WebPushDaemon;
 
 static const ASCIILiteral entitlementName = "com.apple.private.webkit.webpush"_s;
 static const ASCIILiteral defaultMachServiceName = "com.apple.webkit.webpushd.service"_s;
@@ -54,17 +54,17 @@ namespace WebPushD {
 
 static void connectionEventHandler(xpc_object_t request)
 {
-    Daemon::singleton().connectionEventHandler(request);
+    WebPushDaemon::singleton().connectionEventHandler(request);
 }
 
 static void connectionAdded(xpc_connection_t connection)
 {
-    Daemon::singleton().connectionAdded(connection);
+    WebPushDaemon::singleton().connectionAdded(connection);
 }
 
 static void connectionRemoved(xpc_connection_t connection)
 {
-    Daemon::singleton().connectionRemoved(connection);
+    WebPushDaemon::singleton().connectionRemoved(connection);
 }
 
 } // namespace WebPushD
@@ -140,11 +140,11 @@ int WebPushDaemonMain(int argc, char** argv)
         WebKit::startListeningForMachServiceConnections(machServiceName, entitlementName, connectionAdded, connectionRemoved, connectionEventHandler);
 
         if (useMockPushService)
-            ::WebPushD::Daemon::singleton().startMockPushService();
+            ::WebPushD::WebPushDaemon::singleton().startMockPushService();
         else {
             String libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
             String pushDatabasePath = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebPush"_s, "PushDatabase.db"_s });
-            ::WebPushD::Daemon::singleton().startPushService(String::fromLatin1(incomingPushServiceName), pushDatabasePath);
+            ::WebPushD::WebPushDaemon::singleton().startPushService(String::fromLatin1(incomingPushServiceName), pushDatabasePath);
         }
     }
     CFRunLoopRun();


### PR DESCRIPTION
#### 8d79b382f1ebe9bea70756595ce28c74eaa207a8
<pre>
Rename WebPushD::Daemon to WebPushD::WebPushDaemon
<a href="https://bugs.webkit.org/show_bug.cgi?id=260503">https://bugs.webkit.org/show_bug.cgi?id=260503</a>

Reviewed by Alex Christensen.

Refactor to enable upcoming refactoring.

* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::ClientConnection::setHostAppAuditTokenData):
(WebPushD::ClientConnection::broadcastDebugMessage):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::handleWebPushDMessageWithReply):
(WebPushD::handleWebPushDMessage):
(WebPushD::WebPushDaemon::singleton):
(WebPushD::WebPushDaemon::WebPushDaemon):
(WebPushD::WebPushDaemon::startMockPushService):
(WebPushD::WebPushDaemon::startPushService):
(WebPushD::WebPushDaemon::setPushService):
(WebPushD::WebPushDaemon::runAfterStartingPushService):
(WebPushD::WebPushDaemon::ensureIncomingPushTransaction):
(WebPushD::WebPushDaemon::releaseIncomingPushTransaction):
(WebPushD::WebPushDaemon::incomingPushTransactionTimerFired):
(WebPushD::WebPushDaemon::broadcastDebugMessage):
(WebPushD::WebPushDaemon::broadcastAllConnectionIdentities):
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::connectionAdded):
(WebPushD::WebPushDaemon::connectionRemoved):
(WebPushD::CompletionHandler&lt;void):
(WebPushD::WebPushDaemon::decodeAndHandleRawXPCMessage):
(WebPushD::WebPushDaemon::decodeAndHandleMessage):
(WebPushD::WebPushDaemon::echoTwice):
(WebPushD::WebPushDaemon::canRegisterForNotifications):
(WebPushD::WebPushDaemon::requestSystemNotificationPermission):
(WebPushD::WebPushDaemon::getOriginsWithPushAndNotificationPermissions):
(WebPushD::WebPushDaemon::deletePushRegistration):
(WebPushD::WebPushDaemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::WebPushDaemon::deletePushAndNotificationRegistration):
(WebPushD::WebPushDaemon::setDebugModeIsEnabled):
(WebPushD::WebPushDaemon::updateConnectionConfiguration):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
(WebPushD::WebPushDaemon::handleIncomingPush):
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::getPushTopicsForTesting):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::unsubscribeFromPushService):
(WebPushD::WebPushDaemon::getPushSubscription):
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::incrementSilentPushCount):
(WebPushD::WebPushDaemon::removeAllPushSubscriptions):
(WebPushD::WebPushDaemon::removePushSubscriptionsForOrigin):
(WebPushD::WebPushDaemon::setPublicTokenForTesting):
(WebPushD::WebPushDaemon::toClientConnection):
(WebPushD::Daemon::singleton): Deleted.
(WebPushD::Daemon::Daemon): Deleted.
(WebPushD::Daemon::startMockPushService): Deleted.
(WebPushD::Daemon::startPushService): Deleted.
(WebPushD::Daemon::setPushService): Deleted.
(WebPushD::Daemon::runAfterStartingPushService): Deleted.
(WebPushD::Daemon::ensureIncomingPushTransaction): Deleted.
(WebPushD::Daemon::releaseIncomingPushTransaction): Deleted.
(WebPushD::Daemon::incomingPushTransactionTimerFired): Deleted.
(WebPushD::Daemon::broadcastDebugMessage): Deleted.
(WebPushD::Daemon::broadcastAllConnectionIdentities): Deleted.
(WebPushD::Daemon::connectionEventHandler): Deleted.
(WebPushD::Daemon::connectionAdded): Deleted.
(WebPushD::Daemon::connectionRemoved): Deleted.
(WebPushD::Daemon::decodeAndHandleRawXPCMessage): Deleted.
(WebPushD::Daemon::decodeAndHandleMessage): Deleted.
(WebPushD::Daemon::echoTwice): Deleted.
(WebPushD::Daemon::canRegisterForNotifications): Deleted.
(WebPushD::Daemon::requestSystemNotificationPermission): Deleted.
(WebPushD::Daemon::getOriginsWithPushAndNotificationPermissions): Deleted.
(WebPushD::Daemon::deletePushRegistration): Deleted.
(WebPushD::Daemon::setPushAndNotificationsEnabledForOrigin): Deleted.
(WebPushD::Daemon::deletePushAndNotificationRegistration): Deleted.
(WebPushD::Daemon::setDebugModeIsEnabled): Deleted.
(WebPushD::Daemon::updateConnectionConfiguration): Deleted.
(WebPushD::Daemon::injectPushMessageForTesting): Deleted.
(WebPushD::Daemon::injectEncryptedPushMessageForTesting): Deleted.
(WebPushD::Daemon::handleIncomingPush): Deleted.
(WebPushD::Daemon::notifyClientPushMessageIsAvailable): Deleted.
(WebPushD::Daemon::getPendingPushMessages): Deleted.
(WebPushD::Daemon::getPushTopicsForTesting): Deleted.
(WebPushD::Daemon::subscribeToPushService): Deleted.
(WebPushD::Daemon::unsubscribeFromPushService): Deleted.
(WebPushD::Daemon::getPushSubscription): Deleted.
(WebPushD::Daemon::getPushPermissionState): Deleted.
(WebPushD::Daemon::incrementSilentPushCount): Deleted.
(WebPushD::Daemon::removeAllPushSubscriptions): Deleted.
(WebPushD::Daemon::removePushSubscriptionsForOrigin): Deleted.
(WebPushD::Daemon::setPublicTokenForTesting): Deleted.
(WebPushD::Daemon::toClientConnection): Deleted.
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebPushD::connectionEventHandler):
(WebPushD::connectionAdded):
(WebPushD::connectionRemoved):
(WebKit::WebPushDaemonMain):

Canonical link: <a href="https://commits.webkit.org/267120@main">https://commits.webkit.org/267120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7244a303113d91e5b9ab7575d4847903ddfcf2ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17517 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14785 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16168 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16415 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/18279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13664 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21127 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17646 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14984 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14231 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->