### PR TITLE
Adjust _WKWebExtensionWindow and _WKWebExtensionTab APIs based on feedback.

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2184,6 +2184,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionTabCreationOptions {
+    header "_WKWebExtensionTabCreationOptions.h"
+    export *
+  }
+
   explicit module _WKWebExtensionUtilities {
     header "_WKWebExtensionUtilities.h"
     export *
@@ -2196,6 +2201,11 @@ framework module WebKit_Private [system] {
 
   explicit module _WKWebExtensionWindow {
     header "_WKWebExtensionWindow.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionWindowCreationOptions {
+    header "_WKWebExtensionWindowCreationOptions.h"
     export *
   }
 

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3086,6 +3086,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionTabCreationOptions {
+    header "_WKWebExtensionTabCreationOptions.h"
+    export *
+  }
+
   explicit module _WKWebExtensionUtilities {
     header "_WKWebExtensionUtilities.h"
     export *
@@ -3098,6 +3103,11 @@ framework module WebKit_Private [system] {
 
   explicit module _WKWebExtensionWindow {
     header "_WKWebExtensionWindow.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionWindowCreationOptions {
+    header "_WKWebExtensionWindowCreationOptions.h"
     export *
   }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -493,7 +493,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 /*!
  @abstract Should be called by the app when a window is closed to fire appropriate events with only this extension.
  @param newWindow The window that was closed.
- @discussion This method informs only the specific extension of the closure of a window. If the intention is to inform all loaded 
+ @discussion This method informs only the specific extension of the closure of a window. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  @seealso didOpenWindow:
  @seealso openWindows
@@ -522,12 +522,20 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Should be called by the app when a tab is closed to fire appropriate events with only this extension.
  @param closedTab The tab that was closed.
  @param windowIsClosing A boolean value indicating whether the window containing the tab is also closing.
- @discussion This method informs only the specific extension of the closure of a tab. If the intention is to inform all loaded 
+ @discussion This method informs only the specific extension of the closure of a tab. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  @seealso didOpenTab:
  @seealso openTabs
  */
 - (void)didCloseTab:(id <_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing;
+
+/*!
+ @abstract Should be called by the app when a tab is activated to notify only this specific extension.
+ @param activatedTab The activated tab.
+ @discussion This method informs only the specific extension of the tab activation. If the intention is to inform all loaded
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didActivateTab:(id <_WKWebExtensionTab>)activatedTab;
 
 /*!
  @abstract Should be called by the app when tabs are selected to fire appropriate events with only this extension.
@@ -543,7 +551,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @param movedTab The tab that was moved.
  @param index The old index of the tab within the window.
  @param oldWindow The window that the tab was moved from, or \c nil if the window stayed the same.
- @discussion This method informs only the specific extension that a tab has been moved. If the intention is to inform all loaded 
+ @discussion This method informs only the specific extension that a tab has been moved. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
 - (void)didMoveTab:(id <_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(nullable id <_WKWebExtensionWindow>)oldWindow NS_SWIFT_NAME(didMoveTab(_:from:in:));
@@ -552,7 +560,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Should be called by the app when a tab is replaced by another tab to fire appropriate events with only this extension.
  @param oldTab The tab that was replaced.
  @param newTab The tab that replaced the old tab.
- @discussion This method informs only the specific extension that a tab has been replaced. If the intention is to inform all loaded 
+ @discussion This method informs only the specific extension that a tab has been replaced. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
 - (void)didReplaceTab:(id <_WKWebExtensionTab>)oldTab withTab:(id <_WKWebExtensionTab>)newTab NS_SWIFT_NAME(didReplaceTab(_:with:));
@@ -561,7 +569,7 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Should be called by the app when the properties of a tab are changed to fire appropriate events with only this extension.
  @param properties The properties of the tab that were changed.
  @param changedTab The tab whose properties were changed.
- @discussion This method informs only the specific extension of the changes to a tab's properties. If the intention is to inform all loaded 
+ @discussion This method informs only the specific extension of the changes to a tab's properties. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
 - (void)didChangeTabProperties:(_WKWebExtensionTabChangedProperties)properties forTab:(id <_WKWebExtensionTab>)changedTab NS_SWIFT_NAME(didChangeTabProperties(_:for:));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -581,6 +581,13 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSSet<id<_WKWebExtensio
     _webExtensionContext->didCloseTab(toImpl(closedTab, *_webExtensionContext), windowIsClosing ? WebKit::WebExtensionContext::WindowIsClosing::Yes : WebKit::WebExtensionContext::WindowIsClosing::No);
 }
 
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
+{
+    NSParameterAssert([activatedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+
+    _webExtensionContext->didActivateTab(toImpl(activatedTab, *_webExtensionContext));
+}
+
 - (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
 {
     NSParameterAssert([selectedTabs isKindOfClass:NSSet.class]);
@@ -609,8 +616,13 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 {
     OptionSet<WebKit::WebExtensionTab::ChangedProperties> result;
 
-    if (properties & _WKWebExtensionTabChangedPropertiesNone)
-        result.add(WebKit::WebExtensionTab::ChangedProperties::None);
+    if (properties == _WKWebExtensionTabChangedPropertiesNone)
+        return result;
+
+    if (properties == _WKWebExtensionTabChangedPropertiesAll) {
+        result.add(WebKit::WebExtensionTab::ChangedProperties::All);
+        return result;
+    }
 
     if (properties & _WKWebExtensionTabChangedPropertiesAudible)
         result.add(WebKit::WebExtensionTab::ChangedProperties::Audible);
@@ -638,9 +650,6 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 
     if (properties & _WKWebExtensionTabChangedPropertiesZoomFactor)
         result.add(WebKit::WebExtensionTab::ChangedProperties::ZoomFactor);
-
-    if (properties & _WKWebExtensionTabChangedPropertiesAll)
-        result.add(WebKit::WebExtensionTab::ChangedProperties::All);
 
     return result;
 }
@@ -919,6 +928,10 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (void)didCloseTab:(id<_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
+{
+}
+
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -158,6 +158,14 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 - (void)didCloseTab:(id <_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing;
 
 /*!
+ @abstract Should be called by the app when a tab is activated to notify all loaded web extensions.
+ @param activatedTab The activated tab.
+ @discussion This method informs all loaded extensions of the tab activation, ensuring consistent state awareness across extensions.
+ If the intention is to inform only a specific extension, use the respective method on that extension's context instead.
+ */
+- (void)didActivateTab:(id <_WKWebExtensionTab>)activatedTab;
+
+/*!
  @abstract Should be called by the app when tabs are selected to fire appropriate events with all loaded web extensions.
  @param selectedTabs The set of tabs that were selected. An empty set indicates that no tabs are currently selected or that the
  selected tabs are not visible to extensions.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -164,6 +164,14 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
         [context->wrapper() didCloseTab:closedTab windowIsClosing:windowIsClosing];
 }
 
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
+{
+    NSParameterAssert([activatedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didActivateTab:activatedTab];
+}
+
 - (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
 {
     NSParameterAssert([selectedTabs isKindOfClass:NSSet.class]);
@@ -270,6 +278,10 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 }
 
 - (void)didCloseTab:(id<_WKWebExtensionTab>)closedTab windowIsClosing:(BOOL)windowIsClosing
+{
+}
+
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -30,8 +30,10 @@
 #import <WebKit/_WKWebExtensionPermission.h>
 
 @class _WKWebExtensionContext;
-@class _WKWebExtensionMatchPattern;
 @class _WKWebExtensionController;
+@class _WKWebExtensionMatchPattern;
+@class _WKWebExtensionTabCreationOptions;
+@class _WKWebExtensionWindowCreationOptions;
 @protocol _WKWebExtensionTab;
 @protocol _WKWebExtensionWindow;
 
@@ -66,6 +68,34 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @seealso webExtensionController:openWindowsForExtensionContext:
  */
 - (nullable id <_WKWebExtensionWindow>)webExtensionController:(_WKWebExtensionController *)controller focusedWindowForExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_NAME(webExtensionController(_:focusedWindowFor:));
+
+/*!
+ @abstract Called when an extension context requests a new window to be opened.
+ @param controller The web extension controller that is managing the extension.
+ @param options The set of options specifying how the new window should be created.
+ @param extensionContext The context in which the web extension is running.
+ @param completionHandler A block to be called with the newly created window or \c nil if the window wasn't created. An error should be
+ provided if any errors occured.
+ @discussion This method should be implemented by the app to handle requests to open new windows. The app can decide how to handle
+ the creation based on the provided options and existing windows. Once handled, the app should call the completion block with the created window
+ or `nil` if the creation was declined or failed. If not implemented or the completion block is not called within a reasonable amount of time, the
+ request is assumed to have been denied.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller openNewWindowWithOptions:(_WKWebExtensionWindowCreationOptions *)options forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(id <_WKWebExtensionWindow> _Nullable newWindow, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(webExtensionController(_:openNewWindowWithOptions:for:completionHandler:));
+
+/*!
+ @abstract Called when an extension context requests a new tab to be opened.
+ @param controller The web extension controller that is managing the extension.
+ @param options The set of options specifying how the new tab should be created.
+ @param extensionContext The context in which the web extension is running.
+ @param completionHandler A block to be called with the newly created tab or \c nil if the tab wasn't created. An error should be
+ provided if any errors occured.
+ @discussion This method should be implemented by the app to handle requests to open new tabs. The app can decide how to handle
+ the creation based on the provided options and existing tabs. Once handled, the app should call the completion block with the created tab
+ or `nil` if the creation was declined or failed. If not implemented or the completion block is not called within a reasonable amount of time,
+ the request is assumed to have been denied.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller openNewTabWithOptions:(_WKWebExtensionTabCreationOptions *)options forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(id <_WKWebExtensionTab> _Nullable newTab, NSError * _Nullable error))completionHandler NS_SWIFT_NAME(webExtensionController(_:openNewTabWithOptions:for:completionHandler:));
 
 /*!
  @abstract Called when an extension context requests permissions.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -29,6 +29,7 @@
 
 @class WKWebView;
 @class _WKWebExtensionContext;
+@class _WKWebExtensionTabCreationOptions;
 @protocol _WKWebExtensionWindow;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -101,7 +102,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the title of the tab is needed.
  @param context The context in which the web extension is running.
  @return The title of the tab.
- @discussion Defaults to the title of the main web view if not implemented.
+ @discussion Defaults to `title` for the main web view if not implemented.
  */
 - (nullable NSString *)tabTitleForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -122,14 +123,6 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (BOOL)isPinnedForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the ephemeral state of the tab is needed.
- @param context The context in which the web extension is running.
- @return `YES` if the tab is ephemeral, `NO` otherwise.
- @discussion Used to indicated "private browsing" windows. Defaults to `NO` if not implemented.
- */
-- (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
-
-/*!
  @abstract Called to check if reader mode is available for the tab.
  @param context The context in which the web extension is running.
  @return `YES` if reader mode is available for the tab, `NO` otherwise.
@@ -148,9 +141,11 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 /*!
  @abstract Called to toggle reader mode for the tab.
  @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
  */
-- (void)toggleReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)toggleReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to check if the tab is currently playing audio.
@@ -171,16 +166,20 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 /*!
  @abstract Called to mute the tab.
  @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
  */
-- (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to unmute the tab.
  @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
  */
-- (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called when the size of the tab is needed.
@@ -194,15 +193,25 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the zoom factor of the tab is needed.
  @param context The context in which the web extension is running.
  @return The zoom factor of the tab.
- @discussion Defaults to zoom factor of the main web view if not implemented.
+ @discussion Defaults to `pageZoom` for the main web view if not implemented.
  */
 - (double)zoomFactorForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to set the zoom factor of the tab.
+ @param zoomFactor The desired zoom factor for the tab.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occured.
+ @discussion Sets `pageZoom` for the main web view if not implemented..
+ */
+- (void)setZoomFactor:(double)zoomFactor forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called when the URL of the tab is needed.
  @param context The context in which the web extension is running.
  @return The URL of the tab.
- @discussion Defaults to the URL of the main web view if not implemented.
+ @discussion Defaults to `URL` for the main web view if not implemented.
  */
 - (nullable NSURL *)urlForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -219,69 +228,109 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to check if the tab has finished loading.
  @param context The context in which the web extension is running.
  @return `YES` if the tab has finished loading, `NO` otherwise.
- @discussion Defaults to the loading state of the main web view if not implemented.
+ @discussion Defaults to `isLoading` for the main web view if not implemented.
  */
 - (BOOL)isLoadingCompleteForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called to detect the locale of the webpage currently loaded in the tab.
  @param context The context in which the web extension is running.
- @param completionHandler A block to be called when the locale has been detected. The block takes a single argument, the
- detected locale, which may be \c nil if no locale could be detected.
- @discussion Defaults to calling the `completionHandler` with `nil` if not implemented.
+ @param completionHandler A block that must be called upon completion. The block takes two arguments:
+ the detected locale (or \c nil if the locale is unknown) and an error, which should be provided if any errors occured.
+ @discussion No action is performed if not implemented.
  */
-- (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale * _Nullable locale))completionHandler;
+- (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale * _Nullable locale, NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to load a URL in the tab.
  @param url The URL to be loaded in the tab.
  @param context The context in which the web extension is running.
- @discussion If the tab is already loading a page, calling this method should stop the current page from loading and start loading the new URL.
- Loads the URL in the main web view if not implemented.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occured.
+ @discussion If the tab is already loading a page, calling this method should stop the current page from loading and start
+ loading the new URL. Loads the URL in the main web view via `loadRequest:` if not implemented.
  */
-- (void)loadURL:(NSURL *)url forWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)loadURL:(NSURL *)url forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to reload the current page in the tab.
  @param context The context in which the web extension is running.
- @discussion Reloads the main web view if not implemented.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occured.
+ @discussion Reloads the main web view via `reload` if not implemented.
  */
-- (void)reloadForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)reloadForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to reload the current page in the tab, bypassing the cache.
  @param context The context in which the web extension is running.
- @discussion Reloads the main web view, bypassing the cache, if not implemented.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occured.
+ @discussion Reloads the main web view via `reloadFromOrigin` if not implemented.
  */
-- (void)reloadFromOriginForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)reloadFromOriginForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to navigate the tab to the previous page in its history.
  @param context The context in which the web extension is running.
- @discussion Navigates to the previous page in the main web view if not implemented.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occured.
+ @discussion Navigates to the previous page in the main web view via `goBack` if not implemented.
  */
-- (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to navigate the tab to the next page in its history.
  @param context The context in which the web extension is running.
- @discussion Navigates to the next page in the main web view if not implemented.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occured.
+ @discussion Navigates to the next page in the main web view via `goForward` if not implemented.
  */
-- (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called to activate the tab, making it frontmost.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion Upon activation, the tab should become the frontmost and either be the sole selected tab or
+ be included among the selected tabs. No action is performed if not implemented.
+ @seealso selectForWebExtensionContext:extendSelection:completionHandler:
+ */
+- (void)activateForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called to select the tab, potentially extending the current selection to include multiple tabs.
+ @param context The context in which the web extension is running.
+ @param extendSelection A boolean value that determines whether the selection should be extended. If set to \c YES,
+ the selection should contain the tab along with any previously selected tabs without changing the active tab.
+ If set to \c NO, the selection should be cleared, and the tab should be the active tab and only one selected.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion This is equivalent to the user clicking on the tab in a tab bar. No action is performed if not implemented.
+ @seealso activateForWebExtensionContext:completionHandler:
+ */
+- (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context extendSelection:(BOOL)extendSelection completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called to duplicate the tab.
+ @param context The context in which the web extension is running.
+ @param options The tab creation options influencing the duplicated tab's properties.
+ @param completionHandler A block that must be called upon completion. It takes two arguments:
+ the duplicated tab (or \c nil if no tab was created) and an error, which should be provided if any errors occured.
+ @discussion This is equivalent to the user selecting to duplicate the tab through a menu item, with the specified options.
+ No action is performed if not implemented.
+ */
+- (void)duplicateForWebExtensionContext:(_WKWebExtensionContext *)context withOptions:(_WKWebExtensionTabCreationOptions *)options completionHandler:(void (^)(id <_WKWebExtensionTab> _Nullable duplicatedTab, NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to close the tab.
  @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
  */
-- (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context;
-
-/*!
- @abstract Called to select the tab.
- @param context The context in which the web extension is running.
- @discussion This is equivalent to the user clicking on the tab in a tab bar. No action is performed if not implemented.
- */
-- (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+@protocol _WKWebExtensionTab;
+@protocol _WKWebExtensionWindow;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @abstract A `_WKWebExtensionWindowCreationOptions` object encapsulates new window creation options for an extension.
+ @discussion This class holds the various options that influence the behavior and initial state of a newly created window.
+ The app retains the discretion to disregard any or all of these options, or even opt not to create a new window.
+ */
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKWebExtensionTabCreationOptions : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/*!
+ @abstract Indicates the window where the new tab should be opened.
+ @discussion If this property is set to `nil`, no window was specified.
+ */
+@property (nonatomic, nullable, readonly, strong) id <_WKWebExtensionWindow> desiredWindow;
+
+/*! @abstract Indicates the position where the new tab should be opened within the window. */
+@property (nonatomic, readonly) NSUInteger desiredIndex;
+
+/*!
+ @abstract Indicates the parent tab with which the new tab should be related.
+ @discussion If this property is set to `nil`, no parent tab was specified.
+ */
+@property (nonatomic, nullable, readonly, strong) id <_WKWebExtensionTab> desiredParentTab;
+
+/*!
+ @abstract Indicates the initial URL for the new tab.
+ @discussion If this property is set to `nil`, the app's default "start page" should appear in the new tab.
+ */
+@property (nonatomic, nullable, readonly, copy) NSURL *desiredURL;
+
+/*!
+ @abstract Indicates whether the new tab should be selected.
+ @discussion If this property is set to `YES`, and if `shouldExtendSelection` is also `YES`, the new tab
+ should be added to the current selection without altering the frontmost tab. If `shouldExtendSelection` is `NO`,
+ the previous selection should be cleared and the new tab should be the only one selected. If `shouldSelect` is `NO`,
+ this tab should not be part of the selection regardless of the `shouldExtendSelection` value.
+ @seealso shouldExtendSelection
+ */
+@property (nonatomic, readonly) BOOL shouldSelect;
+
+/*!
+ @abstract Indicates whether the new tab's selection should extend the current selection.
+ @discussion If this property is set to `YES`, and if `shouldSelect` is also `YES`, the new tab should be added
+ to the current selection without altering the frontmost tab. If this property is set to `NO`, or if `shouldSelect` is `NO`,
+ the current selection state of other tabs should not be affected by the creation of the new tab.
+ @seealso shouldSelect
+ */
+@property (nonatomic, readonly) BOOL shouldExtendSelection;
+
+/*! @abstract Indicates whether the new tab should be pinned. */
+@property (nonatomic, readonly) BOOL shouldPin;
+
+/*! @abstract Indicates whether the new tab should be muted. */
+@property (nonatomic, readonly) BOOL shouldMute;
+
+/*! @abstract Indicates whether the new tab should be in reader mode. */
+@property (nonatomic, readonly) BOOL shouldShowReaderMode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.mm
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionTabCreationOptionsInternal.h"
+
+@implementation _WKWebExtensionTabCreationOptions
+
+- (instancetype)_init
+{
+    return [super init];
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "_WKWebExtensionTabCreationOptions.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+@interface _WKWebExtensionTabCreationOptions ()
+
+- (instancetype)_init;
+
+@property (readwrite, setter=_setDesiredWindow:) id <_WKWebExtensionWindow> desiredWindow;
+@property (readwrite, setter=_setDesiredIndex:) NSUInteger desiredIndex;
+@property (readwrite, setter=_setDesiredParentTab:) id <_WKWebExtensionTab> desiredParentTab;
+@property (readwrite, setter=_setDesiredURL:) NSURL *desiredURL;
+@property (readwrite, setter=_setShouldSelect:) BOOL shouldSelect;
+@property (readwrite, setter=_setShouldExtendSelection:) BOOL shouldExtendSelection;
+@property (readwrite, setter=_setShouldPin:) BOOL shouldPin;
+@property (readwrite, setter=_setShouldMute:) BOOL shouldMute;
+@property (readwrite, setter=_setShouldShowReaderMode:) BOOL shouldShowReaderMode;
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -94,20 +94,49 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (_WKWebExtensionWindowState)windowStateForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the ephemeral state of the window is needed.
+ @abstract Called to set the state of the window.
  @param context The context in which the web extension is running.
- @return `YES` if the window is ephemeral, `NO` otherwise.
- @discussion Used to indicated "private browsing" windows. Defaults to `NO` if not implemented.
+ @param state The new state of the window.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion No action is performed if not implemented.
  */
-- (BOOL)isEphemeralForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (void)setWindowState:(_WKWebExtensionWindowState)state forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called when the private browsing state of the window is needed.
+ @param context The context in which the web extension is running.
+ @return `YES` if the window is private, `NO` otherwise.
+ @discussion Defaults to `NO` if not implemented.
+ */
+- (BOOL)isUsingPrivateBrowsingForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called when the frame of the window is needed.
  @param context The context in which the web extension is running.
- @return The frame of the window.
- @discussion The frame is the bounding rectangle of the window, in screen coordinates. Defaults to `CGRectZero` if not implemented.
+ @return The frame of the window, in screen coordinates
+ @discussion Defaults to `CGRectZero` if not implemented.
  */
 - (CGRect)frameForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to set the frame of the window.
+ @param context The context in which the web extension is running.
+ @param frame The new frame of the window, in screen coordinates.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion No action is performed if not implemented.
+ */
+- (void)setFrame:(CGRect)frame forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called to close the window.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion No action is performed if not implemented.
+ */
+- (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+#import <WebKit/_WKWebExtensionWindow.h>
+
+@protocol _WKWebExtensionTab;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @abstract A `_WKWebExtensionWindowCreationOptions` object encapsulates new window creation options for an extension.
+ @discussion This class holds the various options that influence the behavior and initial state of a newly created window.
+ The app retains the discretion to disregard any or all of these options, or even opt not to create a new window.
+ */
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKWebExtensionWindowCreationOptions : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/*! @abstract Indicates the window type for the new window. */
+@property (nonatomic, readonly) _WKWebExtensionWindowType desiredWindowType;
+
+/*! @abstract Indicates the window state for the new window. */
+@property (nonatomic, readonly) _WKWebExtensionWindowState desiredWindowState;
+
+/*!
+ @abstract Indicates the frame where the new window should be positioned on screen.
+ @discussion If this property is set to `CGRectZero`, the app's default position and size are suggested.
+ */
+@property (nonatomic, readonly) CGRect desiredFrame;
+
+/*!
+ @abstract Indicates a list of URLs that the new window should initially load as new tabs.
+ @discussion If the array is empty, and `desiredTabs` is empty, the app's default "start page" should appear in a new tab.
+ @seealso desiredTabs
+ */
+@property (nonatomic, readonly, copy) NSArray<NSURL *> *desiredURLs;
+
+/*!
+ @abstract Indicates a list of existing tabs that should be moved to the new window.
+ @discussion If the array is empty, and `desiredURLs` is empty, the app's default "start page" should appear in a new tab.
+ @seealso desiredURLs
+ */
+@property (nonatomic, readonly, copy) NSArray<id <_WKWebExtensionTab>> *desiredTabs;
+
+/*! @abstract Indicates whether the new window should be focused. */
+@property (nonatomic, readonly) BOOL shouldFocus;
+
+/*! @abstract Indicates whether the new window should be using private browsing. */
+@property (nonatomic, readonly) BOOL shouldUsePrivateBrowsing;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.mm
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionWindowCreationOptionsInternal.h"
+
+@implementation _WKWebExtensionWindowCreationOptions
+
+- (instancetype)_init
+{
+    return [super init];
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptionsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptionsInternal.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "_WKWebExtensionWindowCreationOptions.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+@interface _WKWebExtensionWindowCreationOptions ()
+
+- (instancetype)_init;
+
+@property (readwrite, setter=_setDesiredFrame:) CGRect desiredFrame;
+@property (readwrite, setter=_setDesiredWindowType:) _WKWebExtensionWindowType desiredWindowType;
+@property (readwrite, setter=_setDesiredWindowState:) _WKWebExtensionWindowState desiredWindowState;
+@property (readwrite, setter=_setDesiredURLs:) NSArray<NSURL *> *desiredURLs;
+@property (readwrite, setter=_setDesiredTabs:) NSArray<id <_WKWebExtensionTab>> *desiredTabs;
+@property (readwrite, setter=_setShouldFocus:) BOOL shouldFocus;
+@property (readwrite, setter=_setSouldUsePrivateBrowsing:) BOOL shouldUsePrivateBrowsing;
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1361,6 +1361,18 @@ void WebExtensionContext::didCloseTab(const WebExtensionTab& tab, WindowIsClosin
     // FIXME: Fire event here.
 }
 
+void WebExtensionContext::didActivateTab(const WebExtensionTab& tab)
+{
+    ASSERT(tab.extensionContext() == this);
+    ASSERT(m_tabMap.contains(tab.identifier()));
+    ASSERT(m_tabMap.get(tab.identifier()) == &tab);
+
+    if (!isLoaded())
+        return;
+
+    // FIXME: Fire event here.
+}
+
 void WebExtensionContext::didSelectTabs(const TabSet& tabs)
 {
 #ifndef NDEBUG

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -33,6 +33,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "CocoaHelpers.h"
+#import "Logging.h"
 #import "WebExtensionContext.h"
 #import "_WKWebExtensionTab.h"
 #import "_WKWebExtensionWindow.h"
@@ -47,8 +48,11 @@ WebExtensionWindow::WebExtensionWindow(const WebExtensionContext& context, _WKWe
     , m_respondsToActiveTab([delegate respondsToSelector:@selector(activeTabForWebExtensionContext:)])
     , m_respondsToWindowType([delegate respondsToSelector:@selector(windowTypeForWebExtensionContext:)])
     , m_respondsToWindowState([delegate respondsToSelector:@selector(windowStateForWebExtensionContext:)])
-    , m_respondsToIsEphemeral([delegate respondsToSelector:@selector(isEphemeralForWebExtensionContext:)])
+    , m_respondsToSetWindowState([delegate respondsToSelector:@selector(setWindowState:forWebExtensionContext:completionHandler:)])
+    , m_respondsToIsUsingPrivateBrowsing([delegate respondsToSelector:@selector(isUsingPrivateBrowsingForWebExtensionContext:)])
     , m_respondsToFrame([delegate respondsToSelector:@selector(frameForWebExtensionContext:)])
+    , m_respondsToSetFrame([delegate respondsToSelector:@selector(setFrame:forWebExtensionContext:completionHandler:)])
+    , m_respondsToClose([delegate respondsToSelector:@selector(closeForWebExtensionContext:completionHandler:)])
 {
     ASSERT([delegate conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
 }
@@ -151,6 +155,39 @@ WebExtensionWindow::State WebExtensionWindow::state() const
     return toImpl([m_delegate windowStateForWebExtensionContext:m_extensionContext->wrapper()]);
 }
 
+static inline _WKWebExtensionWindowState toAPI(WebExtensionWindow::State state)
+{
+    switch (state) {
+    case WebExtensionWindow::State::Normal:
+        return _WKWebExtensionWindowStateNormal;
+    case WebExtensionWindow::State::Minimized:
+        return _WKWebExtensionWindowStateMinimized;
+    case WebExtensionWindow::State::Maximized:
+        return _WKWebExtensionWindowStateMaximized;
+    case WebExtensionWindow::State::Fullscreen:
+        return _WKWebExtensionWindowStateFullscreen;
+    }
+
+    ASSERT_NOT_REACHED();
+    return _WKWebExtensionWindowStateNormal;
+}
+
+void WebExtensionWindow::setState(WebExtensionWindow::State state, CompletionHandler<void(Error)>&& completionHandler)
+{
+    if (!isValid() || !m_respondsToSetWindowState)
+        return;
+
+    [m_delegate setWindowState:toAPI(state) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:^(NSError *error) {
+        if (error) {
+            RELEASE_LOG_ERROR(Extensions, "Error for setWindowState: %{private}@", error);
+            completionHandler(error.localizedDescription);
+            return;
+        }
+
+        completionHandler(std::nullopt);
+    }];
+}
+
 bool WebExtensionWindow::isFocused() const
 {
     if (!isValid())
@@ -159,12 +196,12 @@ bool WebExtensionWindow::isFocused() const
     return this == m_extensionContext->focusedWindow();
 }
 
-bool WebExtensionWindow::isEphemeral() const
+bool WebExtensionWindow::isPrivate() const
 {
-    if (!isValid() || !m_respondsToIsEphemeral)
+    if (!isValid() || !m_respondsToIsUsingPrivateBrowsing)
         return false;
 
-    return [m_delegate isEphemeralForWebExtensionContext:m_extensionContext->wrapper()];
+    return [m_delegate isUsingPrivateBrowsingForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
 CGRect WebExtensionWindow::frame() const
@@ -173,6 +210,38 @@ CGRect WebExtensionWindow::frame() const
         return CGRectZero;
 
     return [m_delegate frameForWebExtensionContext:m_extensionContext->wrapper()];
+}
+
+void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Error)>&& completionHandler)
+{
+    if (!isValid() || !m_respondsToSetFrame)
+        return;
+
+    [m_delegate setFrame:frame forWebExtensionContext:m_extensionContext->wrapper() completionHandler:^(NSError *error) {
+        if (error) {
+            RELEASE_LOG_ERROR(Extensions, "Error for setFrame: %{private}@", error);
+            completionHandler(error.localizedDescription);
+            return;
+        }
+
+        completionHandler(std::nullopt);
+    }];
+}
+
+void WebExtensionWindow::close(CompletionHandler<void(Error)>&& completionHandler)
+{
+    if (!isValid() || !m_respondsToClose)
+        return;
+
+    [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:^(NSError *error) {
+        if (error) {
+            RELEASE_LOG_ERROR(Extensions, "Error for window close: %{private}@", error);
+            completionHandler(error.localizedDescription);
+            return;
+        }
+
+        completionHandler(std::nullopt);
+    }];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -238,6 +238,7 @@ public:
 
     void didOpenTab(const WebExtensionTab&);
     void didCloseTab(const WebExtensionTab&, WindowIsClosing = WindowIsClosing::No);
+    void didActivateTab(const WebExtensionTab&);
     void didSelectTabs(const TabSet&);
 
     void didMoveTab(const WebExtensionTab&, uint64_t index, WebExtensionWindow* oldWindow = nullptr);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -68,12 +68,18 @@ public:
         All        = Audible | Loading | Muted | Pinned | ReaderMode | Size | Title | URL | ZoomFactor,
     };
 
+    enum class ExtendSelection : bool { No, Yes };
+
+    using Error = std::optional<String>;
+
     WebExtensionTabIdentifier identifier() const { return m_identifier; }
     WebExtensionContext* extensionContext() const { return m_extensionContext.get(); }
 
     bool operator==(const WebExtensionTab&) const;
 
     RefPtr<WebExtensionWindow> window() const;
+    size_t index() const;
+
     RefPtr<WebExtensionTab> parentTab() const;
 
     WKWebView *mainWebView() const;
@@ -83,38 +89,45 @@ public:
 
     bool isSelected() const;
     bool isPinned() const;
+    bool isPrivate() const;
 
-    void toggleReaderMode();
+    void toggleReaderMode(CompletionHandler<void(Error)>&&);
 
     bool isReaderModeAvailable() const;
     bool isShowingReaderMode() const;
 
-    void mute();
-    void unmute();
+    void mute(CompletionHandler<void(Error)>&&);
+    void unmute(CompletionHandler<void(Error)>&&);
 
     bool isAudible() const;
     bool isMuted() const;
 
     CGSize size() const;
+
     double zoomFactor() const;
+    void setZoomFactor(double, CompletionHandler<void(Error)>&&);
 
     URL url() const;
     URL pendingURL() const;
 
     bool isLoadingComplete() const;
 
-    void detectWebpageLocale(CompletionHandler<void(NSLocale *)>&&);
+    void detectWebpageLocale(CompletionHandler<void(NSLocale *, Error)>&&);
 
-    void loadURL(URL);
+    void loadURL(URL, CompletionHandler<void(Error)>&&);
 
-    void reload();
-    void reloadFromOrigin();
+    void reload(CompletionHandler<void(Error)>&&);
+    void reloadFromOrigin(CompletionHandler<void(Error)>&&);
 
-    void goBack();
-    void goForward();
+    void goBack(CompletionHandler<void(Error)>&&);
+    void goForward(CompletionHandler<void(Error)>&&);
 
-    void close();
-    void select();
+    void activate(CompletionHandler<void(Error)>&&);
+    void select(ExtendSelection, CompletionHandler<void(Error)>&&);
+
+    void duplicate(CompletionHandler<void(RefPtr<WebExtensionTab>, Error)>&&);
+
+    void close(CompletionHandler<void(Error)>&&);
 
 #ifdef __OBJC__
     _WKWebExtensionTab *delegate() const { return m_delegate.getAutoreleased(); }
@@ -133,7 +146,6 @@ private:
     bool m_respondsToTabTitle : 1 { false };
     bool m_respondsToIsSelected : 1 { false };
     bool m_respondsToIsPinned : 1 { false };
-    bool m_respondsToIsEphemeral : 1 { false };
     bool m_respondsToIsReaderModeAvailable : 1 { false };
     bool m_respondsToIsShowingReaderMode : 1 { false };
     bool m_respondsToToggleReaderMode : 1 { false };
@@ -143,6 +155,7 @@ private:
     bool m_respondsToUnmute : 1 { false };
     bool m_respondsToSize : 1 { false };
     bool m_respondsToZoomFactor : 1 { false };
+    bool m_respondsToSetZoomFactor : 1 { false };
     bool m_respondsToURL : 1 { false };
     bool m_respondsToPendingURL : 1 { false };
     bool m_respondsToIsLoadingComplete : 1 { false };
@@ -152,8 +165,10 @@ private:
     bool m_respondsToReloadFromOrigin : 1 { false };
     bool m_respondsToGoBack : 1 { false };
     bool m_respondsToGoForward : 1 { false };
-    bool m_respondsToClose : 1 { false };
+    bool m_respondsToActivate : 1 { false };
     bool m_respondsToSelect : 1 { false };
+    bool m_respondsToDuplicate : 1 { false };
+    bool m_respondsToClose : 1 { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -63,6 +63,7 @@ public:
         Fullscreen,
     };
 
+    using Error = std::optional<String>;
     using TabVector = Vector<Ref<WebExtensionTab>>;
 
     WebExtensionWindowIdentifier identifier() const { return m_identifier; }
@@ -74,12 +75,17 @@ public:
     RefPtr<WebExtensionTab> activeTab() const;
 
     Type type() const;
+
     State state() const;
+    void setState(State, CompletionHandler<void(Error)>&&);
 
     bool isFocused() const;
-    bool isEphemeral() const;
+    bool isPrivate() const;
 
     CGRect frame() const;
+    void setFrame(CGRect, CompletionHandler<void(Error)>&&);
+
+    void close(CompletionHandler<void(Error)>&&);
 
 #ifdef __OBJC__
     _WKWebExtensionWindow *delegate() const { return m_delegate.getAutoreleased(); }
@@ -95,8 +101,11 @@ private:
     bool m_respondsToActiveTab : 1 { false };
     bool m_respondsToWindowType : 1 { false };
     bool m_respondsToWindowState : 1 { false };
-    bool m_respondsToIsEphemeral : 1 { false };
+    bool m_respondsToSetWindowState : 1 { false };
+    bool m_respondsToIsUsingPrivateBrowsing : 1 { false };
     bool m_respondsToFrame : 1 { false };
+    bool m_respondsToSetFrame : 1 { false };
+    bool m_respondsToClose : 1 { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -441,6 +441,12 @@
 		1C5ACFB42A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACFB32A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C5ACFB62A96FA2800C041C0 /* WebExtensionAPITabsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACFB52A96FA2800C041C0 /* WebExtensionAPITabsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C5ACFB82A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C5ACF8C2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACF8A2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C5ACF8D2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACF8B2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C5ACF902A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACF8E2A955CAF00C041C0 /* _WKWebExtensionTabCreationOptions.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C5ACF912A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACF8F2A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C5ACF932A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACF922A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h */; };
+		1C5ACF952A965C4C00C041C0 /* _WKWebExtensionWindowCreationOptionsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACF942A965C4B00C041C0 /* _WKWebExtensionWindowCreationOptionsInternal.h */; };
 		1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C5DC45F2909B05A0061EC62 /* JSWebExtensionWrapperCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5DC45A29099F010061EC62 /* JSWebExtensionWrapperCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3472,6 +3478,12 @@
 		1C5ACFB32A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWindowsEventCocoa.mm; sourceTree = "<group>"; };
 		1C5ACFB52A96FA2800C041C0 /* WebExtensionAPITabsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPITabsCocoa.mm; sourceTree = "<group>"; };
 		1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWindowsCocoa.mm; sourceTree = "<group>"; };
+		1C5ACF8A2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionWindowCreationOptions.h; sourceTree = "<group>"; };
+		1C5ACF8B2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionWindowCreationOptions.mm; sourceTree = "<group>"; };
+		1C5ACF8E2A955CAF00C041C0 /* _WKWebExtensionTabCreationOptions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionTabCreationOptions.mm; sourceTree = "<group>"; };
+		1C5ACF8F2A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionTabCreationOptions.h; sourceTree = "<group>"; };
+		1C5ACF922A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionTabCreationOptionsInternal.h; sourceTree = "<group>"; };
+		1C5ACF942A965C4B00C041C0 /* _WKWebExtensionWindowCreationOptionsInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionWindowCreationOptionsInternal.h; sourceTree = "<group>"; };
 		1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIObject.h; sourceTree = "<group>"; };
 		1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPINamespace.h; sourceTree = "<group>"; };
 		1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPINamespaceCocoa.mm; sourceTree = "<group>"; };
@@ -10065,7 +10077,13 @@
 				1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */,
 				1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */,
 				1C04983C289AFF9B0010308B /* _WKWebExtensionTab.h */,
+				1C5ACF8F2A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h */,
+				1C5ACF8E2A955CAF00C041C0 /* _WKWebExtensionTabCreationOptions.mm */,
+				1C5ACF922A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h */,
 				1C04983D289AFF9B0010308B /* _WKWebExtensionWindow.h */,
+				1C5ACF8A2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.h */,
+				1C5ACF8B2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.mm */,
+				1C5ACF942A965C4B00C041C0 /* _WKWebExtensionWindowCreationOptionsInternal.h */,
 				1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */,
 				1AE286751C7E76510069AC4F /* _WKWebsiteDataSize.mm */,
 				1AE2867F1C7F92BF0069AC4F /* _WKWebsiteDataSizeInternal.h */,
@@ -14151,9 +14169,13 @@
 				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
 				1C049840289AFF9B0010308B /* _WKWebExtensionTab.h in Headers */,
+				1C5ACF912A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h in Headers */,
+				1C5ACF932A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h in Headers */,
 				337822472947FBA5002106BB /* _WKWebExtensionUtilities.h in Headers */,
 				337822442947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h in Headers */,
 				1C049841289AFF9B0010308B /* _WKWebExtensionWindow.h in Headers */,
+				1C5ACF8C2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.h in Headers */,
+				1C5ACF952A965C4C00C041C0 /* _WKWebExtensionWindowCreationOptionsInternal.h in Headers */,
 				1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */,
 				1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */,
 				5120C8351E5B74B90025B250 /* _WKWebsiteDataStoreConfiguration.h in Headers */,
@@ -17009,8 +17031,10 @@
 				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
+				1C5ACF902A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.mm in Sources */,
 				337822482947FBA5002106BB /* _WKWebExtensionUtilities.mm in Sources */,
 				337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */,
+				1C5ACF8D2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.mm in Sources */,
 				07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,


### PR DESCRIPTION
#### 8987771749cd19e4bfdff5daf2d57a1f276789f9
<pre>
Adjust _WKWebExtensionWindow and _WKWebExtensionTab APIs based on feedback.
<a href="https://webkit.org/b/260156">https://webkit.org/b/260156</a>

Reviewed by Brian Weinstein.

* Added delegate methods for window and tab creation with new helper classes to hold sugested properties
for the new windows and tabs.
* Have all action methods for windows and tabs take a completionHandler so clients that need do do them
async can report when they are complete.
* Renamed isEphemerial to isUsingPrivateBrowsing to be more clear and match common wording.
* Added missing close method, and setter methods for frame and windowState on the window protocol.
* Removed method for isEphemeral on the tab protocol, since tabs are required to be in a private window.
* Added missing activate, duplicate, and setZoomFactor methods on the tab protocol.

* Source/WebKit/Modules/OSX_Private.modulemap: Added new headers.
* Source/WebKit/Modules/iOS_Private.modulemap: Added new headers.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toImpl): Fix the cases for All and None.
(-[_WKWebExtensionContext didActivateTab:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController didActivateTab:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.mm: Added.
(-[_WKWebExtensionTabCreationOptions _init]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.mm: Added.
(-[_WKWebExtensionWindowCreationOptions _init]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptionsInternal.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didActivateTab): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::window const):
(WebKit::WebExtensionTab::index const): Added.
(WebKit::WebExtensionTab::isPrivate const): Return the result from the containing window.
(WebKit::WebExtensionTab::toggleReaderMode):
(WebKit::WebExtensionTab::mute):
(WebKit::WebExtensionTab::unmute):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::reloadFromOrigin):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::activate): Added.
(WebKit::WebExtensionTab::select):
(WebKit::WebExtensionTab::duplicate):
(WebKit::WebExtensionTab::close):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::WebExtensionWindow):
(WebKit::toAPI): Added.
(WebKit::WebExtensionWindow::setState): Added.
(WebKit::WebExtensionWindow::isPrivate const): Renamed from isEphemeral.
(WebKit::WebExtensionWindow::setFrame): Added.
(WebKit::WebExtensionWindow::close): Added.
(WebKit::WebExtensionWindow::isEphemeral const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added new files.

Canonical link: <a href="https://commits.webkit.org/267240@main">https://commits.webkit.org/267240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c2489a5356ee689660860bfab74c88ab4cc9203

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16074 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15091 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18601 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/14964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18902 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1968 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->