### PR TITLE
Container query with font units should invalidate when font changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-calc-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-calc-dynamic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL font-relative calc() is responsive to container font-size changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS font-relative calc() is responsive to container font-size changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL em units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS em units respond to changes
 PASS rem units respond to changes
-FAIL ex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS ex units respond to changes
 FAIL rex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL ch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS ch units respond to changes
 FAIL cap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL rch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL lh units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS lh units respond to changes
 PASS rlh units respond to changes
-FAIL ic units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS ic units respond to changes
 FAIL ric units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL rcap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -70,7 +70,7 @@ private:
     enum class QueryContainerAction : uint8_t { None, Resolve, Continue };
     enum class DescendantsToResolve : uint8_t { None, ChildrenWithExplicitInherit, Children, All };
 
-    QueryContainerAction updateStateForQueryContainer(Element&, const RenderStyle*, ContainerType previousContainerType, Change&, DescendantsToResolve&);
+    QueryContainerAction updateStateForQueryContainer(Element&, const RenderStyle*, Change&, DescendantsToResolve&);
 
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 


### PR DESCRIPTION
#### 0b06dbb375788621d903a2be904c2cf595557d85
<pre>
Container query with font units should invalidate when font changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=253940">https://bugs.webkit.org/show_bug.cgi?id=253940</a>
rdar://106739736

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-calc-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt:

The remaining failures are units we don&apos;t support.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::styleChangeAffectsRelativeUnits):

Factor into a function.

(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::updateStateForQueryContainer):

If the container font size changes we need to evaluate all descendants in case there are container queries that use
font-relative units.

* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/267258@main">https://commits.webkit.org/267258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10138147185565112f6b082f9e565aab8f1d120a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16550 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18651 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17985 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15345 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14572 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3843 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->