### PR TITLE
REGRESSION (Safari 17 beta): [MSE] Can no longer play .FLAC inside MP4

### DIFF
--- a/LayoutTests/media/media-can-play-case-sensitive-flac-expected.txt
+++ b/LayoutTests/media/media-can-play-case-sensitive-flac-expected.txt
@@ -1,0 +1,6 @@
+Tests that both flac and fLaC are reported as playable in a mp4 container.
+EXPECTED (mediaElement.canPlayType('audio/mp4; codecs="flac"') == 'probably') OK
+EXPECTED (mediaElement.canPlayType('audio/mp4; codecs="fLaC"') == 'probably') OK
+EXPECTED (mediaElement.canPlayType('audio/mp4; codecs="FlAc"') == '') OK
+END OF TEST
+

--- a/LayoutTests/media/media-can-play-case-sensitive-flac.html
+++ b/LayoutTests/media/media-can-play-case-sensitive-flac.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>media-can-play-type-case-sensitive</title>
+    <script src="video-test.js"></script>
+    <script>
+        window.addEventListener('load', event => {
+            mediaElement = document.createElement('video');
+            testExpected(`mediaElement.canPlayType('audio/mp4; codecs="flac"')`, 'probably');
+            testExpected(`mediaElement.canPlayType('audio/mp4; codecs="fLaC"')`, 'probably');
+            testExpected(`mediaElement.canPlayType('audio/mp4; codecs="FlAc"')`, '');
+            endTest();
+        });
+    </script>
+</head>
+<body>
+    <div>Tests that both <code>flac</code> and <code>fLaC</code> are reported as playable in a mp4 container.</div>
+</body>
+</html>

--- a/LayoutTests/media/media-can-play-type-case-sensitive-expected.txt
+++ b/LayoutTests/media/media-can-play-type-case-sensitive-expected.txt
@@ -1,0 +1,9 @@
+Tests that subsequent tests of incorrectly cased codecs do not incorrectly report they are supported
+RUN(mediaElement.canPlayType('audio/mp4; codecs="fLaC"'))
+EXPECTED (mediaElement.canPlayType('audio/mp4; codecs="FlAc"') == '') OK
+RUN(mediaElement.canPlayType('video/mp4; codecs="avc1"'))
+EXPECTED (mediaElement.canPlayType('video/mp4; codecs="AvC1"') == '') OK
+RUN(mediaElement.canPlayType('video/ogg; codecs="vorbis"'))
+EXPECTED (mediaElement.canPlayType('video/ogg; codecs="vOrBiS"') == '') OK
+END OF TEST
+

--- a/LayoutTests/media/media-can-play-type-case-sensitive.html
+++ b/LayoutTests/media/media-can-play-type-case-sensitive.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>media-can-play-type-case-sensitive</title>
+    <script src="video-test.js"></script>
+    <script>
+        window.addEventListener('load', event => {
+            mediaElement = document.createElement('video');
+            run(`mediaElement.canPlayType('audio/mp4; codecs="fLaC"')`);
+            testExpected(`mediaElement.canPlayType('audio/mp4; codecs="FlAc"')`, '');
+            run(`mediaElement.canPlayType('video/mp4; codecs="avc1"')`);
+            testExpected(`mediaElement.canPlayType('video/mp4; codecs="AvC1"')`, '');
+            run(`mediaElement.canPlayType('video/ogg; codecs="vorbis"')`);
+            testExpected(`mediaElement.canPlayType('video/ogg; codecs="vOrBiS"')`, '');
+            endTest();
+        });
+    </script>
+</head>
+<body>
+    <div>Tests that subsequent tests of incorrectly cased codecs do not incorrectly report they are supported</div>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3423,6 +3423,8 @@ imported/w3c/web-platform-tests/html/canvas/offscreen/text/fontVariantCaps-1.htm
 imported/w3c/web-platform-tests/html/canvas/offscreen/text/fontVariantCaps-3.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/text/fontVariantCaps-4.html [ ImageOnlyFailure ]
 
+webkit.org/b/260625 media/media-can-play-case-sensitive-flac.html [ Failure ]
+webkit.org/b/260625 media/media-can-play-type-case-sensitive.html [ Failure ]
 
 # End: Common failures between GTK and WPE.
 

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -231,10 +231,10 @@ HashSet<String, ASCIICaseInsensitiveHash>& MIMETypeRegistry::supportedNonImageMI
     return types;
 }
 
-const HashSet<String, ASCIICaseInsensitiveHash>& MIMETypeRegistry::supportedMediaMIMETypes()
+const HashSet<String>& MIMETypeRegistry::supportedMediaMIMETypes()
 {
     static NeverDestroyed types = [] {
-        HashSet<String, ASCIICaseInsensitiveHash> types;
+        HashSet<String> types;
 #if ENABLE(VIDEO)
         MediaPlayer::getSupportedTypes(types);
 #endif

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -132,7 +132,7 @@ public:
     WEBCORE_EXPORT static FixedVector<ASCIILiteral> supportedImageMIMETypes();
     static HashSet<String, ASCIICaseInsensitiveHash>& additionalSupportedImageMIMETypes();
     WEBCORE_EXPORT static HashSet<String, ASCIICaseInsensitiveHash>& supportedNonImageMIMETypes();
-    WEBCORE_EXPORT static const HashSet<String, ASCIICaseInsensitiveHash>& supportedMediaMIMETypes();
+    WEBCORE_EXPORT static const HashSet<String>& supportedMediaMIMETypes();
     WEBCORE_EXPORT static FixedVector<ASCIILiteral> pdfMIMETypes();
     WEBCORE_EXPORT static FixedVector<ASCIILiteral> unsupportedTextMIMETypes();
     WEBCORE_EXPORT static FixedVector<ASCIILiteral> usdMIMETypes();

--- a/Source/WebCore/platform/graphics/MIMETypeCache.cpp
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.cpp
@@ -30,10 +30,10 @@
 
 namespace WebCore {
 
-HashSet<String, ASCIICaseInsensitiveHash>& MIMETypeCache::supportedTypes()
+HashSet<String>& MIMETypeCache::supportedTypes()
 {
     if (!m_supportedTypes) {
-        m_supportedTypes = HashSet<String, ASCIICaseInsensitiveHash> { };
+        m_supportedTypes = HashSet<String> { };
         initializeCache(*m_supportedTypes);
     }
 
@@ -88,7 +88,7 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
     } while (0);
 
     if (!m_cachedResults)
-        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType, ASCIICaseInsensitiveHash>();
+        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType>();
     m_cachedResults->add(mimeType, result);
 
     return result;
@@ -97,7 +97,7 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
 void MIMETypeCache::addSupportedTypes(const Vector<String>& newTypes)
 {
     if (!m_supportedTypes)
-        m_supportedTypes = HashSet<String, ASCIICaseInsensitiveHash> { };
+        m_supportedTypes = HashSet<String> { };
 
     for (auto& type : newTypes)
         m_supportedTypes->add(type);
@@ -123,7 +123,7 @@ bool MIMETypeCache::isEmpty() const
     return m_supportedTypes && m_supportedTypes->isEmpty();
 }
 
-void MIMETypeCache::initializeCache(HashSet<String, ASCIICaseInsensitiveHash>&)
+void MIMETypeCache::initializeCache(HashSet<String>&)
 {
 }
 

--- a/Source/WebCore/platform/graphics/MIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.h
@@ -43,7 +43,7 @@ public:
 
     virtual bool isAvailable() const;
     virtual MediaPlayerEnums::SupportsType canDecodeType(const String&);
-    virtual HashSet<String, ASCIICaseInsensitiveHash>& supportedTypes();
+    virtual HashSet<String>& supportedTypes();
 
     bool isEmpty() const;
     bool supportsContainerType(const String&);
@@ -54,13 +54,13 @@ protected:
 private:
     virtual bool isStaticContainerType(StringView);
     virtual bool isUnsupportedContainerType(const String&);
-    virtual void initializeCache(HashSet<String, ASCIICaseInsensitiveHash>&);
+    virtual void initializeCache(HashSet<String>&);
     virtual bool canDecodeExtendedType(const ContentType&);
 
     bool shouldOverrideExtendedType(const ContentType&);
 
-    std::optional<HashSet<String, ASCIICaseInsensitiveHash>> m_supportedTypes;
-    std::optional<HashMap<String, MediaPlayerEnums::SupportsType, ASCIICaseInsensitiveHash>> m_cachedResults;
+    std::optional<HashSet<String>> m_supportedTypes;
+    std::optional<HashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1185,10 +1185,10 @@ MediaPlayer::SupportsType MediaPlayer::supportsType(const MediaEngineSupportPara
     return engine->supportsTypeAndCodecs(parameters);
 }
 
-void MediaPlayer::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayer::getSupportedTypes(HashSet<String>& types)
 {
     for (auto& engine : installedMediaEngines()) {
-        HashSet<String, ASCIICaseInsensitiveHash> engineTypes;
+        HashSet<String> engineTypes;
         engine->getSupportedTypes(engineTypes);
         types.add(engineTypes.begin(), engineTypes.end());
     }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -316,7 +316,7 @@ public:
     using MediaPlayerEnums::SupportsType;
     static const MediaPlayerFactory* mediaEngine(MediaPlayerEnums::MediaEngineIdentifier);
     static SupportsType supportsType(const MediaEngineSupportParameters&);
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedTypes(HashSet<String>&);
     static bool isAvailable();
     static HashSet<SecurityOriginData> originsInMediaCache(const String& path);
     static void clearMediaCache(const String& path, WallTime modifiedSince);
@@ -781,7 +781,7 @@ public:
 
     virtual MediaPlayerEnums::MediaEngineIdentifier identifier() const  = 0;
     virtual std::unique_ptr<MediaPlayerPrivateInterface> createMediaEnginePlayer(MediaPlayer*) const = 0;
-    virtual void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&) const = 0;
+    virtual void getSupportedTypes(HashSet<String>&) const = 0;
     virtual MediaPlayer::SupportsType supportsTypeAndCodecs(const MediaEngineSupportParameters&) const = 0;
 
     virtual HashSet<SecurityOriginData> originsInMediaCache(const String&) const { return { }; }

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -1115,9 +1115,9 @@ WTFLogChannel& MediaPlayerPrivateAVFoundation::logChannel() const
 }
 #endif
 
-const HashSet<String, ASCIICaseInsensitiveHash>& MediaPlayerPrivateAVFoundation::staticMIMETypeList()
+const HashSet<String>& MediaPlayerPrivateAVFoundation::staticMIMETypeList()
 {
-    static NeverDestroyed cache = HashSet<String, ASCIICaseInsensitiveHash> {
+    static NeverDestroyed cache = HashSet<String> {
         "application/vnd.apple.mpegurl"_s,
         "application/x-mpegurl"_s,
         "audio/3gpp"_s,

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -274,7 +274,7 @@ protected:
     virtual bool isHLS() const { return false; }
 
     static bool isUnsupportedMIMEType(const String&);
-    static const HashSet<String, ASCIICaseInsensitiveHash>& staticMIMETypeList();
+    static const HashSet<String>& staticMIMETypeList();
 
     void updateStates();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.h
@@ -51,7 +51,7 @@ private:
     bool isStaticContainerType(StringView) final;
     bool isUnsupportedContainerType(const String&) final;
     bool canDecodeExtendedType(const ContentType&) final;
-    void initializeCache(HashSet<String, ASCIICaseInsensitiveHash>&) final;
+    void initializeCache(HashSet<String>&) final;
 
     CacheMIMETypesCallback m_cacheTypeCallback;
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h
@@ -42,14 +42,14 @@ public:
 
     bool isAvailable() const final;
     MediaPlayerEnums::SupportsType canDecodeType(const String&) final;
-    HashSet<String, ASCIICaseInsensitiveHash>& supportedTypes() final;
+    HashSet<String>& supportedTypes() final;
 
 private:
     friend NeverDestroyed<AVStreamDataParserMIMETypeCache>;
     AVStreamDataParserMIMETypeCache() = default;
 
     bool canDecodeExtendedType(const ContentType&) final;
-    void initializeCache(HashSet<String, ASCIICaseInsensitiveHash>&) final;
+    void initializeCache(HashSet<String>&) final;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
@@ -74,7 +74,7 @@ MediaPlayerEnums::SupportsType AVStreamDataParserMIMETypeCache::canDecodeType(co
     return MediaPlayerEnums::SupportsType::IsNotSupported;
 }
 
-HashSet<String, ASCIICaseInsensitiveHash>& AVStreamDataParserMIMETypeCache::supportedTypes()
+HashSet<String>& AVStreamDataParserMIMETypeCache::supportedTypes()
 {
     if (isAvailable())
         return MIMETypeCache::supportedTypes();
@@ -108,7 +108,7 @@ bool AVStreamDataParserMIMETypeCache::canDecodeExtendedType(const ContentType& t
     return false;
 }
 
-void AVStreamDataParserMIMETypeCache::initializeCache(HashSet<String, ASCIICaseInsensitiveHash>& cache)
+void AVStreamDataParserMIMETypeCache::initializeCache(HashSet<String>& cache)
 {
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
     if (!isAvailable())

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -144,7 +144,7 @@ private:
     // engine support
     class Factory;
     static bool isAvailable();
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types);
+    static void getSupportedTypes(HashSet<String>& types);
     static MediaPlayer::SupportsType supportsTypeAndCodecs(const MediaEngineSupportParameters&);
     static bool supportsKeySystem(const String& keySystem, const String& mimeType);
     static HashSet<SecurityOriginData> originsInMediaCache(const String&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -288,7 +288,7 @@ private:
         return makeUnique<MediaPlayerPrivateAVFoundationObjC>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateAVFoundationObjC::getSupportedTypes(types);
     }
@@ -2043,7 +2043,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return image;
 }
 
-void MediaPlayerPrivateAVFoundationObjC::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& supportedTypes)
+void MediaPlayerPrivateAVFoundationObjC::getSupportedTypes(HashSet<String>& supportedTypes)
 {
     supportedTypes = AVAssetMIMETypeCache::singleton().supportedTypes();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -73,7 +73,7 @@ public:
 
     // MediaPlayer Factory Methods
     static bool isAvailable();
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types);
+    static void getSupportedTypes(HashSet<String>& types);
     static MediaPlayer::SupportsType supportsTypeAndCodecs(const MediaEngineSupportParameters&);
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -232,7 +232,7 @@ private:
         return makeUnique<MediaPlayerPrivateMediaSourceAVFObjC>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateMediaSourceAVFObjC::getSupportedTypes(types);
     }
@@ -263,7 +263,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::isAvailable()
         && class_getInstanceMethod(PAL::getAVSampleBufferAudioRendererClass(), @selector(setMuted:));
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateMediaSourceAVFObjC::getSupportedTypes(HashSet<String>& types)
 {
     types = AVStreamDataParserMIMETypeCache::singleton().supportedTypes();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -69,7 +69,7 @@ public:
 
     // MediaPlayer Factory Methods
     static bool isAvailable();
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types);
+    static void getSupportedTypes(HashSet<String>& types);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
     MediaPlayer::NetworkState networkState() const override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -198,7 +198,7 @@ private:
         return makeUnique<MediaPlayerPrivateMediaStreamAVFObjC>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes(types);
     }
@@ -222,7 +222,7 @@ bool MediaPlayerPrivateMediaStreamAVFObjC::isAvailable()
     return PAL::isAVFoundationFrameworkAvailable() && PAL::isCoreMediaFrameworkAvailable() && PAL::getAVSampleBufferDisplayLayerClass();
 }
 
-void MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes(HashSet<String>& types)
 {
     // FIXME: Is it really correct to list no supported types?
     types.clear();

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -252,7 +252,7 @@ private:
 
     friend class MediaPlayerFactoryWebM;
     static bool isAvailable();
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedTypes(HashSet<String>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -127,9 +127,9 @@ static bool isCopyDisplayedPixelBufferAvailable()
 
 #endif // HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
 
-static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
+static HashSet<String>& mimeTypeCache()
 {
-    static NeverDestroyed cache = HashSet<String, ASCIICaseInsensitiveHash>();
+    static NeverDestroyed cache = HashSet<String>();
     if (cache->isEmpty()) {
         auto types = SourceBufferParserWebM::supportedMIMETypes();
         cache->add(types.begin(), types.end());
@@ -137,7 +137,7 @@ static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
     return cache;
 }
 
-void MediaPlayerPrivateWebM::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateWebM::getSupportedTypes(HashSet<String>& types)
 {
     types = mimeTypeCache();
 }
@@ -1535,7 +1535,7 @@ private:
         return makeUnique<MediaPlayerPrivateWebM>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateWebM::getSupportedTypes(types);
     }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -120,7 +120,7 @@ GStreamerRegistryScanner& GStreamerRegistryScanner::singleton()
     return sharedInstance;
 }
 
-void GStreamerRegistryScanner::getSupportedDecodingTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void GStreamerRegistryScanner::getSupportedDecodingTypes(HashSet<String>& types)
 {
     if (isInWebProcess())
         types = singleton().mimeTypeSet(GStreamerRegistryScanner::Configuration::Decoding);
@@ -356,7 +356,7 @@ void GStreamerRegistryScanner::refresh()
 #endif
 }
 
-const HashSet<String, ASCIICaseInsensitiveHash>& GStreamerRegistryScanner::mimeTypeSet(Configuration configuration) const
+const HashSet<String>& GStreamerRegistryScanner::mimeTypeSet(Configuration configuration) const
 {
     switch (configuration) {
     case Configuration::Decoding:

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -40,7 +40,7 @@ class GStreamerRegistryScanner {
 public:
     static bool singletonNeedsInitialization();
     static GStreamerRegistryScanner& singleton();
-    static void getSupportedDecodingTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedDecodingTypes(HashSet<String>&);
 
     explicit GStreamerRegistryScanner(bool isMediaSource = false);
     ~GStreamerRegistryScanner() = default;
@@ -52,7 +52,7 @@ public:
         Encoding
     };
 
-    const HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeSet(Configuration) const;
+    const HashSet<String>& mimeTypeSet(Configuration) const;
     bool isContainerTypeSupported(Configuration, const String& containerType) const;
 
     struct RegistryLookupResult {
@@ -197,9 +197,9 @@ private:
 #endif
 
     bool m_isMediaSource { false };
-    HashSet<String, ASCIICaseInsensitiveHash> m_decoderMimeTypeSet;
+    HashSet<String> m_decoderMimeTypeSet;
     HashMap<AtomString, RegistryLookupResult> m_decoderCodecMap;
-    HashSet<String, ASCIICaseInsensitiveHash> m_encoderMimeTypeSet;
+    HashSet<String> m_encoderMimeTypeSet;
     HashMap<AtomString, RegistryLookupResult> m_encoderCodecMap;
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -264,7 +264,7 @@ private:
         return makeUnique<MediaPlayerPrivateGStreamer>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateGStreamer::getSupportedTypes(types);
     }
@@ -2758,7 +2758,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
     timeChanged();
 }
 
-void MediaPlayerPrivateGStreamer::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateGStreamer::getSupportedTypes(HashSet<String>& types)
 {
     GStreamerRegistryScanner::getSupportedDecodingTypes(types);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -445,7 +445,7 @@ private:
     bool isMediaStreamPlayer() const;
 
     friend class MediaPlayerFactoryGStreamer;
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedTypes(HashSet<String>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
     void syncOnClock(bool sync);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp
@@ -32,7 +32,7 @@ GStreamerRegistryScannerMSE& GStreamerRegistryScannerMSE::singleton()
     return sharedInstance;
 }
 
-void GStreamerRegistryScannerMSE::getSupportedDecodingTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void GStreamerRegistryScannerMSE::getSupportedDecodingTypes(HashSet<String>& types)
 {
     if (isInWebProcess())
         types = singleton().mimeTypeSet(GStreamerRegistryScanner::Configuration::Decoding);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.h
@@ -30,7 +30,7 @@ namespace WebCore {
 class GStreamerRegistryScannerMSE : public GStreamerRegistryScanner {
 public:
     static GStreamerRegistryScannerMSE& singleton();
-    static void getSupportedDecodingTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedDecodingTypes(HashSet<String>&);
     GStreamerRegistryScannerMSE();
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -82,7 +82,7 @@ private:
         return makeUnique<MediaPlayerPrivateGStreamerMSE>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateGStreamerMSE::getSupportedTypes(types);
     }
@@ -351,7 +351,7 @@ void MediaPlayerPrivateGStreamerMSE::startSource(const Vector<RefPtr<MediaSource
     webKitMediaSrcEmitStreams(WEBKIT_MEDIA_SRC(m_source.get()), tracks);
 }
 
-void MediaPlayerPrivateGStreamerMSE::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateGStreamerMSE::getSupportedTypes(HashSet<String>& types)
 {
     GStreamerRegistryScannerMSE::getSupportedDecodingTypes(types);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -91,7 +91,7 @@ public:
 
 private:
     friend class MediaPlayerFactoryGStreamerMSE;
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedTypes(HashSet<String>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
     friend class AppendPipeline;

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -102,9 +102,9 @@ RefPtr<TextureMapperPlatformLayerProxy> MediaPlayerPrivateHolePunch::proxy() con
 }
 #endif
 
-static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
+static HashSet<String>& mimeTypeCache()
 {
-    static NeverDestroyed<HashSet<String, ASCIICaseInsensitiveHash>> cache;
+    static NeverDestroyed<HashSet<String>> cache;
     static bool typeListInitialized = false;
 
     if (typeListInitialized)
@@ -122,7 +122,7 @@ static HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
     return cache;
 }
 
-void MediaPlayerPrivateHolePunch::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateHolePunch::getSupportedTypes(HashSet<String>& types)
 {
     types = mimeTypeCache();
 }
@@ -151,7 +151,7 @@ private:
         return makeUnique<MediaPlayerPrivateHolePunch>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateHolePunch::getSupportedTypes(types);
     }

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -102,7 +102,7 @@ public:
 
 private:
     friend class MediaPlayerFactoryHolePunch;
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
+    static void getSupportedTypes(HashSet<String>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
     void notifyReadyState();

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -134,7 +134,7 @@ private:
         return makeUnique<MediaPlayerPrivateMediaFoundation>(player);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MediaPlayerPrivateMediaFoundation::getSupportedTypes(types);
     }
@@ -157,9 +157,9 @@ bool MediaPlayerPrivateMediaFoundation::isAvailable()
     return isMediaFoundationAvailable;
 }
 
-static const HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
+static const HashSet<String>& mimeTypeCache()
 {
-    static NeverDestroyed<HashSet<String, ASCIICaseInsensitiveHash>> cachedTypes;
+    static NeverDestroyed<HashSet<String>> cachedTypes;
 
     if (cachedTypes.get().size() > 0)
         return cachedTypes;
@@ -182,7 +182,7 @@ static const HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
     return cachedTypes;
 }
 
-void MediaPlayerPrivateMediaFoundation::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types)
+void MediaPlayerPrivateMediaFoundation::getSupportedTypes(HashSet<String>& types)
 {
     types = mimeTypeCache();
 }

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -55,7 +55,7 @@ public:
     ~MediaPlayerPrivateMediaFoundation();
     static void registerMediaEngine(MediaEngineRegistrar);
 
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types);
+    static void getSupportedTypes(HashSet<String>& types);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
     static bool isAvailable();
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -44,7 +44,7 @@ private:
 
     std::unique_ptr<MediaPlayerPrivateInterface> createMediaEnginePlayer(MediaPlayer* player) const final { return makeUnique<MockMediaPlayerMediaSource>(player); }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return MockMediaPlayerMediaSource::getSupportedTypes(types);
     }
@@ -62,16 +62,16 @@ void MockMediaPlayerMediaSource::registerMediaEngine(MediaEngineRegistrar regist
 }
 
 // FIXME: What does the word "cache" mean here?
-static const HashSet<String, ASCIICaseInsensitiveHash>& mimeTypeCache()
+static const HashSet<String>& mimeTypeCache()
 {
-    static NeverDestroyed cache = HashSet<String, ASCIICaseInsensitiveHash> {
+    static NeverDestroyed cache = HashSet<String> {
         "video/mock"_s,
         "audio/mock"_s,
     };
     return cache;
 }
 
-void MockMediaPlayerMediaSource::getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& supportedTypes)
+void MockMediaPlayerMediaSource::getSupportedTypes(HashSet<String>& supportedTypes)
 {
     supportedTypes = mimeTypeCache();
 }
@@ -81,7 +81,7 @@ MediaPlayer::SupportsType MockMediaPlayerMediaSource::supportsType(const MediaEn
     if (!parameters.isMediaSource)
         return MediaPlayer::SupportsType::IsNotSupported;
 
-    auto containerType = parameters.type.containerType();
+    auto containerType = parameters.type.containerType().convertToASCIILowercase();
     if (containerType.isEmpty() || !mimeTypeCache().contains(containerType))
         return MediaPlayer::SupportsType::IsNotSupported;
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -44,7 +44,7 @@ public:
 
     // MediaPlayer Engine Support
     WEBCORE_EXPORT static void registerMediaEngine(MediaEngineRegistrar);
-    static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types);
+    static void getSupportedTypes(HashSet<String>& types);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
     virtual ~MockMediaPlayerMediaSource();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -97,7 +97,7 @@ void RemoteMediaPlayerManagerProxy::getSupportedTypes(MediaPlayerEnums::MediaEng
         return;
     }
 
-    HashSet<String, ASCIICaseInsensitiveHash> engineTypes;
+    HashSet<String> engineTypes;
     engine->getSupportedTypes(engineTypes);
 
     auto result = WTF::map(engineTypes, [] (auto& type) {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -52,7 +52,7 @@ bool RemoteMediaPlayerMIMETypeCache::isEmpty() const
     return m_hasPopulatedSupportedTypesCacheFromGPUProcess && m_supportedTypesCache.isEmpty();
 }
 
-HashSet<String, ASCIICaseInsensitiveHash>& RemoteMediaPlayerMIMETypeCache::supportedTypes()
+HashSet<String>& RemoteMediaPlayerMIMETypeCache::supportedTypes()
 {
     ASSERT(isMainRunLoop());
     if (!m_hasPopulatedSupportedTypesCacheFromGPUProcess) {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -46,7 +46,7 @@ public:
     RemoteMediaPlayerMIMETypeCache(RemoteMediaPlayerManager&, WebCore::MediaPlayerEnums::MediaEngineIdentifier);
     ~RemoteMediaPlayerMIMETypeCache() = default;
 
-    HashSet<String, ASCIICaseInsensitiveHash>& supportedTypes();
+    HashSet<String>& supportedTypes();
     WebCore::MediaPlayerEnums::SupportsType supportsTypeAndCodecs(const WebCore::MediaEngineSupportParameters&);
     void addSupportedTypes(const Vector<String>&);
     bool isEmpty() const;
@@ -57,7 +57,7 @@ private:
 
     using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool, bool>;
     std::optional<HashMap<SupportedTypesAndCodecsKey, WebCore::MediaPlayerEnums::SupportsType>> m_supportsTypeAndCodecsCache;
-    HashSet<String, ASCIICaseInsensitiveHash> m_supportedTypesCache;
+    HashSet<String> m_supportedTypesCache;
     bool m_hasPopulatedSupportedTypesCacheFromGPUProcess { false };
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -67,7 +67,7 @@ public:
         return m_manager.createRemoteMediaPlayer(player, m_remoteEngineIdentifier);
     }
 
-    void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>& types) const final
+    void getSupportedTypes(HashSet<String>& types) const final
     {
         return m_manager.getSupportedTypes(m_remoteEngineIdentifier, types);
     }
@@ -210,7 +210,7 @@ MediaPlayerIdentifier RemoteMediaPlayerManager::findRemotePlayerId(const MediaPl
     return { };
 }
 
-void RemoteMediaPlayerManager::getSupportedTypes(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, HashSet<String, ASCIICaseInsensitiveHash>& result)
+void RemoteMediaPlayerManager::getSupportedTypes(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, HashSet<String>& result)
 {
     result = typeCache(remoteEngineIdentifier).supportedTypes();
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -82,7 +82,7 @@ private:
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
     friend class MediaPlayerRemoteFactory;
-    void getSupportedTypes(WebCore::MediaPlayerEnums::MediaEngineIdentifier, HashSet<String, ASCIICaseInsensitiveHash>&);
+    void getSupportedTypes(WebCore::MediaPlayerEnums::MediaEngineIdentifier, HashSet<String>&);
     WebCore::MediaPlayer::SupportsType supportsTypeAndCodecs(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const WebCore::MediaEngineSupportParameters&);
     bool supportsKeySystem(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String& keySystem, const String& mimeType);
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -90,12 +90,6 @@ using JSC::Yarr::RegularExpression;
 
 @implementation WebHTMLRepresentation
 
-static RetainPtr<NSArray> createNSArray(const HashSet<String, ASCIICaseInsensitiveHash>& set)
-{
-    auto vector = copyToVectorOf<NSString *>(set);
-    return adoptNS([[NSArray alloc] initWithObjects:vector.data() count:vector.size()]);
-}
-
 + (NSArray *)supportedMIMETypes
 {
     static NeverDestroyed<RetainPtr<NSArray>> staticSupportedMIMETypes = [[[self supportedNonImageMIMETypes] arrayByAddingObjectsFromArray:


### PR DESCRIPTION
#### 73b6e9fe2ab416a18e1ef0ca356c27fa507f7e63
<pre>
REGRESSION (Safari 17 beta): [MSE] Can no longer play .FLAC inside MP4
<a href="https://bugs.webkit.org/show_bug.cgi?id=260491">https://bugs.webkit.org/show_bug.cgi?id=260491</a>
rdar://114276660

Reviewed by Eric Carlson.

In iOS 17 and macOS Sonoma, -[AVURLAsset isPlayableExtendedMIMEType:] is much more restrictive when
reporting which codec types are supported. Previously, any CoreMedia FourCC code was listed as
playable when paired with an ISO BMFF container type such as &quot;video/mp4&quot;. Now, only those codec
strings listed with the MP4 registration authority are considered valid. Since the official MP4RA
string for the Flac audio codec is &quot;fLaC&quot;, this means that whereas `audio/mp4; codecs=&quot;flac&quot;` would
previously succeed, those queries will now fail.

While it is technically &quot;correct&quot; to reject the &quot;flac&quot; codec string when paired with ISO BMFF, there
are a number of pages which are currently broken due to this change, so transform &quot;flac&quot; to &quot;fLaC&quot;
at the WebCore layer.

Additionally, while MIME container types are case-insensitive, the codec parameters on those
container types are case-sensitive, so every Hash container where WebKit caches media MIME types
must be changed from ASCIICaseInsensitiveHash to the default StringHash. This prevents both false
positives and false negatives if the correct or incorrectly-cased versions are queried first.

* LayoutTests/media/media-can-play-case-sensitive-flac-expected.txt: Added.
* LayoutTests/media/media-can-play-case-sensitive-flac.html: Added.
* LayoutTests/media/media-can-play-type-case-sensitive-expected.txt: Added.
* LayoutTests/media/media-can-play-type-case-sensitive.html: Added.
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::supportedMediaMIMETypes):
* Source/WebCore/platform/MIMETypeRegistry.h:
* Source/WebCore/platform/graphics/MIMETypeCache.cpp:
(WebCore::MIMETypeCache::supportedTypes):
(WebCore::MIMETypeCache::canDecodeType):
(WebCore::MIMETypeCache::addSupportedTypes):
(WebCore::MIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/MIMETypeCache.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::getSupportedTypes):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::staticMIMETypeList):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::AVAssetMIMETypeCache::canDecodeExtendedType):
(WebCore::AVAssetMIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::supportedTypes):
(WebCore::AVStreamDataParserMIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::getSupportedTypes):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::getSupportedTypes):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::mimeTypeCache):
(WebCore::MediaPlayerPrivateWebM::getSupportedTypes):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::mimeTypeCache):
(WebCore::MockMediaPlayerMediaSource::getSupportedTypes):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::getSupportedTypes):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::getSupportedTypes):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(createNSArray): Deleted.

Canonical link: <a href="https://commits.webkit.org/267250@main">https://commits.webkit.org/267250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d6ff1f776883d8af4e9485ceb521119fee38040

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16073 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16498 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18600 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21390 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13843 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14963 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17941 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12972 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16273 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14372 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4057 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18901 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17438 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15118 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3851 "Passed tests") | 
<!--EWS-Status-Bubble-End-->