### PR TITLE
Move off of UIKit SPI: -_dragInteraction:item:shouldDelaySetDownAnimationWithCompletion:

### DIFF
--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -38,6 +38,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+enum class AddPreviewViewToContainer : bool { No, Yes };
+
 static UIDragItem *dragItemMatchingIdentifier(id <UIDragSession> session, NSInteger identifier)
 {
     for (UIDragItem *item in session.items) {
@@ -48,7 +50,7 @@ static UIDragItem *dragItemMatchingIdentifier(id <UIDragSession> session, NSInte
     return nil;
 }
 
-static RetainPtr<UITargetedDragPreview> createTargetedDragPreview(UIImage *image, UIView *rootView, UIView *previewContainer, const FloatRect& frameInRootViewCoordinates, const Vector<FloatRect>& clippingRectsInFrameCoordinates, UIColor *backgroundColor, UIBezierPath *visiblePath)
+static RetainPtr<UITargetedDragPreview> createTargetedDragPreview(UIImage *image, UIView *rootView, UIView *previewContainer, const FloatRect& frameInRootViewCoordinates, const Vector<FloatRect>& clippingRectsInFrameCoordinates, UIColor *backgroundColor, UIBezierPath *visiblePath, AddPreviewViewToContainer addPreviewViewToContainer)
 {
     if (frameInRootViewCoordinates.isEmpty() || !image || !previewContainer.window)
         return nullptr;
@@ -77,6 +79,9 @@ static RetainPtr<UITargetedDragPreview> createTargetedDragPreview(UIImage *image
 
     if (visiblePath)
         [parameters setVisiblePath:visiblePath];
+
+    if (addPreviewViewToContainer == AddPreviewViewToContainer::Yes)
+        [previewContainer addSubview:imageView.get()];
 
     CGPoint centerInContainerCoordinates = { CGRectGetMidX(frameInContainerCoordinates), CGRectGetMidY(frameInContainerCoordinates) };
     auto target = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:previewContainer center:centerInContainerCoordinates]);
@@ -229,7 +234,7 @@ void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UI
         return;
 
     auto textIndicatorImage = uiImageForImage(indicator.contentImage.get());
-    auto preview = createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator.textBoundingRectInRootViewCoordinates, indicator.textRectsInBoundingRectCoordinates, cocoaColor(indicator.estimatedBackgroundColor).get(), nil);
+    auto preview = createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator.textBoundingRectInRootViewCoordinates, indicator.textRectsInBoundingRectCoordinates, cocoaColor(indicator.estimatedBackgroundColor).get(), nil, AddPreviewViewToContainer::No);
     for (auto& itemAndPreviewProvider : m_delayedItemPreviewProviders)
         itemAndPreviewProvider.provider(preview.get());
     m_delayedItemPreviewProviders.clear();
@@ -297,7 +302,19 @@ void DragDropInteractionState::clearAllDelayedItemPreviewProviders()
     m_delayedItemPreviewProviders.clear();
 }
 
-UITargetedDragPreview *DragDropInteractionState::previewForDragItem(UIDragItem *item, UIView *contentView, UIView *previewContainer) const
+UITargetedDragPreview *DragDropInteractionState::previewForLifting(UIDragItem *item, UIView *contentView, UIView *previewContainer) const
+{
+    return createDragPreviewInternal(item, contentView, previewContainer, AddPreviewViewToContainer::No).autorelease();
+}
+
+UITargetedDragPreview *DragDropInteractionState::previewForCancelling(UIDragItem *item, UIView *contentView, UIView *previewContainer)
+{
+    auto preview = createDragPreviewInternal(item, contentView, previewContainer, AddPreviewViewToContainer::Yes);
+    m_previewViewForDragCancel = [preview view];
+    return preview.autorelease();
+}
+
+RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInternal(UIDragItem *item, UIView *contentView, UIView *previewContainer, AddPreviewViewToContainer addPreviewViewToContainer) const
 {
     auto foundSource = activeDragSourceForItem(item);
     if (!foundSource)
@@ -308,23 +325,18 @@ UITargetedDragPreview *DragDropInteractionState::previewForDragItem(UIDragItem *
         if (shouldUseVisiblePathToCreatePreviewForDragSource(source)) {
             auto path = source.visiblePath.value();
             UIBezierPath *visiblePath = [UIBezierPath bezierPathWithCGPath:path.platformPath()];
-            return createTargetedDragPreview(source.image.get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, visiblePath).autorelease();
+            return createTargetedDragPreview(source.image.get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, visiblePath, addPreviewViewToContainer).autorelease();
         }
-        return createTargetedDragPreview(source.image.get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, nil).autorelease();
+        return createTargetedDragPreview(source.image.get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, nil, addPreviewViewToContainer).autorelease();
     }
 
     if (shouldUseTextIndicatorToCreatePreviewForDragSource(source)) {
         auto indicator = source.indicatorData.value();
         auto textIndicatorImage = uiImageForImage(indicator.contentImage.get());
-        return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator.textBoundingRectInRootViewCoordinates, indicator.textRectsInBoundingRectCoordinates, cocoaColor(indicator.estimatedBackgroundColor).get(), nil).autorelease();
+        return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator.textBoundingRectInRootViewCoordinates, indicator.textRectsInBoundingRectCoordinates, cocoaColor(indicator.estimatedBackgroundColor).get(), nil, addPreviewViewToContainer).autorelease();
     }
 
     return nil;
-}
-
-void DragDropInteractionState::dragSessionWillDelaySetDownAnimation(dispatch_block_t completion)
-{
-    m_dragCancelSetDownBlock = completion;
 }
 
 bool DragDropInteractionState::shouldRequestAdditionalItemForDragSession(id <UIDragSession> session) const
@@ -379,11 +391,11 @@ void DragDropInteractionState::dragAndDropSessionsDidEnd()
 {
     clearAllDelayedItemPreviewProviders();
 
+    if (auto previewView = takePreviewViewForDragCancel())
+        [previewView removeFromSuperview];
+
     // If any of UIKit's completion blocks are still in-flight when the drag interaction ends, we need to ensure that they are still invoked
     // to prevent UIKit from getting into an inconsistent state.
-    if (auto completionBlock = takeDragCancelSetDownBlock())
-        completionBlock();
-
     if (auto completionBlock = takeAddDragItemCompletionBlock())
         completionBlock(@[ ]);
 


### PR DESCRIPTION
#### d3379615c46a7fbd6bdf60a47a101c44c9aa93d5
<pre>
Move off of UIKit SPI: -_dragInteraction:item:shouldDelaySetDownAnimationWithCompletion:
<a href="https://bugs.webkit.org/show_bug.cgi?id=260502">https://bugs.webkit.org/show_bug.cgi?id=260502</a>
rdar://114259800

Reviewed by Aditya Keerthi.

While dragging a selected text range, we paint any text within the selected range at 0.25 opacity
during the drag. Once the drag completes or is cancelled, we&apos;ll remove this effect and repaint the
dragged content like normal. In the case of the latter (i.e. cancelling a drag), the drag preview
animates back to its original location on the page and UIKit performs a set-down animation where the
drag preview fades to reveal the content underneath it; as such, we need to coordinate the repaint
at full opacity with this set-down animation, such that the text is still shows with 25%-opacity
while the drag preview is animating back into place, but once the drag preview begins the set-down
animation, it cross-fades to reveal the original, full-opacity content underneath.

We currently achieve this via `-_dragInteraction:item:shouldDelaySetDownAnimationWithCompletion:`
by returning `YES` and calling the completion handler after the next presentation update *after* the
cancel animation completes. This tells UIKit to halt the cancel animation after the drag preview
&quot;flies&quot; back into place but before the set-down animation begins, such that the original drag
preview covers the webpage. We then use this opportunity to issue a repaint of the page without
dragged content ranges, and finally tell UIKit to commence the set-down animation once we&apos;re
finished painting. The drag preview naturally cross-fades to reveal the original web content
underneath it.

To move off of this SPI, we can instead leverage the fact that UIKit will *only* automatically
remove the targeted preview&apos;s view after the set-down animation, if the preview view was not
*already* in the targeted preview container&apos;s view hierarchy upon creating the targeted preview.
This means that if we add the preview view as a subview of the `_interactionViewsContainerView`
ourselves prior to creating the preview in `-dragInteraction:previewForCancellingItem:withDefault:`,
the targeted preview will run the set-down animation, but then cross-fade to reveal the preview view
underneath (rather than the web page). Importantly, this allows us to ensure that the preview view
still covers the webpage while we repaint, and then only remove the preview view from the view
hierarchy once the repaint finishes, to reveal the actual webpage.

I manually tested this by adding a 100 ms sleep in `WebPage::dragCancelled()`, and verifying that
we&apos;re still able to (gracefully) coordinate the set-down animation during a drag cancel.

* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:

Remove `m_dragCancelSetDownBlock`, and replace it with `m_previewViewForDragCancel`, which the
content view will use during set-down to coordinate fading out and in the preview view.

(WebKit::DragDropInteractionState::takePreviewViewForDragCancel const):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::createTargetedDragPreview):

Make this take a new enum to indicate whether the preview view should be added to the view hierarchy
upon creating the targeted preview. See below for more details.

(WebKit::DragDropInteractionState::deliverDelayedDropPreview):
(WebKit::DragDropInteractionState::previewForLifting const):
(WebKit::DragDropInteractionState::previewForCancelling):

Split `previewForDragItem` into two methods: a helper method for the lift preview, and another
helper for the cancel preview. Both are effectively wrappers around the same logic, which is now
moved into a private helper method below; `previewForLifting` behaves exactly the same way as it
does currently, while `previewForCancelling` will automatically add the preview view to the view
hierarchy before returning the preview, and will also save a reference to the preview view.

(WebKit::DragDropInteractionState::createDragPreviewInternal const):
(WebKit::DragDropInteractionState::dragAndDropSessionsDidEnd):
(WebKit::DragDropInteractionState::previewForDragItem const): Deleted.
(WebKit::DragDropInteractionState::dragSessionWillDelaySetDownAnimation): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dragInteraction:previewForLiftingItem:session:]):

Use `previewForLiftingItem` to construct the targeted preview when cancelling a drag. There is a
caveat here, which is that any targeted preview returned by the UI delegate SPI won&apos;t go through the
new codepath for managing the drag cancel preview view. In practice, the only internal client that
uses this SPI is Mail, which only uses it for certain types of attachments that (currently) don&apos;t
fade as they&apos;re dragged, so the mechanism for delaying the set-down animation didn&apos;t affect this
scenario anyways.

(-[WKContentView dragInteraction:previewForCancellingItem:withDefault:]):
(-[WKContentView dragInteraction:item:willAnimateCancelWithAnimator:]):

Implement the main fix here — when the cancel animation begins, we start the preview at `alpha=0`,
since we don&apos;t want it to obscure the webpage yet. Once the completion block is invoked (i.e. the
set-down animation begins), we then set `alpha=1` to make the preview cover the page as it&apos;s being
painted. Finally, upon finishing the next presentation update, we remove the preview view
altogether, revealing the original (non-dragged) appearance of the web page underneath.

(-[WKContentView _dragInteraction:item:shouldDelaySetDownAnimationWithCompletion:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/267165@main">https://commits.webkit.org/267165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e3b74ea255eeefec937f368319dec3f2069da1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17320 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18316 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13711 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12742 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14274 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3784 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->