### PR TITLE
Revert 266884@main

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -163,11 +163,6 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 {
     for (auto& transaction : transactions)
         commitLayerTreeTransaction(connection, transaction.first, transaction.second);
-
-    if (std::exchange(m_commitLayerTreeMessageState, NeedsDisplayDidRefresh) == MissedCommit)
-        didRefreshDisplay();
-
-    scheduleDisplayRefreshCallbacks();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection& connection, const RemoteLayerTreeTransaction& layerTreeTransaction, const RemoteScrollingCoordinatorTransaction& scrollingTreeTransaction)
@@ -250,6 +245,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     }
 
     m_webPageProxy.layerTreeCommitComplete();
+
+    if (!layerTreeTransaction.isMainFrameProcessTransaction())
+        connection.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
+    else if (std::exchange(m_commitLayerTreeMessageState, NeedsDisplayDidRefresh) == MissedCommit)
+        didRefreshDisplay();
+
+    scheduleDisplayRefreshCallbacks();
 
     if (didUpdateEditorState)
         m_webPageProxy.dispatchDidUpdateEditorState();

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -125,13 +125,8 @@ public:
     virtual void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) = 0;
     virtual void addRootFrame(WebCore::FrameIdentifier) { }
     // FIXME: Add a corresponding removeRootFrame.
-
-    // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;
-    // Cause a rendering update to happen at the next suitable time,
-    // as determined by the drawing area.
     virtual bool scheduleRenderingUpdate() { return false; }
-
     virtual void renderingUpdateFramesPerSecondChanged() { }
 
     virtual void willStartRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -146,7 +146,7 @@ void RemoteLayerTreeDrawingArea::setRootCompositingLayer(WebCore::Frame& frame, 
             rootLayer.contentLayer = rootGraphicsLayer;
     }
     updateRootLayers();
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight&, CompletionHandler<void()>&& completionHandler)
@@ -170,7 +170,7 @@ void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool fl
         size = contentSize;
     }
 
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
     completionHandler();
 }
 
@@ -224,7 +224,7 @@ void RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen(bool isFrozen)
 
     if (!m_isRenderingSuspended && m_hasDeferredRenderingUpdate) {
         m_hasDeferredRenderingUpdate = false;
-        scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+        startRenderingUpdateTimer();
     }
 }
 
@@ -234,7 +234,7 @@ void RemoteLayerTreeDrawingArea::forceRepaint()
         return;
 
     m_webPage.corePage()->forceRepaintAllFrames();
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    updateRendering();
 }
 
 void RemoteLayerTreeDrawingArea::acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier layerID, const String& key, MonotonicTime startTime)
@@ -273,23 +273,24 @@ void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedC
         return;
 
     frameView->setExposedContentRect(exposedContentRect);
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::startRenderingUpdateTimer()
 {
-    RELEASE_ASSERT(m_state != State::WaitingForDisplayDidRefresh);
-    if (m_updateRenderingTimer.isActive()) {
-        RELEASE_ASSERT(m_state == State::WaitingForUpdateRenderingTimer);
+    if (m_updateRenderingTimer.isActive())
         return;
-    }
-    m_state = State::WaitingForUpdateRenderingTimer;
     m_updateRenderingTimer.startOneShot(0_s);
 }
 
 void RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
 {
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    if (m_isRenderingSuspended) {
+        m_hasDeferredRenderingUpdate = true;
+        return;
+    }
+
+    startRenderingUpdateTimer();
 }
 
 void RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageDecoding()
@@ -299,23 +300,22 @@ void RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageD
 
 void RemoteLayerTreeDrawingArea::updateRendering()
 {
-    RELEASE_ASSERT(m_updateRenderingIsPending);
-    RELEASE_ASSERT(m_state == State::WaitingForUpdateRenderingTimer);
-    m_updateRenderingIsPending = false;
-
     if (m_isRenderingSuspended) {
         m_hasDeferredRenderingUpdate = true;
         return;
     }
 
+    if (m_waitingForBackingStoreSwap) {
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
+        return;
+    }
+
     // This function is not reentrant, e.g. a rAF callback may force repaint.
-    RELEASE_ASSERT(!m_inUpdateRendering);
+    if (m_inUpdateRendering)
+        return;
 
     if (auto* page = m_webPage.corePage(); page && !page->rootFrames().computeSize())
         return;
-
-    RELEASE_ASSERT(!m_updateRenderingTimer.isActive());
-    m_state = State::WaitingForDisplayDidRefresh;
 
     scaleViewToFitDocumentIfNeeded();
 
@@ -371,6 +371,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         
         willCommitLayerTree(layerTransaction);
 
+        m_waitingForBackingStoreSwap = true;
+
         send(Messages::RemoteLayerTreeDrawingAreaProxy::WillCommitLayerTree(layerTransaction.transactionID()));
 
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
@@ -421,7 +423,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
     // FIXME: This should use a counted replacement for setLayerTreeStateIsFrozen, but
     // the callers of that function are not strictly paired.
 
-    RELEASE_ASSERT(m_state == State::WaitingForDisplayDidRefresh);
+    auto wasWaitingForBackingStoreSwap = std::exchange(m_waitingForBackingStoreSwap, false);
 
     if (!WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM)) {
         // This empty transaction serves to trigger CA's garbage collection of IOSurfaces. See <rdar://problem/16110687>
@@ -429,10 +431,12 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
         [CATransaction commit];
     }
 
-    m_state = State::Idle;
-    RELEASE_ASSERT(!m_updateRenderingTimer.isActive());
-    if (m_updateRenderingIsPending && !m_scheduleRenderingTimer.isActive())
-        startRenderingUpdateTimer();
+    if (m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap || (m_isScheduled && !m_scheduleRenderingTimer.isActive())) {
+        triggerRenderingUpdate();
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
+        m_isScheduled = false;
+    } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
     else
         send(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTreeNotTriggered(nextTransactionID()));
 }
@@ -494,7 +498,7 @@ void RemoteLayerTreeDrawingArea::activityStateDidChange(OptionSet<WebCore::Activ
     if (activityStateChangeID != ActivityStateChangeAsynchronous) {
         m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding();
         m_activityStateChangeID = activityStateChangeID;
-        scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+        startRenderingUpdateTimer();
     }
 
     // FIXME: We may want to match behavior in TiledCoreAnimationDrawingArea by firing these callbacks after the next compositing flush, rather than immediately after
@@ -509,7 +513,7 @@ void RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing(IPC::AsyncReplyID 
     m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding();
 
     m_pendingCallbackIDs.append(callbackID);
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDrawingArea)
@@ -523,45 +527,32 @@ void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDraw
 
 void RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired()
 {
-    if (m_state == State::WaitingForScheduleRenderingTimer)
-        startRenderingUpdateTimer();
-}
-
-void RemoteLayerTreeDrawingArea::scheduleRenderingUpdate(ScheduleRenderingUrgency urgency)
-{
-    if (m_updateRenderingIsPending && urgency != ScheduleRenderingUrgency::AsSoonAsPossible)
-        return;
-
-    tracePoint(RemoteLayerTreeScheduleRenderingUpdate, m_state == State::WaitingForDisplayDidRefresh);
-
-    m_updateRenderingIsPending = true;
-
-    if (m_preferredFramesPerSecond) {
-        if (m_state == State::WaitingForDisplayDidRefresh)
-            return;
-
-        if (urgency == ScheduleRenderingUrgency::AsSoonAsPossible)
-            startRenderingUpdateTimer();
-        else {
-            m_state = State::WaitingForCallOnMainRunLoop;
-            callOnMainRunLoop([self = WeakPtr { this }] () {
-                // It's possible that an ASAP request got ahead of this
-                // and started a rendering update already and we're no
-                // longer waiting for this callback.
-                if (self && self->m_state == State::WaitingForCallOnMainRunLoop)
-                    self->startRenderingUpdateTimer();
-            });
-        }
-    } else if (m_state == State::Idle || m_state == State::WaitingForDisplayDidRefresh) {
-        ASSERT(!m_scheduleRenderingTimer.isActive());
-        m_state = State::WaitingForScheduleRenderingTimer;
-        m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);
-    }
+    triggerRenderingUpdate();
+    m_isScheduled = false;
 }
 
 bool RemoteLayerTreeDrawingArea::scheduleRenderingUpdate()
 {
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::NextSuitableTime);
+    if (m_isScheduled)
+        return true;
+
+    tracePoint(RemoteLayerTreeScheduleRenderingUpdate, m_waitingForBackingStoreSwap);
+
+    m_isScheduled = true;
+
+    if (m_preferredFramesPerSecond) {
+        if (displayDidRefreshIsPending())
+            return true;
+
+        callOnMainRunLoop([self = WeakPtr { this }] () {
+            if (self) {
+                self->m_isScheduled = false;
+                self->triggerRenderingUpdate();
+            }
+        });
+    } else
+        m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);
+
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -79,7 +79,7 @@ void RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage(double scale, Float
     FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     unscrolledOrigin.moveBy(-unobscuredContentRect.location());
     m_webPage.scalePage(scale / m_webPage.viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    updateRendering();
 }
 
 void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::FloatPoint origin)


### PR DESCRIPTION
#### 8b08522cfac867bec58937c4153f47a59166de75
<pre>
Revert 266884@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=260566">https://bugs.webkit.org/show_bug.cgi?id=260566</a>
rdar://114295072

Unreviewed.

It broke drawing with site isolation enabled, and broke several site isolation tests.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefreshIsPending const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer):
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::RemoteLayerTreeDrawingArea::forceRepaint):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):

Canonical link: <a href="https://commits.webkit.org/267173@main">https://commits.webkit.org/267173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2e0cb91b05cb32c070c91a8a187e325e7d1527c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17632 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/14895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16286 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16530 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18390 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13779 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14771 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15097 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/18707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1946 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->