### PR TITLE
[JSC] Baseline JIT IC should not have ability to change stubInfoGPR

### DIFF
--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -467,7 +467,7 @@ void JIT::emit_op_iterator_open(const JSInstruction* instruction)
         CacheableIdentifier::createFromImmortalIdentifier(ident->impl()), baseJSR, resultJSR, stubInfoGPR, AccessType::GetById);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_getByIds.append(gen);
@@ -576,7 +576,7 @@ void JIT::emit_op_iterator_next(const JSInstruction* instruction)
             CacheableIdentifier::createFromImmortalIdentifier(vm().propertyNames->done.impl()), returnValueJSR, doneJSR, stubInfoGPR, AccessType::GetById);
         gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-        gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+        gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
         resetSP(); // We might OSR exit here, so we need to conservatively reset SP
         addSlowCase();
         m_getByIds.append(gen);
@@ -604,7 +604,7 @@ void JIT::emit_op_iterator_next(const JSInstruction* instruction)
             CacheableIdentifier::createFromImmortalIdentifier(vm().propertyNames->value.impl()), baseJSR, resultJSR, stubInfoGPR, AccessType::GetById);
         gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-        gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+        gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
         resetSP(); // We might OSR exit here, so we need to conservatively reset SP
         addSlowCase();
         m_getByIds.append(gen);

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
@@ -160,12 +160,13 @@ void JITGetByIdGenerator::generateFastPath(CCallHelpers& jit, GPRReg scratchGPR)
     m_done = jit.label();
 }
 
-void JITGetByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo, GPRReg stubInfoGPR)
+void JITGetByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
 {
     m_start = jit.label();
 
     using BaselineJITRegisters::GetById::baseJSR;
     using BaselineJITRegisters::GetById::resultJSR;
+    using BaselineJITRegisters::GetById::FastPath::stubInfoGPR;
     using BaselineJITRegisters::GetById::FastPath::scratchGPR;
 
     jit.loadConstant(stubInfo, stubInfoGPR);
@@ -210,12 +211,13 @@ void JITGetByIdWithThisGenerator::generateFastPath(CCallHelpers& jit, GPRReg scr
     m_done = jit.label();
 }
 
-void JITGetByIdWithThisGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo, GPRReg stubInfoGPR)
+void JITGetByIdWithThisGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
 {
     m_start = jit.label();
 
     using BaselineJITRegisters::GetByIdWithThis::baseJSR;
     using BaselineJITRegisters::GetByIdWithThis::resultJSR;
+    using BaselineJITRegisters::GetByIdWithThis::FastPath::stubInfoGPR;
     using BaselineJITRegisters::GetByIdWithThis::FastPath::scratchGPR;
 
     jit.loadConstant(stubInfo, stubInfoGPR);
@@ -255,17 +257,16 @@ static void generatePutByIdInlineAccess(CCallHelpers& jit, GPRReg stubInfoGPR, J
     jit.storeProperty(valueJSR, baseJSR.payloadGPR(), scratchGPR, scratch2GPR);
 }
 
-void JITPutByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo, GPRReg stubInfoGPR)
+void JITPutByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
 {
-    m_start = jit.label();
-
-    jit.loadConstant(stubInfo, stubInfoGPR);
-
     using BaselineJITRegisters::PutById::baseJSR;
     using BaselineJITRegisters::PutById::valueJSR;
+    using BaselineJITRegisters::PutById::FastPath::stubInfoGPR;
     using BaselineJITRegisters::PutById::FastPath::scratchGPR;
     using BaselineJITRegisters::PutById::FastPath::scratch2GPR;
 
+    m_start = jit.label();
+    jit.loadConstant(stubInfo, stubInfoGPR);
     generatePutByIdInlineAccess(jit, stubInfoGPR, baseJSR, valueJSR, scratchGPR, scratch2GPR);
     m_done = jit.label();
 }
@@ -343,6 +344,12 @@ void JITDelByValGenerator::generateFastPath(CCallHelpers& jit)
     m_done = jit.label();
 }
 
+void JITDelByValGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::DelByVal::FastPath::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
+}
+
 void JITDelByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_stubInfo);
@@ -375,6 +382,12 @@ void JITDelByIdGenerator::generateFastPath(CCallHelpers& jit)
     m_done = jit.label();
 }
 
+void JITDelByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::DelById::FastPath::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
+}
+
 void JITDelByIdGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_stubInfo);
@@ -401,6 +414,12 @@ void JITInByValGenerator::generateFastPath(CCallHelpers& jit)
     } else
         m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
+}
+
+void JITInByValGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::InByVal::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
 }
 
 void JITInByValGenerator::finalize(
@@ -454,18 +473,16 @@ void JITInByIdGenerator::generateFastPath(CCallHelpers& jit, GPRReg scratchGPR)
     m_done = jit.label();
 }
 
-void JITInByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo, GPRReg stubInfoGPR)
+void JITInByIdGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
 {
-    m_start = jit.label();
-
-    jit.loadConstant(stubInfo, stubInfoGPR);
-
     using BaselineJITRegisters::InById::baseJSR;
     using BaselineJITRegisters::InById::resultJSR;
+    using BaselineJITRegisters::InById::stubInfoGPR;
     using BaselineJITRegisters::InById::scratchGPR;
 
+    m_start = jit.label();
+    jit.loadConstant(stubInfo, stubInfoGPR);
     generateInByIdInlineAccess(jit, stubInfoGPR, baseJSR, scratchGPR, resultJSR);
-
     m_done = jit.label();
 }
 
@@ -502,6 +519,12 @@ void JITInstanceOfGenerator::generateFastPath(CCallHelpers& jit)
     m_done = jit.label();
 }
 
+void JITInstanceOfGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::Instanceof::FastPath::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
+}
+
 void JITInstanceOfGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_stubInfo);
@@ -530,6 +553,12 @@ void JITGetByValGenerator::generateFastPath(CCallHelpers& jit)
     } else
         m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
+}
+
+void JITGetByValGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::GetByVal::FastPath::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
 }
 
 void JITGetByValGenerator::generateEmptyPath(CCallHelpers& jit)
@@ -568,6 +597,14 @@ void JITGetByValWithThisGenerator::generateFastPath(CCallHelpers& jit)
     m_done = jit.label();
 }
 
+#if USE(JSVALUE64)
+void JITGetByValWithThisGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::GetByValWithThis::FastPath::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
+}
+#endif
+
 void JITGetByValWithThisGenerator::generateEmptyPath(CCallHelpers& jit)
 {
     m_start = jit.label();
@@ -604,6 +641,12 @@ void JITPutByValGenerator::generateFastPath(CCallHelpers& jit)
     m_done = jit.label();
 }
 
+void JITPutByValGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::PutByVal::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
+}
+
 void JITPutByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_stubInfo);
@@ -631,6 +674,12 @@ void JITPrivateBrandAccessGenerator::generateFastPath(CCallHelpers& jit)
     } else
         m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
+}
+
+void JITPrivateBrandAccessGenerator::generateBaselineDataICFastPath(JIT& jit, unsigned stubInfo)
+{
+    using BaselineJITRegisters::PrivateBrand::FastPath::stubInfoGPR;
+    JITInlineCacheGenerator::generateBaselineDataICFastPath(jit, stubInfo, stubInfoGPR);
 }
 
 void JITPrivateBrandAccessGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
@@ -74,7 +74,6 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer,
         CodeLocationLabel<JITStubRoutinePtrTag> start);
 
-    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
 #if ENABLE(DFG_JIT)
     void generateDFGDataICFastPath(DFG::JITCompiler&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
 #endif
@@ -99,6 +98,8 @@ public:
     }
 
 protected:
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
+
     StructureStubInfo* m_stubInfo { nullptr };
     AccessType m_accessType;
 
@@ -171,7 +172,7 @@ public:
         JSValueRegs base, JSValueRegs value, GPRReg stubInfoGPR, AccessType);
     
     void generateFastPath(CCallHelpers&, GPRReg scratchGPR);
-    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 #if ENABLE(DFG_JIT)
     void generateDFGDataICFastPath(DFG::JITCompiler&, unsigned stubInfoConstant, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
 #endif
@@ -197,7 +198,7 @@ public:
         JSValueRegs value, JSValueRegs base, JSValueRegs thisRegs, GPRReg stubInfoGPR);
 
     void generateFastPath(CCallHelpers&, GPRReg scratchGPR);
-    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 #if ENABLE(DFG_JIT)
     void generateDFGDataICFastPath(DFG::JITCompiler&, unsigned stubInfoConstant, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
 #endif
@@ -227,7 +228,7 @@ public:
         JSValueRegs base, JSValueRegs value, GPRReg stubInfoGPR, GPRReg scratch, ECMAMode, AccessType);
     
     void generateFastPath(CCallHelpers&, GPRReg scratchGPR, GPRReg scratch2GPR);
-    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 #if ENABLE(DFG_JIT)
     void generateDFGDataICFastPath(DFG::JITCompiler&, unsigned stubInfoConstant, JSValueRegs baseJSR, JSValueRegs valueJSR, GPRReg stubInfoGPR, GPRReg scratchGPR, GPRReg scratch2GPR);
 #endif
@@ -269,6 +270,7 @@ public:
     void finalize(LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo,
@@ -329,6 +331,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo,
@@ -377,6 +380,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo,
@@ -424,6 +428,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo,
@@ -462,7 +467,7 @@ public:
         JSValueRegs base, JSValueRegs value, GPRReg stubInfoGPR);
 
     void generateFastPath(CCallHelpers&, GPRReg scratchGPR);
-    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant, GPRReg stubInfoGPR);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 #if ENABLE(DFG_JIT)
     void generateDFGDataICFastPath(DFG::JITCompiler&, unsigned stubInfoConstant, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratchGPR);
 #endif
@@ -487,6 +492,7 @@ public:
         bool prototypeIsKnownObject = false);
     
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     CCallHelpers::Jump slowPathJump() const
     {
@@ -545,6 +551,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
     
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     void generateEmptyPath(CCallHelpers&);
 
@@ -597,6 +604,7 @@ public:
     void finalize(LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
 
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     void generateEmptyPath(CCallHelpers&);
 
@@ -653,6 +661,7 @@ public:
         LinkBuffer& fastPathLinkBuffer, LinkBuffer& slowPathLinkBuffer);
     
     void generateFastPath(CCallHelpers&);
+    void generateBaselineDataICFastPath(JIT&, unsigned stubInfoConstant);
 
     template<typename StubInfo>
     static void setUpStubInfo(StubInfo& stubInfo,

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -175,7 +175,7 @@ void JIT::emit_op_instanceof(const JSInstruction* currentInstruction)
         stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
 #if USE(JSVALUE32_64)
     boxBoolean(resultJSR.payloadGPR(), resultJSR);
 #endif

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -76,7 +76,7 @@ void JIT::emit_op_get_by_val(const JSInstruction* currentInstruction)
     emitJumpSlowCaseIfNotJSCell(baseJSR, base);
     emitArrayProfilingSiteWithCell(bytecode, baseJSR.payloadGPR(), scratchGPR);
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
 
     addSlowCase();
     m_getByVals.append(gen);
@@ -177,7 +177,7 @@ void JIT::emit_op_get_private_name(const JSInstruction* currentInstruction)
         RegisterSetBuilder::stubUnavailableRegisters(), baseJSR, propertyJSR, resultJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_getByVals.append(gen);
 
@@ -264,7 +264,7 @@ void JIT::emit_op_set_private_brand(const JSInstruction* currentInstruction)
         baseJSR, brandJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_privateBrandAccesses.append(gen);
 
@@ -319,7 +319,7 @@ void JIT::emit_op_check_private_brand(const JSInstruction* currentInstruction)
         baseJSR, brandJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_privateBrandAccesses.append(gen);
 }
@@ -380,7 +380,7 @@ void JIT::emit_op_put_by_val(const JSInstruction* currentInstruction)
         stubInfo->propertyIsInt32 = true;
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_putByVals.append(gen);
@@ -493,7 +493,7 @@ void JIT::emit_op_put_private_name(const JSInstruction* currentInstruction)
         baseJSR, propertyJSR, valueJSR, InvalidGPRReg, stubInfoGPR, ECMAMode::sloppy());
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_putByVals.append(gen);
 
@@ -653,7 +653,7 @@ void JIT::emit_op_del_by_id(const JSInstruction* currentInstruction)
         baseJSR, resultJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_delByIds.append(gen);
 
@@ -759,7 +759,7 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
         baseJSR, propertyJSR, resultJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_delByVals.append(gen);
 
@@ -862,7 +862,7 @@ void JIT::emit_op_try_get_by_id(const JSInstruction* currentInstruction)
         CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_unlinkedCodeBlock, *ident), baseJSR, resultJSR, stubInfoGPR, AccessType::TryGetById);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_getByIds.append(gen);
 
@@ -918,7 +918,7 @@ void JIT::emit_op_get_by_id_direct(const JSInstruction* currentInstruction)
         CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_unlinkedCodeBlock, *ident), baseJSR, resultJSR, stubInfoGPR, AccessType::GetByIdDirect);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_getByIds.append(gen);
 
@@ -984,7 +984,7 @@ void JIT::emit_op_get_by_id(const JSInstruction* currentInstruction)
         CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_unlinkedCodeBlock, *ident), baseJSR, resultJSR, stubInfoGPR, AccessType::GetById);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_getByIds.append(gen);
@@ -1079,7 +1079,7 @@ void JIT::emit_op_get_by_id_with_this(const JSInstruction* currentInstruction)
         CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_unlinkedCodeBlock, *ident), resultJSR, baseJSR, thisJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_getByIdsWithThis.append(gen);
@@ -1180,7 +1180,7 @@ void JIT::emit_op_put_by_id(const JSInstruction* currentInstruction)
         baseJSR, valueJSR, stubInfoGPR, scratchGPR, ecmaMode, direct ? (ecmaMode.isStrict() ? AccessType::PutByIdDirectStrict : AccessType::PutByIdDirectSloppy) : (ecmaMode.isStrict() ? AccessType::PutByIdStrict : AccessType::PutByIdSloppy));
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_putByIds.append(gen);
@@ -1273,7 +1273,7 @@ void JIT::emit_op_in_by_id(const JSInstruction* currentInstruction)
         CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_unlinkedCodeBlock, *ident), baseJSR, resultJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_inByIds.append(gen);
 
@@ -1333,7 +1333,7 @@ void JIT::emit_op_in_by_val(const JSInstruction* currentInstruction)
         baseJSR, propertyJSR, resultJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_inByVals.append(gen);
 
@@ -1385,7 +1385,7 @@ void JIT::emitHasPrivate(VirtualRegister dst, VirtualRegister base, VirtualRegis
         baseJSR, propertyJSR, resultJSR, stubInfoGPR);
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     addSlowCase();
     m_inByVals.append(gen);
 
@@ -2187,7 +2187,7 @@ void JIT::emit_op_get_by_val_with_this(const JSInstruction* currentInstruction)
     emitJumpSlowCaseIfNotJSCell(baseJSR, base);
     emitArrayProfilingSiteWithCell(bytecode, baseJSR.payloadGPR(), scratchGPR);
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
 
     addSlowCase();
     m_getByValsWithThis.append(gen);
@@ -2374,10 +2374,10 @@ void JIT::emit_op_enumerator_get_by_val(const JSInstruction* currentInstruction)
     constexpr GPRReg resultGPR = BaselineJITRegisters::EnumeratorGetByVal::resultJSR.payloadGPR();
     constexpr GPRReg baseGPR = BaselineJITRegisters::EnumeratorGetByVal::baseJSR.payloadGPR();
     constexpr GPRReg propertyGPR = BaselineJITRegisters::EnumeratorGetByVal::propertyJSR.payloadGPR();
-    constexpr GPRReg stubInfoGPR = BaselineJITRegisters::EnumeratorGetByVal::stubInfoGPR;
-    constexpr GPRReg scratch1 = BaselineJITRegisters::EnumeratorGetByVal::scratch1;
-    constexpr GPRReg scratch2 = BaselineJITRegisters::EnumeratorGetByVal::scratch2;
-    constexpr GPRReg scratch3 = BaselineJITRegisters::EnumeratorGetByVal::scratch3;
+    using BaselineJITRegisters::EnumeratorGetByVal::stubInfoGPR;
+    using BaselineJITRegisters::EnumeratorGetByVal::scratch1;
+    using BaselineJITRegisters::EnumeratorGetByVal::scratch2;
+    using BaselineJITRegisters::EnumeratorGetByVal::scratch3;
 
     emitGetVirtualRegister(base, baseGPR);
     emitGetVirtualRegister(mode, scratch3);
@@ -2432,7 +2432,7 @@ void JIT::emit_op_enumerator_get_by_val(const JSInstruction* currentInstruction)
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
     stubInfo->isEnumerator = true;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_getByVals.append(gen);
@@ -2511,9 +2511,9 @@ void JIT::emit_op_enumerator_put_by_val(const JSInstruction* currentInstruction)
     constexpr GPRReg valueGPR = BaselineJITRegisters::EnumeratorPutByVal::valueJSR.payloadGPR();
     constexpr GPRReg baseGPR = BaselineJITRegisters::EnumeratorPutByVal::baseJSR.payloadGPR();
     constexpr GPRReg propertyGPR = BaselineJITRegisters::EnumeratorPutByVal::propertyJSR.payloadGPR();
-    constexpr GPRReg profileGPR = BaselineJITRegisters::EnumeratorPutByVal::profileGPR;
-    constexpr GPRReg stubInfoGPR = BaselineJITRegisters::EnumeratorPutByVal::stubInfoGPR;
-    constexpr GPRReg scratch1 = BaselineJITRegisters::EnumeratorPutByVal::scratch1;
+    using BaselineJITRegisters::EnumeratorPutByVal::profileGPR;
+    using BaselineJITRegisters::EnumeratorPutByVal::stubInfoGPR;
+    using BaselineJITRegisters::EnumeratorPutByVal::scratch1;
 
     // These four registers need to be set up before jumping to SlowPath code.
     emitGetVirtualRegister(base, baseGPR);
@@ -2578,7 +2578,7 @@ void JIT::emit_op_enumerator_put_by_val(const JSInstruction* currentInstruction)
     gen.m_unlinkedStubInfoConstantIndex = stubInfoIndex;
     stubInfo->isEnumerator = true;
 
-    gen.generateBaselineDataICFastPath(*this, stubInfoIndex, stubInfoGPR);
+    gen.generateBaselineDataICFastPath(*this, stubInfoIndex);
     resetSP(); // We might OSR exit here, so we need to conservatively reset SP
     addSlowCase();
     m_putByVals.append(gen);


### PR DESCRIPTION
#### 51e8e5ed42b64629606627a327b66407b97d6914
<pre>
[JSC] Baseline JIT IC should not have ability to change stubInfoGPR
<a href="https://bugs.webkit.org/show_bug.cgi?id=260645">https://bugs.webkit.org/show_bug.cgi?id=260645</a>
rdar://114364991

Reviewed by Mark Lam.

This patch refactors Baseline Data IC so that we ensure that we are always using predefined stubInfoGPR.
This is important to introduce handler IC where IC has strong assumptions on register use.

* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_iterator_open):
(JSC::JIT::emit_op_iterator_next):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp:
(JSC::JITGetByIdGenerator::generateBaselineDataICFastPath):
(JSC::JITGetByIdWithThisGenerator::generateBaselineDataICFastPath):
(JSC::JITPutByIdGenerator::generateBaselineDataICFastPath):
(JSC::JITDelByValGenerator::generateBaselineDataICFastPath):
(JSC::JITDelByIdGenerator::generateBaselineDataICFastPath):
(JSC::JITInByValGenerator::generateBaselineDataICFastPath):
(JSC::JITInByIdGenerator::generateBaselineDataICFastPath):
(JSC::JITInstanceOfGenerator::generateBaselineDataICFastPath):
(JSC::JITGetByValGenerator::generateBaselineDataICFastPath):
(JSC::JITGetByValWithThisGenerator::generateBaselineDataICFastPath):
(JSC::JITPutByValGenerator::generateBaselineDataICFastPath):
(JSC::JITPrivateBrandAccessGenerator::generateBaselineDataICFastPath):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.h:
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_instanceof):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_get_by_val):
(JSC::JIT::emit_op_get_private_name):
(JSC::JIT::emit_op_set_private_brand):
(JSC::JIT::emit_op_check_private_brand):
(JSC::JIT::emit_op_put_by_val):
(JSC::JIT::emit_op_put_private_name):
(JSC::JIT::emit_op_del_by_id):
(JSC::JIT::emit_op_del_by_val):
(JSC::JIT::emit_op_try_get_by_id):
(JSC::JIT::emit_op_get_by_id_direct):
(JSC::JIT::emit_op_get_by_id):
(JSC::JIT::emit_op_get_by_id_with_this):
(JSC::JIT::emit_op_put_by_id):
(JSC::JIT::emit_op_in_by_id):
(JSC::JIT::emit_op_in_by_val):
(JSC::JIT::emitHasPrivate):
(JSC::JIT::emit_op_get_by_val_with_this):
(JSC::JIT::emit_op_enumerator_get_by_val):
(JSC::JIT::emit_op_enumerator_put_by_val):

Canonical link: <a href="https://commits.webkit.org/267220@main">https://commits.webkit.org/267220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b66bcb00d79bc797d0fcc35a136dbd002c0f36b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16429 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18533 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14470 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13778 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17877 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15245 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12914 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16207 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14470 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4049 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18839 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17371 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1960 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15054 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3842 "Passed tests") | 
<!--EWS-Status-Bubble-End-->