### PR TITLE
VideoDecoder.configure should not throw on unsupported codecs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
@@ -1,13 +1,26 @@
 
+PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Missing codec
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Empty codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Unrecognized codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Audio codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
+PASS Test that VideoDecoder.configure() rejects invalid config:Missing codec
 PASS Test that VideoDecoder.configure() rejects invalid config:Empty codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Unrecognized codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Audio codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Ambiguous codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Codec with MIME type
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecognized codec with dataview description
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Audio codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Codec with MIME type
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized codec
+PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized codec with dataview description
+PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
+PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction
+PASS Test that VideoDecoder.isConfigSupported() accepts config:valid codec with spaces
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
@@ -3,26 +3,14 @@
 
 const invalidConfigs = [
   {
+    comment: 'Missing codec',
+    config: {},
+  },
+  {
     comment: 'Empty codec',
     config: {codec: ''},
   },
-  {
-    comment: 'Unrecognized codec',
-    config: {codec: 'bogus'},
-  },
-  {
-    comment: 'Audio codec',
-    config: {codec: 'vorbis'},
-  },
-  {
-    comment: 'Ambiguous codec',
-    config: {codec: 'vp9'},
-  },
-  {
-    comment: 'Codec with MIME type',
-    config: {codec: 'video/webm; codecs="vp8"'},
-  },
-];  //  invalidConfigs
+];  // invalidConfigs
 
 invalidConfigs.forEach(entry => {
   promise_test(
@@ -47,6 +35,84 @@ invalidConfigs.forEach(entry => {
           entry.comment);
 });
 
+const arrayBuffer = new ArrayBuffer(12583);
+const arrayBufferView = new DataView(arrayBuffer);
+
+const validButUnsupportedConfigs = [
+  {
+    comment: 'Unrecognized codec',
+    config: {codec: 'bogus'},
+  },
+  {
+    comment: 'Unrecognized codec with dataview description',
+    config: {
+      codec: '7󠎢ﷺ۹.9',
+      description: arrayBufferView,
+    },
+  },
+  {
+    comment: 'Audio codec',
+    config: {codec: 'vorbis'},
+  },
+  {
+    comment: 'Ambiguous codec',
+    config: {codec: 'vp9'},
+  },
+  {
+    comment: 'Codec with MIME type',
+    config: {codec: 'video/webm; codecs="vp8"'},
+  },
+  {
+    comment: 'Possible future H264 codec string',
+    config: {codec: 'avc1.FF000b'},
+  },
+  {
+    comment: 'Possible future HEVC codec string',
+    config: {codec: 'hvc1.C99.6FFFFFF.L93'},
+  },
+  {
+    comment: 'Possible future VP9 codec string',
+    config: {codec: 'vp09.99.99.08'},
+  },
+  {
+    comment: 'Possible future AV1 codec string',
+    config: {codec: 'av01.9.99M.08'},
+  },
+];  //  validButUnsupportedConfigs
+
+validButUnsupportedConfigs.forEach(entry => {
+  promise_test(
+      t => {
+        return VideoDecoder.isConfigSupported(entry.config).then(support => {
+          assert_false(support.supported);
+        });
+      },
+      'Test that VideoDecoder.isConfigSupported() doesn\'t support config: ' +
+          entry.comment);
+});
+
+validButUnsupportedConfigs.forEach(entry => {
+  promise_test(
+    async t => {
+        const callbacks = {
+          output: t.unreached_func('unexpected output'),
+        };
+        const error = new Promise(resolve => callbacks.error = e => {
+          resolve(e);
+        });
+        let codec = new VideoDecoder(callbacks);
+        codec.configure(entry.config);
+        let e = await error;
+        assert_true(e instanceof DOMException);
+        assert_equals(e.name, 'NotSupportedError');
+        assert_equals(codec.state, 'closed', 'state');
+
+        t.done();
+      },
+      'Test that VideoDecoder.configure() doesn\'t support config: ' +
+          entry.comment);
+});
+
 promise_test(t => {
   // VideoDecoderInit lacks required fields.
   assert_throws_js(TypeError, () => {
@@ -62,3 +128,23 @@ promise_test(t => {
 
   return endAfterEventLoopTurn();
 }, 'Test VideoDecoder construction');
+
+const validConfigs = [
+  {
+    comment: 'valid codec with spaces',
+    config: {codec: '  vp09.00.10.08  '},
+  },
+];  // validConfigs
+
+validConfigs.forEach(entry => {
+  promise_test(
+    async t => {
+      try {
+        await VideoDecoder.isConfigSupported(entry.config);
+      } catch (e) {
+        assert_true(false, entry.comment + ' should not throw');
+      }
+    },
+    'Test that VideoDecoder.isConfigSupported() accepts config:' +
+        entry.comment);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
@@ -1,13 +1,26 @@
 
+PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Missing codec
 PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Empty codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Unrecognized codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Audio codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
-PASS Test that VideoDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
+PASS Test that VideoDecoder.configure() rejects invalid config:Missing codec
 PASS Test that VideoDecoder.configure() rejects invalid config:Empty codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Unrecognized codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Audio codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Ambiguous codec
-PASS Test that VideoDecoder.configure() rejects invalid config:Codec with MIME type
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecognized codec with dataview description
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Audio codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Codec with MIME type
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized codec
+PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized codec with dataview description
+PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
+PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction
+PASS Test that VideoDecoder.isConfigSupported() accepts config:valid codec with spaces
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1149,6 +1149,10 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worke
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?av1 [ Failure ]
 
+# Detection of bad HEVC codec string
+imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.html [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker.html [ Skip ]
+
 # This test is flaky crashing with the current GStreamer version of the SDK (1.22), raising a
 # critical warning in GStreamer, but the issue is not happening with GStreamer 1.23. So this test is
 # expected to pass again once we update to GStreamer 1.24.

--- a/Source/WebCore/platform/graphics/HEVCUtilities.cpp
+++ b/Source/WebCore/platform/graphics/HEVCUtilities.cpp
@@ -64,9 +64,9 @@ std::optional<AVCParameters> parseAVCCodecParameters(StringView codecString)
     auto profileFlagsAndLevel = parseInteger<uint32_t>(*nextElement, 16);
     if (!profileFlagsAndLevel)
         return std::nullopt;
-    parameters.profileIDC = (*profileFlagsAndLevel & 0xF00) >> 16;
-    parameters.constraintsFlags = (*profileFlagsAndLevel & 0xF0) >> 8;
-    parameters.levelIDC = *profileFlagsAndLevel & 0xF;
+    parameters.profileIDC = (*profileFlagsAndLevel >> 16) & 0xFF;
+    parameters.constraintsFlags = (*profileFlagsAndLevel >> 8) & 0xFF;
+    parameters.levelIDC = *profileFlagsAndLevel & 0xFF;
 
     return parameters;
 }

--- a/Source/WebCore/platform/graphics/cocoa/HEVCUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/HEVCUtilitiesCocoa.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 struct MediaCapabilitiesInfo;
 
-std::optional<MediaCapabilitiesInfo> validateHEVCParameters(const HEVCParameters&, bool hasAlphaChannel, bool hdrSupport);
+WEBCORE_EXPORT std::optional<MediaCapabilitiesInfo> validateHEVCParameters(const HEVCParameters&, bool hasAlphaChannel, bool hdrSupport);
 std::optional<MediaCapabilitiesInfo> validateDoViParameters(const DoViParameters&, bool hasAlphaChannel, bool hdrSupport);
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -82,7 +82,7 @@ private:
     // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    void createDecoder(VideoDecoderIdentifier, VideoCodecType, bool useRemoteFrames, bool enableAdditionalLogging);
+    void createDecoder(VideoDecoderIdentifier, VideoCodecType, const String& codecString, bool useRemoteFrames, bool enableAdditionalLogging, CompletionHandler<void(bool)>&&);
     void releaseDecoder(VideoDecoderIdentifier);
     void flushDecoder(VideoDecoderIdentifier);
     void setDecoderFormatDescription(VideoDecoderIdentifier, const IPC::DataReference&, uint16_t width, uint16_t height);

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -24,7 +24,7 @@
 #if USE(LIBWEBRTC) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 messages -> LibWebRTCCodecsProxy NotRefCounted {
-    CreateDecoder(WebKit::VideoDecoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, bool useRemoteFrames, bool enableAdditionalLogging)
+    CreateDecoder(WebKit::VideoDecoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, String codecString, bool useRemoteFrames, bool enableAdditionalLogging) -> (bool success);
     ReleaseDecoder(WebKit::VideoDecoderIdentifier id)
     FlushDecoder(WebKit::VideoDecoderIdentifier id)
     SetDecoderFormatDescription(WebKit::VideoDecoderIdentifier id, IPC::DataReference description, uint16_t width, uint16_t height)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -84,6 +84,7 @@ public:
     public:
         VideoDecoderIdentifier identifier;
         VideoCodecType type;
+        String codec;
         void* decodedImageCallback WTF_GUARDED_BY_LOCK(decodedImageCallbackLock) { nullptr };
         DecoderCallback decoderCallback;
         Lock decodedImageCallbackLock;
@@ -94,7 +95,7 @@ public:
     };
 
     Decoder* createDecoder(VideoCodecType);
-    void createDecoderAndWaitUntilReady(VideoCodecType, Function<void(Decoder&)>&&);
+    void createDecoderAndWaitUntilReady(VideoCodecType, const String& codec, Function<void(Decoder*)>&&);
 
     int32_t releaseDecoder(Decoder&);
     void flushDecoder(Decoder&, Function<void()>&&);
@@ -187,7 +188,7 @@ private:
     template<typename Buffer> bool copySharedVideoFrame(LibWebRTCCodecs::Encoder&, IPC::Connection&, Buffer&&);
     WorkQueue& workQueue() const { return m_queue; }
 
-    Decoder* createDecoderInternal(VideoCodecType, Function<void(Decoder&)>&&);
+    Decoder* createDecoderInternal(VideoCodecType, const String& codec, Function<void(Decoder(*))>&&);
     Encoder* createEncoderInternal(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
     template<typename Frame> int32_t encodeFrameInternal(Encoder&, const Frame&, bool shouldEncodeAsKeyFrame, WebCore::VideoFrameRotation, MediaTime, int64_t timestamp, std::optional<uint64_t> duration);
 


### PR DESCRIPTION
#### a7b3c2e07fde5c075d317f64cfa1efdef53f9207
<pre>
VideoDecoder.configure should not throw on unsupported codecs
<a href="https://bugs.webkit.org/show_bug.cgi?id=260622">https://bugs.webkit.org/show_bug.cgi?id=260622</a>
rdar://114336853

Reviewed by Eric Carlson.

Make sure isConfigSupported resolves the promise with unsupported = true in this case.
Ditto for VideoDecoder.configure.

To do this, we add additional checks in LibWebRTCCodecsProxy to better validate codec string support in GPUProcess.
Since decoder creation may now fail, we update IPC code like for encoders to return the failure to WebProcess.
We add specific checks for VP9, H264 and H265.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js:
(validButUnsupportedConfigs.forEach.entry.promise_test.async t):
(validConfigs.forEach.entry.promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::isSupportedDecoderCodec):
(WebCore::isValidDecoderConfig):
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::isConfigSupported):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/HEVCUtilities.cpp:
(WebCore::parseAVCCodecParameters):
* Source/WebCore/platform/graphics/cocoa/HEVCUtilitiesCocoa.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::validateCodecString):
(WebKit::LibWebRTCCodecsProxy::createDecoder):
(WebKit::LibWebRTCCodecsProxy::releaseDecoder):
(WebKit::LibWebRTCCodecsProxy::doDecoderTask):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createDecoder):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::videoCodecTypeFromWebCodec):
(WebKit::createRemoteDecoder):
(WebKit::LibWebRTCCodecs::createDecoder):
(WebKit::LibWebRTCCodecs::createDecoderAndWaitUntilReady):
(WebKit::LibWebRTCCodecs::createDecoderInternal):
(WebKit::LibWebRTCCodecs::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Canonical link: <a href="https://commits.webkit.org/267272@main">https://commits.webkit.org/267272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd8303bee8fbe9035c20f74b6fc747effb779c60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16581 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18682 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21454 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13036 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14601 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->