### PR TITLE
[@property] <resolution> should not accept negative resolutions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt
@@ -34,6 +34,7 @@ PASS syntax:'<length>', initialValue:'10vmin' is valid
 PASS syntax:'<percentage> | <length>+', initialValue:'calc(100vh - 10px) 30px' is valid
 PASS syntax:'<number>', initialValue:'-109' is valid
 PASS syntax:'<number>', initialValue:'2.3e4' is valid
+PASS syntax:'<number>', initialValue:'calc(1 / 2)' is valid
 PASS syntax:'<integer>', initialValue:'-109' is valid
 PASS syntax:'<integer>', initialValue:'19' is valid
 PASS syntax:'<integer>', initialValue:'calc(1)' is valid
@@ -47,7 +48,6 @@ PASS syntax:'<time>', initialValue:'2s' is valid
 PASS syntax:'<time>', initialValue:'calc(2s - 9ms)' is valid
 PASS syntax:'<resolution>', initialValue:'10dpi' is valid
 PASS syntax:'<resolution>', initialValue:'3dPpX' is valid
-PASS syntax:'<resolution>', initialValue:'-5.3dpcm' is valid
 PASS syntax:'<transform-function>', initialValue:'translateX(2px)' is valid
 PASS syntax:'<transform-function>|<integer>', initialValue:'5' is valid
 PASS syntax:'<transform-function>|<integer>', initialValue:'scale(2)' is valid
@@ -60,6 +60,7 @@ PASS syntax:'<image>', initialValue:'url(a)' is valid
 PASS syntax:'<image>', initialValue:'linear-gradient(yellow, blue)' is valid
 PASS syntax:'<url>', initialValue:'url(a)' is valid
 PASS syntax:'<color>+', initialValue:'yellow blue' is valid
+PASS syntax:'<color>+', initialValue:'yellow blue ' is valid
 PASS syntax:'<color>+ | <color>', initialValue:'yellow blue' is valid
 PASS syntax:'<color> | <color>+', initialValue:'yellow blue' is valid
 PASS syntax:'<color># | <color>', initialValue:'yellow, blue' is valid
@@ -79,6 +80,7 @@ PASS syntax:'<transform-list> | <transform-function># ', initialValue:'scale(2) 
 PASS syntax:'<transform-function># | <transform-list>', initialValue:'scale(2) rotate(90deg)' is valid
 PASS syntax:'<transform-list> | <transform-function># ', initialValue:'scale(2), rotate(90deg)' is valid
 PASS syntax:'<transform-function># | <transform-list>', initialValue:'scale(2), rotate(90deg)' is valid
+PASS syntax:'<transform-list>', initialValue:'scale(2) rotate(90deg) ' is valid
 PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1' is valid
 PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1 1' is valid
 PASS syntax:'<integer>+ | <percentage>+ | <length>+ ', initialValue:'1%' is valid
@@ -107,6 +109,7 @@ PASS syntax:'hmm\1F914', initialValue:'hmm🤔' is valid
 PASS syntax:'\1F914hmm', initialValue:'🤔hmm' is valid
 PASS syntax:'\1F914 hmm', initialValue:'🤔hmm' is valid
 PASS syntax:'\1F914\1F914', initialValue:'🤔🤔' is valid
+PASS syntax:'<color>#', initialValue:'yellow blue' is invalid
 PASS syntax:'banana,nya', initialValue:'banana' is invalid
 PASS syntax:'<\6c ength>', initialValue:'10px' is invalid
 PASS syntax:'<banana>', initialValue:'banana' is invalid
@@ -123,6 +126,8 @@ PASS syntax:'<length>##', initialValue:'10px' is invalid
 PASS syntax:'<length>+#', initialValue:'10px' is invalid
 PASS syntax:'<length>#+', initialValue:'10px' is invalid
 PASS syntax:'<length> | *', initialValue:'10px' is invalid
+PASS syntax:'<length>+', initialValue:'2px,7px,calc(8px)' is invalid
+PASS syntax:'<length>#', initialValue:'2px 7px calc(8px)' is invalid
 PASS syntax:'*|banana', initialValue:'banana' is invalid
 PASS syntax:'|banana', initialValue:'banana' is invalid
 PASS syntax:'*+', initialValue:'banana' is invalid
@@ -203,6 +208,7 @@ PASS syntax:'<angle>', initialValue:'0' is invalid
 PASS syntax:'<angle>', initialValue:'10%' is invalid
 PASS syntax:'<time>', initialValue:'2px' is invalid
 PASS syntax:'<resolution>', initialValue:'10' is invalid
+PASS syntax:'<resolution>', initialValue:'-5.3dpcm' is invalid
 PASS syntax:'<transform-function>', initialValue:'scale()' is invalid
 PASS syntax:'<transform-list>', initialValue:'scale()' is invalid
 PASS syntax:'<transform-list>+', initialValue:'translateX(2px) rotate(20deg)' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html
@@ -60,6 +60,7 @@ assert_valid("<percentage> | <length>+", "calc(100vh - 10px) 30px");
 
 assert_valid("<number>", "-109");
 assert_valid("<number>", "2.3e4");
+assert_valid("<number>", "calc(1 / 2)");
 assert_valid("<integer>", "-109");
 assert_valid("<integer>", "19");
 assert_valid("<integer>", "calc(1)");
@@ -74,7 +75,6 @@ assert_valid("<time>", "2s");
 assert_valid("<time>", "calc(2s - 9ms)");
 assert_valid("<resolution>", "10dpi");
 assert_valid("<resolution>", "3dPpX");
-assert_valid("<resolution>", "-5.3dpcm");
 assert_valid("<transform-function>", "translateX(2px)");
 assert_valid("<transform-function>|<integer>", "5");
 assert_valid("<transform-function>|<integer>", "scale(2)");
@@ -89,6 +89,7 @@ assert_valid("<image>", "linear-gradient(yellow, blue)");
 assert_valid("<url>", "url(a)");
 
 assert_valid("<color>+", "yellow blue");
+assert_valid("<color>+", "yellow blue ");
 assert_valid("<color>+ | <color>", "yellow blue");
 assert_valid("<color> | <color>+", "yellow blue");
 assert_valid("<color># | <color>", "yellow, blue");
@@ -108,6 +109,7 @@ assert_valid("<transform-list> | <transform-function># ", "scale(2) rotate(90deg
 assert_valid("<transform-function># | <transform-list>", "scale(2) rotate(90deg)");
 assert_valid("<transform-list> | <transform-function># ", "scale(2), rotate(90deg)");
 assert_valid("<transform-function># | <transform-list>", "scale(2), rotate(90deg)");
+assert_valid("<transform-list>", "scale(2) rotate(90deg) ");
 assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1");
 assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1 1");
 assert_valid("<integer>+ | <percentage>+ | <length>+ ", "1%");
@@ -139,6 +141,7 @@ assert_valid("\\1F914 hmm", "🤔hmm");
 assert_valid("\\1F914\\1F914", "🤔🤔");
 
 // Invalid syntax
+assert_invalid("<color>#", "yellow blue");
 assert_invalid("banana,nya", "banana");
 assert_invalid("<\\6c ength>", "10px");
 assert_invalid("<banana>", "banana");
@@ -156,6 +159,8 @@ assert_invalid("<length>##", "10px");
 assert_invalid("<length>+#", "10px");
 assert_invalid("<length>#+", "10px");
 assert_invalid("<length> | *", "10px");
+assert_invalid("<length>+", "2px,7px,calc(8px)");
+assert_invalid("<length>#", "2px 7px calc(8px)");
 assert_invalid("*|banana", "banana");
 assert_invalid("|banana", "banana");
 assert_invalid("*+", "banana");
@@ -246,6 +251,11 @@ assert_invalid("<angle>", "0");
 assert_invalid("<angle>", "10%");
 assert_invalid("<time>", "2px");
 assert_invalid("<resolution>", "10");
+
+// "The allowed range of <resolution> values always excludes negative values"
+// https://www.w3.org/TR/css-values-4/#resolution-value
+assert_invalid("<resolution>", "-5.3dpcm");
+
 assert_invalid("<transform-function>", "scale()");
 assert_invalid("<transform-list>", "scale()");
 assert_invalid("<transform-list>+", "translateX(2px) rotate(20deg)");

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -250,7 +250,7 @@ bool GenericMediaQueryParserBase::validateFeatureAgainstSchema(Feature& feature,
             return primitiveValue->isLength();
 
         case FeatureSchema::ValueType::Resolution:
-            return primitiveValue && primitiveValue->isResolution() && primitiveValue->doubleValue() >= 0;
+            return primitiveValue && primitiveValue->isResolution();
 
         case FeatureSchema::ValueType::Identifier:
             return primitiveValue && primitiveValue->isValueID() && schema.valueIdentifiers.contains(primitiveValue->valueID());


### PR DESCRIPTION
#### d72a71047daaf802bc62dea229d53d4faaa668b0
<pre>
[@property] &lt;resolution&gt; should not accept negative resolutions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260506">https://bugs.webkit.org/show_bug.cgi?id=260506</a>
rdar://114235642

Reviewed by Cameron McCormack.

Reject negative resolutions inside consumeResolution &amp; ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeDimensionConsumer as per the css-values spec.

Also remove the other one-off fixes that were made to reject negative resolutions, since we now reject them all in a single place now.

* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/register-property-syntax-parsing.html:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::ResolutionCSSPrimitiveValueWithCalcWithKnownTokenTypeDimensionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::consumeResolution):
(WebCore::CSSPropertyParserHelpers::consumeImageSetOption):
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::GenericMediaQueryParserBase::validateFeatureAgainstSchema):

Canonical link: <a href="https://commits.webkit.org/267134@main">https://commits.webkit.org/267134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b8d598d974d22a71a52ef6d2060245ec64f5535

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16417 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13415 "1 api test failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18273 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21130 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14987 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12704 "12 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3766 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->