### PR TITLE
REGRESSION(265135@main): CSS filter is not applied on SVG element

### DIFF
--- a/LayoutTests/svg/filters/css-filter-specified-on-svg-root-expected.html
+++ b/LayoutTests/svg/filters/css-filter-specified-on-svg-root-expected.html
@@ -1,0 +1,10 @@
+<style>
+  #rect {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+    filter: drop-shadow(10px 10px 0px green);
+  }
+</style>
+
+<div id="rect"></div>

--- a/LayoutTests/svg/filters/css-filter-specified-on-svg-root.html
+++ b/LayoutTests/svg/filters/css-filter-specified-on-svg-root.html
@@ -1,0 +1,11 @@
+<style>
+  svg {
+    width: 100px;
+    height: 100px;
+    filter: drop-shadow(10px 10px 0px green);
+  }
+</style>
+
+<svg width="100" height="100">
+  <rect width="100" height="100" fill="red"/>
+</svg>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -886,11 +886,6 @@ bool RenderLayer::paintsWithFilters() const
     if (!hasFilter())
         return false;
 
-    // The SVG rendering codepath should've already applied the filter to the SVG root,
-    // so do not apply the filter again.
-    if (renderer().isSVGRootOrLegacySVGRoot())
-        return false;
-
     if (RenderLayerFilters::isIdentity(renderer()))
         return false;
 
@@ -5584,8 +5579,9 @@ void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const Rend
         return;
     }
 
-    // Add the filter as a client to this renderer.
-    if (renderer().style().filter().hasReferenceFilter()) {
+    // Add the filter as a client to this renderer, unless we are a RenderLayer accommodating
+    // an SVG. In that case it takes care of its own resource management for filters.
+    if (renderer().style().filter().hasReferenceFilter() && !renderer().isSVGRootOrLegacySVGRoot()) {
         ensureLayerFilters();
         m_filters->updateReferenceFilterClients(renderer().style().filter());
     } else if (m_filters)

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -159,7 +159,9 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
             return;
     }
 
-    if (!isRenderingMask) {
+    // SVG roots with filters specified (using CSS or SVG presentation attributes) are applied
+    // as CSSFilter by RenderLayer, so don't reapply the filter here.
+    if (!isRenderingMask && !renderer.isSVGRootOrLegacySVGRoot()) {
         m_filter = resources->filter();
         if (m_filter && !m_filter->isIdentity()) {
             m_savedContext = &m_paintInfo->context();


### PR DESCRIPTION
#### d4e801ecf045fd89d0fe6b4f7e1f27f8648dbea0
<pre>
REGRESSION(265135@main): CSS filter is not applied on SVG element
<a href="https://bugs.webkit.org/show_bug.cgi?id=260152">https://bugs.webkit.org/show_bug.cgi?id=260152</a>
rdar://114204485

Reviewed by Said Abou-Hallawa.

Before 265135@main, an SVG root with a filter specified as presentation attribute
(e.g: &lt;svg filter=&quot;...&quot;&gt;) was filtered twice instead of once: once by SVGRenderingContext,
and another by RenderLayer. 265135@main attempted to fix this by instructing RenderLayer
not to apply filters when rendering an SVG root. This caused a regression where an SVG root
with a filter specified using CSS filter property is not filtered, because SVGRenderingContext
is not responsible for apply CSS filters, and RenderLayer refuses to filter because it&apos;s an
SVG root. Fix the previous attempt by fixing SVGRenderingContext to not filter when rendering
an SVG root, so RenderLayer is now solely responsible for filtering SVG roots.

Test: LayoutTests/svg/filters/css-filter-specified-on-svg-root.html

* LayoutTests/svg/filters/css-filter-specified-on-svg-root-expected.html: Added.
* LayoutTests/svg/filters/css-filter-specified-on-svg-root.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintsWithFilters const):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):

Canonical link: <a href="https://commits.webkit.org/267236@main">https://commits.webkit.org/267236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb2fa30065cdac7d115652b10cb92b1b3c02238d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18454 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21276 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17815 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12857 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14236 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3829 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->