### PR TITLE
[CSS] color-mix() should respect :visited style to resolve "currentcolor"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html> 
+<meta charset="utf-8">
+<title>currentcolor is taken from :visited pseudo-class correctly in color-mix()</title>
+<style>
+a { color: green; background-color: color-mix(in srgb, green, white 75%); }
+</style>
+
+<a href="unvisited">This background should be green and not red</a>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-getcomputedstyle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-getcomputedstyle-expected.txt
@@ -1,0 +1,4 @@
+This background should be green and not red
+
+PASS Property background-color value 'color-mix(in srgb, currentcolor, white)' should not leak :visited for computed style
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-getcomputedstyle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-getcomputedstyle.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>color-mix and currentcolor with :visited don't leak information via getComputedStyle</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<style>
+a:link { color: red; }
+a:visited { color: green; }
+</style>
+
+<a href=""><span id="target">This background should be green and not red</span></a>
+
+<script>
+test_computed_value("background-color", "color-mix(in srgb, currentcolor, white)", "color(srgb 1 0.5 0.5)", "should not leak :visited for computed style");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html> 
+<meta charset="utf-8">
+<title>currentcolor is taken from :visited pseudo-class correctly in color-mix()</title>
+<style>
+a { color: green; background-color: color-mix(in srgb, green, white 75%); }
+</style>
+
+<a href="unvisited">This background should be green and not red</a>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="color-mix-currentcolor-visited-ref.html">
+<title>currentcolor is taken from :visited pseudo-class correctly in color-mix()</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#color-mix">
+<link rel="author" title="Matthieu Dubet" href="https://github.com/mdubet">
+<style>
+a:link { color: red; }
+a:visited { color: green; }
+span {
+    background-color: color-mix(in srgb, currentcolor, white 75%);
+}
+</style>
+<a href=""><span>This background should be green and not red</span></a>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2435,12 +2435,12 @@ Color RenderStyle::colorResolvingCurrentColor(CSSPropertyID colorProperty, bool 
         return visitedLink ? visitedLinkColor() : color();
     }
 
-    return colorResolvingCurrentColor(result);
+    return colorResolvingCurrentColor(result, visitedLink);
 }
 
-Color RenderStyle::colorResolvingCurrentColor(const StyleColor& color) const
+Color RenderStyle::colorResolvingCurrentColor(const StyleColor& color, bool visitedLink) const
 {
-    return color.resolveColor(this->color());
+    return color.resolveColor(visitedLink ? visitedLinkColor() : this->color());
 }
 
 Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty, OptionSet<PaintBehavior> paintBehavior) const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1741,7 +1741,7 @@ public:
     Color colorResolvingCurrentColor(CSSPropertyID colorProperty, bool visitedLink) const;
 
     // Resolves the currentColor keyword, but must not be used for the "color" property which has a different semantic.
-    WEBCORE_EXPORT Color colorResolvingCurrentColor(const StyleColor&) const;
+    WEBCORE_EXPORT Color colorResolvingCurrentColor(const StyleColor&, bool visitedLink = false) const;
 
     WEBCORE_EXPORT Color visitedDependentColor(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
     WEBCORE_EXPORT Color visitedDependentColorWithColorFilter(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -159,11 +159,6 @@ StyleColor BuilderState::colorFromPrimitiveValue(const CSSPrimitiveValue& value,
     return { WebCore::Style::colorFromPrimitiveValue(document(), m_style, value, forVisitedLink) };
 }
 
-Color BuilderState::colorFromPrimitiveValueWithResolvedCurrentColor(const CSSPrimitiveValue& value) const
-{
-    return WebCore::Style::colorFromPrimitiveValueWithResolvedCurrentColor(document(), m_style, value);
-}
-
 void BuilderState::registerContentAttribute(const AtomString& attributeLocalName)
 {
     if (style().styleType() == PseudoId::Before || style().styleType() == PseudoId::After)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -96,8 +96,6 @@ public:
 
     static bool isColorFromPrimitiveValueDerivedFromElement(const CSSPrimitiveValue&);
     StyleColor colorFromPrimitiveValue(const CSSPrimitiveValue&, ForVisitedLink = ForVisitedLink::No) const;
-    // FIXME: Remove. 'currentcolor' should be resolved at use time. All call sites are broken with inheritance.
-    Color colorFromPrimitiveValueWithResolvedCurrentColor(const CSSPrimitiveValue&) const;
 
     const Vector<AtomString>& registeredContentAttributes() const { return m_registeredContentAttributes; }
     void registerContentAttribute(const AtomString& attributeLocalName);


### PR DESCRIPTION
#### 7b938d011b0e9b85fe21bb865c31cb8709cf95db
<pre>
[CSS] color-mix() should respect :visited style to resolve &quot;currentcolor&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=259063">https://bugs.webkit.org/show_bug.cgi?id=259063</a>
rdar://112419198

Reviewed by Tim Nguyen.

This patch passes the visitedLink parameter down the stack
to correctly resolve &quot;currentcolor&quot;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-getcomputedstyle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-getcomputedstyle.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-visited.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::colorResolvingCurrentColor const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::colorFromPrimitiveValueWithResolvedCurrentColor const): Deleted.
* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/267271@main">https://commits.webkit.org/267271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c39d15f8789028d4a3961ade17f1855ff40f6de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16589 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17568 "Build is in progress. Recent messages:") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16356 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18690 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14626 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14791 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/18026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13042 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3854 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->