### PR TITLE
[JSC] Throw OOM error if constructArrayNegativeIndexed() fails to allocate

### DIFF
--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1349,6 +1349,7 @@ bool JSArray::isIteratorProtocolFastAndNonObservable()
     return true;
 }
 
+template<AllocationFailureMode failureMode>
 inline JSArray* constructArray(ObjectInitializationScope& scope, Structure* arrayStructure, unsigned length)
 {
     JSArray* array = JSArray::tryCreateUninitializedRestricted(scope, arrayStructure, length);
@@ -1357,7 +1358,10 @@ inline JSArray* constructArray(ObjectInitializationScope& scope, Structure* arra
     // when making this change we should check that all clients of this
     // function will correctly handle an exception being thrown from here.
     // https://bugs.webkit.org/show_bug.cgi?id=169786
-    RELEASE_ASSERT(array);
+    if constexpr (failureMode == AllocationFailureMode::Assert)
+        RELEASE_ASSERT(array);
+    else if (!array)
+        return nullptr;
 
     // FIXME: We only need this for subclasses of Array because we might need to allocate a new structure to change
     // indexing types while initializing. If this triggered a GC then we might scan our currently uninitialized
@@ -1374,7 +1378,7 @@ JSArray* constructArray(JSGlobalObject* globalObject, Structure* arrayStructure,
     unsigned length = values.size();
     ObjectInitializationScope scope(vm);
 
-    JSArray* array = constructArray(scope, arrayStructure, length);
+    JSArray* array = constructArray<AllocationFailureMode::Assert>(scope, arrayStructure, length);
     for (unsigned i = 0; i < length; ++i)
         array->initializeIndex(scope, i, values.at(i));
     return array;
@@ -1385,7 +1389,7 @@ JSArray* constructArray(JSGlobalObject* globalObject, Structure* arrayStructure,
     VM& vm = globalObject->vm();
     ObjectInitializationScope scope(vm);
 
-    JSArray* array = constructArray(scope, arrayStructure, length);
+    JSArray* array = constructArray<AllocationFailureMode::Assert>(scope, arrayStructure, length);
     for (unsigned i = 0; i < length; ++i)
         array->initializeIndex(scope, i, values[i]);
     return array;
@@ -1394,9 +1398,15 @@ JSArray* constructArray(JSGlobalObject* globalObject, Structure* arrayStructure,
 JSArray* constructArrayNegativeIndexed(JSGlobalObject* globalObject, Structure* arrayStructure, const JSValue* values, unsigned length)
 {
     VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     ObjectInitializationScope scope(vm);
 
-    JSArray* array = constructArray(scope, arrayStructure, length);
+    JSArray* array = constructArray<AllocationFailureMode::ReturnNull>(scope, arrayStructure, length);
+    if (UNLIKELY(!array)) {
+        throwOutOfMemoryError(globalObject, throwScope);
+        return nullptr;
+    }
+
     for (int i = 0; i < static_cast<int>(length); ++i)
         array->initializeIndex(scope, i, values[-i]);
     return array;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -304,7 +304,11 @@ inline JSArray* constructArrayNegativeIndexed(JSGlobalObject* globalObject, Arra
     auto scope = DECLARE_THROW_SCOPE(vm);
     Structure* structure = globalObject->arrayStructureForProfileDuringAllocation(globalObject, profile, newTarget);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    return ArrayAllocationProfile::updateLastAllocationFor(profile, constructArrayNegativeIndexed(globalObject, structure, values, length));
+    scope.release();
+    JSArray* array = constructArrayNegativeIndexed(globalObject, structure, values, length);
+    if (UNLIKELY(!array))
+        return nullptr;
+    return ArrayAllocationProfile::updateLastAllocationFor(profile, array);
 }
 
 inline OptionSet<CodeGenerationMode> JSGlobalObject::defaultCodeGenerationMode() const


### PR DESCRIPTION
#### ddd9cbc5f5a7def601a5abb74cb0d8ea5f6a4585
<pre>
[JSC] Throw OOM error if constructArrayNegativeIndexed() fails to allocate
<a href="https://bugs.webkit.org/show_bug.cgi?id=260559">https://bugs.webkit.org/show_bug.cgi?id=260559</a>
&lt;rdar://114202373&gt;

Reviewed by Mark Lam.

This change leverages AllocationFailureMode to throw an OOM error if constructArrayNegativeIndexed()
fails to allocate an array, which does happen in the wild (iOS apps).

All clients of constructArrayNegativeIndexed() were updated to correctly handle thrown exception.

* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::constructArray):
(JSC::constructArrayNegativeIndexed):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::constructArrayNegativeIndexed):

Canonical link: <a href="https://commits.webkit.org/267300@main">https://commits.webkit.org/267300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e75f36943c48db09a2e1d9206ff635bb9454aba0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15217 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18745 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14678 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13965 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18074 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15453 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15436 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16419 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14664 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3875 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19028 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17585 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15259 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3882 "Passed tests") | 
<!--EWS-Status-Bubble-End-->