### PR TITLE
[@property] Handle dynamic updates to viewport units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-viewport-units-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/at-property-viewport-units-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL @property: viewport units in initial value (dynamic) assert_equals: expected "10px" but got "40px"
+PASS @property: viewport units in initial value (dynamic)
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1701,24 +1701,6 @@ void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependenci
     case CSSUnitType::CSS_CALC:
         m_value.calc->collectComputedStyleDependencies(dependencies);
         break;
-    case CSSUnitType::CSS_NUMBER:
-    case CSSUnitType::CSS_INTEGER:
-    case CSSUnitType::CSS_PERCENTAGE:
-    case CSSUnitType::CSS_PX:
-    case CSSUnitType::CSS_CM:
-    case CSSUnitType::CSS_MM:
-    case CSSUnitType::CSS_IN:
-    case CSSUnitType::CSS_PT:
-    case CSSUnitType::CSS_PC:
-    case CSSUnitType::CSS_DEG:
-    case CSSUnitType::CSS_RAD:
-    case CSSUnitType::CSS_GRAD:
-    case CSSUnitType::CSS_TURN:
-    case CSSUnitType::CSS_MS:
-    case CSSUnitType::CSS_S:
-    case CSSUnitType::CSS_HZ:
-    case CSSUnitType::CSS_KHZ:
-    case CSSUnitType::CSS_DIMENSION:
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_VH:
     case CSSUnitType::CSS_VMIN:
@@ -1743,6 +1725,26 @@ void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependenci
     case CSSUnitType::CSS_DVMAX:
     case CSSUnitType::CSS_DVB:
     case CSSUnitType::CSS_DVI:
+        dependencies.viewportDimensions = true;
+        break;
+    case CSSUnitType::CSS_NUMBER:
+    case CSSUnitType::CSS_INTEGER:
+    case CSSUnitType::CSS_PERCENTAGE:
+    case CSSUnitType::CSS_PX:
+    case CSSUnitType::CSS_CM:
+    case CSSUnitType::CSS_MM:
+    case CSSUnitType::CSS_IN:
+    case CSSUnitType::CSS_PT:
+    case CSSUnitType::CSS_PC:
+    case CSSUnitType::CSS_DEG:
+    case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_GRAD:
+    case CSSUnitType::CSS_TURN:
+    case CSSUnitType::CSS_MS:
+    case CSSUnitType::CSS_S:
+    case CSSUnitType::CSS_HZ:
+    case CSSUnitType::CSS_KHZ:
+    case CSSUnitType::CSS_DIMENSION:
     case CSSUnitType::CSS_DPPX:
     case CSSUnitType::CSS_X:
     case CSSUnitType::CSS_DPI:

--- a/Source/WebCore/css/CSSRegisteredCustomProperty.h
+++ b/Source/WebCore/css/CSSRegisteredCustomProperty.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class CSSCustomPropertyValue;
+class CSSVariableData;
 
 struct CSSRegisteredCustomProperty {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -39,6 +40,7 @@ struct CSSRegisteredCustomProperty {
     CSSCustomPropertySyntax syntax;
     bool inherits;
     RefPtr<const CSSCustomPropertyValue> initialValue;
+    RefPtr<const CSSVariableData> initialValueTokensForViewportUnits;
 
     ~CSSRegisteredCustomProperty();
 };

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -50,8 +50,9 @@ struct ComputedStyleDependencies {
     Vector<CSSPropertyID> properties;
     Vector<CSSPropertyID> rootProperties;
     bool containerDimensions { false };
+    bool viewportDimensions { false };
 
-    bool isEmpty() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions; }
+    bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions; }
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);

--- a/Source/WebCore/style/CustomPropertyRegistry.h
+++ b/Source/WebCore/style/CustomPropertyRegistry.h
@@ -50,14 +50,20 @@ public:
 
     const RenderStyle& initialValuePrototypeStyle() const;
 
+    bool invalidatePropertiesWithViewportUnits(Document&);
+
+    enum class ViewportUnitDependency : bool { No, Yes };
+    enum class ParseInitialValueError : uint8_t { NotComputationallyIndependent, DidNotParse };
+    static Expected<std::pair<RefPtr<CSSCustomPropertyValue>, ViewportUnitDependency>, ParseInitialValueError> parseInitialValue(const Document&, const AtomString& propertyName, const CSSCustomPropertySyntax&, CSSParserTokenRange);
+
 private:
     void invalidate(const AtomString&);
     void notifyAnimationsOfCustomPropertyRegistration(const AtomString&);
 
     Scope& m_scope;
 
-    HashMap<AtomString, std::unique_ptr<const CSSRegisteredCustomProperty>> m_propertiesFromAPI;
-    HashMap<AtomString, std::unique_ptr<const CSSRegisteredCustomProperty>> m_propertiesFromStylesheet;
+    HashMap<AtomString, UniqueRef<CSSRegisteredCustomProperty>> m_propertiesFromAPI;
+    HashMap<AtomString, UniqueRef<CSSRegisteredCustomProperty>> m_propertiesFromStylesheet;
 
     mutable std::unique_ptr<RenderStyle> m_initialValuePrototypeStyle;
     mutable bool m_hasInvalidPrototypeStyle { false };

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -845,6 +845,14 @@ void Scope::didChangeViewportSize()
         return;
     resolver->clearCachedDeclarationsAffectedByViewportUnits();
 
+    if (customPropertyRegistry().invalidatePropertiesWithViewportUnits(m_document)) {
+        if (!m_shadowRoot) {
+            if (auto element = m_document.documentElement())
+                element->invalidateStyleForSubtree();
+        }
+        return;
+    }
+
     // FIXME: Ideally, we should save the list of elements that have viewport units and only iterate over those.
     for (RefPtr element = ElementTraversal::firstWithin(rootNode); element; element = ElementTraversal::nextIncludingPseudo(*element)) {
         auto* renderer = element->renderer();


### PR DESCRIPTION
#### bb27e4ae20f7f78a43ef1347c25be6eead488f29
<pre>
[@property] Handle dynamic updates to viewport units
<a href="https://bugs.webkit.org/show_bug.cgi?id=255689">https://bugs.webkit.org/show_bug.cgi?id=255689</a>
rdar://108287215

Reviewed by Antti Koivisto.

Viewport units are &quot;computationally independent&quot;, and so are allowed in
registered custom property initial values. But we don&apos;t have any
mechanism to invalidate them when the viewport size changes.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const):

Record whether the value had any viewport units.

* Source/WebCore/css/CSSRegisteredCustomProperty.h:

Store the CSS parser tokens an initial value was created from if it
it contains viewport units, so that we can re-parse it when the viewport
is resized.

* Source/WebCore/css/CSSValue.h:
(WebCore::ComputedStyleDependencies::isComputationallyIndependent const):
(WebCore::ComputedStyleDependencies::isEmpty const): Deleted.

Rename isEmpty, since we don&apos;t want it to look at the new
viewportDimensions member.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::customPropertyValue const):
(WebCore::ComputedStyleExtractor::propertyValue const):

Flush layout in the parent document if there are viewport units used
anywhere in the current document.

* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::registerProperty):
* Source/WebCore/style/CustomPropertyRegistry.cpp:
(WebCore::Style::CustomPropertyRegistry::registerFromAPI):
(WebCore::Style::CustomPropertyRegistry::registerFromStylesheet):
(WebCore::Style::CustomPropertyRegistry::parseInitialValue):

Factor out initial value parsing from
DOMCSSRegisterCustomProperty::registerProperty and
CustomPropertyRegistry::registerFromStylesheet into a new function
parseInitialValue, which returns both the newly parsed
CSSCustomPropertyValue as well as whether it contained viewport unit
values.

* Source/WebCore/style/CustomPropertyRegistry.h:
(WebCore::Style::CustomPropertyRegistry::invalidatePropertiesWithViewportUnits):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::didChangeViewportSize):

Respond to viewport size changes by invalidating all registered custom
properties whose initial value contains viewport units.

Canonical link: <a href="https://commits.webkit.org/267590@main">https://commits.webkit.org/267590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fd8ad18d12c629a6ba52528aaaa5fa99c9319e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17081 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17548 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19683 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15513 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20032 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13799 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15424 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->