### PR TITLE
Add a Loader malloc heap zone

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1363,6 +1363,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/LinkLoader.h
     loader/LinkLoaderClient.h
     loader/LoadSchedulingMode.h
+    loader/LoaderMalloc.h
     loader/LoaderStrategy.h
     loader/LocalFrameLoaderClient.h
     loader/MediaResourceLoader.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1777,6 +1777,7 @@ loader/ImageLoader.cpp
 loader/LinkHeader.cpp
 loader/LinkLoader.cpp
 loader/LinkPreloadResourceClients.cpp
+loader/LoaderMalloc.cpp
 loader/LoaderStrategy.cpp
 loader/MediaResourceLoader.cpp
 loader/MixedContentChecker.cpp

--- a/Source/WebCore/loader/ApplicationManifestLoader.h
+++ b/Source/WebCore/loader/ApplicationManifestLoader.h
@@ -30,6 +30,7 @@
 #include "ApplicationManifest.h"
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
+#include "LoaderMalloc.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/URL.h>
@@ -40,7 +41,7 @@ class CachedApplicationManifest;
 class DocumentLoader;
 
 class ApplicationManifestLoader final : private CachedRawResourceClient {
-WTF_MAKE_NONCOPYABLE(ApplicationManifestLoader); WTF_MAKE_FAST_ALLOCATED;
+WTF_MAKE_NONCOPYABLE(ApplicationManifestLoader); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     typedef Function<void (CachedResourceHandle<CachedApplicationManifest>)> CompletionHandlerType;
 

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -28,6 +28,7 @@
 #if ENABLE(CONTENT_FILTERING)
 
 #include "CachedResourceHandle.h"
+#include "LoaderMalloc.h"
 #include "PlatformContentFilter.h"
 #include "ResourceError.h"
 #include <functional>
@@ -44,7 +45,7 @@ class ResourceResponse;
 class SubstituteData;
 
 class ContentFilter {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(ContentFilter);
 
 public:

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.h
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include "StoredCredentialsPolicy.h"
 #include <pal/SessionID.h>
 #include <wtf/Expected.h>
@@ -41,7 +42,7 @@ class HTTPHeaderMap;
 class ResourceResponse;
 
 class CrossOriginPreflightResultCacheItem {
-    WTF_MAKE_NONCOPYABLE(CrossOriginPreflightResultCacheItem); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CrossOriginPreflightResultCacheItem); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     static Expected<UniqueRef<CrossOriginPreflightResultCacheItem>, String> create(StoredCredentialsPolicy, const ResourceResponse&);
 
@@ -64,7 +65,7 @@ private:
 };
 
 class CrossOriginPreflightResultCache {
-    WTF_MAKE_NONCOPYABLE(CrossOriginPreflightResultCache); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CrossOriginPreflightResultCache); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     WEBCORE_EXPORT static CrossOriginPreflightResultCache& singleton();
     WEBCORE_EXPORT void appendEntry(PAL::SessionID, const String& origin, const URL&, std::unique_ptr<CrossOriginPreflightResultCacheItem>);

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -33,6 +33,7 @@
 
 #include "ContentSecurityPolicy.h"
 #include "CrossOriginPreflightChecker.h"
+#include "LoaderMalloc.h"
 #include "ResourceLoaderIdentifier.h"
 #include "ResourceResponse.h"
 #include "SecurityOrigin.h"
@@ -46,7 +47,7 @@ namespace WebCore {
     class ThreadableLoaderClient;
 
     class DocumentThreadableLoader : public RefCounted<DocumentThreadableLoader>, public ThreadableLoader, public CachedRawResourceClient {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     public:
         static void loadResourceSynchronously(Document&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&, RefPtr<SecurityOrigin>&&, std::unique_ptr<ContentSecurityPolicy>&&, std::optional<CrossOriginEmbedderPolicy>&&);
         static void loadResourceSynchronously(Document&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -277,7 +277,7 @@ struct ForbidSynchronousLoadsScope : public PageLevelForbidScope {
 };
 
 class FrameLoader::FrameProgressTracker {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit FrameProgressTracker(LocalFrame& frame)
         : m_frame(frame)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -35,6 +35,7 @@
 #include "FrameLoaderStateMachine.h"
 #include "FrameLoaderTypes.h"
 #include "LayoutMilestone.h"
+#include "LoaderMalloc.h"
 #include "PageIdentifier.h"
 #include "PrivateClickMeasurement.h"
 #include "ReferrerPolicy.h"
@@ -97,7 +98,7 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 using ContentPolicyDecisionFunction = Function<void(PolicyAction, PolicyCheckIdentifier)>;
 
 class FrameLoader final {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(FrameLoader);
 public:
     FrameLoader(LocalFrame&, UniqueRef<LocalFrameLoaderClient>&&);

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -43,7 +43,7 @@ struct StringWithDirection;
 
 class FrameLoader::HistoryController {
     WTF_MAKE_NONCOPYABLE(HistoryController);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     enum HistoryUpdateType { UpdateAll, UpdateAllExceptBackForwardList };
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -25,6 +25,7 @@
 #include "CachedImageClient.h"
 #include "CachedResourceHandle.h"
 #include "Element.h"
+#include "LoaderMalloc.h"
 #include "Timer.h"
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
@@ -44,7 +45,7 @@ enum class RelevantMutation : bool { No, Yes };
 enum class LazyImageLoadState : uint8_t { None, Deferred, LoadImmediately, FullImage };
 
 class ImageLoader : public CachedImageClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     virtual ~ImageLoader();
 

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -77,7 +77,7 @@ private:
 };
 
 class LinkPreloadDefaultResourceClient : public LinkPreloadResourceClient, CachedResourceClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     LinkPreloadDefaultResourceClient(LinkLoader& loader, CachedResource& resource)
         : LinkPreloadResourceClient(loader, resource)
@@ -92,7 +92,7 @@ private:
 };
 
 class LinkPreloadStyleResourceClient : public LinkPreloadResourceClient, public CachedStyleSheetClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     LinkPreloadStyleResourceClient(LinkLoader& loader, CachedCSSStyleSheet& resource)
         : LinkPreloadResourceClient(loader, resource)
@@ -113,7 +113,7 @@ private:
 };
 
 class LinkPreloadImageResourceClient : public LinkPreloadResourceClient, public CachedImageClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     LinkPreloadImageResourceClient(LinkLoader& loader, CachedImage& resource)
         : LinkPreloadResourceClient(loader, resource)
@@ -128,7 +128,7 @@ private:
 };
 
 class LinkPreloadFontResourceClient : public LinkPreloadResourceClient, public CachedFontClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     LinkPreloadFontResourceClient(LinkLoader& loader, CachedFont& resource)
         : LinkPreloadResourceClient(loader, resource)
@@ -148,7 +148,7 @@ private:
 };
 
 class LinkPreloadRawResourceClient : public LinkPreloadResourceClient, public CachedRawResourceClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     LinkPreloadRawResourceClient(LinkLoader& loader, CachedRawResource& resource)
         : LinkPreloadResourceClient(loader, resource)

--- a/Source/WebCore/loader/LoaderMalloc.cpp
+++ b/Source/WebCore/loader/LoaderMalloc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
+#include "config.h"
 #include "LoaderMalloc.h"
 
 namespace WebCore {
-
-class LocalFrame;
-
-class ProgressTrackerClient {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
-public:
-    virtual ~ProgressTrackerClient() = default;
-
-    virtual void willChangeEstimatedProgress() { }
-    virtual void didChangeEstimatedProgress() { }
-
-    virtual void progressStarted(LocalFrame& originatingProgressFrame) = 0;
-    virtual void progressEstimateChanged(LocalFrame& originatingProgressFrame) = 0;
-    virtual void progressFinished(LocalFrame& originatingProgressFrame) = 0;
-};
-
-} // namespace WebCore
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Loader);
+}

--- a/Source/WebCore/loader/LoaderMalloc.h
+++ b/Source/WebCore/loader/LoaderMalloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,23 +25,8 @@
 
 #pragma once
 
-#include "LoaderMalloc.h"
+#include <wtf/FastMalloc.h>
 
 namespace WebCore {
-
-class LocalFrame;
-
-class ProgressTrackerClient {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
-public:
-    virtual ~ProgressTrackerClient() = default;
-
-    virtual void willChangeEstimatedProgress() { }
-    virtual void didChangeEstimatedProgress() { }
-
-    virtual void progressStarted(LocalFrame& originatingProgressFrame) = 0;
-    virtual void progressEstimateChanged(LocalFrame& originatingProgressFrame) = 0;
-    virtual void progressFinished(LocalFrame& originatingProgressFrame) = 0;
-};
-
-} // namespace WebCore
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Loader);
+}

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -32,6 +32,7 @@
 #include "FrameLoaderClient.h"
 #include "LayoutMilestone.h"
 #include "LinkIcon.h"
+#include "LoaderMalloc.h"
 #include "RegistrableDomain.h"
 #include "ResourceLoaderIdentifier.h"
 #include <wtf/Expected.h>
@@ -102,7 +103,7 @@ enum class WasPrivateRelayed : bool;
 struct StringWithDirection;
 
 class WEBCORE_EXPORT LocalFrameLoaderClient : public FrameLoaderClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     // An inline function cannot be the first non-abstract virtual function declared
     // in the class as it results in the vtable being generated as a weak symbol.

--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 class NavigationDisabler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     NavigationDisabler(LocalFrame* frame)
         : m_frame(frame)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -62,7 +62,7 @@ namespace WebCore {
 unsigned NavigationDisabler::s_globalNavigationDisableCount = 0;
 
 class ScheduledNavigation {
-    WTF_MAKE_NONCOPYABLE(ScheduledNavigation); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(ScheduledNavigation); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     ScheduledNavigation(double delay, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool wasDuringLoad, bool isLocationChange)
         : m_delay(delay)

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "FrameLoaderTypes.h"
+#include "LoaderMalloc.h"
 #include "Timer.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -47,7 +48,7 @@ class SecurityOrigin;
 enum class NewLoadInProgress : bool { No, Yes };
     
 class NavigationScheduler {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit NavigationScheduler(Frame&);
     ~NavigationScheduler();

--- a/Source/WebCore/loader/PolicyChecker.h
+++ b/Source/WebCore/loader/PolicyChecker.h
@@ -64,7 +64,7 @@ enum class PolicyDecisionMode { Synchronous, Asynchronous };
 
 class FrameLoader::PolicyChecker : public CanMakeWeakPtr<FrameLoader::PolicyChecker> {
     WTF_MAKE_NONCOPYABLE(PolicyChecker);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit PolicyChecker(LocalFrame&);
 

--- a/Source/WebCore/loader/ProgressTracker.cpp
+++ b/Source/WebCore/loader/ProgressTracker.cpp
@@ -63,7 +63,7 @@ static const unsigned minumumBytesPerHeartbeatForProgress = 1024;
 static const Seconds progressNotificationTimeInterval { 200_ms };
 
 struct ProgressItem {
-    WTF_MAKE_NONCOPYABLE(ProgressItem); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(ProgressItem); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit ProgressItem(long long length)
         : bytesReceived(0)

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -43,7 +43,7 @@ struct ProgressItem;
 
 class ProgressTracker {
     WTF_MAKE_NONCOPYABLE(ProgressTracker);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit ProgressTracker(Page&, UniqueRef<ProgressTrackerClient>&&);
     ~ProgressTracker();

--- a/Source/WebCore/loader/ResourceLoadObserver.h
+++ b/Source/WebCore/loader/ResourceLoadObserver.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include "ResourceLoadStatistics.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -37,7 +38,7 @@ class ResourceRequest;
 class ResourceResponse;
 
 class ResourceLoadObserver {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     using TopFrameDomain = WebCore::RegistrableDomain;
     using SubResourceDomain = WebCore::RegistrableDomain;

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include "NetworkLoadMetrics.h"
 #include "ResourceLoadTiming.h"
 #include "ServerTiming.h"
@@ -39,7 +40,7 @@ class ResourceLoadTiming;
 class SecurityOrigin;
 
 class ResourceTiming {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     static ResourceTiming fromMemoryCache(const URL&, const String& initiator, const ResourceLoadTiming&, const ResourceResponse&, const NetworkLoadMetrics&, const SecurityOrigin&);
     static ResourceTiming fromLoad(CachedResource&, const URL&, const String& initiator, const ResourceLoadTiming&, const NetworkLoadMetrics&, const SecurityOrigin&);

--- a/Source/WebCore/loader/SubframeLoader.h
+++ b/Source/WebCore/loader/SubframeLoader.h
@@ -44,7 +44,7 @@ class Widget;
 
 // This is a slight misnomer. It handles the higher level logic of loading both subframes and plugins.
 class FrameLoader::SubframeLoader {
-    WTF_MAKE_NONCOPYABLE(SubframeLoader); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(SubframeLoader); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit SubframeLoader(LocalFrame&);
 

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -119,7 +119,7 @@ private:
 
     class RequestCountTracker {
 #if !COMPILER(MSVC)
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 #endif
     public:
         RequestCountTracker(CachedResourceLoader&, const CachedResource&);

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -29,6 +29,7 @@
 
 #include "CachedResourceClient.h"
 #include "CachedResourceHandle.h"
+#include "LoaderMalloc.h"
 #include "Timer.h"
 #include "WebVTTParser.h"
 #include <memory>
@@ -53,7 +54,7 @@ public:
 
 class TextTrackLoader final : public CachedResourceClient, private WebVTTParserClient {
     WTF_MAKE_NONCOPYABLE(TextTrackLoader); 
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     TextTrackLoader(TextTrackLoaderClient&, Document&);
     virtual ~TextTrackLoader();

--- a/Source/WebCore/loader/ThreadableLoaderClient.h
+++ b/Source/WebCore/loader/ThreadableLoaderClient.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include "ResourceLoaderIdentifier.h"
 
 namespace WebCore {
@@ -41,7 +42,7 @@ class ResourceTiming;
 class SharedBuffer;
 
 class ThreadableLoaderClient {
-    WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     virtual void didSendData(unsigned long long /*bytesSent*/, unsigned long long /*totalBytesToBeSent*/) { }
 

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -48,7 +48,7 @@ class WorkerOrWorkletGlobalScope;
 class WorkerLoaderProxy;
 
 class WorkerThreadableLoader : public RefCounted<WorkerThreadableLoader>, public ThreadableLoader {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     static void loadResourceSynchronously(WorkerOrWorkletGlobalScope&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&);
     static Ref<WorkerThreadableLoader> create(WorkerOrWorkletGlobalScope& WorkerOrWorkletGlobalScope, ThreadableLoaderClient& client, const String& taskMode, ResourceRequest&& request, const ThreadableLoaderOptions& options, const String& referrer)

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -973,7 +973,7 @@ void ApplicationCacheGroup::associateDocumentLoaderWithCache(DocumentLoader* loa
 }
 
 class ChromeClientCallbackTimer final : public TimerBase {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     ChromeClientCallbackTimer(ApplicationCacheGroup& group)
         : m_group(group)

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
@@ -51,7 +51,7 @@ enum ApplicationCacheUpdateOption {
 
 class ApplicationCacheGroup : public CanMakeWeakPtr<ApplicationCacheGroup> {
     WTF_MAKE_NONCOPYABLE(ApplicationCacheGroup);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit ApplicationCacheGroup(Ref<ApplicationCacheStorage>&&, const URL& manifestURL);
     virtual ~ApplicationCacheGroup();

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/URL.h>
@@ -55,7 +56,7 @@ class SubstituteData;
 class WeakPtrImplWithEventTargetData;
 
 class ApplicationCacheHost {
-    WTF_MAKE_NONCOPYABLE(ApplicationCacheHost); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(ApplicationCacheHost); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     // The Status numeric values are specified in the HTML5 spec.
     enum Status {

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.h
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.h
@@ -40,7 +40,7 @@ class ArchiveResource;
 
 class ArchiveResourceCollection {
     WTF_MAKE_NONCOPYABLE(ArchiveResourceCollection);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 
 public:
     ArchiveResourceCollection() = default;

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class FontCreationContext;
 
 class CachedFontLoadRequest final : public FontLoadRequest, public CachedFontClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     CachedFontLoadRequest(CachedFont& font)
         : m_font(&font)

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -25,6 +25,7 @@
 #include "CacheValidation.h"
 #include "CachedResourceClient.h"
 #include "FrameLoaderTypes.h"
+#include "LoaderMalloc.h"
 #include "ResourceCryptographicDigest.h"
 #include "ResourceError.h"
 #include "ResourceLoadPriority.h"
@@ -428,7 +429,7 @@ private:
 };
 
 class CachedResource::Callback {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     Callback(CachedResource&, CachedResourceClient&);
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -77,7 +77,7 @@ enum class FetchMetadataSite : uint8_t { None, SameOrigin, SameSite, CrossSite }
 // are initialized without a Frame), so a Document can keep a CachedResourceLoader
 // alive past detach if scripts still reference the Document.
 class CachedResourceLoader : public RefCounted<CachedResourceLoader>, public CanMakeWeakPtr<CachedResourceLoader> {
-    WTF_MAKE_NONCOPYABLE(CachedResourceLoader); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CachedResourceLoader); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 friend class ImageLoader;
 friend class ResourceCacheValidationSuppressor;
 
@@ -226,7 +226,7 @@ private:
 
 class ResourceCacheValidationSuppressor {
     WTF_MAKE_NONCOPYABLE(ResourceCacheValidationSuppressor);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     ResourceCacheValidationSuppressor(CachedResourceLoader& loader)
         : m_loader(loader)

--- a/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include "ThreadGlobalData.h"
 #include <wtf/text/AtomString.h>
 
@@ -39,7 +40,7 @@ struct CachedResourceRequestInitiatorTypes {
     const AtomString icon;
     const AtomString navigation;
     const AtomString xmlhttprequest;
-    WTF_MAKE_NONCOPYABLE(CachedResourceRequestInitiatorTypes); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CachedResourceRequestInitiatorTypes); WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 private:
     friend class ThreadGlobalData;
 };

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -36,7 +36,7 @@ class CachedResourceLoader;
 struct ResourceLoaderOptions;
 
 class CachedSVGDocumentReference final : public CachedSVGDocumentClient {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     CachedSVGDocumentReference(const String&);
 

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "LoaderMalloc.h"
 #include "SecurityOriginHash.h"
 #include "Timer.h"
 #include <pal/SessionID.h>
@@ -61,7 +62,7 @@ struct ClientOrigin;
 // -------|-----+++++++++++++++|+++++
 
 class MemoryCache {
-    WTF_MAKE_NONCOPYABLE(MemoryCache); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(MemoryCache); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     friend NeverDestroyed<MemoryCache>;
     friend class Internals;
 public:

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -39,7 +39,7 @@ class DocumentLoader;
 class LocalFrame;
 
 class IconLoader final : private CachedRawResourceClient {
-    WTF_MAKE_NONCOPYABLE(IconLoader); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(IconLoader); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     IconLoader(DocumentLoader&, const URL&);
     virtual ~IconLoader();

--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.h
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.h
@@ -40,7 +40,7 @@ class ResourceLoader;
 class ResourceResponse;
 
 class LegacyPreviewLoader final : private PreviewConverterClient, private PreviewConverterProvider {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(LegacyPreviewLoader);
 public:
     LegacyPreviewLoader(ResourceLoader&, const ResourceResponse&);


### PR DESCRIPTION
#### 66b6285e8f367770bb1acc584f8ff1f270259b26
<pre>
Add a Loader malloc heap zone
<a href="https://bugs.webkit.org/show_bug.cgi?id=260623">https://bugs.webkit.org/show_bug.cgi?id=260623</a>
rdar://114340888

Reviewed by Brent Fulgham and Simon Fraser.

This adds a generic Loader allocator that fast malloc classes can use in
the loading subsystem. This will allow us to categorize classes with
WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER into a loader malloc zone
without the need to make a zone for each class.

Use by including &quot;LoaderMalloc.h&quot; (if necessary) and replacing
WTF_MAKE_FAST_ALLOCATED with
WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader) in your loader class.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/ApplicationManifestLoader.h:
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/CrossOriginPreflightResultCache.h:
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkPreloadResourceClients.h:
* Source/WebCore/loader/LoaderMalloc.cpp: Copied from Source/WebCore/loader/ProgressTrackerClient.h.
* Source/WebCore/loader/LoaderMalloc.h: Copied from Source/WebCore/loader/ProgressTrackerClient.h.
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/NavigationDisabler.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/loader/PolicyChecker.h:
* Source/WebCore/loader/ProgressTracker.cpp:
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ProgressTrackerClient.h:
* Source/WebCore/loader/ResourceLoadObserver.h:
* Source/WebCore/loader/ResourceTiming.h:
* Source/WebCore/loader/SubframeLoader.h:
* Source/WebCore/loader/SubresourceLoader.h:
* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/ThreadableLoaderClient.h:
* Source/WebCore/loader/WorkerThreadableLoader.h:
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
* Source/WebCore/loader/appcache/ApplicationCacheGroup.h:
* Source/WebCore/loader/appcache/ApplicationCacheHost.h:
* Source/WebCore/loader/archive/ArchiveResourceCollection.h:
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/loader/cache/CachedResourceRequestInitiatorTypes.h:
* Source/WebCore/loader/cache/CachedSVGDocumentReference.h:
* Source/WebCore/loader/cache/MemoryCache.h:
* Source/WebCore/loader/icon/IconLoader.h:
* Source/WebCore/loader/ios/LegacyPreviewLoader.h:

Canonical link: <a href="https://commits.webkit.org/267205@main">https://commits.webkit.org/267205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6e724c37ae4174895a947a9ff3237cbd40f1a71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15956 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16376 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18479 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14424 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17838 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15183 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14423 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->