### PR TITLE
fixup! Investigating VerifyHashFromNoisyCanvas2DAPI failure Need the bug URL (OOPS!). Include a Radar link (OOPS!).

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -880,11 +880,7 @@ TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIs)
 }
 
 // FIXME when rdar://115137641 is resolved.
-#if PLATFORM(MAC)
-TEST(AdvancedPrivacyProtections, DISABLED_VerifyHashFromNoisyCanvas2DAPI)
-#else
 TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
-#endif
 {
     auto testURL = [NSBundle.mainBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
     auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
@@ -916,7 +912,6 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
                 continue;
             EXPECT_EQ([values.first characterAtIndex:i], [values.second characterAtIndex:i]);
             EXPECT_EQ(i, 0u);
-            break;
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -890,10 +890,10 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
     auto webViewWithPrivacyProtections1 = createWebViewWithAdvancedPrivacyProtections();
     auto webViewWithPrivacyProtections2 = createWebViewWithAdvancedPrivacyProtections();
 
-    [webView1 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
-    [webView1 _test_waitForDidFinishNavigation];
     [webView2 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
     [webView2 _test_waitForDidFinishNavigation];
+    [webView1 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
+    [webView1 _test_waitForDidFinishNavigation];
     [webViewWithPrivacyProtections1 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
     [webViewWithPrivacyProtections1 _test_waitForDidFinishNavigation];
     [webViewWithPrivacyProtections2 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
@@ -910,7 +910,7 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
         for (size_t i = 0; i < length; ++i) {
             if ([values.first characterAtIndex:i] == [values.second characterAtIndex:i])
                 continue;
-            EXPECT_EQ([values.first characterAtIndex:i], [values.second characterAtIndex:i]);
+            EXPECT_EQ((char)[values.first characterAtIndex:i], (char)[values.second characterAtIndex:i]);
             EXPECT_EQ(i, 0u);
         }
     }
@@ -920,6 +920,15 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
         [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]
     };
     EXPECT_FALSE([values.first isEqualToString:values.second]);
+    if ([values.first isEqualToString:values.second]) {
+        auto length = values.first.length > values.second.length ? values.second.length : values.first.length;
+        for (size_t i = 0; i < length; ++i) {
+            if ([values.first characterAtIndex:i] != [values.second characterAtIndex:i])
+                continue;
+            EXPECT_NE((char)[values.first characterAtIndex:i], (char)[values.second characterAtIndex:i]);
+            EXPECT_EQ(i, 0u);
+        }
+    }
 
     values = std::pair {
         [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun],

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -905,10 +905,20 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
 
     auto scriptToRun = @"return fullCanvasHash()";
     auto values = std::pair {
-        [webView1 callAsyncJavaScriptAndWait:scriptToRun],
-        [webView2 callAsyncJavaScriptAndWait:scriptToRun]
+        (NSString*)[webView1 callAsyncJavaScriptAndWait:scriptToRun],
+        (NSString*)[webView2 callAsyncJavaScriptAndWait:scriptToRun]
     };
     EXPECT_TRUE([values.first isEqualToString:values.second]);
+    if (![values.first isEqualToString:values.second]) {
+        auto length = values.first.length > values.second.length ? values.second.length : values.first.length;
+        for (size_t i = 0; i < length; ++i) {
+            if ([values.first characterAtIndex:i] == [values.second characterAtIndex:i])
+                continue;
+            EXPECT_EQ([values.first characterAtIndex:i], [values.second characterAtIndex:i]);
+            EXPECT_EQ(i, 0u);
+            break;
+        }
+    }
 
     values = std::pair {
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
@@ -153,7 +153,8 @@ function initialRadialGradientCanvasImageDataAsObject(length) {
 async function fullCanvasHash(data) {
     if (!data)
         data = fullTextCanvasImageData();
-    return await digestMessage(data.data);
+    //return await digestMessage(data.data);
+    return `${data.data.join(",")}`;
 }
 </script>
 </body>


### PR DESCRIPTION
#### 70e182bddd36f7242f67e499895ab55782096d6e
<pre>
fixup! Investigating VerifyHashFromNoisyCanvas2DAPI failure Need the bug URL (OOPS!). Include a Radar link (OOPS!).
</pre>
----------------------------------------------------------------------
#### 17ec37737d2b24e63b190a6d9678ce9ae4144946
<pre>
fixup! Investigating VerifyHashFromNoisyCanvas2DAPI failure Need the bug URL (OOPS!). Include a Radar link (OOPS!).
</pre>
----------------------------------------------------------------------
#### 40fd5714811fad8c0450959e78ce506deb513f0f
<pre>
Investigating VerifyHashFromNoisyCanvas2DAPI failure
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e182bddd36f7242f67e499895ab55782096d6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29826 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10776 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30290 "1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33505 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11415 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->