### PR TITLE
Make setting a link@rel=stylesheet to “disabled” also set ownerNode=null

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-001-expected.txt
@@ -1,4 +1,4 @@
 
 PASS <link disabled> prevents the stylesheet from being in document.styleSheets (from parser)
-FAIL HTMLLinkElement.disabled reflects the <link disabled> attribute, and behaves consistently assert_equals: expected null but got Element node <link title="alt" rel="stylesheet" href="data:text/css,ht...
+PASS HTMLLinkElement.disabled reflects the <link disabled> attribute, and behaves consistently
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL HTMLLinkElement.disabled reflects the <link disabled> attribute, and behaves consistently, when the sheet is an alternate assert_equals: expected null but got Element node <link title="alt" rel="alternate stylesheet" href="data:t...
+PASS HTMLLinkElement.disabled reflects the <link disabled> attribute, and behaves consistently, when the sheet is an alternate
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -156,6 +156,8 @@ void HTMLLinkElement::setDisabledState(bool disabled)
         process();
     else {
         ASSERT(m_styleScope);
+        if (m_sheet)
+            m_sheet->clearOwnerNode();
         m_styleScope->didChangeActiveStyleSheetCandidates();
     }
 }


### PR DESCRIPTION
#### 9ae24bdf27c4e0cca56def08f8c5508504b6de7d
<pre>
Make setting a link@rel=stylesheet to “disabled” also set ownerNode=null
<a href="https://bugs.webkit.org/show_bug.cgi?id=260642">https://bugs.webkit.org/show_bug.cgi?id=260642</a>

Reviewed by Ryosuke Niwa.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-002-expected.txt:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::setDisabledState):

Canonical link: <a href="https://commits.webkit.org/269168@main">https://commits.webkit.org/269168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7471c79cb12fe076ab488604e686c2607786532

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22450 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24216 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22199 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15850 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17852 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->