### PR TITLE
Remove ParseSdpForH264ProfileLevelId defaulting introduced in https://commits.webkit.org/266392@main

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/H264-422-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/H264-422-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test H264 4.2.2 is not supported
+

--- a/LayoutTests/http/wpt/webcodecs/H264-422.html
+++ b/LayoutTests/http/wpt/webcodecs/H264-422.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+promise_test(async t => {
+    const result = await VideoEncoder.isConfigSupported({
+        codec: "avc1.7A1032",
+        width: 1920,
+        height: 1280,
+        avc: { format: "avc" },
+    });
+    assert_false(result.supported);
+}, 'Test H264 4.2.2 is not supported');
+</script>
+</body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/h264_profile_level_id.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/h264_profile_level_id.cc
@@ -197,7 +197,7 @@ absl::optional<H264ProfileLevelId> ParseSdpForH264ProfileLevelId(
   // FIXME: We might want to return std::nullopt and propagate an error in case of bad parsing.
   return (profile_level_id_it == params.end())
              ? defaultProfileLevelId()
-             : ParseH264ProfileLevelId(profile_level_id_it->second.c_str()).value_or(defaultProfileLevelId());
+             : ParseH264ProfileLevelId(profile_level_id_it->second.c_str());
 }
 #else
 absl::optional<H264ProfileLevelId> ParseSdpForH264ProfileLevelId(

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm
@@ -62,8 +62,11 @@
     if (self = [super init]) {
         if ([codecInfo.name isEqualToString:@"H265"])
             m_h265Encoder = [[RTCVideoEncoderH265 alloc] initWithCodecInfo:codecInfo];
-        else
+        else {
             m_h264Encoder = [[RTCVideoEncoderH264 alloc] initWithCodecInfo:codecInfo];
+            if (!m_h264Encoder)
+                return nil;
+        }
     }
     return self;
 }
@@ -343,6 +346,9 @@ void* createLocalEncoder(const webrtc::SdpVideoFormat& format, bool useAnnexB, L
 {
     auto *codecInfo = [[RTCVideoCodecInfo alloc] initWithNativeSdpVideoFormat: format];
     auto *encoder = [[WK_RTCLocalVideoH264H265Encoder alloc] initWithCodecInfo:codecInfo];
+
+    if (!encoder)
+        return nullptr;
 
     [encoder setCallback:^BOOL(RTCEncodedImage *_Nonnull frame, id<RTCCodecSpecificInfo> _Nonnull codecSpecificInfo, RTCRtpFragmentationHeader * _Nullable header) {
         EncodedImage encodedImage = [frame nativeEncodedImage];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -392,7 +392,11 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
     _packetizationMode = RTCH264PacketizationModeNonInterleaved;
     _profile_level_id =
         webrtc::ParseSdpForH264ProfileLevelId([codecInfo nativeSdpVideoFormat].parameters);
-    _useBaseline = !_profile_level_id || ![(__bridge NSString *)ExtractProfile(*_profile_level_id) containsString: @"High"];
+      if (!_profile_level_id) {
+        return nil;
+      }
+
+    _useBaseline = ![(__bridge NSString *)ExtractProfile(*_profile_level_id) containsString: @"High"];
 #if ENABLE_VCP_FOR_H264_BASELINE
     _useVCP = true;
 #else

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -89,7 +89,7 @@ private:
     void decodeFrame(VideoDecoderIdentifier, int64_t timeStamp, const IPC::DataReference&);
     void setFrameSize(VideoDecoderIdentifier, uint16_t width, uint16_t height);
 
-    void createEncoder(VideoEncoderIdentifier, VideoCodecType, const Vector<std::pair<String, String>>&, bool useLowLatency, bool useAnnexB);
+    void createEncoder(VideoEncoderIdentifier, VideoCodecType, const Vector<std::pair<String, String>>&, bool useLowLatency, bool useAnnexB, CompletionHandler<void(bool)>&&);
     void releaseEncoder(VideoEncoderIdentifier);
     void initializeEncoder(VideoEncoderIdentifier, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     void encodeFrame(VideoEncoderIdentifier, SharedVideoFrame&&, int64_t timeStamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame);

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -31,7 +31,7 @@ messages -> LibWebRTCCodecsProxy NotRefCounted {
     DecodeFrame(WebKit::VideoDecoderIdentifier id, int64_t timeStamp, IPC::DataReference data)
     SetFrameSize(WebKit::VideoDecoderIdentifier id, uint16_t width, uint16_t height)
 
-    CreateEncoder(WebKit::VideoEncoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, Vector<std::pair<String, String>> parameters, bool useLowLatency, bool useAnnexB);
+    CreateEncoder(WebKit::VideoEncoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, Vector<std::pair<String, String>> parameters, bool useLowLatency, bool useAnnexB) -> (bool success);
     ReleaseEncoder(WebKit::VideoEncoderIdentifier id)
     InitializeEncoder(WebKit::VideoEncoderIdentifier id, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate)
     EncodeFrame(WebKit::VideoEncoderIdentifier id, struct WebKit::SharedVideoFrame buffer, int64_t timeStamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -134,7 +134,7 @@ public:
     };
 
     Encoder* createEncoder(VideoCodecType, const std::map<std::string, std::string>&);
-    void createEncoderAndWaitUntilReady(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder&)>&&);
+    void createEncoderAndWaitUntilReady(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
     int32_t releaseEncoder(Encoder&);
     int32_t initializeEncoder(Encoder&, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     int32_t encodeFrame(Encoder&, const WebCore::VideoFrame&, int64_t timestamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame);
@@ -188,7 +188,7 @@ private:
     WorkQueue& workQueue() const { return m_queue; }
 
     Decoder* createDecoderInternal(VideoCodecType, Function<void(Decoder&)>&&);
-    Encoder* createEncoderInternal(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder&)>&&);
+    Encoder* createEncoderInternal(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
     template<typename Frame> int32_t encodeFrameInternal(Encoder&, const Frame&, bool shouldEncodeAsKeyFrame, WebCore::VideoFrameRotation, MediaTime, int64_t timestamp, std::optional<uint64_t> duration);
 
 private:


### PR DESCRIPTION
#### 9743e04f0013d4c3719964096053cddfe1b28578
<pre>
Remove ParseSdpForH264ProfileLevelId defaulting introduced in <a href="https://commits.webkit.org/266392@main">https://commits.webkit.org/266392@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=260467">https://bugs.webkit.org/show_bug.cgi?id=260467</a>
rdar://problem/114311260

Reviewed by Eric Carlson.

Before this patch, in case of bad or unsupported profile, we would downgrade to a default profile.
We are now reporting the error back from RTCVideoEncoderH264 to LibWebRTCCodecsProxy then to LibWebRTCCodecs and RemoteVideoCodecFactory.
This allows to notify WebCodecs JS that a particular profile is not supported.

Covered by added test.

* LayoutTests/http/wpt/webcodecs/H264-422-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/H264-422.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/h264_profile_level_id.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm:
(-[WK_RTCLocalVideoH264H265Encoder initWithCodecInfo:]):
(webrtc::createLocalEncoder):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm:
(-[RTCVideoEncoderH264 initWithCodecInfo:]):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createEncoder):
(WebKit::LibWebRTCCodecsProxy::releaseEncoder):
(WebKit::LibWebRTCCodecsProxy::initializeEncoder):
(WebKit::LibWebRTCCodecsProxy::encodeFrame):
(WebKit::LibWebRTCCodecsProxy::flushEncoder):
(WebKit::LibWebRTCCodecsProxy::setEncodeRates):
(WebKit::LibWebRTCCodecsProxy::setSharedVideoFrameSemaphore):
(WebKit::LibWebRTCCodecsProxy::setSharedVideoFrameMemory):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createEncoder):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::createEncoder):
(WebKit::LibWebRTCCodecs::createEncoderAndWaitUntilReady):
(WebKit::LibWebRTCCodecs::createEncoderInternal):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Canonical link: <a href="https://commits.webkit.org/267193@main">https://commits.webkit.org/267193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/908f6ddf819e160b3c2d1b06a796bf04841c19bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14932 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18428 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21253 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17791 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12830 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->