### PR TITLE
Fix container selection for container units in pseudo elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006-expected.txt
@@ -1,12 +1,12 @@
 First-line
 First-line
 
-FAIL Originating element container for ::before assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::after assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::marker assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::first-line assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::first-letter assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for outer ::first-line assert_equals: expected "30px" but got "40px"
-FAIL Originating element container for outer ::first-letter assert_equals: expected "30px" but got "40px"
-FAIL Originating element container for ::backdrop assert_equals: ::backdrop rendered expected "10px" but got "30px"
+PASS Originating element container for ::before
+PASS Originating element container for ::after
+PASS Originating element container for ::marker
+PASS Originating element container for ::first-line
+PASS Originating element container for ::first-letter
+PASS Originating element container for outer ::first-line
+PASS Originating element container for outer ::first-letter
+PASS Originating element container for ::backdrop
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007-expected.txt
@@ -5,10 +5,10 @@ PASS Initial font-size for ::marker
 PASS Initial font-size for ::first-line
 PASS Initial font-size for ::first-letter
 PASS Initial font-size for ::backdrop
-FAIL font-size for ::before depending on container assert_equals: expected "30px" but got "80px"
-FAIL font-size for ::after depending on container assert_equals: expected "30px" but got "80px"
-FAIL font-size for ::marker depending on container assert_equals: expected "30px" but got "80px"
-FAIL font-size for ::first-line depending on container assert_equals: expected "30px" but got "80px"
-FAIL font-size for ::first-letter depending on container assert_equals: expected "30px" but got "80px"
-FAIL font-size for ::backdrop depending on container assert_equals: expected "30px" but got "80px"
+PASS font-size for ::before depending on container
+PASS font-size for ::after depending on container
+PASS font-size for ::marker depending on container
+PASS font-size for ::first-line depending on container
+PASS font-size for ::first-letter depending on container
+PASS font-size for ::backdrop depending on container
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt
@@ -1,12 +1,12 @@
 First-line
 First-line
 
-FAIL Originating element container for ::before assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::after assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::marker assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::first-line assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for ::first-letter assert_equals: expected "20px" but got "30px"
-FAIL Originating element container for outer ::first-line assert_equals: expected "30px" but got "40px"
-FAIL Originating element container for outer ::first-letter assert_equals: expected "30px" but got "40px"
-FAIL Originating element container for ::backdrop assert_equals: ::backdrop rendered expected "10px" but got "30px"
+PASS Originating element container for ::before
+PASS Originating element container for ::after
+PASS Originating element container for ::marker
+PASS Originating element container for ::first-line
+PASS Originating element container for ::first-letter
+PASS Originating element container for outer ::first-line
+PASS Originating element container for outer ::first-letter
+PASS Originating element container for ::backdrop
 


### PR DESCRIPTION
#### 508ac946574ee4391a8cfbec22af8c95bd8ea57b
<pre>
Fix container selection for container units in pseudo elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=253939">https://bugs.webkit.org/show_bug.cgi?id=253939</a>
rdar://106739553

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/pseudo-elements-008-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::computeNonCalcLengthDouble):

Tell the container selection algorithm that we selecting for a pseudo-element.

Canonical link: <a href="https://commits.webkit.org/267197@main">https://commits.webkit.org/267197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f9ca503f54113ff0b5097087eece4da4f3ec245

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18453 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21273 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17812 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12853 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14400 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3806 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->