### PR TITLE
Fix unified build issues after 267037@main

### DIFF
--- a/Source/WebCore/html/canvas/ANGLEInstancedArrays.h
+++ b/Source/WebCore/html/canvas/ANGLEInstancedArrays.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class ANGLEInstancedArrays final : public RefCounted<ANGLEInstancedArrays>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(ANGLEInstancedArrays);
+    WTF_MAKE_NONCOPYABLE(ANGLEInstancedArrays);
 public:
     explicit ANGLEInstancedArrays(WebGLRenderingContextBase&);
     ~ANGLEInstancedArrays();

--- a/Source/WebCore/html/canvas/EXTBlendMinMax.h
+++ b/Source/WebCore/html/canvas/EXTBlendMinMax.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTBlendMinMax final : public RefCounted<EXTBlendMinMax>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTBlendMinMax);
+    WTF_MAKE_NONCOPYABLE(EXTBlendMinMax);
 public:
     explicit EXTBlendMinMax(WebGLRenderingContextBase&);
     ~EXTBlendMinMax();

--- a/Source/WebCore/html/canvas/EXTClipControl.h
+++ b/Source/WebCore/html/canvas/EXTClipControl.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTClipControl final : public RefCounted<EXTClipControl>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTClipControl);
+    WTF_MAKE_NONCOPYABLE(EXTClipControl);
 public:
     explicit EXTClipControl(WebGLRenderingContextBase&);
     ~EXTClipControl();

--- a/Source/WebCore/html/canvas/EXTColorBufferFloat.h
+++ b/Source/WebCore/html/canvas/EXTColorBufferFloat.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTColorBufferFloat final : public RefCounted<EXTColorBufferFloat>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTColorBufferFloat);
+    WTF_MAKE_NONCOPYABLE(EXTColorBufferFloat);
 public:
     explicit EXTColorBufferFloat(WebGLRenderingContextBase&);
     ~EXTColorBufferFloat();

--- a/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.h
+++ b/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTColorBufferHalfFloat final : public RefCounted<EXTColorBufferHalfFloat>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTColorBufferHalfFloat);
+    WTF_MAKE_NONCOPYABLE(EXTColorBufferHalfFloat);
 public:
     explicit EXTColorBufferHalfFloat(WebGLRenderingContextBase&);
     ~EXTColorBufferHalfFloat();

--- a/Source/WebCore/html/canvas/EXTConservativeDepth.h
+++ b/Source/WebCore/html/canvas/EXTConservativeDepth.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTConservativeDepth final : public RefCounted<EXTConservativeDepth>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTConservativeDepth);
+    WTF_MAKE_NONCOPYABLE(EXTConservativeDepth);
 public:
     explicit EXTConservativeDepth(WebGLRenderingContextBase&);
     ~EXTConservativeDepth();

--- a/Source/WebCore/html/canvas/EXTDepthClamp.h
+++ b/Source/WebCore/html/canvas/EXTDepthClamp.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTDepthClamp final : public RefCounted<EXTDepthClamp>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTDepthClamp);
+    WTF_MAKE_NONCOPYABLE(EXTDepthClamp);
 public:
     explicit EXTDepthClamp(WebGLRenderingContextBase&);
     ~EXTDepthClamp();

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -32,6 +32,7 @@
 #include "EventLoop.h"
 #include "ScriptExecutionContext.h"
 #include "WebGLRenderingContext.h"
+#include "WebGLTimerQueryEXT.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.h
@@ -33,8 +33,11 @@
 
 namespace WebCore {
 
+class WebGLTimerQueryEXT;
+
 class EXTDisjointTimerQuery final : public RefCounted<EXTDisjointTimerQuery>, public WebGLExtension<WebGLRenderingContext> {
     WTF_MAKE_ISO_ALLOCATED(EXTDisjointTimerQuery);
+    WTF_MAKE_NONCOPYABLE(EXTDisjointTimerQuery);
 public:
     explicit EXTDisjointTimerQuery(WebGLRenderingContext&);
     ~EXTDisjointTimerQuery();

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTDisjointTimerQueryWebGL2 final : public RefCounted<EXTDisjointTimerQueryWebGL2>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTDisjointTimerQueryWebGL2);
+    WTF_MAKE_NONCOPYABLE(EXTDisjointTimerQueryWebGL2);
 public:
     explicit EXTDisjointTimerQueryWebGL2(WebGLRenderingContextBase&);
     ~EXTDisjointTimerQueryWebGL2();

--- a/Source/WebCore/html/canvas/EXTFloatBlend.h
+++ b/Source/WebCore/html/canvas/EXTFloatBlend.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTFloatBlend final : public RefCounted<EXTFloatBlend>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTFloatBlend);
+    WTF_MAKE_NONCOPYABLE(EXTFloatBlend);
 public:
     explicit EXTFloatBlend(WebGLRenderingContextBase&);
     ~EXTFloatBlend();

--- a/Source/WebCore/html/canvas/EXTFragDepth.h
+++ b/Source/WebCore/html/canvas/EXTFragDepth.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTFragDepth final : public RefCounted<EXTFragDepth>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTFragDepth);
+    WTF_MAKE_NONCOPYABLE(EXTFragDepth);
 public:
     explicit EXTFragDepth(WebGLRenderingContextBase&);
     ~EXTFragDepth();

--- a/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.h
+++ b/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTPolygonOffsetClamp final : public RefCounted<EXTPolygonOffsetClamp>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTPolygonOffsetClamp);
+    WTF_MAKE_NONCOPYABLE(EXTPolygonOffsetClamp);
 public:
     explicit EXTPolygonOffsetClamp(WebGLRenderingContextBase&);
     ~EXTPolygonOffsetClamp();

--- a/Source/WebCore/html/canvas/EXTRenderSnorm.h
+++ b/Source/WebCore/html/canvas/EXTRenderSnorm.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTRenderSnorm final : public RefCounted<EXTRenderSnorm>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTRenderSnorm);
+    WTF_MAKE_NONCOPYABLE(EXTRenderSnorm);
 public:
     explicit EXTRenderSnorm(WebGLRenderingContextBase&);
     ~EXTRenderSnorm();

--- a/Source/WebCore/html/canvas/EXTShaderTextureLOD.h
+++ b/Source/WebCore/html/canvas/EXTShaderTextureLOD.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTShaderTextureLOD final : public RefCounted<EXTShaderTextureLOD>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTShaderTextureLOD);
+    WTF_MAKE_NONCOPYABLE(EXTShaderTextureLOD);
 public:
     explicit EXTShaderTextureLOD(WebGLRenderingContextBase&);
     ~EXTShaderTextureLOD();

--- a/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.h
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTTextureCompressionRGTC final : public RefCounted<EXTTextureCompressionRGTC>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTTextureCompressionRGTC);
+    WTF_MAKE_NONCOPYABLE(EXTTextureCompressionRGTC);
 public:
     explicit EXTTextureCompressionRGTC(WebGLRenderingContextBase&);
     ~EXTTextureCompressionRGTC();

--- a/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.h
+++ b/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTTextureFilterAnisotropic final : public RefCounted<EXTTextureFilterAnisotropic>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTTextureFilterAnisotropic);
+    WTF_MAKE_NONCOPYABLE(EXTTextureFilterAnisotropic);
 public:
     explicit EXTTextureFilterAnisotropic(WebGLRenderingContextBase&);
     ~EXTTextureFilterAnisotropic();

--- a/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.h
+++ b/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTTextureMirrorClampToEdge final : public RefCounted<EXTTextureMirrorClampToEdge>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTTextureMirrorClampToEdge);
+    WTF_MAKE_NONCOPYABLE(EXTTextureMirrorClampToEdge);
 public:
     explicit EXTTextureMirrorClampToEdge(WebGLRenderingContextBase&);
     ~EXTTextureMirrorClampToEdge();

--- a/Source/WebCore/html/canvas/EXTTextureNorm16.h
+++ b/Source/WebCore/html/canvas/EXTTextureNorm16.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTTextureNorm16 final : public RefCounted<EXTTextureNorm16>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTTextureNorm16);
+    WTF_MAKE_NONCOPYABLE(EXTTextureNorm16);
 public:
     explicit EXTTextureNorm16(WebGLRenderingContextBase&);
     ~EXTTextureNorm16();

--- a/Source/WebCore/html/canvas/EXTsRGB.h
+++ b/Source/WebCore/html/canvas/EXTsRGB.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class EXTsRGB final : public RefCounted<EXTsRGB>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(EXTsRGB);
+    WTF_MAKE_NONCOPYABLE(EXTsRGB);
 public:
     explicit EXTsRGB(WebGLRenderingContextBase&);
     ~EXTsRGB();

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.h
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.h
@@ -33,6 +33,8 @@
 
 namespace WebCore {
 
+class WebGLVertexArrayObjectOES;
+
 class OESVertexArrayObject final : public RefCounted<OESVertexArrayObject>, public WebGLExtension<WebGLRenderingContext> {
     WTF_MAKE_ISO_ALLOCATED(OESVertexArrayObject);
 public:

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.h
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.h
@@ -26,13 +26,17 @@
 #pragma once
 
 #include "WebGLExtension.h"
+#include "WebGLRenderingContextBase.h"
 #include <JavaScriptCore/TypedArrays.h>
+#include <wtf/IsoMalloc.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
 class WebGLMultiDraw final : public RefCounted<WebGLMultiDraw>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(WebGLMultiDraw);
-
+    WTF_MAKE_NONCOPYABLE(WebGLMultiDraw);
 public:
     using Int32List = WebGLRenderingContextBase::TypedList<Int32Array, int32_t>;
 

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.h
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.h
@@ -26,12 +26,17 @@
 #pragma once
 
 #include "WebGLExtension.h"
+#include "WebGLRenderingContextBase.h"
 #include <JavaScriptCore/TypedArrays.h>
+#include <wtf/IsoMalloc.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
 class WebGLMultiDrawInstancedBaseVertexBaseInstance final : public RefCounted<WebGLMultiDrawInstancedBaseVertexBaseInstance>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(WebGLMultiDrawInstancedBaseVertexBaseInstance);
+    WTF_MAKE_NONCOPYABLE(WebGLMultiDrawInstancedBaseVertexBaseInstance);
 public:
     using Int32List = WebGLRenderingContextBase::TypedList<Int32Array, int32_t>;
     using Uint32List = WebGLRenderingContextBase::TypedList<Uint32Array, uint32_t>;

--- a/Source/WebCore/html/canvas/WebGLPolygonMode.h
+++ b/Source/WebCore/html/canvas/WebGLPolygonMode.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class WebGLPolygonMode final : public RefCounted<WebGLPolygonMode>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(WebGLPolygonMode);
+    WTF_MAKE_NONCOPYABLE(WebGLPolygonMode);
 public:
     explicit WebGLPolygonMode(WebGLRenderingContextBase&);
     ~WebGLPolygonMode();

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.h
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class WebGLProvokingVertex final : public RefCounted<WebGLProvokingVertex>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(WebGLProvokingVertex);
+    WTF_MAKE_NONCOPYABLE(WebGLProvokingVertex);
 public:
     explicit WebGLProvokingVertex(WebGLRenderingContextBase&);
     ~WebGLProvokingVertex();

--- a/Source/WebCore/html/canvas/WebGLRenderSharedExponent.h
+++ b/Source/WebCore/html/canvas/WebGLRenderSharedExponent.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class WebGLRenderSharedExponent final : public RefCounted<WebGLRenderSharedExponent>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderSharedExponent);
+    WTF_MAKE_NONCOPYABLE(WebGLRenderSharedExponent);
 public:
     explicit WebGLRenderSharedExponent(WebGLRenderingContextBase&);
     ~WebGLRenderSharedExponent();

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+class WebGLTimerQueryEXT;
+
 class WebGLRenderingContext final : public WebGLRenderingContextBase {
     WTF_MAKE_ISO_ALLOCATED(WebGLRenderingContext);
 public:

--- a/Source/WebCore/html/canvas/WebGLStencilTexturing.h
+++ b/Source/WebCore/html/canvas/WebGLStencilTexturing.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class WebGLStencilTexturing final : public RefCounted<WebGLStencilTexturing>, public WebGLExtension<WebGLRenderingContextBase> {
     WTF_MAKE_ISO_ALLOCATED(WebGLStencilTexturing);
+    WTF_MAKE_NONCOPYABLE(WebGLStencilTexturing);
 public:
     explicit WebGLStencilTexturing(WebGLRenderingContextBase&);
     ~WebGLStencilTexturing();


### PR DESCRIPTION
#### ffc701d1abadc9a6e6dd5c07bd9cacb1bd737077
<pre>
Fix unified build issues after 267037@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=260512">https://bugs.webkit.org/show_bug.cgi?id=260512</a>
rdar://problem/114243089

Unreviewed, build fix.

Fix headers and make NONCOPYABLE consistent among WebGL extensions after
&quot;WebGL extension context loss handling is more complex than needed&quot;.

* Source/WebCore/html/canvas/ANGLEInstancedArrays.h:
* Source/WebCore/html/canvas/EXTBlendMinMax.h:
* Source/WebCore/html/canvas/EXTClipControl.h:
* Source/WebCore/html/canvas/EXTColorBufferFloat.h:
* Source/WebCore/html/canvas/EXTColorBufferHalfFloat.h:
* Source/WebCore/html/canvas/EXTConservativeDepth.h:
* Source/WebCore/html/canvas/EXTDepthClamp.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.h:
* Source/WebCore/html/canvas/EXTFloatBlend.h:
* Source/WebCore/html/canvas/EXTFragDepth.h:
* Source/WebCore/html/canvas/EXTPolygonOffsetClamp.h:
* Source/WebCore/html/canvas/EXTRenderSnorm.h:
* Source/WebCore/html/canvas/EXTShaderTextureLOD.h:
* Source/WebCore/html/canvas/EXTTextureCompressionRGTC.h:
* Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.h:
* Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.h:
* Source/WebCore/html/canvas/EXTTextureNorm16.h:
* Source/WebCore/html/canvas/EXTsRGB.h:
* Source/WebCore/html/canvas/OESVertexArrayObject.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::root):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLMultiDraw.h:
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.h:
* Source/WebCore/html/canvas/WebGLPolygonMode.h:
* Source/WebCore/html/canvas/WebGLProvokingVertex.h:
* Source/WebCore/html/canvas/WebGLRenderSharedExponent.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLStencilTexturing.h:

Canonical link: <a href="https://commits.webkit.org/267127@main">https://commits.webkit.org/267127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19563aae80cef4649c14aa1fe8d499e924f85488

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16187 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15963 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18290 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/14681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15002 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14249 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18618 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1924 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->