### PR TITLE
Restore some removed WebPushD message types

### DIFF
--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -43,7 +43,9 @@ constexpr const char* protocolMessageTypeKey { "message type" };
 
 enum class MessageType : uint8_t {
     EchoTwice = 1,
+    RequestSystemNotificationPermission_UNUSED,
     DeletePushAndNotificationRegistration,
+    GetOriginsWithPushAndNotificationPermissions_UNUSED,
     SetDebugModeIsEnabled,
     UpdateConnectionConfiguration,
     InjectPushMessageForTesting,
@@ -68,7 +70,9 @@ inline bool messageTypeSendsReply(MessageType messageType)
 {
     switch (messageType) {
     case MessageType::EchoTwice:
+    case MessageType::RequestSystemNotificationPermission_UNUSED:
     case MessageType::DeletePushAndNotificationRegistration:
+    case MessageType::GetOriginsWithPushAndNotificationPermissions_UNUSED:
     case MessageType::GetPendingPushMessages:
     case MessageType::InjectPushMessageForTesting:
     case MessageType::InjectEncryptedPushMessageForTesting:

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -485,6 +485,9 @@ void WebPushDaemon::decodeAndHandleMessage(xpc_connection_t connection, MessageT
     case MessageType::SetPublicTokenForTesting:
         handleWebPushDMessageWithReply<MessageInfo::setPublicTokenForTesting>(clientConnection, encodedMessage, WTFMove(replySender));
         break;
+    case MessageType::RequestSystemNotificationPermission_UNUSED:
+    case MessageType::GetOriginsWithPushAndNotificationPermissions_UNUSED:
+        break;
     }
 }
 


### PR DESCRIPTION
#### e3a806233691a7d437a0593d60b904821b127388
<pre>
Restore some removed WebPushD message types
<a href="https://bugs.webkit.org/show_bug.cgi?id=260644">https://bugs.webkit.org/show_bug.cgi?id=260644</a>
rdar://114363467

Reviewed by Alex Christensen.

Existing WebPushD needs these constants in place for this protocol version.

Restore them now (even if unused) as we continue to hack on WebPushD messaging.

* Source/WebKit/Shared/WebPushDaemonConstants.h:
(WebKit::WebPushD::messageTypeSendsReply):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::decodeAndHandleMessage):

Canonical link: <a href="https://commits.webkit.org/267225@main">https://commits.webkit.org/267225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cf6737496d6957f48d9a1b029120d4290179756

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15026 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17465 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18531 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13912 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21330 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17876 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14468 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3822 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->