### PR TITLE
[visionOS] Fullscreen windows do not cast shadows

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -149,6 +149,10 @@
 #import <UIKit/_UIInvalidatable.h>
 #endif
 
+#if PLATFORM(VISION)
+#import <UIKit/UIView+SpatialComputing.h>
+#endif
+
 // FIXME: STAGING for rdar://75546704 Remove later.
 #define UIWKSelectionFlipped 2
 
@@ -739,6 +743,20 @@ typedef NS_ENUM (NSInteger, _UIBackdropMaskViewFlags) {
 - (UIColor *)_inheritedInteractionTintColor;
 - (NSString *)recursiveDescription;
 @end
+
+#if PLATFORM(VISION)
+
+typedef NS_ENUM(NSInteger, _UIPlatterGroundingShadowVisibility) {
+    _UIPlatterGroundingShadowVisibilityAutomatic = 0,
+    _UIPlatterGroundingShadowVisibilityVisible = 1,
+    _UIPlatterGroundingShadowVisibilityHidden = 2
+};
+
+@interface UIView (SpatialComputing)
+@property (nonatomic, setter=_setPreferredGroundingShadowVisibility:) _UIPlatterGroundingShadowVisibility _preferredGroundingShadowVisibility;
+@end
+
+#endif
 
 typedef NS_ENUM(NSInteger, UIWKSelectionTouch) {
     UIWKSelectionTouchStarted = 0,

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -825,6 +825,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         [_window setAlpha:0];
         [_window setClipsToBounds:YES];
         [_window _setContinuousCornerRadius:kFullScreenWindowCornerRadius];
+        [_window _setPreferredGroundingShadowVisibility:_UIPlatterGroundingShadowVisibilityVisible];
         [_window setNeedsLayout];
         [_window layoutIfNeeded];
     }


### PR DESCRIPTION
#### b938895dd2133d2caa69e79f4b525e252b61dbd6
<pre>
[visionOS] Fullscreen windows do not cast shadows
<a href="https://bugs.webkit.org/show_bug.cgi?id=260620">https://bugs.webkit.org/show_bug.cgi?id=260620</a>
rdar://114049859

Reviewed by Richard Robinson and Tim Horton.

Adopt UIKit SPI to add a grounding shadow to the fullscreen window. The
fullscreen window does not get a shadow by default since it&apos;s not platter-backed.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):

Canonical link: <a href="https://commits.webkit.org/267201@main">https://commits.webkit.org/267201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3893ba7bf7d880c3e6494f0ffbe01ca6d8be5e18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14961 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16355 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18457 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13844 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21278 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17817 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18773 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1953 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->