### PR TITLE
Update IPInt SIMD to use OfflineASM

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -3625,13 +3625,9 @@ unimplementedInstruction(_simd_v128_store_mem)
 instructionLabel(_simd_v128_const)
     # v128.const
     leap [PM, MC], t0
-    if ARM64 or ARM64E
-        emit "ldr q0, [x0, #1]"
-    else
-        emit "movdqu 1(%eax), %xmm1"
-    end
+    loadv 1[t0], v0
     loadb [t0], t0
-    pushVectorReg0()
+    pushv v0
     advancePCByReg(t0)
     advanceMC(17)
     nextIPIntInstruction()
@@ -3657,20 +3653,21 @@ unimplementedInstruction(_simd_i16x8_replace_lane)
 instructionLabel(_simd_i32x4_extract_lane)
     # i32x4.extract_lane (lane)
     loadb 2[PB, PC], t0  # lane index
-    popVectorReg0()
+    popv v0
     if ARM64 or ARM64E
         pcrtoaddr _simd_i32x4_extract_lane_0, t1
         leap [t1, t0, 8], t0
         _simd_i32x4_extract_lane_0:
-        emit "smov x0, v0.s[0]"
+        umovi t0, v0_i, 0
         jmp _simd_i32x4_extract_lane_end
-        emit "smov x0, v0.s[1]"
+        umovi t0, v0_i, 1
         jmp _simd_i32x4_extract_lane_end
-        emit "smov x0, v0.s[2]"
+        umovi t0, v0_i, 2
         jmp _simd_i32x4_extract_lane_end
-        emit "smov x0, v0.s[3]"
+        umovi t0, v0_i, 3
         jmp _simd_i32x4_extract_lane_end
     elsif X86_64
+        # FIXME: implement SIMD instructions for x86 and finish this implementation!
     end
 _simd_i32x4_extract_lane_end:
     pushInt32(t0)

--- a/Source/JavaScriptCore/offlineasm/ast.rb
+++ b/Source/JavaScriptCore/offlineasm/ast.rb
@@ -698,6 +698,48 @@ class FPRegisterID < NoChildren
     end
 end
 
+class VecRegisterID < NoChildren
+    attr_reader :name
+    
+    def initialize(codeOrigin, name)
+        super(codeOrigin)
+        @name = name
+    end
+    
+    @@mapping = {}
+    
+    def self.forName(codeOrigin, name)
+        unless @@mapping[name]
+            @@mapping[name] = VecRegisterID.new(codeOrigin, name)
+        end
+        @@mapping[name]
+    end
+    
+    def dump
+        name
+    end
+    
+    def address?
+        false
+    end
+    
+    def label?
+        false
+    end
+    
+    def immediate?
+        false
+    end
+    
+    def immediateOperand?
+        false
+    end
+    
+    def register?
+        true
+    end
+end
+
 class SpecialRegister < NoChildren
     attr_reader :name
 

--- a/Source/JavaScriptCore/offlineasm/instructions.rb
+++ b/Source/JavaScriptCore/offlineasm/instructions.rb
@@ -141,7 +141,9 @@ MACRO_INSTRUCTIONS =
      "bcd2i",
      "movdz",
      "pop",
+     "popv",
      "push",
+     "pushv",
      "move",
      "sxi2q",
      "zxi2q",
@@ -379,6 +381,10 @@ X86_INSTRUCTIONS =
      "fence",
     ]
 
+X86_SIMD_INSTRUCTIONS =
+    [
+    ]
+
 ARM_INSTRUCTIONS =
     [
      "adci",
@@ -448,6 +454,14 @@ ARM64_INSTRUCTIONS =
      "storepaird",
     ]
 
+ARM64_SIMD_INSTRUCTIONS =
+    [
+     "umovb",
+     "umovh",
+     "umovi",
+     "umovq",
+    ]
+
 RISC_INSTRUCTIONS =
     [
      "smulli",  # Multiply two 32-bit words and produce a 64-bit word
@@ -496,7 +510,7 @@ CXX_INSTRUCTIONS =
      "cloopDo",              # no operands
     ]
 
-INSTRUCTIONS = MACRO_INSTRUCTIONS + X86_INSTRUCTIONS + ARM_INSTRUCTIONS + ARM64_INSTRUCTIONS + RISC_INSTRUCTIONS + MIPS_INSTRUCTIONS + CXX_INSTRUCTIONS
+INSTRUCTIONS = MACRO_INSTRUCTIONS + X86_INSTRUCTIONS + X86_SIMD_INSTRUCTIONS + ARM_INSTRUCTIONS + ARM64_INSTRUCTIONS + ARM64_SIMD_INSTRUCTIONS + RISC_INSTRUCTIONS + MIPS_INSTRUCTIONS + CXX_INSTRUCTIONS
 
 INSTRUCTION_SET = INSTRUCTIONS.to_set
 

--- a/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/Source/JavaScriptCore/offlineasm/parser.rb
@@ -359,7 +359,9 @@ class Parser
     
     def parseVariable
         if isRegister(@tokens[@idx])
-            if @tokens[@idx] =~ FPR_PATTERN || @tokens[@idx] =~ WASM_FPR_PATTERN
+            if @tokens[@idx] =~ VEC_PATTERN
+                result = VecRegisterID.forName(@tokens[@idx].codeOrigin, @tokens[@idx].string)
+            elsif @tokens[@idx] =~ FPR_PATTERN || @tokens[@idx] =~ WASM_FPR_PATTERN
                 result = FPRegisterID.forName(@tokens[@idx].codeOrigin, @tokens[@idx].string)
             else
                 result = RegisterID.forName(@tokens[@idx].codeOrigin, @tokens[@idx].string)

--- a/Source/JavaScriptCore/offlineasm/registers.rb
+++ b/Source/JavaScriptCore/offlineasm/registers.rb
@@ -89,6 +89,50 @@ FPRS =
      "fr"
     ]
 
+VECS =
+    [
+     "v0",
+     "v0_b",
+     "v0_h",
+     "v0_i",
+     "v0_q",
+     "v1",
+     "v1_b",
+     "v1_h",
+     "v1_i",
+     "v1_q",
+     "v2",
+     "v2_b",
+     "v2_h",
+     "v2_i",
+     "v2_q",
+     "v3",
+     "v3_b",
+     "v3_h",
+     "v3_i",
+     "v3_q",
+     "v4",
+     "v4_b",
+     "v4_h",
+     "v4_i",
+     "v4_q",
+     "v5",
+     "v5_b",
+     "v5_h",
+     "v5_i",
+     "v5_q",
+     "v6",
+     "v6_b",
+     "v6_h",
+     "v6_i",
+     "v6_q",
+     "v7",
+     "v7_b",
+     "v7_h",
+     "v7_i",
+     "v7_q",
+    ]
+
 WASM_GPRS =
     [
      "wa0",
@@ -122,10 +166,11 @@ WASM_SCRATCHS =
      "ws3",
     ]
 
-REGISTERS = GPRS + FPRS + WASM_GPRS + WASM_FPRS + WASM_SCRATCHS
+REGISTERS = GPRS + FPRS + VECS + WASM_GPRS + WASM_FPRS + WASM_SCRATCHS
 
 GPR_PATTERN = Regexp.new('\\A((' + GPRS.join(')|(') + '))\\Z')
 FPR_PATTERN = Regexp.new('\\A((' + FPRS.join(')|(') + '))\\Z')
+VEC_PATTERN = Regexp.new('\\A((' + VECS.join(')|(') + '))\\Z')
 WASM_GPR_PATTERN = Regexp.new('\\A((' + WASM_GPRS.join(')|(') + '))\\Z')
 WASM_FPR_PATTERN = Regexp.new('\\A((' + WASM_FPRS.join(')|(') + '))\\Z')
 

--- a/Source/JavaScriptCore/offlineasm/transform.rb
+++ b/Source/JavaScriptCore/offlineasm/transform.rb
@@ -679,6 +679,11 @@ class FPRegisterID
     end
 end
 
+class VecRegisterID
+    def validate
+    end
+end
+
 class Address
     def validate
         validateChildren

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -358,6 +358,94 @@ class FPRegisterID
     end
 end
 
+class VecRegisterID
+    def x86Operand(kind)
+        case @name
+        when 'v0'
+            register('xmm0')
+        when 'v0_b'
+            register('xmm0')
+        when 'v0_h'
+            register('xmm0')
+        when 'v0_i'
+            register('xmm0')
+        when 'v0_q'
+            register('xmm0')
+        when 'v1'
+            register('xmm1')
+        when 'v1_b'
+            register('xmm1')
+        when 'v1_h'
+            register('xmm1')
+        when 'v1_i'
+            register('xmm1')
+        when 'v1_q'
+            register('xmm1')
+        when 'v2'
+            register('xmm2')
+        when 'v2_b'
+            register('xmm2')
+        when 'v2_h'
+            register('xmm2')
+        when 'v2_i'
+            register('xmm2')
+        when 'v2_q'
+            register('xmm2')
+        when 'v3'
+            register('xmm3')
+        when 'v3_b'
+            register('xmm3')
+        when 'v3_h'
+            register('xmm3')
+        when 'v3_i'
+            register('xmm3')
+        when 'v3_q'
+            register('xmm3')
+        when 'v5'
+            register('xmm4')
+        when 'v4_b'
+            register('xmm4')
+        when 'v4_h'
+            register('xmm4')
+        when 'v4_i'
+            register('xmm4')
+        when 'v4_q'
+            register('xmm4')
+        when 'v5'
+            register('xmm5')
+        when 'v5_b'
+            register('xmm5')
+        when 'v5_h'
+            register('xmm5')
+        when 'v5_i'
+            register('xmm5')
+        when 'v5_q'
+            register('xmm5')
+        when 'v6'
+            register('xmm6')
+        when 'v6_b'
+            register('xmm6')
+        when 'v6_h'
+            register('xmm6')
+        when 'v6_i'
+            register('xmm6')
+        when 'v6_q'
+            register('xmm6')
+        when 'v7'
+            register('xmm7')
+        when 'v7_b'
+            register('xmm7')
+        when 'v7_h'
+            register('xmm7')
+        when 'v7_i'
+            register('xmm7')
+        when 'v7_q'
+            register('xmm7')
+        else "Bad register name #{@name} at #{codeOriginString}"
+        end
+    end
+end
+
 class Immediate
     def validX86Immediate?
         if isX64
@@ -1403,10 +1491,22 @@ class Instruction
                 | op |
                 $asm.puts "pop #{op.x86Operand(:ptr)}"
             }
+        when "popv"
+            operands.each {
+                | op |
+                $asm.puts "movdqu (%esp), #{op.x86Operand(:vector)}"
+                $asm.puts "add $16, %esp"
+            }
         when "push"
             operands.each {
                 | op |
                 $asm.puts "push #{op.x86Operand(:ptr)}"
+            }
+        when "pushv"
+            operands.each {
+                | op |
+                $asm.puts "sub $16, %esp"
+                $asm.puts "movdqu #{op.x86Operand(:vector)}, (%esp)"
             }
         when "move"
             handleMove


### PR DESCRIPTION
#### 887079092fa848bb96985674473e6a20ccb150d2
<pre>
Update IPInt SIMD to use OfflineASM
<a href="https://bugs.webkit.org/show_bug.cgi?id=260627">https://bugs.webkit.org/show_bug.cgi?id=260627</a>
rdar://114346517

Reviewed by Yusuke Suzuki.

Updated the offline assembler to support emitting SIMD registers and a single test instruction (umov) for ARM64.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/offlineasm/arm64.rb:
* Source/JavaScriptCore/offlineasm/ast.rb:
* Source/JavaScriptCore/offlineasm/instructions.rb:
* Source/JavaScriptCore/offlineasm/parser.rb:
* Source/JavaScriptCore/offlineasm/registers.rb:
* Source/JavaScriptCore/offlineasm/transform.rb:

Canonical link: <a href="https://commits.webkit.org/267318@main">https://commits.webkit.org/267318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/837c7314583367fe1fc510b713214382ac7e1cd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15233 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18766 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21525 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13983 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18100 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15471 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13102 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16437 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14679 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4090 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3890 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19045 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17603 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15277 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3883 "Passed tests") | 
<!--EWS-Status-Bubble-End-->