### PR TITLE
When stopped, a cloned MediaStreamTrack will stop its base MediaStreamTrack if the source is muted

### DIFF
--- a/LayoutTests/fast/mediastream/stop-clone-when-muted-expected.txt
+++ b/LayoutTests/fast/mediastream/stop-clone-when-muted-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Stopping a muted clone should not mute the track
+

--- a/LayoutTests/fast/mediastream/stop-clone-when-muted.html
+++ b/LayoutTests/fast/mediastream/stop-clone-when-muted.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script>
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video:true });
+    const track = stream.getVideoTracks()[0];
+    const trackClone = track.clone();
+
+    const promise = new Promise(resolve => track.onmute = resolve);
+    if (window.internals) {
+        internals.setMediaStreamTrackMuted(track, true);
+        await promise;
+    }
+
+    const resultPromise = new Promise((resolve, reject) => {
+        setTimeout(resolve, 500);
+        track.onended = () => reject("track is ended");
+    });
+    trackClone.stop();
+
+    return resultPromise;
+}, "Stopping a muted clone should not mute the track");
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -252,11 +252,11 @@ void MediaStreamTrackPrivate::sourceConfigurationChanged()
     });
 }
 
-bool MediaStreamTrackPrivate::preventSourceFromStopping()
+bool MediaStreamTrackPrivate::preventSourceFromEnding()
 {
     ALWAYS_LOG(LOGIDENTIFIER, m_isEnded);
 
-    // Do not allow the source to stop if we are still using it.
+    // Do not allow the source to end if we are still using it.
     return !m_isEnded;
 }
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -135,7 +135,7 @@ private:
     void sourceMutedChanged() final;
     void sourceSettingsChanged() final;
     void sourceConfigurationChanged() final;
-    bool preventSourceFromStopping() final;
+    bool preventSourceFromEnding() final;
     void audioUnitWillStart() final;
     void hasStartedProducingData() final;
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -398,12 +398,12 @@ void RealtimeMediaSource::stop()
 
 void RealtimeMediaSource::requestToEnd(Observer& callingObserver)
 {
-    bool hasObserverPreventingStopping = false;
+    bool hasObserverPreventingEnding = false;
     forEachObserver([&](auto& observer) {
-        if (observer.preventSourceFromStopping())
-            hasObserverPreventingStopping = true;
+        if (observer.preventSourceFromEnding())
+            hasObserverPreventingEnding = true;
     });
-    if (hasObserverPreventingStopping)
+    if (hasObserverPreventingEnding)
         return;
 
     ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -98,7 +98,7 @@ public:
         virtual void sourceConfigurationChanged() { }
 
         // Observer state queries.
-        virtual bool preventSourceFromStopping() { return false; }
+        virtual bool preventSourceFromEnding() { return false; }
 
         virtual void hasStartedProducingData() { }
     };

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -112,6 +112,7 @@ public:
     void end()
     {
         m_isStopped = true;
+        m_isEnded = true;
         m_source->requestToEnd(*this);
     }
 
@@ -280,10 +281,10 @@ private:
         return m_rotationSession->rotate(videoFrame, rotation, ImageRotationSessionVT::IsCGImageCompatible::No);
     }
 
-    bool preventSourceFromStopping()
+    bool preventSourceFromEnding()
     {
-        // Do not allow the source to stop if we are still using it.
-        return !m_isStopped;
+        // Do not allow the source to end if we are still using it.
+        return !m_isEnded;
     }
 
     RealtimeMediaSourceIdentifier m_id;
@@ -294,6 +295,7 @@ private:
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     std::optional<CAAudioStreamDescription> m_description;
     bool m_isStopped { false };
+    bool m_isEnded { false };
     std::unique_ptr<ImageRotationSessionVT> m_rotationSession;
     bool m_shouldApplyRotation { false };
     std::unique_ptr<IPC::Semaphore> m_captureSemaphore;


### PR DESCRIPTION
#### fc3228ea6a4e97dd4624dfda0c3488d9f19ea666
<pre>
When stopped, a cloned MediaStreamTrack will stop its base MediaStreamTrack if the source is muted
<a href="https://bugs.webkit.org/show_bug.cgi?id=260655">https://bugs.webkit.org/show_bug.cgi?id=260655</a>
rdar://111534033

Reviewed by Eric Carlson.

When we have two track clones, and the tracks are muted, stopping one of the track will end the other one.
This is due to the fact that when stopping a track, we request the source to end.
We then check each observer to know whether they are stopped, which is true when the track is muted.
We are adding a ended flag in UserMediaCaptureManagerProxy::SourceProxy and we rename preventSourceFromStopping in preventSourceFromEnding to clarify what we are doing.

* LayoutTests/fast/mediastream/stop-clone-when-muted-expected.txt: Added.
* LayoutTests/fast/mediastream/stop-clone-when-muted.html: Added.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::preventSourceFromEnding):
(WebCore::MediaStreamTrackPrivate::preventSourceFromStopping): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::requestToEnd):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::end):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::preventSourceFromEnding):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::preventSourceFromStopping): Deleted.

Canonical link: <a href="https://commits.webkit.org/267247@main">https://commits.webkit.org/267247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc6ff254e9bb25bbd835a9ebbae18c5bf7ae48a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17484 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18556 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14331 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3836 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->