### PR TITLE
[CSS] "currentcolor" should correctly inherit computed :visited style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+* {
+    color: green;
+}
+</style>
+<div>
+    <a href=""><div>This should be green and not red.</div></a>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+* {
+    color: green;
+}
+</style>
+<div>
+    <a href=""><div>This should be green and not red.</div></a>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="currentcolor-004-ref.html">
+<title>currentcolor and visited computed parent color</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#color-mix">
+<link rel="author" title="Matthieu Dubet" href="https://github.com/mdubet">
+<style>
+a { color: red; }
+a:visited { color: green; }
+div {
+    color: currentcolor;
+}
+</style>
+<div>
+    <a href=""><div>This should be green and not red.</div></a>
+</div>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1945,22 +1945,18 @@ inline void BuilderCustom::applyValueStrokeColor(BuilderState& builderState, CSS
     builderState.style().setHasExplicitlySetStrokeColor(true);
 }
 
+// For the color property, "currentcolor" is actually the inherited computed color.
 inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue& value)
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
-    // For the color property, current color is actually the inherited computed color.
-    auto resolveColor = [&](const StyleColor& color) {
-        return color.resolveColor(builderState.parentStyle().color());
-    };
-
     if (builderState.applyPropertyToRegularStyle()) {
         auto color = builderState.colorFromPrimitiveValue(primitiveValue, ForVisitedLink::No);
-        builderState.style().setColor(resolveColor(color));
+        builderState.style().setColor(color.resolveColor(builderState.parentStyle().color()));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         auto color = builderState.colorFromPrimitiveValue(primitiveValue, ForVisitedLink::Yes);
-        builderState.style().setVisitedLinkColor(resolveColor(color));
+        builderState.style().setVisitedLinkColor(color.resolveColor(builderState.parentStyle().visitedLinkColor()));
     }
 
     builderState.style().setDisallowsFastPathInheritance();


### PR DESCRIPTION
#### 72fc87a3b8db2919f0cc4e2e1ae2adfe9da56af4
<pre>
[CSS] &quot;currentcolor&quot; should correctly inherit computed :visited style
<a href="https://bugs.webkit.org/show_bug.cgi?id=260517">https://bugs.webkit.org/show_bug.cgi?id=260517</a>
rdar://114254856

Reviewed by Tim Nguyen.

When using &quot;currentcolor&quot; in the color property,
its value is the inherit computed value (per spec).
This patch fixes it when we are computing :visited style for links.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-004.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueColor):

Canonical link: <a href="https://commits.webkit.org/267139@main">https://commits.webkit.org/267139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9396017d2ab555ba4b34116287d61763b944ceae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17308 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18301 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21154 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17675 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14092 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3769 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->