### PR TITLE
[JSC] Make PerfLog work on Darwin

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2015,6 +2015,7 @@
 		E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7826E867B800E4C28B /* TemporalPlainTime.h */; };
 		E386FD7F26E867B800E4C28B /* TemporalPlainTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */; };
 		E389D854291226BC0085C3DC /* PageCount.h in Headers */ = {isa = PBXBuildFile; fileRef = E389D852291226BC0085C3DC /* PageCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E38DAB532A95D23A0050B7A8 /* PerfLog.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DAB512A95D23A0050B7A8 /* PerfLog.h */; };
 		E38DB2E727F588F80027BD3F /* ScriptExecutableInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DB2E627F588F70027BD3F /* ScriptExecutableInlines.h */; };
 		E38E8790254B978400F6F9E4 /* JSDateMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9788FC221471AD0C0068CE2D /* JSDateMath.cpp */; };
 		E38F091A288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5650,6 +5651,8 @@
 		E38D060B1F8E814100649CF2 /* JSScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060D1F8E814100649CF2 /* JSScriptFetchParameters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSScriptFetchParameters.cpp; sourceTree = "<group>"; };
+		E38DAB512A95D23A0050B7A8 /* PerfLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerfLog.h; sourceTree = "<group>"; };
+		E38DAB522A95D23A0050B7A8 /* PerfLog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PerfLog.cpp; sourceTree = "<group>"; };
 		E38DB2E627F588F70027BD3F /* ScriptExecutableInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptExecutableInlines.h; sourceTree = "<group>"; };
 		E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectAdaptiveStructureWatchpoint.h; sourceTree = "<group>"; };
 		E39006202208BFC3001019CF /* SubspaceAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SubspaceAccess.h; sourceTree = "<group>"; };
@@ -9259,6 +9262,8 @@
 				65860177185A8F5E00030EEE /* MaxFrameExtentForSlowPathCall.h */,
 				86C568DF11A213EE0007F7F0 /* MIPSAssembler.h */,
 				86C568DF11A213EE0007F7FF /* MIPSRegisters.h */,
+				E38DAB522A95D23A0050B7A8 /* PerfLog.cpp */,
+				E38DAB512A95D23A0050B7A8 /* PerfLog.h */,
 				FE63DD551EA9BC5D00103A69 /* Printer.cpp */,
 				FE63DD531EA9B60E00103A69 /* Printer.h */,
 				FE10AAF31F46826D009DEDC5 /* ProbeContext.cpp */,
@@ -11388,6 +11393,7 @@
 				65303D641447B9E100D3F904 /* ParserTokens.h in Headers */,
 				2BDF4F7129E9E8BB0056BF50 /* PASReportCrashPrivate.h in Headers */,
 				792CB34A1C4EED5C00D13AF3 /* PCToCodeOriginMap.h in Headers */,
+				E38DAB532A95D23A0050B7A8 /* PerfLog.h in Headers */,
 				A5AB49DD1BEC8086007020FB /* PerGlobalObjectWrapperWorld.h in Headers */,
 				0FE834181A6EF97B00D04847 /* PolymorphicCallStubRoutine.h in Headers */,
 				521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */,

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -32,10 +32,7 @@
 #include "Disassembler.h"
 #include "JITCode.h"
 #include "Options.h"
-
-#if OS(LINUX)
 #include "PerfLog.h"
-#endif
 
 namespace JSC {
 
@@ -57,17 +54,19 @@ LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithDisassemblyImp
 {
     CodeRef<LinkBufferPtrTag> result = finalizeCodeWithoutDisassemblyImpl();
 
-#if OS(LINUX)
+#if OS(LINUX) || OS(DARWIN)
     if (Options::logJITCodeForPerf()) {
         StringPrintStream out;
         va_list argList;
-        va_start(argList, format);
         va_start(argList, format);
         out.vprintf(format, argList);
         va_end(argList);
         PerfLog::log(out.toCString(), result.code().untaggedPtr<const uint8_t*>(), result.size());
     }
 #endif
+
+    if (!dumpDisassembly && !Options::logJIT())
+        return result;
 
     bool justDumpingHeader = !dumpDisassembly || m_alreadyDisassembled;
 

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -431,19 +431,10 @@ private:
     static size_t s_profileCummulativeLinkedCounts[numberOfProfiles];
 };
 
-#if OS(LINUX)
 #define FINALIZE_CODE_IF(condition, linkBufferReference, resultPtrTag, ...) \
-    (UNLIKELY((condition) || JSC::Options::logJIT()) \
-        ? (linkBufferReference).finalizeCodeWithDisassembly<resultPtrTag>((condition), __VA_ARGS__) \
-        : (UNLIKELY(JSC::Options::logJITCodeForPerf()) \
-            ? (linkBufferReference).finalizeCodeWithDisassembly<resultPtrTag>(false, __VA_ARGS__) \
-            : (linkBufferReference).finalizeCodeWithoutDisassembly<resultPtrTag>()))
-#else
-#define FINALIZE_CODE_IF(condition, linkBufferReference, resultPtrTag, ...) \
-    (UNLIKELY((condition) || JSC::Options::logJIT()) \
+    (UNLIKELY((condition) || JSC::Options::logJIT() || JSC::Options::logJITCodeForPerf()) \
         ? (linkBufferReference).finalizeCodeWithDisassembly<resultPtrTag>((condition), __VA_ARGS__) \
         : (linkBufferReference).finalizeCodeWithoutDisassembly<resultPtrTag>())
-#endif
 
 #define FINALIZE_CODE_FOR(codeBlock, linkBufferReference, resultPtrTag, ...)  \
     FINALIZE_CODE_IF((shouldDumpDisassemblyFor(codeBlock) || Options::asyncDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <yusukesuzuki@slowstart.org>.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,10 +26,11 @@
 
 #pragma once
 
-#if ENABLE(ASSEMBLER) && OS(LINUX)
+#if ENABLE(ASSEMBLER) && (OS(LINUX) || OS(DARWIN))
 
 #include <stdio.h>
 #include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
@@ -36,6 +38,7 @@ namespace JSC {
 class PerfLog {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PerfLog);
+    friend class LazyNeverDestroyed<PerfLog>;
 public:
     static void log(CString&&, const uint8_t* executableAddress, size_t);
 
@@ -55,4 +58,4 @@ private:
 
 } // namespace JSC
 
-#endif // ENABLE(ASSEMBLER) && OS(LINUX)
+#endif  // ENABLE(ASSEMBLER) && (OS(LINUX) || OS(DARWIN))

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -393,7 +393,7 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
 
     auto tryCreatePageReservation = [] (size_t reservationSize) {
 #if OS(LINUX)
-        // If we use uncommitted reservation, mmap operation is recorded with small page size in perf command's output.
+        // On Linux, if we use uncommitted reservation, mmap operation is recorded with small page size in perf command's output.
         // This makes the following JIT code logging broken and some of JIT code is not recorded correctly.
         // To avoid this problem, we use committed reservation if we need perf JITDump logging.
         if (Options::logJITCodeForPerf())

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -240,7 +240,7 @@ bool Options::isAvailable(Options::ID id, Options::Availability availability)
     if (id == maxSingleAllocationSizeID)
         return true;
 #endif
-#if ENABLE(ASSEMBLER) && OS(LINUX)
+#if ENABLE(ASSEMBLER) && (OS(LINUX) || OS(DARWIN))
     if (id == logJITCodeForPerfID)
         return true;
 #endif


### PR DESCRIPTION
#### 7f950e05da63384e2e49fb9375558f688b4667db
<pre>
[JSC] Make PerfLog work on Darwin
<a href="https://bugs.webkit.org/show_bug.cgi?id=260626">https://bugs.webkit.org/show_bug.cgi?id=260626</a>
rdar://problem/114345611

Reviewed by Justin Michaud.

This patch makes PerfLog work on Darwin, which generates JITDump[1] on Darwin.
While this is not performance efficient enough, we can later optimize the way to dump this, and try using it for a prototype.

[1]: <a href="https://raw.githubusercontent.com/torvalds/linux/master/tools/perf/Documentation/jitdump-specification.txt">https://raw.githubusercontent.com/torvalds/linux/master/tools/perf/Documentation/jitdump-specification.txt</a>

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::finalizeCodeWithDisassemblyImpl):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::singleton):
(JSC::getCurrentThreadID):
* Source/JavaScriptCore/assembler/PerfLog.h:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::isAvailable):

Canonical link: <a href="https://commits.webkit.org/267211@main">https://commits.webkit.org/267211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/037b758711caef690b38f4f7b7528a58a2a49dca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15974 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14996 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18500 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14437 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/13745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17853 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12884 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16174 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14438 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4043 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18807 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17339 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1957 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15021 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3836 "Passed tests") | 
<!--EWS-Status-Bubble-End-->