### PR TITLE
Rename WebPushD::ClientConnection to WebPushD::PushClientConnection

### DIFF
--- a/Source/WebKit/webpushd/AppBundleRequest.h
+++ b/Source/WebKit/webpushd/AppBundleRequest.h
@@ -35,7 +35,7 @@
 namespace WebPushD {
 
 class PushAppBundle;
-class ClientConnection;
+class PushClientConnection;
 
 class AppBundleRequest : public PushAppBundleClient {
     WTF_MAKE_FAST_ALLOCATED;
@@ -48,11 +48,11 @@ public:
     void cancel();
 
 protected:
-    AppBundleRequest(ClientConnection&, const String& originString);
+    AppBundleRequest(PushClientConnection&, const String& originString);
 
     void cleanupAfterCompletionHandler();
 
-    WeakPtr<ClientConnection> m_connection;
+    WeakPtr<PushClientConnection> m_connection;
     String m_originString;
     RefPtr<PushAppBundle> m_appBundle;
     OSObjectPtr<os_transaction_t> m_transaction;
@@ -64,7 +64,7 @@ private:
 template<typename CompletionType>
 class AppBundleRequestImpl : public AppBundleRequest {
 protected:
-    AppBundleRequestImpl(ClientConnection& connection, const String& originString, CompletionHandler<void(CompletionType)>&& completionHandler)
+    AppBundleRequestImpl(PushClientConnection& connection, const String& originString, CompletionHandler<void(CompletionType)>&& completionHandler)
         : AppBundleRequest(connection, originString)
         , m_completionHandler(WTFMove(completionHandler))
     {
@@ -92,7 +92,7 @@ private:
 
 class AppBundlePermissionsRequest : public AppBundleRequestImpl<bool> {
 public:
-    AppBundlePermissionsRequest(ClientConnection& connection, const String& originString, CompletionHandler<void(bool)>&& completionHandler)
+    AppBundlePermissionsRequest(PushClientConnection& connection, const String& originString, CompletionHandler<void(bool)>&& completionHandler)
         : AppBundleRequestImpl(connection, originString, WTFMove(completionHandler))
     {
     }
@@ -108,7 +108,7 @@ private:
 
 class AppBundleDeletionRequest : public AppBundleRequestImpl<const String&> {
 public:
-    AppBundleDeletionRequest(ClientConnection& connection, const String& originString, CompletionHandler<void(const String&)>&& completionHandler)
+    AppBundleDeletionRequest(PushClientConnection& connection, const String& originString, CompletionHandler<void(const String&)>&& completionHandler)
         : AppBundleRequestImpl(connection, originString,  WTFMove(completionHandler))
     {
     }

--- a/Source/WebKit/webpushd/AppBundleRequest.mm
+++ b/Source/WebKit/webpushd/AppBundleRequest.mm
@@ -33,7 +33,7 @@
 
 namespace WebPushD {
 
-AppBundleRequest::AppBundleRequest(ClientConnection& connection, const String& originString)
+AppBundleRequest::AppBundleRequest(PushClientConnection& connection, const String& originString)
     : m_connection(connection)
     , m_originString(originString)
 {

--- a/Source/WebKit/webpushd/ICAppBundle.h
+++ b/Source/WebKit/webpushd/ICAppBundle.h
@@ -36,12 +36,12 @@
 
 namespace WebPushD {
 
-class ClientConnection;
+class PushClientConnection;
 
 class ICAppBundle : public PushAppBundle, public CanMakeWeakPtr<ICAppBundle> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ICAppBundle> create(ClientConnection& connection, const String& originString, PushAppBundleClient& client)
+    static Ref<ICAppBundle> create(PushClientConnection& connection, const String& originString, PushAppBundleClient& client)
     {
         return adoptRef(*new ICAppBundle(connection, originString, client));
     }
@@ -49,10 +49,10 @@ public:
     void bundleCreationSucceeded();
     void bundleCreationFailed(NSError *);
 
-    static void getOriginsWithRegistrations(ClientConnection&, CompletionHandler<void(const Vector<String>&)>&&);
+    static void getOriginsWithRegistrations(PushClientConnection&, CompletionHandler<void(const Vector<String>&)>&&);
 
 private:
-    ICAppBundle(ClientConnection&, const String& originString, PushAppBundleClient&);
+    ICAppBundle(PushClientConnection&, const String& originString, PushAppBundleClient&);
 
     const String& getBundleIdentifier();
 
@@ -67,7 +67,7 @@ private:
     RetainPtr<_WKAppInstallCoordinatorObserver> m_appInstallObserver;
 
     String m_originString;
-    RefPtr<ClientConnection> m_clientConnection;
+    RefPtr<PushClientConnection> m_clientConnection;
 
     String m_bundleIdentifier;
 };

--- a/Source/WebKit/webpushd/ICAppBundle.mm
+++ b/Source/WebKit/webpushd/ICAppBundle.mm
@@ -84,7 +84,7 @@ static void broadcastDebugMessage(const String& message)
     WebPushDaemon::singleton().broadcastDebugMessage(makeString("ICAppBundle: ", message));
 }
 
-ICAppBundle::ICAppBundle(ClientConnection& clientConnection, const String& originString, PushAppBundleClient& client)
+ICAppBundle::ICAppBundle(PushClientConnection& clientConnection, const String& originString, PushAppBundleClient& client)
     : PushAppBundle(client)
     , m_originString(originString)
     , m_clientConnection(&clientConnection)
@@ -146,7 +146,7 @@ static String bundleNameForOriginStringAndHostAppIdentifier(const String& origin
     return makeString(bundlePrefixForHostAppIdentifier(hostAppIdentifier), encodeOriginStringForBundleIdentifier(originString));
 }
 
-void ICAppBundle::getOriginsWithRegistrations(ClientConnection& connection, CompletionHandler<void(const Vector<String>&)>&& completionHandler)
+void ICAppBundle::getOriginsWithRegistrations(PushClientConnection& connection, CompletionHandler<void(const Vector<String>&)>&& completionHandler)
 {
     Vector<String> results;
 

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -50,10 +50,10 @@ namespace WebPushD {
 
 class AppBundleRequest;
 
-class ClientConnection : public RefCounted<ClientConnection>, public CanMakeWeakPtr<ClientConnection>, public Identified<ClientConnection> {
+class PushClientConnection : public RefCounted<PushClientConnection>, public CanMakeWeakPtr<PushClientConnection>, public Identified<PushClientConnection> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ClientConnection> create(xpc_connection_t);
+    static Ref<PushClientConnection> create(xpc_connection_t);
 
     void updateConnectionConfiguration(const WebPushDaemonConnectionConfiguration&);
 
@@ -82,7 +82,7 @@ public:
     void sendDebugMessage(const String&);
 
 private:
-    ClientConnection(xpc_connection_t);
+    PushClientConnection(xpc_connection_t);
 
     void maybeStartNextAppBundleRequest();
     void setHostAppAuditTokenData(const Vector<uint8_t>&);

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -72,25 +72,25 @@ public:
     void handleIncomingPush(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
 
     // Message handlers
-    void echoTwice(ClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
-    void requestSystemNotificationPermission(ClientConnection*, const String&, CompletionHandler<void(bool)>&& replySender);
-    void getOriginsWithPushAndNotificationPermissions(ClientConnection*, CompletionHandler<void(const Vector<String>&)>&& replySender);
-    void setPushAndNotificationsEnabledForOrigin(ClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
-    void deletePushAndNotificationRegistration(ClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);
-    void setDebugModeIsEnabled(ClientConnection*, bool);
-    void updateConnectionConfiguration(ClientConnection*, const WebPushDaemonConnectionConfiguration&);
-    void injectPushMessageForTesting(ClientConnection*, const PushMessageForTesting&, CompletionHandler<void(bool)>&&);
-    void injectEncryptedPushMessageForTesting(ClientConnection*, const String&, CompletionHandler<void(bool)>&&);
-    void getPendingPushMessages(ClientConnection*, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
+    void echoTwice(PushClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
+    void requestSystemNotificationPermission(PushClientConnection*, const String&, CompletionHandler<void(bool)>&& replySender);
+    void getOriginsWithPushAndNotificationPermissions(PushClientConnection*, CompletionHandler<void(const Vector<String>&)>&& replySender);
+    void setPushAndNotificationsEnabledForOrigin(PushClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
+    void deletePushAndNotificationRegistration(PushClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);
+    void setDebugModeIsEnabled(PushClientConnection*, bool);
+    void updateConnectionConfiguration(PushClientConnection*, const WebPushDaemonConnectionConfiguration&);
+    void injectPushMessageForTesting(PushClientConnection*, const PushMessageForTesting&, CompletionHandler<void(bool)>&&);
+    void injectEncryptedPushMessageForTesting(PushClientConnection*, const String&, CompletionHandler<void(bool)>&&);
+    void getPendingPushMessages(PushClientConnection*, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
     void getPushTopicsForTesting(OSObjectPtr<xpc_object_t>&&);
-    void subscribeToPushService(ClientConnection*, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
-    void unsubscribeFromPushService(ClientConnection*, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
-    void getPushSubscription(ClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
-    void getPushPermissionState(ClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender);
-    void incrementSilentPushCount(ClientConnection*, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
-    void removeAllPushSubscriptions(ClientConnection*, CompletionHandler<void(unsigned)>&&);
-    void removePushSubscriptionsForOrigin(ClientConnection*, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
-    void setPublicTokenForTesting(ClientConnection*, const String& publicToken, CompletionHandler<void()>&&);
+    void subscribeToPushService(PushClientConnection*, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
+    void unsubscribeFromPushService(PushClientConnection*, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
+    void getPushSubscription(PushClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
+    void getPushPermissionState(PushClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender);
+    void incrementSilentPushCount(PushClientConnection*, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
+    void removeAllPushSubscriptions(PushClientConnection*, CompletionHandler<void(unsigned)>&&);
+    void removePushSubscriptionsForOrigin(PushClientConnection*, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
+    void setPublicTokenForTesting(PushClientConnection*, const String& publicToken, CompletionHandler<void()>&&);
 
     void broadcastDebugMessage(const String&);
     void broadcastAllConnectionIdentities();
@@ -102,7 +102,7 @@ private:
     void decodeAndHandleRawXPCMessage(WebKit::WebPushD::RawXPCMessageType, OSObjectPtr<xpc_object_t>&&);
     void decodeAndHandleMessage(xpc_connection_t, WebKit::WebPushD::MessageType, std::span<const uint8_t> encodedMessage, CompletionHandler<void(EncodedMessage&&)>&&);
 
-    bool canRegisterForNotifications(ClientConnection&);
+    bool canRegisterForNotifications(PushClientConnection&);
 
     void notifyClientPushMessageIsAvailable(const WebCore::PushSubscriptionSetIdentifier&);
 
@@ -115,8 +115,8 @@ private:
 
     void deletePushRegistration(const WebCore::PushSubscriptionSetIdentifier&, const String&, CompletionHandler<void()>&&);
 
-    ClientConnection* toClientConnection(xpc_connection_t);
-    HashMap<xpc_connection_t, Ref<ClientConnection>> m_connectionMap;
+    PushClientConnection* toPushClientConnection(xpc_connection_t);
+    HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;
 
     std::unique_ptr<PushService> m_pushService;
     bool m_pushServiceStarted { false };

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -265,7 +265,7 @@ WebPushD::EncodedMessage removePushSubscriptionsForOrigin::encodeReply(unsigned 
 } // namespace MessageInfo
 
 template<typename Info>
-void handleWebPushDMessageWithReply(ClientConnection* connection, std::span<const uint8_t> encodedMessage, CompletionHandler<void(WebPushD::EncodedMessage&&)>&& replySender)
+void handleWebPushDMessageWithReply(PushClientConnection* connection, std::span<const uint8_t> encodedMessage, CompletionHandler<void(WebPushD::EncodedMessage&&)>&& replySender)
 {
     WebKit::Daemon::Decoder decoder(encodedMessage);
 
@@ -282,7 +282,7 @@ void handleWebPushDMessageWithReply(ClientConnection* connection, std::span<cons
 }
 
 template<typename Info>
-void handleWebPushDMessage(ClientConnection* connection, std::span<const uint8_t> encodedMessage)
+void handleWebPushDMessage(PushClientConnection* connection, std::span<const uint8_t> encodedMessage)
 {
     WebKit::Daemon::Decoder decoder(encodedMessage);
 
@@ -382,7 +382,7 @@ void WebPushDaemon::broadcastAllConnectionIdentities()
     broadcastDebugMessage("===\nCurrent connections:"_s);
 
     auto connections = copyToVector(m_connectionMap.values());
-    std::sort(connections.begin(), connections.end(), [] (const Ref<ClientConnection>& a, const Ref<ClientConnection>& b) {
+    std::sort(connections.begin(), connections.end(), [] (const Ref<PushClientConnection>& a, const Ref<PushClientConnection>& b) {
         return a->identifier() < b->identifier();
     });
 
@@ -423,7 +423,7 @@ void WebPushDaemon::connectionAdded(xpc_connection_t connection)
     broadcastDebugMessage(makeString("New connection: 0x", hex(reinterpret_cast<uint64_t>(connection), WTF::HexConversionMode::Lowercase)));
 
     RELEASE_ASSERT(!m_connectionMap.contains(connection));
-    m_connectionMap.set(connection, ClientConnection::create(connection));
+    m_connectionMap.set(connection, PushClientConnection::create(connection));
 }
 
 void WebPushDaemon::connectionRemoved(xpc_connection_t connection)
@@ -460,7 +460,7 @@ void WebPushDaemon::decodeAndHandleMessage(xpc_connection_t connection, MessageT
 {
     ASSERT(messageTypeSendsReply(messageType) == !!replySender);
 
-    auto* clientConnection = toClientConnection(connection);
+    auto* clientConnection = toPushClientConnection(connection);
 
     switch (messageType) {
     case MessageType::EchoTwice:
@@ -520,22 +520,22 @@ void WebPushDaemon::decodeAndHandleMessage(xpc_connection_t connection, MessageT
     }
 }
 
-void WebPushDaemon::echoTwice(ClientConnection*, const String& message, CompletionHandler<void(const String&)>&& replySender)
+void WebPushDaemon::echoTwice(PushClientConnection*, const String& message, CompletionHandler<void(const String&)>&& replySender)
 {
     replySender(makeString(message, message));
 }
 
-bool WebPushDaemon::canRegisterForNotifications(ClientConnection& connection)
+bool WebPushDaemon::canRegisterForNotifications(PushClientConnection& connection)
 {
     if (connection.hostAppCodeSigningIdentifier().isEmpty()) {
-        RELEASE_LOG_ERROR(Push, "ClientConnection cannot interact with notifications: Unknown host application code signing identifier");
+        RELEASE_LOG_ERROR(Push, "PushClientConnection cannot interact with notifications: Unknown host application code signing identifier");
         return false;
     }
 
     return true;
 }
 
-void WebPushDaemon::requestSystemNotificationPermission(ClientConnection* connection, const String& originString, CompletionHandler<void(bool)>&& replySender)
+void WebPushDaemon::requestSystemNotificationPermission(PushClientConnection* connection, const String& originString, CompletionHandler<void(bool)>&& replySender)
 {
     if (!canRegisterForNotifications(*connection)) {
         replySender(false);
@@ -545,7 +545,7 @@ void WebPushDaemon::requestSystemNotificationPermission(ClientConnection* connec
     connection->enqueueAppBundleRequest(makeUnique<AppBundlePermissionsRequest>(*connection, originString, WTFMove(replySender)));
 }
 
-void WebPushDaemon::getOriginsWithPushAndNotificationPermissions(ClientConnection* connection, CompletionHandler<void(const Vector<String>&)>&& replySender)
+void WebPushDaemon::getOriginsWithPushAndNotificationPermissions(PushClientConnection* connection, CompletionHandler<void(const Vector<String>&)>&& replySender)
 {
     if (!canRegisterForNotifications(*connection)) {
         replySender({ });
@@ -578,7 +578,7 @@ void WebPushDaemon::deletePushRegistration(const PushSubscriptionSetIdentifier& 
     });
 }
 
-void WebPushDaemon::setPushAndNotificationsEnabledForOrigin(ClientConnection* connection, const String& originString, bool enabled, CompletionHandler<void()>&& replySender)
+void WebPushDaemon::setPushAndNotificationsEnabledForOrigin(PushClientConnection* connection, const String& originString, bool enabled, CompletionHandler<void()>&& replySender)
 {
     if (!canRegisterForNotifications(*connection)) {
         replySender();
@@ -595,7 +595,7 @@ void WebPushDaemon::setPushAndNotificationsEnabledForOrigin(ClientConnection* co
     });
 }
 
-void WebPushDaemon::deletePushAndNotificationRegistration(ClientConnection* connection, const String& originString, CompletionHandler<void(const String&)>&& replySender)
+void WebPushDaemon::deletePushAndNotificationRegistration(PushClientConnection* connection, const String& originString, CompletionHandler<void(const String&)>&& replySender)
 {
     if (!canRegisterForNotifications(*connection)) {
         replySender("Could not delete push and notification registrations for connection: Unknown host application code signing identifier"_s);
@@ -615,17 +615,17 @@ void WebPushDaemon::deletePushAndNotificationRegistration(ClientConnection* conn
 #endif
 }
 
-void WebPushDaemon::setDebugModeIsEnabled(ClientConnection* clientConnection, bool enabled)
+void WebPushDaemon::setDebugModeIsEnabled(PushClientConnection* clientConnection, bool enabled)
 {
     clientConnection->setDebugModeIsEnabled(enabled);
 }
 
-void WebPushDaemon::updateConnectionConfiguration(ClientConnection* clientConnection, const WebPushDaemonConnectionConfiguration& configuration)
+void WebPushDaemon::updateConnectionConfiguration(PushClientConnection* clientConnection, const WebPushDaemonConnectionConfiguration& configuration)
 {
     clientConnection->updateConnectionConfiguration(configuration);
 }
 
-void WebPushDaemon::injectPushMessageForTesting(ClientConnection* connection, const PushMessageForTesting& message, CompletionHandler<void(bool)>&& replySender)
+void WebPushDaemon::injectPushMessageForTesting(PushClientConnection* connection, const PushMessageForTesting& message, CompletionHandler<void(bool)>&& replySender)
 {
     if (!connection->hostAppHasPushInjectEntitlement()) {
         connection->broadcastDebugMessage("Attempting to inject a push message from an unentitled process"_s);
@@ -652,7 +652,7 @@ void WebPushDaemon::injectPushMessageForTesting(ClientConnection* connection, co
     replySender(true);
 }
 
-void WebPushDaemon::injectEncryptedPushMessageForTesting(ClientConnection* connection, const String& message, CompletionHandler<void(bool)>&& replySender)
+void WebPushDaemon::injectEncryptedPushMessageForTesting(PushClientConnection* connection, const String& message, CompletionHandler<void(bool)>&& replySender)
 {
     if (!connection->hostAppHasPushInjectEntitlement()) {
         connection->broadcastDebugMessage("Attempting to inject a push message from an unentitled process"_s);
@@ -735,7 +735,7 @@ void WebPushDaemon::notifyClientPushMessageIsAvailable(const WebCore::PushSubscr
 #endif
 }
 
-void WebPushDaemon::getPendingPushMessages(ClientConnection* connection, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender)
+void WebPushDaemon::getPendingPushMessages(PushClientConnection* connection, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender)
 {
     auto hostAppCodeSigningIdentifier = connection->hostAppCodeSigningIdentifier();
     if (hostAppCodeSigningIdentifier.isEmpty()) {
@@ -795,7 +795,7 @@ void WebPushDaemon::getPushTopicsForTesting(OSObjectPtr<xpc_object_t>&& request)
     });
 }
 
-void WebPushDaemon::subscribeToPushService(ClientConnection* connection, const URL& scopeURL, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender)
+void WebPushDaemon::subscribeToPushService(PushClientConnection* connection, const URL& scopeURL, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender)
 {
     runAfterStartingPushService([this, identifier = connection->subscriptionSetIdentifier(), scope = scopeURL.string(), vapidPublicKey, replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -807,7 +807,7 @@ void WebPushDaemon::subscribeToPushService(ClientConnection* connection, const U
     });
 }
 
-void WebPushDaemon::unsubscribeFromPushService(ClientConnection* connection, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> subscriptionIdentifier, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender)
+void WebPushDaemon::unsubscribeFromPushService(PushClientConnection* connection, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> subscriptionIdentifier, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender)
 {
     runAfterStartingPushService([this, identifier = connection->subscriptionSetIdentifier(), scope = scopeURL.string(), subscriptionIdentifier, replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -819,7 +819,7 @@ void WebPushDaemon::unsubscribeFromPushService(ClientConnection* connection, con
     });
 }
 
-void WebPushDaemon::getPushSubscription(ClientConnection* connection, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender)
+void WebPushDaemon::getPushSubscription(PushClientConnection* connection, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender)
 {
     runAfterStartingPushService([this, identifier = connection->subscriptionSetIdentifier(), scope = scopeURL.string(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -831,7 +831,7 @@ void WebPushDaemon::getPushSubscription(ClientConnection* connection, const URL&
     });
 }
 
-void WebPushDaemon::getPushPermissionState(ClientConnection* connection, const URL& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender)
+void WebPushDaemon::getPushPermissionState(PushClientConnection* connection, const URL& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender)
 {
     // FIXME: This doesn't actually get called right now, since the permission is currently checked
     // in WebProcess. However, we've left this stub in for now because there is a chance that we
@@ -839,7 +839,7 @@ void WebPushDaemon::getPushPermissionState(ClientConnection* connection, const U
     replySender(static_cast<uint8_t>(WebCore::PushPermissionState::Denied));
 }
 
-void WebPushDaemon::incrementSilentPushCount(ClientConnection* connection, const WebCore::SecurityOriginData& securityOrigin, CompletionHandler<void(unsigned)>&& replySender)
+void WebPushDaemon::incrementSilentPushCount(PushClientConnection* connection, const WebCore::SecurityOriginData& securityOrigin, CompletionHandler<void(unsigned)>&& replySender)
 {
     runAfterStartingPushService([this, identifier = connection->subscriptionSetIdentifier(), securityOrigin = securityOrigin.toString(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -851,7 +851,7 @@ void WebPushDaemon::incrementSilentPushCount(ClientConnection* connection, const
     });
 }
 
-void WebPushDaemon::removeAllPushSubscriptions(ClientConnection* connection, CompletionHandler<void(unsigned)>&& replySender)
+void WebPushDaemon::removeAllPushSubscriptions(PushClientConnection* connection, CompletionHandler<void(unsigned)>&& replySender)
 {
     runAfterStartingPushService([this, identifier = connection->subscriptionSetIdentifier(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -863,7 +863,7 @@ void WebPushDaemon::removeAllPushSubscriptions(ClientConnection* connection, Com
     });
 }
 
-void WebPushDaemon::removePushSubscriptionsForOrigin(ClientConnection* connection, const WebCore::SecurityOriginData& securityOrigin, CompletionHandler<void(unsigned)>&& replySender)
+void WebPushDaemon::removePushSubscriptionsForOrigin(PushClientConnection* connection, const WebCore::SecurityOriginData& securityOrigin, CompletionHandler<void(unsigned)>&& replySender)
 {
     runAfterStartingPushService([this, identifier = connection->subscriptionSetIdentifier(), securityOrigin = securityOrigin.toString(), replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -875,7 +875,7 @@ void WebPushDaemon::removePushSubscriptionsForOrigin(ClientConnection* connectio
     });
 }
 
-void WebPushDaemon::setPublicTokenForTesting(ClientConnection*, const String& publicToken, CompletionHandler<void()>&& replySender)
+void WebPushDaemon::setPublicTokenForTesting(PushClientConnection*, const String& publicToken, CompletionHandler<void()>&& replySender)
 {
     runAfterStartingPushService([this, publicToken, replySender = WTFMove(replySender)]() mutable {
         if (!m_pushService) {
@@ -888,7 +888,7 @@ void WebPushDaemon::setPublicTokenForTesting(ClientConnection*, const String& pu
     });
 }
 
-ClientConnection* WebPushDaemon::toClientConnection(xpc_connection_t connection)
+PushClientConnection* WebPushDaemon::toPushClientConnection(xpc_connection_t connection)
 {
     auto clientConnection = m_connectionMap.get(connection);
     RELEASE_ASSERT(clientConnection);


### PR DESCRIPTION
#### a46e44a6e91f78eb10feeab086316029154c6006
<pre>
Rename WebPushD::ClientConnection to WebPushD::PushClientConnection
<a href="https://bugs.webkit.org/show_bug.cgi?id=260536">https://bugs.webkit.org/show_bug.cgi?id=260536</a>
rdar://114273768

Reviewed by Tim Horton and Alex Christensen.

* Source/WebKit/webpushd/AppBundleRequest.h:
(WebPushD::AppBundleRequestImpl::AppBundleRequestImpl):
(WebPushD::AppBundlePermissionsRequest::AppBundlePermissionsRequest):
(WebPushD::AppBundleDeletionRequest::AppBundleDeletionRequest):
* Source/WebKit/webpushd/AppBundleRequest.mm:
(WebPushD::AppBundleRequest::AppBundleRequest):
* Source/WebKit/webpushd/ICAppBundle.h:
(WebPushD::ICAppBundle::create):
* Source/WebKit/webpushd/ICAppBundle.mm:
(WebPushD::ICAppBundle::ICAppBundle):
(WebPushD::ICAppBundle::getOriginsWithRegistrations):
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::ClientConnection::hasHostAppAuditToken const): Deleted.
(WebPushD::ClientConnection::pushPartitionString const): Deleted.
(WebPushD::ClientConnection::dataStoreIdentifier const): Deleted.
(WebPushD::ClientConnection::debugModeIsEnabled const): Deleted.
(WebPushD::ClientConnection::useMockBundlesForTesting const): Deleted.
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::create):
(WebPushD::PushClientConnection::PushClientConnection):
(WebPushD::PushClientConnection::updateConnectionConfiguration):
(WebPushD::PushClientConnection::setHostAppAuditTokenData):
(WebPushD::PushClientConnection::subscriptionSetIdentifier):
(WebPushD::PushClientConnection::hostAppCodeSigningIdentifier):
(WebPushD::PushClientConnection::bundleIdentifierFromAuditToken):
(WebPushD::PushClientConnection::hostAppHasPushEntitlement):
(WebPushD::PushClientConnection::hostAppHasPushInjectEntitlement):
(WebPushD::PushClientConnection::hostHasEntitlement):
(WebPushD::PushClientConnection::setDebugModeIsEnabled):
(WebPushD::PushClientConnection::broadcastDebugMessage):
(WebPushD::PushClientConnection::sendDebugMessage):
(WebPushD::PushClientConnection::enqueueAppBundleRequest):
(WebPushD::PushClientConnection::maybeStartNextAppBundleRequest):
(WebPushD::PushClientConnection::didCompleteAppBundleRequest):
(WebPushD::PushClientConnection::connectionClosed):
(WebPushD::PushClientConnection::sendDaemonMessage const):
(WebPushD::ClientConnection::create): Deleted.
(WebPushD::ClientConnection::ClientConnection): Deleted.
(WebPushD::ClientConnection::updateConnectionConfiguration): Deleted.
(WebPushD::ClientConnection::setHostAppAuditTokenData): Deleted.
(WebPushD::ClientConnection::subscriptionSetIdentifier): Deleted.
(WebPushD::ClientConnection::hostAppCodeSigningIdentifier): Deleted.
(WebPushD::ClientConnection::bundleIdentifierFromAuditToken): Deleted.
(WebPushD::ClientConnection::hostAppHasPushEntitlement): Deleted.
(WebPushD::ClientConnection::hostAppHasPushInjectEntitlement): Deleted.
(WebPushD::ClientConnection::hostHasEntitlement): Deleted.
(WebPushD::ClientConnection::setDebugModeIsEnabled): Deleted.
(WebPushD::ClientConnection::broadcastDebugMessage): Deleted.
(WebPushD::ClientConnection::sendDebugMessage): Deleted.
(WebPushD::ClientConnection::enqueueAppBundleRequest): Deleted.
(WebPushD::ClientConnection::maybeStartNextAppBundleRequest): Deleted.
(WebPushD::ClientConnection::didCompleteAppBundleRequest): Deleted.
(WebPushD::ClientConnection::connectionClosed): Deleted.
(WebPushD::ClientConnection::sendDaemonMessage const): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::handleWebPushDMessageWithReply):
(WebPushD::handleWebPushDMessage):
(WebPushD::WebPushDaemon::broadcastAllConnectionIdentities):
(WebPushD::WebPushDaemon::connectionAdded):
(WebPushD::WebPushDaemon::decodeAndHandleMessage):
(WebPushD::WebPushDaemon::echoTwice):
(WebPushD::WebPushDaemon::canRegisterForNotifications):
(WebPushD::WebPushDaemon::requestSystemNotificationPermission):
(WebPushD::WebPushDaemon::getOriginsWithPushAndNotificationPermissions):
(WebPushD::WebPushDaemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::WebPushDaemon::deletePushAndNotificationRegistration):
(WebPushD::WebPushDaemon::setDebugModeIsEnabled):
(WebPushD::WebPushDaemon::updateConnectionConfiguration):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::unsubscribeFromPushService):
(WebPushD::WebPushDaemon::getPushSubscription):
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::incrementSilentPushCount):
(WebPushD::WebPushDaemon::removeAllPushSubscriptions):
(WebPushD::WebPushDaemon::removePushSubscriptionsForOrigin):
(WebPushD::WebPushDaemon::setPublicTokenForTesting):
(WebPushD::WebPushDaemon::toPushClientConnection):
(WebPushD::WebPushDaemon::toClientConnection): Deleted.

Canonical link: <a href="https://commits.webkit.org/267148@main">https://commits.webkit.org/267148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bddbd4acec3405ef3a8cb1b1608fe9793afd217a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14844 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16230 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18334 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13726 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21176 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17700 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12753 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14289 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3771 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->