### PR TITLE
Remove single Mode::Rfc2045 caller in CDMPrivate

### DIFF
--- a/LayoutTests/platform/mac/media/encrypted-media/videoCapabilities-contentType-parsing-expected.txt
+++ b/LayoutTests/platform/mac/media/encrypted-media/videoCapabilities-contentType-parsing-expected.txt
@@ -1,0 +1,6 @@
+Test contentType video/mp4XXX; codecs="avc1.64001F"
+Promise rejected correctly OK
+Test contentType video/mp4 ; codecs="avc1.64001F"
+Promise resolved OK
+END OF TEST
+

--- a/LayoutTests/platform/mac/media/encrypted-media/videoCapabilities-contentType-parsing.html
+++ b/LayoutTests/platform/mac/media/encrypted-media/videoCapabilities-contentType-parsing.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<title>videoCapabilities contentType parsing</title>
+<script src="../../../../media/video-test.js"></script>
+<script>
+window.addEventListener('load', async event => {
+    const tests = [
+        {
+            "input": 'video/mp4XXX; codecs="avc1.64001F"',
+            "success": false
+        },
+        {
+            "input": '\nvideo/mp4\n; codecs="avc1.64001F"',
+            "success": true
+        }
+    ];
+
+    try {
+        for (const { input, success } of tests) {
+            consoleWrite("Test contentType " + input);
+            const access = navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{
+                initDataTypes: ["cenc"],
+                videoCapabilities: [{contentType : input}]
+            }]);
+            await (success ? shouldResolve(access) : shouldReject(access));
+        }
+    } catch(e) {
+    } finally {
+        endTest();
+    }
+});
+</script>

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -386,12 +386,12 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
             return std::nullopt;
 
         // 3.4. If content type is an invalid or unrecognized MIME type, continue to the next iteration.
-        std::optional<ParsedContentType> contentType = ParsedContentType::create(requestedCapability.contentType, Mode::Rfc2045);
+        auto contentType = ParsedContentType::create(requestedCapability.contentType);
         if (!contentType)
             continue;
 
         // 3.5. Let container be the container type specified by content type.
-        String container = contentType->mimeType();
+        auto container = contentType->mimeType();
 
         // 3.6. If the user agent does not support container, continue to the next iteration. The case-sensitivity
         //      of string comparisons is determined by the appropriate RFC.
@@ -399,7 +399,7 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
         // 3.8. If the user agent does not recognize one or more parameters, continue to the next iteration.
         // 3.9. Let media types be the set of codecs and codec constraints specified by parameters. The case-sensitivity
         //      of string comparisons is determined by the appropriate RFC or other specification.
-        String codecs = contentType->parameterValueForName("codecs"_s);
+        auto codecs = contentType->parameterValueForName("codecs"_s);
         if (contentType->parameterCount() > (codecs.isEmpty() ? 0 : 1))
             continue;
 


### PR DESCRIPTION
#### 0be8627dc40bb69cf288da969a27d662c6416a01
<pre>
Remove single Mode::Rfc2045 caller in CDMPrivate
<a href="https://bugs.webkit.org/show_bug.cgi?id=260605">https://bugs.webkit.org/show_bug.cgi?id=260605</a>
<a href="https://rdar.apple.com/114311586">rdar://114311586</a>

Reviewed by Jean-Yves Avenard.

The specification appears to require use of the MIME Sniffing standard
definition of MIME type albeit somewhat poorly written. We also don&apos;t
want to have multiple MIME type parsers in our code base.

* LayoutTests/platform/mac/media/encrypted-media/videoCapabilities-contentType-parsing-expected.txt: Added.
* LayoutTests/platform/mac/media/encrypted-media/videoCapabilities-contentType-parsing.html: Added.
* Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
(WebCore::CDMPrivate::getSupportedCapabilitiesForAudioVideoType):

Canonical link: <a href="https://commits.webkit.org/288916@main">https://commits.webkit.org/288916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97ec84d8c437f8c3556ffc1d8d2ae31b4ff88395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35686 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65878 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74350 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17843 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3416 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17366 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->