### PR TITLE
ASSERTION FAILED: isAllowedByContentSecurityPolicy(request.url(), ContentSecurityPolicy::RedirectResponseReceived::No) seen with multiple tests under http/wpt/workers/modules/

### DIFF
--- a/LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp-expected.txt
+++ b/LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp-expected.txt
@@ -5,7 +5,7 @@ FAIL script-src 'self' directive should disallow cross origin static import. ass
 PASS script-src * directive should allow cross origin static import.
 PASS worker-src * directive should override script-src 'self' directive and allow cross origin static import.
 FAIL worker-src 'self' directive should override script-src * directive and disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
-FAIL script-src 'self' directive should disallow cross origin dynamic import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS script-src 'self' directive should disallow cross origin dynamic import.
 PASS script-src * directive should allow cross origin dynamic import.
 PASS worker-src 'self' directive should not take effect on dynamic import.
 

--- a/LayoutTests/http/wpt/workers/modules/shared-worker-import-csp-expected.txt
+++ b/LayoutTests/http/wpt/workers/modules/shared-worker-import-csp-expected.txt
@@ -5,7 +5,7 @@ FAIL script-src 'self' directive should disallow cross origin static import. ass
 PASS script-src * directive should allow cross origin static import.
 PASS worker-src * directive should override script-src 'self' directive and allow cross origin static import.
 FAIL worker-src 'self' directive should override script-src * directive and disallow cross origin static import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
-FAIL script-src 'self' directive should disallow cross origin dynamic import. assert_array_equals: expected property 0 to be "ERROR" but got "export-on-load-script.js" (expected array ["ERROR"] got ["export-on-load-script.js"])
+PASS script-src 'self' directive should disallow cross origin dynamic import.
 PASS script-src * directive should allow cross origin dynamic import.
 PASS worker-src 'self' directive should not take effect on dynamic import.
 

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -869,6 +869,3 @@ webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ 
 webkit.org/b/259409 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Pass Failure ]
 
 webkit.org/b/259482 fast/media/managed-media-source-open-crash.html [ Pass Failure ]
-
-webkit.org/b/260107 [ Debug ] http/wpt/workers/modules/dedicated-worker-import-csp.html [ Skip ]
-webkit.org/b/260107 [ Debug ] http/wpt/workers/modules/shared-worker-import-csp.html [ Skip ]

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
@@ -50,7 +50,7 @@ public:
 
     virtual ~WorkerModuleScriptLoader();
 
-    bool load(ScriptExecutionContext&, URL&& sourceURL);
+    void load(ScriptExecutionContext&, URL&& sourceURL);
 
     WorkerScriptLoader& scriptLoader() { return m_scriptLoader.get(); }
 


### PR DESCRIPTION
#### 0495446c22a5e5e8b5615363f9a6c100ec00f3ff
<pre>
ASSERTION FAILED: isAllowedByContentSecurityPolicy(request.url(), ContentSecurityPolicy::RedirectResponseReceived::No) seen with multiple tests under http/wpt/workers/modules/
<a href="https://bugs.webkit.org/show_bug.cgi?id=260107">https://bugs.webkit.org/show_bug.cgi?id=260107</a>
rdar://113777310

Reviewed by Chris Dumez.

CSP initial checks are done by each fetch client currently.
WorkerModuleScriptLoader needs to add the same checks as other clients.

* LayoutTests/http/wpt/workers/modules/dedicated-worker-import-csp-expected.txt:
* LayoutTests/http/wpt/workers/modules/shared-worker-import-csp-expected.txt:
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy):

Canonical link: <a href="https://commits.webkit.org/267194@main">https://commits.webkit.org/267194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268529e68ad4b85e9c0b26551c8b99e5e3e9174e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17378 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18410 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21236 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17774 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12815 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14358 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3800 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->