### PR TITLE
PathStream::currentPoint should have a fast path for getting end point immediately

### DIFF
--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -44,6 +44,13 @@ FloatPoint PathSegment::calculateEndPoint(const FloatPoint& currentPoint, FloatP
     });
 }
 
+std::optional<FloatPoint> PathSegment::tryGetEndPointWithoutContext() const
+{
+    return WTF::switchOn(m_data, [&](auto& data) {
+        return data.tryGetEndPointWithoutContext();
+    });
+}
+
 void PathSegment::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
     WTF::switchOn(m_data, [&](auto& data) {

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -62,6 +62,7 @@ public:
     bool isCloseSubPath() const { return std::holds_alternative<PathCloseSubpath>(m_data); }
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -38,6 +38,12 @@ FloatPoint PathMoveTo::calculateEndPoint(const FloatPoint&, FloatPoint& lastMove
     return lastMoveToPoint;
 }
 
+std::optional<FloatPoint> PathMoveTo::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
+}
+
 void PathMoveTo::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect&) const
 {
 }
@@ -70,6 +76,12 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathMoveTo& data)
 FloatPoint PathLineTo::calculateEndPoint(const FloatPoint&, FloatPoint&) const
 {
     return point;
+}
+
+std::optional<FloatPoint> PathLineTo::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathLineTo::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
@@ -107,6 +119,12 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathLineTo& data)
 FloatPoint PathQuadCurveTo::calculateEndPoint(const FloatPoint&, FloatPoint&) const
 {
     return endPoint;
+}
+
+std::optional<FloatPoint> PathQuadCurveTo::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathQuadCurveTo::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint&, FloatRect& boundingRect) const
@@ -183,6 +201,12 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathQuadCurveTo& data)
 FloatPoint PathBezierCurveTo::calculateEndPoint(const FloatPoint&, FloatPoint&) const
 {
     return endPoint;
+}
+
+std::optional<FloatPoint> PathBezierCurveTo::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathBezierCurveTo::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint&, FloatRect& boundingRect) const
@@ -322,6 +346,11 @@ FloatPoint PathArcTo::calculateEndPoint(const FloatPoint& currentPoint, FloatPoi
     return calculateArcToEndPoint(currentPoint, controlPoint1, controlPoint2, radius);
 }
 
+std::optional<FloatPoint> PathArcTo::tryGetEndPointWithoutContext() const
+{
+    return std::nullopt;
+}
+
 void PathArcTo::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint&, FloatRect& boundingRect) const
 {
     boundingRect.extend(currentPoint);
@@ -351,6 +380,12 @@ FloatPoint PathArc::calculateEndPoint(const FloatPoint&, FloatPoint& lastMoveToP
 {
     lastMoveToPoint = center + FloatSize { radius * cos(startAngle), - radius * sin(startAngle) };
     return center + FloatSize { radius * cos(endAngle), - radius * sin(endAngle) };
+}
+
+std::optional<FloatPoint> PathArc::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathArc::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect& boundingRect) const
@@ -435,6 +470,12 @@ FloatPoint PathEllipse::calculateEndPoint(const FloatPoint&, FloatPoint& lastMov
     return rotation.mapPoint(endPoint);
 }
 
+std::optional<FloatPoint> PathEllipse::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
+}
+
 void PathEllipse::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect& boundingRect) const
 {
     auto minXMinYCorner = center - FloatSize { radiusX, radiusY };
@@ -477,6 +518,12 @@ FloatPoint PathEllipseInRect::calculateEndPoint(const FloatPoint&, FloatPoint& l
     return lastMoveToPoint;
 }
 
+std::optional<FloatPoint> PathEllipseInRect::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
+}
+
 void PathEllipseInRect::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
     extendBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
@@ -503,6 +550,12 @@ FloatPoint PathRect::calculateEndPoint(const FloatPoint&, FloatPoint& lastMoveTo
 {
     lastMoveToPoint = rect.location();
     return lastMoveToPoint;
+}
+
+std::optional<FloatPoint> PathRect::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathRect::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
@@ -533,6 +586,12 @@ FloatPoint PathRoundedRect::calculateEndPoint(const FloatPoint&, FloatPoint& las
     return lastMoveToPoint;
 }
 
+std::optional<FloatPoint> PathRoundedRect::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
+}
+
 void PathRoundedRect::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
     extendBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
@@ -559,6 +618,12 @@ FloatPoint PathDataLine::calculateEndPoint(const FloatPoint&, FloatPoint& lastMo
 {
     lastMoveToPoint = start;
     return end;
+}
+
+std::optional<FloatPoint> PathDataLine::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathDataLine::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
@@ -602,6 +667,12 @@ FloatPoint PathDataQuadCurve::calculateEndPoint(const FloatPoint&, FloatPoint& l
 {
     lastMoveToPoint = start;
     return endPoint;
+}
+
+std::optional<FloatPoint> PathDataQuadCurve::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathDataQuadCurve::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect& boundingRect) const
@@ -650,6 +721,12 @@ FloatPoint PathDataBezierCurve::calculateEndPoint(const FloatPoint&, FloatPoint&
 {
     lastMoveToPoint = start;
     return endPoint;
+}
+
+std::optional<FloatPoint> PathDataBezierCurve::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
 }
 
 void PathDataBezierCurve::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect& boundingRect) const
@@ -703,6 +780,12 @@ FloatPoint PathDataArc::calculateEndPoint(const FloatPoint&, FloatPoint& lastMov
     return calculateArcToEndPoint(start, controlPoint1, controlPoint2, radius);
 }
 
+std::optional<FloatPoint> PathDataArc::tryGetEndPointWithoutContext() const
+{
+    FloatPoint lastMoveToPoint;
+    return calculateEndPoint({ }, lastMoveToPoint);
+}
+
 void PathDataArc::extendFastBoundingRect(const FloatPoint&, const FloatPoint&, FloatRect& boundingRect) const
 {
     boundingRect.extend(start);
@@ -734,6 +817,11 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataArc& data)
 FloatPoint PathCloseSubpath::calculateEndPoint(const FloatPoint&, FloatPoint& lastMoveToPoint) const
 {
     return lastMoveToPoint;
+}
+
+std::optional<FloatPoint> PathCloseSubpath::tryGetEndPointWithoutContext() const
+{
+    return std::nullopt;
 }
 
 void PathCloseSubpath::extendFastBoundingRect(const FloatPoint&, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -47,6 +47,7 @@ struct PathMoveTo {
     bool operator==(const PathMoveTo&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -68,6 +69,7 @@ struct PathLineTo {
     bool operator==(const PathLineTo&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -90,6 +92,7 @@ struct PathQuadCurveTo {
     bool operator==(const PathQuadCurveTo&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -113,6 +116,7 @@ struct PathBezierCurveTo {
     bool operator==(const PathBezierCurveTo&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -136,6 +140,7 @@ struct PathArcTo {
     bool operator==(const PathArcTo&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -158,6 +163,7 @@ struct PathArc {
     bool operator==(const PathArc&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -182,6 +188,7 @@ struct PathEllipse {
     bool operator==(const PathEllipse&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -200,6 +207,7 @@ struct PathEllipseInRect {
     bool operator==(const PathEllipseInRect&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -218,6 +226,7 @@ struct PathRect {
     bool operator==(const PathRect&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -242,6 +251,7 @@ struct PathRoundedRect {
     bool operator==(const PathRoundedRect&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -261,6 +271,7 @@ struct PathDataLine {
     bool operator==(const PathDataLine&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -284,6 +295,7 @@ struct PathDataQuadCurve {
     bool operator==(const PathDataQuadCurve&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -308,6 +320,7 @@ struct PathDataBezierCurve {
     bool operator==(const PathDataBezierCurve&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -332,6 +345,7 @@ struct PathDataArc {
     bool operator==(const PathDataArc&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -348,6 +362,7 @@ struct PathCloseSubpath {
     bool operator==(const PathCloseSubpath&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+    std::optional<FloatPoint> tryGetEndPointWithoutContext() const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -269,6 +269,12 @@ bool PathStream::isClosed() const
 
 FloatPoint PathStream::currentPoint() const
 {
+    if (m_segmentsData->segments.isEmpty())
+        return { };
+
+    if (auto result = m_segmentsData->segments.last().tryGetEndPointWithoutContext())
+        return result.value();
+
     FloatPoint lastMoveToPoint;
     FloatPoint currentPoint;
 


### PR DESCRIPTION
#### 7fcf207fdda17d52fb187617f33064b721f2d556
<pre>
PathStream::currentPoint should have a fast path for getting end point immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=260652">https://bugs.webkit.org/show_bug.cgi?id=260652</a>
rdar://114371099

Reviewed by Cameron McCormack.

PathStream::currentPoint is computing the end point by traversing all the past segments.
But if we would like to get the end point, in most of cases, we can immediately get that
from the last segment&apos;s information. We are traversing this every time we call `lineTo`
function, and this becomes costly when the path gets many segments.
This patch adds a fast path covering most of cases. We add tryGetEndPointWithoutContext
function, which may return the end point if it can compute it directly without context.
And lineTo function calls this for the last segment and attempt to skip traversing of
segments.

* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::tryGetEndPointWithoutContext const):
* Source/WebCore/platform/graphics/PathSegment.h:
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::PathMoveTo::tryGetEndPointWithoutContext const):
(WebCore::PathLineTo::tryGetEndPointWithoutContext const):
(WebCore::PathQuadCurveTo::tryGetEndPointWithoutContext const):
(WebCore::PathBezierCurveTo::tryGetEndPointWithoutContext const):
(WebCore::PathArcTo::tryGetEndPointWithoutContext const):
(WebCore::PathArc::tryGetEndPointWithoutContext const):
(WebCore::PathEllipse::tryGetEndPointWithoutContext const):
(WebCore::PathEllipseInRect::tryGetEndPointWithoutContext const):
(WebCore::PathRect::tryGetEndPointWithoutContext const):
(WebCore::PathRoundedRect::tryGetEndPointWithoutContext const):
(WebCore::PathDataLine::tryGetEndPointWithoutContext const):
(WebCore::PathDataQuadCurve::tryGetEndPointWithoutContext const):
(WebCore::PathDataBezierCurve::tryGetEndPointWithoutContext const):
(WebCore::PathDataArc::tryGetEndPointWithoutContext const):
(WebCore::PathCloseSubpath::tryGetEndPointWithoutContext const):
* Source/WebCore/platform/graphics/PathSegmentData.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::currentPoint const):

Canonical link: <a href="https://commits.webkit.org/267231@main">https://commits.webkit.org/267231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e7cb939a72b5d9469af25bb104674e3829e958

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17475 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18544 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21340 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12923 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18850 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1963 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->