### PR TITLE
[GStreamer] Set audio track ID to stream value in regular playback

### DIFF
--- a/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language-expected.txt
+++ b/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language-expected.txt
@@ -5,8 +5,8 @@ EVENT(canplaythrough)
 
 ** Check in-band kind attributes
 EXPECTED (video.audioTracks.length == '2') OK
-EXPECTED (video.audioTracks.getTrackById('A0').language == 'en') OK
-EXPECTED (video.audioTracks.getTrackById('A1').language == 'la') OK
+EXPECTED (video.audioTracks[0].language == 'en') OK
+EXPECTED (video.audioTracks[1].language == 'la') OK
 
 END OF TEST
 

--- a/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language.html
+++ b/LayoutTests/media/track/audio/audio-track-mkv-vorbis-language.html
@@ -7,7 +7,7 @@
         <script src=../../video-test.js></script>
         <script src=../../in-band-tracks.js></script>
     </head>
-    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'audio', 'language', {'A0': 'en', 'A1': 'la'})">
+    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'audio', 'language', ['en', 'la'])">
         <video controls></video>
         <p>Check audio tracks' language attributes.</p>
     </body>

--- a/LayoutTests/media/track/video/video-track-mkv-theora-language-expected.txt
+++ b/LayoutTests/media/track/video/video-track-mkv-theora-language-expected.txt
@@ -5,8 +5,8 @@ EVENT(canplaythrough)
 
 ** Check in-band kind attributes
 EXPECTED (video.videoTracks.length == '2') OK
-EXPECTED (video.videoTracks.getTrackById('V0').language == 'zh') OK
-EXPECTED (video.videoTracks.getTrackById('V1').language == 'ru') OK
+EXPECTED (video.videoTracks[0].language == 'zh') OK
+EXPECTED (video.videoTracks[1].language == 'ru') OK
 
 END OF TEST
 

--- a/LayoutTests/media/track/video/video-track-mkv-theora-language.html
+++ b/LayoutTests/media/track/video/video-track-mkv-theora-language.html
@@ -7,7 +7,7 @@
         <script src=../../video-test.js></script>
         <script src=../../in-band-tracks.js></script>
     </head>
-    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'video', 'language', {'V0':'zh', 'V1':'ru'})">
+    <body onload="testAttribute('../../content/two-audio-and-video-tracks.mkv', 'video', 'language', ['zh', 'ru'])">
         <video controls></video>
         <p>Check video tracks' language attributes.</p>
     </body>

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -61,11 +61,11 @@ public:
     AtomString language() const final { return m_language; }
 
 protected:
-    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&);
-    void updateConfigurationFromTags(const GRefPtr<GstTagList>&);
+    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&&) override;
+    void updateConfigurationFromTags(const GRefPtr<GstTagList>&&) override;
 
-    void tagsChanged(const GRefPtr<GstTagList>& tags) final { updateConfigurationFromTags(tags); }
-    void capsChanged(const String& streamId, const GRefPtr<GstCaps>&) final;
+    void tagsChanged(GRefPtr<GstTagList>&& tags) final { updateConfigurationFromTags(WTFMove(tags)); }
+    void capsChanged(const String& streamId, GRefPtr<GstCaps>&&) final;
 
 private:
     AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -318,9 +318,6 @@ protected:
     void ensureSeekFlags();
 
     static void sourceSetupCallback(MediaPlayerPrivateGStreamer*, GstElement*);
-    static void videoChangedCallback(MediaPlayerPrivateGStreamer*);
-    static void audioChangedCallback(MediaPlayerPrivateGStreamer*);
-    static void textChangedCallback(MediaPlayerPrivateGStreamer*);
 
     void timeChanged(const MediaTime&); // If MediaTime is valid, indicates that a seek has completed.
     void loadingFailed(MediaPlayer::NetworkState, MediaPlayer::ReadyState = MediaPlayer::ReadyState::HaveNothing, bool forceNotifications = false);

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -67,6 +67,8 @@ public:
     void setInitialCaps(GRefPtr<GstCaps>&& caps) { m_initialCaps = WTFMove(caps); }
     const GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
 
+    static String trackIdFromPadStreamStartOrUniqueID(TrackType, unsigned index, const GRefPtr<GstPad>&);
+
 protected:
     TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
     TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GstStream*);
@@ -76,8 +78,13 @@ protected:
 
     GstObject* objectForLogging() const;
 
-    virtual void tagsChanged(const GRefPtr<GstTagList>&) { }
-    virtual void capsChanged(const String&, const GRefPtr<GstCaps>&) { }
+    virtual void tagsChanged(GRefPtr<GstTagList>&&) { }
+    virtual void capsChanged(const String&, GRefPtr<GstCaps>&&) { }
+    void installUpdateConfigurationHandlers();
+    virtual void updateConfigurationFromCaps(const GRefPtr<GstCaps>&&) { }
+    virtual void updateConfigurationFromTags(const GRefPtr<GstTagList>&&) { }
+
+    static GRefPtr<GstTagList> getAllTags(const GRefPtr<GstPad>&);
 
     enum MainThreadNotification {
         TagsChanged = 1 << 1,

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -62,11 +62,11 @@ public:
     AtomString language() const final { return m_language; }
 
 protected:
-    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&);
-    void updateConfigurationFromTags(const GRefPtr<GstTagList>&);
+    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&&) override;
+    void updateConfigurationFromTags(const GRefPtr<GstTagList>&&) override;
 
-    void tagsChanged(const GRefPtr<GstTagList>& tags) final { updateConfigurationFromTags(tags); }
-    void capsChanged(const String&, const GRefPtr<GstCaps>&) final;
+    void tagsChanged(GRefPtr<GstTagList>&& tags) final { updateConfigurationFromTags(WTFMove(tags)); }
+    void capsChanged(const String&, GRefPtr<GstCaps>&&) final;
 
 private:
     VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);


### PR DESCRIPTION
#### b750030983005416b9601a3ab58b3b3886dbbd90
<pre>
[GStreamer] Set audio track ID to stream value in regular playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=260520">https://bugs.webkit.org/show_bug.cgi?id=260520</a>

Reviewed by Xabier Rodriguez-Calvar.

This change only affects playbin2 implementations (regular playback),
where tracks are based on pads instead of in streams.

The proper track IDs are only actually available when the stream-start
bus message is received. The track creation is delayed until that moment.
At that point, all the audio and video pads handled by GStreamer are
processed and the corresponding audio/video tracks are created. The proper
track IDs are present at that moment. This means that the old
audio/videoChanged callbacks aren&apos;t needed anymore.

After that, we listen to changes in caps and tags in the pad and trigger
the needed updates, which will complete the information available for the
corresponding track.

Some approaches that were tried and resulted to be unsuccessful:

Trying to create the track the first time (on video-changed or
audio-changed), already with the definitive id isn&apos;t a valid approach,
since the sticky stream-start event isn&apos;t available at that moment.
Creating the track with a synthesized id and then updating it when the
stream-start event is available isn&apos;t a good idea, because the only way
to update the track is by removing it from audio/videoTracks and readding
it, and that triggers spureous events visible from JavaScript. Therefore,
the proper way was to delay track creation until stream-start comes.

Trying to install a probe on the audio/video pads and detecting the
stream-start event from there (instead of relying on the bus message),
but calling the track manipulation code from a non-main thread would be
unsafe and would require deferring the manipulation to the main thread.
Even in that case, there&apos;s no guarantee for the stream-start sticky event
to be available when the manipulation code runs in the main thread,
because that sticky event is stored after probe processing and there&apos;s
a race.

Some layout tests had to be changed to refer to the tracks by index
instead of by track id. The GStreamer based ports now return the native
id embedded in the stream container, while Apple ports still use synthesized
ids (A1, A2, V1...). That was the best way to deal with the differences
without duplicating the tests for different platforms.

Co-authored by Enrique Ocaña González &lt;eocanha@igalia.com&gt;

* LayoutTests/media/track/audio/audio-track-mkv-vorbis-language-expected.txt: Changed expected output.
* LayoutTests/media/track/audio/audio-track-mkv-vorbis-language.html: Refer to the tracks by index instead of by id.
* LayoutTests/media/track/video/video-track-mkv-theora-language-expected.txt: Changed expected output.
* LayoutTests/media/track/video/video-track-mkv-theora-language.html: Refer to the tracks by index instead of by id.
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer): Install configuration change handlers. Use move semantics.
(WebCore::AudioTrackPrivateGStreamer::capsChanged): Updated signature, use move semantics.
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromTags): Updated signature.
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromCaps): Ditto.
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h: Declare configuration change handlers as overridding the base implementation. Updated some signatures to use r-value references.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack): Set track IDs (now always valid and final at this point, unlike before) and only notify the media engine if actual changes have been made. This is because this method can now be called even if no tracks of the given
type have appeared.
(WebCore::MediaPlayerPrivateGStreamer::handleMessage): Listen to stream-start bus message and unconditionally notify for audio/video track creation. notifyPlayerOfTrack() will know if tracks of each type have been created or not.
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin): Don&apos;t listen audio/video/text-changed anymore. We now have everything we need when stream-start comes.
(WebCore::MediaPlayerPrivateGStreamer::audioChangedCallback): Deleted.
(WebCore::MediaPlayerPrivateGStreamer::textChangedCallback): Deleted.
(WebCore::MediaPlayerPrivateGStreamer::videoChangedCallback): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: Deleted audio/video/textChangedCallback().
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::findBestUpstreamPad): Added protection against null pad.
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer): Generate ID from pad stream-start or synthesize one. This factors in common code and avoids repetition.
(WebCore::TrackPrivateBaseGStreamer::setPad): Protect against null m_bestUpstreamPad and reuse preexistent streamId from track.
(WebCore::TrackPrivateBaseGStreamer::tagsChanged): Initialize tags list to avoid uninitialized pointer in case parsing fails. Use move semantics.
(WebCore::TrackPrivateBaseGStreamer::capsChanged): Use move semantics.
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged): Avoid leak. Use move semantics.
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged): Protect against null pad.
(WebCore::TrackPrivateBaseGStreamer::installUpdateConfigurationHandlers): Listen to caps and tags changes and update configuration accordingly by calling the abstract handlers (to be implemented by subclasses as needed, empty by default). This installation works for pad-based (playbin2) as well as stream-based (playbin3) variants.
(WebCore::TrackPrivateBaseGStreamer::updateConfigurationFromCaps): Use r-value references.
(WebCore::TrackPrivateBaseGStreamer::updateConfigurationFromTags): Ditto.
(WebCore::TrackPrivateBaseGStreamer::trackIdFromPadStreamStartOrUniqueID): Extract the track ID name from the pad, or synthesize an ID if it can&apos;t be extracted.
(WebCore::TrackPrivateBaseGStreamer::getAllTags): Utility function to merge multiple tags stored in a pad as a sticky tags event.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h: Factored in common code into trackIdFromPadStreamStartOrUniqueID(). Added default empty abstract implementations of configuration change handlers and common method to install them, for those subclasses that chose to do so. Use r-value references in some signatures.
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h: Declare configuration change handlers as overridding the base implementation.
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer): Install configuration change handlers.
(WebCore::VideoTrackPrivateGStreamer::capsChanged): Use move semantics.
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromTags): Ditto.
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromCaps): Ditto.

Canonical link: <a href="https://commits.webkit.org/268194@main">https://commits.webkit.org/268194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe7953cebcaac53f9c1befe462c3fabe60da195

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19416 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21565 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23598 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21497 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17920 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15201 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->