### PR TITLE
WebGL DEPTH and STENCIL_ATTACHMENT overwrite deletes DEPTH_STENCIL_ATTACHMENT object prematurely

### DIFF
--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/renderbuffers/framebuffer-object-attachment.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/renderbuffers/framebuffer-object-attachment.html
@@ -111,9 +111,10 @@ function testFramebufferWebGL1RequiredCombinations() {
     gl.deleteFramebuffer(fbo);
 }
 
-function testDepthStencilAttachmentBehaviors() {
+function testDepthStencilAttachmentBehaviors(testOrphanedRenderbuffers) {
+    let suffix = testOrphanedRenderbuffers ? " with deleted renderbuffer" : "";
     debug("");
-    debug("Checking ES3 DEPTH_STENCIL_ATTACHMENT behaviors are implemented for WebGL 2");
+    debug("Checking ES3 DEPTH_STENCIL_ATTACHMENT behaviors are implemented for WebGL 2" + suffix);
     // DEPTH_STENCIL_ATTACHMENT is treated as an independent attachment point in WebGL 1;
     // however, in WebGL 2, it is treated as an alias for DEPTH_ATTACHMENT + STENCIL_ATTACHMENT.
     var size = 16;
@@ -127,24 +128,45 @@ function testDepthStencilAttachmentBehaviors() {
     gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, size, size);
     checkFramebuffer([gl.FRAMEBUFFER_COMPLETE]);
 
-    var depthBuffer = gl.createRenderbuffer();
-    gl.bindRenderbuffer(gl.RENDERBUFFER, depthBuffer);
-    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, size, size);
+    function createDepthBuffer() {
+        let buffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, size, size);
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+        return buffer;
+    }
 
-    var stencilBuffer = gl.createRenderbuffer();
-    gl.bindRenderbuffer(gl.RENDERBUFFER, stencilBuffer);
-    gl.renderbufferStorage(gl.RENDERBUFFER, gl.STENCIL_INDEX8, size, size);
+    function createStencilBuffer() {
+        let buffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.STENCIL_INDEX8, size, size);
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+        return buffer;
+    }
 
-    var depthStencilBuffer = gl.createRenderbuffer();
-    gl.bindRenderbuffer(gl.RENDERBUFFER, depthStencilBuffer);
-    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, size, size);
+    function createDepthStencilBuffer() {
+        let buffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, size, size);
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+        return buffer;
+    }
+
+    function orphan(renderbuffer) {
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.deleteRenderbuffer(renderbuffer);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    }
 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
     debug("");
-    debug("color + depth");
+    debug("color + depth" + suffix);
+    var depthBuffer = createDepthBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
@@ -153,9 +175,12 @@ function testDepthStencilAttachmentBehaviors() {
     checkBufferBits(gl.DEPTH_ATTACHMENT);
 
     debug("");
-    debug("color + depth + stencil: depth != stencil");
+    debug("color + depth + stencil: depth != stencil" + suffix);
+    var stencilBuffer = createStencilBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, stencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(stencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", stencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
@@ -170,9 +195,12 @@ function testDepthStencilAttachmentBehaviors() {
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
 
     debug("");
-    debug("color + depth: DEPTH_STENCIL for DEPTH_ATTACHMENT");
+    debug("color + depth: DEPTH_STENCIL for DEPTH_ATTACHMENT" + suffix);
+    var depthStencilBuffer = createDepthStencilBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
@@ -181,9 +209,16 @@ function testDepthStencilAttachmentBehaviors() {
     checkBufferBits(gl.DEPTH_ATTACHMENT);
 
     debug("");
-    debug("color + depth + stencil: DEPTH_STENCIL for DEPTH_ATTACHMENT and STENCIL_ATTACHMENT");
+    debug("color + depth + stencil: DEPTH_STENCIL for DEPTH_ATTACHMENT and STENCIL_ATTACHMENT" + suffix);
+    if (testOrphanedRenderbuffers) {
+        depthStencilBuffer = createDepthStencilBuffer();
+        gl.framebufferRenderbuffer(
+            gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    }
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
@@ -192,7 +227,7 @@ function testDepthStencilAttachmentBehaviors() {
     checkBufferBits(gl.DEPTH_STENCIL_ATTACHMENT);
 
     debug("");
-    debug("color + depth_stencil");
+    debug("color + depth_stencil" + suffix);
     var texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH24_STENCIL8, size, size, 0, gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, null);
@@ -209,8 +244,12 @@ function testDepthStencilAttachmentBehaviors() {
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
+    if (testOrphanedRenderbuffers)
+        depthStencilBuffer = createDepthStencilBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
@@ -219,16 +258,24 @@ function testDepthStencilAttachmentBehaviors() {
     checkBufferBits(gl.DEPTH_STENCIL_ATTACHMENT);
 
     debug("");
-    debug("DEPTH_STENCIL_ATTACHMENT overwrites DEPTH_ATTACHMENT/STENCIL_ATTACHMENT")
+    debug("DEPTH_STENCIL_ATTACHMENT overwrites DEPTH_ATTACHMENT/STENCIL_ATTACHMENT" + suffix);
+    if (testOrphanedRenderbuffers)
+        depthBuffer = createDepthBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
 
+    if (testOrphanedRenderbuffers)
+        depthStencilBuffer = createDepthStencilBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
@@ -244,9 +291,13 @@ function testDepthStencilAttachmentBehaviors() {
     checkBufferBits();
 
     debug("");
-    debug("STENCIL_ATTACHMENT overwrites stencil set by DEPTH_STENCIL_ATTACHMENT")
+    debug("STENCIL_ATTACHMENT overwrites stencil set by DEPTH_STENCIL_ATTACHMENT" + suffix);
+    if (testOrphanedRenderbuffers)
+        depthStencilBuffer = createDepthStencilBuffer();
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
     shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
@@ -260,6 +311,28 @@ function testDepthStencilAttachmentBehaviors() {
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
     checkFramebuffer([gl.FRAMEBUFFER_COMPLETE]);
     checkBufferBits(gl.DEPTH_ATTACHMENT);
+
+    debug("");
+    debug("DEPTH_ATTACHMENT overwrites depth set by DEPTH_STENCIL_ATTACHMENT" + suffix);
+    if (testOrphanedRenderbuffers)
+        depthStencilBuffer = createDepthStencilBuffer();
+    gl.framebufferRenderbuffer(
+        gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
+    if (testOrphanedRenderbuffers)
+        orphan(depthStencilBuffer);
+    shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
+    shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
+    shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+    gl.framebufferRenderbuffer(
+        gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, null);
+    shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
+    shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", depthStencilBuffer);
+    shouldEvaluateTo("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
+    checkFramebuffer([gl.FRAMEBUFFER_COMPLETE]);
+    checkBufferBits(gl.STENCIL_ATTACHMENT);
 }
 
 function testFramebufferIncompleteAttachment() {
@@ -469,7 +542,8 @@ description("Test framebuffer object attachment behaviors");
 shouldBeNonNull("gl = wtu.create3DContext(undefined, undefined, 2)");
 
 testFramebufferWebGL1RequiredCombinations();
-testDepthStencilAttachmentBehaviors();
+testDepthStencilAttachmentBehaviors(false);
+testDepthStencilAttachmentBehaviors(true);
 testFramebufferIncompleteAttachment();
 testFramebufferIncompleteMissingAttachment();
 testFramebufferWithImagesOfDifferentSizes();

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -53,7 +53,6 @@ public:
 
         virtual WebGLObject* getObject() const = 0;
         virtual bool isSharedObject(WebGLObject*) const = 0;
-        virtual bool isValid() const = 0;
         virtual void onDetached(const AbstractLocker&, GraphicsContextGL*) = 0;
         virtual void attach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) = 0;
         virtual void unattach(GraphicsContextGL*, GCGLenum target, GCGLenum attachment) = 0;
@@ -74,12 +73,9 @@ public:
     void setAttachmentForBoundFramebuffer(GCGLenum target, GCGLenum attachment, WebGLRenderbuffer*);
     // If an object is attached to the currently bound framebuffer, remove it.
     void removeAttachmentFromBoundFramebuffer(const AbstractLocker&, GCGLenum target, WebGLObject*);
-    // If a given attachment point for the currently bound framebuffer is not null, remove the attached object.
-    void removeAttachmentFromBoundFramebuffer(const AbstractLocker&, GCGLenum target, GCGLenum attachment);
     WebGLObject* getAttachmentObject(GCGLenum) const;
 
     void didBind() { m_hasEverBeenBound = true; }
-    bool hasStencilBuffer() const;
 
     // Wrapper for drawBuffersEXT/drawBuffersARB to work around a driver bug.
     void drawBuffers(const Vector<GCGLenum>& bufs);
@@ -105,6 +101,9 @@ private:
     WebGLFramebuffer(WebGLRenderingContextBase&, PlatformGLObject, Type);
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
+
+    // If a given attachment point for the currently bound framebuffer is not null, remove the attached object.
+    void removeAttachmentFromBoundFramebuffer(const AbstractLocker&, GCGLenum target, GCGLenum attachment);
 
     WebGLAttachment* getAttachment(GCGLenum) const;
 

--- a/Source/WebCore/html/canvas/WebGLObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLObject.cpp
@@ -95,13 +95,9 @@ void WebGLObject::deleteObject(const AbstractLocker& locker, GraphicsContextGL* 
         m_object = 0;
 }
 
-void WebGLObject::detach()
-{
-    m_attachmentCount = 0; // Make sure OpenGL resource is deleted.
-}
-
 void WebGLObject::onDetached(const AbstractLocker& locker, GraphicsContextGL* context3d)
 {
+    ASSERT(m_attachmentCount); // FIXME: handle attachment with WebGLAttachmentPoint RAII object and remove the ifs.
     if (m_attachmentCount)
         --m_attachmentCount;
     if (m_deleted)

--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -123,8 +123,6 @@ protected:
     // deleteObjectImpl should be only called once to delete the OpenGL resource.
     virtual void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) = 0;
 
-    virtual void detach();
-
     WeakPtr<WebGLRenderingContextBase> m_context;
 private:
     PlatformGLObject m_object { 0 };


### PR DESCRIPTION
#### 491458f894ee187a16daa0824656b2752ce614a6
<pre>
WebGL DEPTH and STENCIL_ATTACHMENT overwrite deletes DEPTH_STENCIL_ATTACHMENT object prematurely
<a href="https://bugs.webkit.org/show_bug.cgi?id=260606">https://bugs.webkit.org/show_bug.cgi?id=260606</a>
rdar://problem/114317226

Reviewed by Dan Glastonbury.

In WebGL2, DEPTH_STENCIL_ATTACHMENT attachment point is simulated
and changes DEPTH_ATTACHMENT and STENCIL_ATTACHMENT.
WebGLFramebuffer would store the attachment to
 - DEPTH_STENCIL_ATTACHMENT
 - DEPTH_ATTACHMENT
 - STENCIL_ATTACHMENT
However, it would call onAttached() only for the first one.
If the attachments would be modified with DEPTH_ATTACHMENT
or STENCIL_ATTACHMENT, the modification would result in
onDetached for these modifications. This imbalance of attach/detach
would leave the attachment counters inconsistent.

The bug would be observable when attaching a renderbuffer or texture and
then deleting it (orphaning). In this case the imbalanced detach would
delete the object, and queries about the object name through the framebuffer
attachment point would return &quot;not found&quot;, since the object was really
deleted and not only orphaned.

* LayoutTests/webgl/resources/webgl_test_files/conformance2/renderbuffers/framebuffer-object-attachment.html:
This will be upstreamed to the CTS later.
Test that DEPTH_STENCIL_ATTACHMENT behavior with normal buffers are
the same as with orphaned buffers.

* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::setAttachmentForBoundFramebuffer):
(WebCore::WebGLFramebuffer::removeAttachmentFromBoundFramebuffer):
(WebCore::WebGLFramebuffer::setAttachmentInternal):
(WebCore::WebGLFramebuffer::removeAttachmentInternal):
(WebCore::WebGLFramebuffer::hasStencilBuffer const): Deleted.
Delete unused function.

* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLObject.cpp:
(WebCore::WebGLObject::onDetached):
(WebCore::WebGLObject::detach): Deleted.
Delete unused function.

* Source/WebCore/html/canvas/WebGLObject.h:

Canonical link: <a href="https://commits.webkit.org/267422@main">https://commits.webkit.org/267422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/417a0065085d3f3913f169d4b123ad0ed1fa080b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17799 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19024 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21720 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14887 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3962 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->