### PR TITLE
WebGL resource creation is not robust against context loss

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1946,6 +1946,8 @@ RefPtr<WebGLSync> WebGL2RenderingContext::fenceSync(GCGLenum condition, GCGLbitf
         return nullptr;
     }
     auto sync = WebGLSync::create(*this);
+    if (!sync)
+        return nullptr;
     sync->scheduleAllowCacheUpdate(*this);
     return sync;
 }

--- a/Source/WebCore/html/canvas/WebGLBuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLBuffer.cpp
@@ -35,15 +35,17 @@
 
 namespace WebCore {
 
-Ref<WebGLBuffer> WebGLBuffer::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLBuffer> WebGLBuffer::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLBuffer(ctx));
+    auto object = context.graphicsContextGL()->createBuffer();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLBuffer { context, object });
 }
 
-WebGLBuffer::WebGLBuffer(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
+WebGLBuffer::WebGLBuffer(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    setObject(ctx.graphicsContextGL()->createBuffer());
 }
 
 WebGLBuffer::~WebGLBuffer()

--- a/Source/WebCore/html/canvas/WebGLBuffer.h
+++ b/Source/WebCore/html/canvas/WebGLBuffer.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class WebGLBuffer final : public WebGLObject {
 public:
-    static Ref<WebGLBuffer> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLBuffer> create(WebGLRenderingContextBase&);
     virtual ~WebGLBuffer();
 
     GCGLenum getTarget() const { return m_target; }
@@ -47,7 +47,7 @@ public:
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return m_target; }
 private:
-    WebGLBuffer(WebGLRenderingContextBase&);
+    WebGLBuffer(WebGLRenderingContextBase&, PlatformGLObject);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.cpp
@@ -190,26 +190,31 @@ WebGLFramebuffer::WebGLAttachment::WebGLAttachment() = default;
 
 WebGLFramebuffer::WebGLAttachment::~WebGLAttachment() = default;
 
-Ref<WebGLFramebuffer> WebGLFramebuffer::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLFramebuffer> WebGLFramebuffer::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLFramebuffer(ctx));
+    auto object = context.graphicsContextGL()->createFramebuffer();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLFramebuffer { context, object, Type::Plain });
 }
 
 #if ENABLE(WEBXR)
-
-Ref<WebGLFramebuffer> WebGLFramebuffer::createOpaque(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLFramebuffer> WebGLFramebuffer::createOpaque(WebGLRenderingContextBase& context)
 {
-    auto framebuffer = adoptRef(*new WebGLFramebuffer(ctx));
-    framebuffer->m_opaque = true;
-    return framebuffer;
+    auto object = context.graphicsContextGL()->createFramebuffer();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLFramebuffer { context, object, Type::Opaque });
 }
-
 #endif
 
-WebGLFramebuffer::WebGLFramebuffer(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
+WebGLFramebuffer::WebGLFramebuffer(WebGLRenderingContextBase& context, PlatformGLObject object, Type type)
+    : WebGLObject(context, object)
+#if ENABLE(WEBXR)
+    , m_isOpaque(type == Type::Opaque)
+#endif
 {
-    setObject(ctx.graphicsContextGL()->createFramebuffer());
+    UNUSED_PARAM(type);
 }
 
 WebGLFramebuffer::~WebGLFramebuffer()

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -65,9 +65,9 @@ public:
 
     virtual ~WebGLFramebuffer();
 
-    static Ref<WebGLFramebuffer> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLFramebuffer> create(WebGLRenderingContextBase&);
 #if ENABLE(WEBXR)
-    static Ref<WebGLFramebuffer> createOpaque(WebGLRenderingContextBase&);
+    static RefPtr<WebGLFramebuffer> createOpaque(WebGLRenderingContextBase&);
 #endif
 
     void setAttachmentForBoundFramebuffer(GCGLenum target, GCGLenum attachment, GCGLenum texTarget, WebGLTexture*, GCGLint level, GCGLint layer);
@@ -89,15 +89,20 @@ public:
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
 
 #if ENABLE(WEBXR)
-    bool isOpaque() const { return m_opaque; }
-    void setOpaqueActive(bool active) { m_opaqueActive = active; }
+    bool isOpaque() const { return m_isOpaque; }
 #endif
 
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
-    WebGLFramebuffer(WebGLRenderingContextBase&);
+    enum class Type : bool {
+        Plain,
+#if ENABLE(WEBXR)
+        Opaque
+#endif
+    };
+    WebGLFramebuffer(WebGLRenderingContextBase&, PlatformGLObject, Type);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
@@ -119,17 +124,12 @@ private:
     void removeAttachmentInternal(const AbstractLocker&, GCGLenum attachment);
 
     typedef HashMap<GCGLenum, RefPtr<WebGLAttachment>> AttachmentMap;
-
     AttachmentMap m_attachments;
-
     bool m_hasEverBeenBound { false };
-
     Vector<GCGLenum> m_drawBuffers;
     Vector<GCGLenum> m_filteredDrawBuffers;
-
 #if ENABLE(WEBXR)
-    bool m_opaque { false };
-    bool m_opaqueActive { false };
+    const bool m_isOpaque;
 #endif
 };
 

--- a/Source/WebCore/html/canvas/WebGLObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLObject.cpp
@@ -37,8 +37,9 @@
 
 namespace WebCore {
 
-WebGLObject::WebGLObject(WebGLRenderingContextBase& context)
+WebGLObject::WebGLObject(WebGLRenderingContextBase& context, PlatformGLObject object)
     : m_context(context.createRefForContextObject())
+    , m_object(object)
 {
 }
 
@@ -57,13 +58,6 @@ Lock& WebGLObject::objectGraphLockForContext()
 GraphicsContextGL* WebGLObject::graphicsContextGL() const
 {
     return m_context ? m_context->graphicsContextGL() : nullptr;
-}
-
-void WebGLObject::setObject(PlatformGLObject object)
-{
-    ASSERT(!m_object);
-    ASSERT(!m_deleted);
-    m_object = object;
 }
 
 void WebGLObject::runDestructor()

--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -116,10 +116,7 @@ public:
     virtual bool isTexture() const { return false; }
 
 protected:
-    WebGLObject(WebGLRenderingContextBase&);
-
-    // setObject should be only called once right after creating a WebGLObject.
-    void setObject(PlatformGLObject);
+    WebGLObject(WebGLRenderingContextBase&, PlatformGLObject);
 
     void runDestructor();
 

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -54,23 +54,24 @@ Lock& WebGLProgram::instancesLock()
     return s_instancesLock;
 }
 
-Ref<WebGLProgram> WebGLProgram::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLProgram> WebGLProgram::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLProgram(ctx));
+    auto object = context.graphicsContextGL()->createProgram();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLProgram { context, object });
 }
 
-WebGLProgram::WebGLProgram(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
-    , ContextDestructionObserver(ctx.scriptExecutionContext())
+WebGLProgram::WebGLProgram(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
+    , ContextDestructionObserver(context.scriptExecutionContext())
 {
     ASSERT(scriptExecutionContext());
 
     {
         Locker locker { instancesLock() };
-        instances().add(this, &ctx);
+        instances().add(this, &context);
     }
-
-    setObject(ctx.graphicsContextGL()->createProgram());
 }
 
 WebGLProgram::~WebGLProgram()

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -50,7 +50,7 @@ class WebGLShader;
 
 class WebGLProgram final : public WebGLObject, public ContextDestructionObserver {
 public:
-    static Ref<WebGLProgram> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLProgram> create(WebGLRenderingContextBase&);
     virtual ~WebGLProgram();
 
     static HashMap<WebGLProgram*, WebGLRenderingContextBase*>& instances() WTF_REQUIRES_LOCK(instancesLock());
@@ -94,7 +94,7 @@ public:
     bool isInitialized() const { return true; }
 
 private:
-    WebGLProgram(WebGLRenderingContextBase&);
+    WebGLProgram(WebGLRenderingContextBase&, PlatformGLObject);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 

--- a/Source/WebCore/html/canvas/WebGLQuery.cpp
+++ b/Source/WebCore/html/canvas/WebGLQuery.cpp
@@ -34,9 +34,12 @@
 
 namespace WebCore {
     
-Ref<WebGLQuery> WebGLQuery::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLQuery> WebGLQuery::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLQuery(ctx));
+    auto object = context.graphicsContextGL()->createQuery();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLQuery { context, object });
 }
 
 WebGLQuery::~WebGLQuery()
@@ -47,10 +50,9 @@ WebGLQuery::~WebGLQuery()
     runDestructor();
 }
 
-WebGLQuery::WebGLQuery(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
+WebGLQuery::WebGLQuery(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    setObject(ctx.graphicsContextGL()->createQuery());
 }
 
 void WebGLQuery::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)

--- a/Source/WebCore/html/canvas/WebGLQuery.h
+++ b/Source/WebCore/html/canvas/WebGLQuery.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class WebGLQuery final : public WebGLObject {
 public:
-    static Ref<WebGLQuery> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLQuery> create(WebGLRenderingContextBase&);
     virtual ~WebGLQuery();
 
     bool isResultAvailable() const { return m_isResultAvailable; }
@@ -49,7 +49,7 @@ public:
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return true; }
 private:
-    explicit WebGLQuery(WebGLRenderingContextBase&);
+    WebGLQuery(WebGLRenderingContextBase&, PlatformGLObject);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
     bool m_isResultAvailable { false };

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
@@ -35,9 +35,12 @@
 
 namespace WebCore {
 
-Ref<WebGLRenderbuffer> WebGLRenderbuffer::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLRenderbuffer> WebGLRenderbuffer::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLRenderbuffer(ctx));
+    auto object = context.graphicsContextGL()->createRenderbuffer();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLRenderbuffer { context, object });
 }
 
 WebGLRenderbuffer::~WebGLRenderbuffer()
@@ -48,10 +51,9 @@ WebGLRenderbuffer::~WebGLRenderbuffer()
     runDestructor();
 }
 
-WebGLRenderbuffer::WebGLRenderbuffer(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
+WebGLRenderbuffer::WebGLRenderbuffer(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    setObject(ctx.graphicsContextGL()->createRenderbuffer());
 }
 
 void WebGLRenderbuffer::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.h
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.h
@@ -36,7 +36,7 @@ class WebGLRenderbuffer final : public WebGLObject {
 public:
     virtual ~WebGLRenderbuffer();
 
-    static Ref<WebGLRenderbuffer> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLRenderbuffer> create(WebGLRenderingContextBase&);
 
     void setInternalFormat(GCGLenum internalformat)
     {
@@ -62,7 +62,7 @@ public:
     bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
-    WebGLRenderbuffer(WebGLRenderingContextBase&);
+    WebGLRenderbuffer(WebGLRenderingContextBase&, PlatformGLObject);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1600,7 +1600,9 @@ RefPtr<WebGLProgram> WebGLRenderingContextBase::createProgram()
     if (isContextLost())
         return nullptr;
     auto program = WebGLProgram::create(*this);
-    InspectorInstrumentation::didCreateWebGLProgram(*this, program.get());
+    if (!program)
+        return nullptr;
+    InspectorInstrumentation::didCreateWebGLProgram(*this, *program);
     return program;
 }
 

--- a/Source/WebCore/html/canvas/WebGLSampler.cpp
+++ b/Source/WebCore/html/canvas/WebGLSampler.cpp
@@ -34,9 +34,12 @@
 
 namespace WebCore {
 
-Ref<WebGLSampler> WebGLSampler::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLSampler> WebGLSampler::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLSampler(ctx));
+    auto object = context.graphicsContextGL()->createSampler();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLSampler { context, object });
 }
 
 WebGLSampler::~WebGLSampler()
@@ -47,10 +50,9 @@ WebGLSampler::~WebGLSampler()
     runDestructor();
 }
 
-WebGLSampler::WebGLSampler(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
+WebGLSampler::WebGLSampler(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    setObject(ctx.graphicsContextGL()->createSampler());
 }
 
 void WebGLSampler::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)

--- a/Source/WebCore/html/canvas/WebGLSampler.h
+++ b/Source/WebCore/html/canvas/WebGLSampler.h
@@ -37,13 +37,13 @@ namespace WebCore {
 
 class WebGLSampler final : public WebGLObject {
 public:
-    static Ref<WebGLSampler> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLSampler> create(WebGLRenderingContextBase&);
     virtual ~WebGLSampler();
     void didBind() { }
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return true; }
 private:
-    explicit WebGLSampler(WebGLRenderingContextBase&);
+    explicit WebGLSampler(WebGLRenderingContextBase&, PlatformGLObject);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;
 };
 

--- a/Source/WebCore/html/canvas/WebGLShader.cpp
+++ b/Source/WebCore/html/canvas/WebGLShader.cpp
@@ -35,17 +35,19 @@
 
 namespace WebCore {
 
-Ref<WebGLShader> WebGLShader::create(WebGLRenderingContextBase& ctx, GCGLenum type)
+RefPtr<WebGLShader> WebGLShader::create(WebGLRenderingContextBase& context, GCGLenum type)
 {
-    return adoptRef(*new WebGLShader(ctx, type));
+    auto object = context.graphicsContextGL()->createShader(type);
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLShader(context, object, type));
 }
 
-WebGLShader::WebGLShader(WebGLRenderingContextBase& ctx, GCGLenum type)
-    : WebGLObject(ctx)
+WebGLShader::WebGLShader(WebGLRenderingContextBase& context, PlatformGLObject object, GCGLenum type)
+    : WebGLObject(context, object)
     , m_type(type)
     , m_source(emptyString())
 {
-    setObject(ctx.graphicsContextGL()->createShader(type));
 }
 
 WebGLShader::~WebGLShader()

--- a/Source/WebCore/html/canvas/WebGLShader.h
+++ b/Source/WebCore/html/canvas/WebGLShader.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class WebGLShader final : public WebGLObject {
 public:
-    static Ref<WebGLShader> create(WebGLRenderingContextBase&, GCGLenum);
+    static RefPtr<WebGLShader> create(WebGLRenderingContextBase&, GCGLenum);
     virtual ~WebGLShader();
 
     GCGLenum getType() const { return m_type; }
@@ -45,7 +45,7 @@ public:
     bool isUsable() const { return object(); }
     bool isInitialized() const { return true; }
 private:
-    WebGLShader(WebGLRenderingContextBase&, GCGLenum);
+    WebGLShader(WebGLRenderingContextBase&, PlatformGLObject, GCGLenum);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;
 

--- a/Source/WebCore/html/canvas/WebGLSync.h
+++ b/Source/WebCore/html/canvas/WebGLSync.h
@@ -36,7 +36,7 @@ class WebGLSync final : public WebGLObject {
 public:
     virtual ~WebGLSync();
 
-    static Ref<WebGLSync> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLSync> create(WebGLRenderingContextBase&);
 
     void updateCache(WebGLRenderingContextBase&);
     GCGLint getCachedResult(GCGLenum pname) const;
@@ -46,13 +46,12 @@ public:
     bool isUsable() const { return object() && !isDeleted(); }
     bool isInitialized() const { return true; }
 private:
-    WebGLSync(WebGLRenderingContextBase&);
+    WebGLSync(WebGLRenderingContextBase&, GCGLsync);
+    void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
     bool m_allowCacheUpdate = { false };
     GCGLint m_syncStatus = { GraphicsContextGL::UNSIGNALED };
     GCGLsync m_sync;
-
-    void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLTexture.cpp
@@ -34,15 +34,17 @@
 
 namespace WebCore {
 
-Ref<WebGLTexture> WebGLTexture::create(WebGLRenderingContextBase& ctx)
+RefPtr<WebGLTexture> WebGLTexture::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLTexture(ctx));
+    auto object = context.graphicsContextGL()->createTexture();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLTexture { context, object });
 }
 
-WebGLTexture::WebGLTexture(WebGLRenderingContextBase& ctx)
-    : WebGLObject(ctx)
+WebGLTexture::WebGLTexture(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    setObject(ctx.graphicsContextGL()->createTexture());
 }
 
 WebGLTexture::~WebGLTexture()

--- a/Source/WebCore/html/canvas/WebGLTexture.h
+++ b/Source/WebCore/html/canvas/WebGLTexture.h
@@ -43,7 +43,7 @@ public:
 
     virtual ~WebGLTexture();
 
-    static Ref<WebGLTexture> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLTexture> create(WebGLRenderingContextBase&);
 
     void didBind(GCGLenum);
     GCGLenum getTarget() const { return m_target; }
@@ -54,13 +54,11 @@ public:
     bool isInitialized() const { return m_target; }
 
 private:
-    WebGLTexture(WebGLRenderingContextBase&);
-
+    WebGLTexture(WebGLRenderingContextBase&, PlatformGLObject);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
-
     bool isTexture() const override { return true; }
-
     int mapTargetToIndex(GCGLenum) const;
+
     GCGLenum m_target { 0 };
 };
 

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
@@ -32,9 +32,12 @@
 
 namespace WebCore {
 
-Ref<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
+RefPtr<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLTimerQueryEXT(context));
+    auto object = context.graphicsContextGL()->createQueryEXT();
+    if (!object)
+        return nullptr;
+    return adoptRef(*new WebGLTimerQueryEXT { context, object });
 }
 
 WebGLTimerQueryEXT::~WebGLTimerQueryEXT()
@@ -45,10 +48,9 @@ WebGLTimerQueryEXT::~WebGLTimerQueryEXT()
     runDestructor();
 }
 
-WebGLTimerQueryEXT::WebGLTimerQueryEXT(WebGLRenderingContextBase& context)
-    : WebGLObject(context)
+WebGLTimerQueryEXT::WebGLTimerQueryEXT(WebGLRenderingContextBase& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    setObject(context.graphicsContextGL()->createQueryEXT());
 }
 
 void WebGLTimerQueryEXT::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class WebGLTimerQueryEXT final : public WebGLObject {
 public:
-    static Ref<WebGLTimerQueryEXT> create(WebGLRenderingContextBase&);
+    static RefPtr<WebGLTimerQueryEXT> create(WebGLRenderingContextBase&);
     virtual ~WebGLTimerQueryEXT();
 
     bool isResultAvailable() const { return m_isResultAvailable; }
@@ -50,7 +50,7 @@ public:
     bool isInitialized() const { return true; }
 
 private:
-    explicit WebGLTimerQueryEXT(WebGLRenderingContextBase&);
+    WebGLTimerQueryEXT(WebGLRenderingContextBase&, PlatformGLObject);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
     bool m_isResultAvailable { false };

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -39,12 +39,10 @@ namespace WebCore {
 
 RefPtr<WebGLTransformFeedback> WebGLTransformFeedback::create(WebGL2RenderingContext& context)
 {
-    auto glObject = context.graphicsContextGL()->createTransformFeedback();
-    if (!glObject)
+    auto object = context.graphicsContextGL()->createTransformFeedback();
+    if (!object)
         return nullptr;
-    auto instance = adoptRef(*new WebGLTransformFeedback(context));
-    instance->setObject(glObject);
-    return instance;
+    return adoptRef(*new WebGLTransformFeedback { context, object });
 }
 
 WebGLTransformFeedback::~WebGLTransformFeedback()
@@ -55,10 +53,10 @@ WebGLTransformFeedback::~WebGLTransformFeedback()
     runDestructor();
 }
 
-WebGLTransformFeedback::WebGLTransformFeedback(WebGL2RenderingContext& ctx)
-    : WebGLObject(ctx)
+WebGLTransformFeedback::WebGLTransformFeedback(WebGL2RenderingContext& context, PlatformGLObject object)
+    : WebGLObject(context, object)
 {
-    m_boundIndexedTransformFeedbackBuffers.resize(ctx.maxTransformFeedbackSeparateAttribs());
+    m_boundIndexedTransformFeedbackBuffers.resize(context.maxTransformFeedbackSeparateAttribs());
 }
 
 void WebGLTransformFeedback::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL* context3d, PlatformGLObject object)

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.h
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.h
@@ -81,7 +81,7 @@ public:
     bool isInitialized() const { return m_hasEverBeenBound; }
 
 private:
-    WebGLTransformFeedback(WebGL2RenderingContext&);
+    WebGLTransformFeedback(WebGL2RenderingContext&, PlatformGLObject);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
@@ -36,12 +36,10 @@ namespace WebCore {
     
 RefPtr<WebGLVertexArrayObject> WebGLVertexArrayObject::create(WebGLRenderingContextBase& context, Type type)
 {
-    auto glObject = context.graphicsContextGL()->createVertexArray();
-    if (!glObject)
+    auto object = context.graphicsContextGL()->createVertexArray();
+    if (!object)
         return nullptr;
-    auto instance = adoptRef(*new WebGLVertexArrayObject(context, type));
-    instance->setObject(glObject);
-    return instance;
+    return adoptRef(*new WebGLVertexArrayObject { context, object, type });
 }
 
 WebGLVertexArrayObject::~WebGLVertexArrayObject()
@@ -52,8 +50,8 @@ WebGLVertexArrayObject::~WebGLVertexArrayObject()
     runDestructor();
 }
 
-WebGLVertexArrayObject::WebGLVertexArrayObject(WebGLRenderingContextBase& context, Type type)
-    : WebGLVertexArrayObjectBase(context, type)
+WebGLVertexArrayObject::WebGLVertexArrayObject(WebGLRenderingContextBase& context, PlatformGLObject object, Type type)
+    : WebGLVertexArrayObjectBase(context, object, type)
 {
 }
 

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.h
@@ -42,7 +42,7 @@ public:
     static RefPtr<WebGLVertexArrayObject> create(WebGLRenderingContextBase&, Type);
     virtual ~WebGLVertexArrayObject();
 private:
-    WebGLVertexArrayObject(WebGLRenderingContextBase&, Type);
+    WebGLVertexArrayObject(WebGLRenderingContextBase&, PlatformGLObject, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;
 };
 

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -35,8 +35,8 @@
 
 namespace WebCore {
 
-WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase(WebGLRenderingContextBase& context, Type type)
-    : WebGLObject(context)
+WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase(WebGLRenderingContextBase& context, PlatformGLObject object, Type type)
+    : WebGLObject(context, object)
     , m_type(type)
 {
     m_vertexAttribState.resize(context.getMaxVertexAttribs());

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
@@ -89,7 +89,7 @@ public:
     bool isInitialized() const { return m_hasEverBeenBound; }
 
 protected:
-    WebGLVertexArrayObjectBase(WebGLRenderingContextBase&, Type);
+    WebGLVertexArrayObjectBase(WebGLRenderingContextBase&, PlatformGLObject, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override = 0;
 
     Type m_type;

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
@@ -35,21 +35,19 @@ namespace WebCore {
 
 Ref<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createDefault(WebGLRenderingContextBase& context)
 {
-    return adoptRef(*new WebGLVertexArrayObjectOES(context, Type::Default));
+    return adoptRef(*new WebGLVertexArrayObjectOES(context, 0, Type::Default));
 }
 
 RefPtr<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createUser(WebGLRenderingContextBase& context)
 {
-    auto glObject = context.graphicsContextGL()->createVertexArray();
-    if (!glObject)
+    auto object = context.graphicsContextGL()->createVertexArray();
+    if (!object)
         return nullptr;
-    auto instance = adoptRef(*new WebGLVertexArrayObjectOES(context, Type::User));
-    instance->setObject(glObject);
-    return instance;
+    return adoptRef(*new WebGLVertexArrayObjectOES { context, object, Type::User });
 }
 
-WebGLVertexArrayObjectOES::WebGLVertexArrayObjectOES(WebGLRenderingContextBase& context, Type type)
-    : WebGLVertexArrayObjectBase(context, type)
+WebGLVertexArrayObjectOES::WebGLVertexArrayObjectOES(WebGLRenderingContextBase& context, PlatformGLObject object, Type type)
+    : WebGLVertexArrayObjectBase(context, object, type)
 {
 }
 

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.h
@@ -37,7 +37,7 @@ public:
     static RefPtr<WebGLVertexArrayObjectOES> createUser(WebGLRenderingContextBase&);
     virtual ~WebGLVertexArrayObjectOES();
 private:
-    WebGLVertexArrayObjectOES(WebGLRenderingContextBase&, Type);
+    WebGLVertexArrayObjectOES(WebGLRenderingContextBase&, PlatformGLObject, Type);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) final;
 };
 


### PR DESCRIPTION
#### 6a55c5eda697bbd893e6db2a7e7b899553c9227d
<pre>
WebGL resource creation is not robust against context loss
<a href="https://bugs.webkit.org/show_bug.cgi?id=260513">https://bugs.webkit.org/show_bug.cgi?id=260513</a>
rdar://problem/114245538

Reviewed by Dan Glastonbury.

At the moment, the various GraphicsContextGL::create{Resource}() calls
might return 0 if the context is lost during that call. Handle this in
all the WebGL resource constructors. Return RefPtr and handle the
nullptr in the caller.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::create):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::fenceSync):
* Source/WebCore/html/canvas/WebGLBuffer.cpp:
(WebCore::WebGLBuffer::create):
(WebCore::WebGLBuffer::WebGLBuffer):
* Source/WebCore/html/canvas/WebGLBuffer.h:
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::create):
(WebCore::WebGLFramebuffer::createOpaque):
(WebCore::WebGLFramebuffer::WebGLFramebuffer):
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLObject.cpp:
(WebCore::WebGLObject::WebGLObject):
(WebCore::WebGLObject::setObject): Deleted.
* Source/WebCore/html/canvas/WebGLObject.h:
* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::create):
(WebCore::WebGLProgram::WebGLProgram):
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/canvas/WebGLQuery.cpp:
(WebCore::WebGLQuery::create):
(WebCore::WebGLQuery::WebGLQuery):
* Source/WebCore/html/canvas/WebGLQuery.h:
* Source/WebCore/html/canvas/WebGLRenderbuffer.cpp:
(WebCore::WebGLRenderbuffer::create):
(WebCore::WebGLRenderbuffer::WebGLRenderbuffer):
* Source/WebCore/html/canvas/WebGLRenderbuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::createProgram):
* Source/WebCore/html/canvas/WebGLSampler.cpp:
(WebCore::WebGLSampler::create):
(WebCore::WebGLSampler::WebGLSampler):
* Source/WebCore/html/canvas/WebGLSampler.h:
* Source/WebCore/html/canvas/WebGLShader.cpp:
(WebCore::WebGLShader::create):
(WebCore::WebGLShader::WebGLShader):
* Source/WebCore/html/canvas/WebGLShader.h:
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::create):
(WebCore::WebGLSync::WebGLSync):
(WebCore::m_sync):
(WebCore::WebGLSync::deleteObjectImpl):
* Source/WebCore/html/canvas/WebGLSync.h:
* Source/WebCore/html/canvas/WebGLTexture.cpp:
(WebCore::WebGLTexture::create):
(WebCore::WebGLTexture::WebGLTexture):
* Source/WebCore/html/canvas/WebGLTexture.h:
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp:
(WebCore::WebGLTimerQueryEXT::create):
(WebCore::WebGLTimerQueryEXT::WebGLTimerQueryEXT):
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.h:
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp:
(WebCore::WebGLTransformFeedback::create):
(WebCore::WebGLTransformFeedback::WebGLTransformFeedback):
* Source/WebCore/html/canvas/WebGLTransformFeedback.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp:
(WebCore::WebGLVertexArrayObject::create):
(WebCore::WebGLVertexArrayObject::WebGLVertexArrayObject):
* Source/WebCore/html/canvas/WebGLVertexArrayObject.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::WebGLVertexArrayObjectBase):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp:
(WebCore::WebGLVertexArrayObjectOES::createDefault):
(WebCore::WebGLVertexArrayObjectOES::createUser):
(WebCore::WebGLVertexArrayObjectOES::WebGLVertexArrayObjectOES):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.h:

Canonical link: <a href="https://commits.webkit.org/267183@main">https://commits.webkit.org/267183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13c496dd7f58112dbf63490c670fa858ad5669aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16319 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18422 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21248 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17786 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14369 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->