### PR TITLE
jsfiddles cannot get access to feature policy gated features like camera

### DIFF
--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -31,6 +31,7 @@
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
 #include "LocalDOMWindow.h"
+#include "Quirks.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {
@@ -164,8 +165,12 @@ static inline void processOriginItem(Document& document, const HTMLIFrameElement
 
 static inline void updateList(Document& document, const HTMLIFrameElement& iframe, FeaturePolicy::AllowRule& rule, StringView value)
 {
-    // We keep the empty string value equivalent to '*' for existing websites.
     if (value.isEmpty()) {
+        if (document.quirks().shouldStarBeFeaturePolicyDefaultValue()) {
+            rule.type = FeaturePolicy::AllowRule::Type::All;
+            return;
+        }
+
         // The allowlist for the features named in the attribute may be empty; in that case,
         // the default value for the allowlist is 'src', which represents the origin of the
         // URL in the iframe’s src attribute.

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1583,4 +1583,16 @@ bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 #endif
 }
 
+bool Quirks::shouldStarBeFeaturePolicyDefaultValue() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldStarBeFeaturePolicyDefaultValueQuirk) {
+        auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
+        m_shouldStarBeFeaturePolicyDefaultValueQuirk = domain == "jsfiddle.net"_s;
+    }
+    return *m_shouldStarBeFeaturePolicyDefaultValueQuirk;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -172,6 +172,8 @@ public:
 
     bool needsResettingTransitionCancelsRunningTransitionQuirk() const;
 
+    bool shouldStarBeFeaturePolicyDefaultValue() const;
+
 private:
     bool needsQuirks() const;
 
@@ -231,6 +233,7 @@ private:
     mutable std::optional<bool> m_shouldDisableLazyIframeLoadingQuirk;
     bool m_needsConfigurableIndexedPropertiesQuirk { false };
     bool m_needsToCopyUserSelectNoneQuirk { false };
+    mutable std::optional<bool> m_shouldStarBeFeaturePolicyDefaultValueQuirk;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 54bc44e6551791dc2ea46aae2420fa2866a3d6a1
<pre>
jsfiddles cannot get access to feature policy gated features like camera
<a href="https://bugs.webkit.org/show_bug.cgi?id=260656">https://bugs.webkit.org/show_bug.cgi?id=260656</a>
rdar://114378082

Reviewed by Eric Carlson and Chris Dumez.

<a href="https://commits.webkit.org/265641@main">https://commits.webkit.org/265641@main</a> tightened feature policy parsing and aligned it with spec.
This was known to not work for some websites, like jsfiddle.
Add a temporary quirk to fix jsfiddle.
Manually tested.

* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::updateList):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldStarBeFeaturePolicyDefaultValue const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/267266@main">https://commits.webkit.org/267266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a15577e9461a5faa70b33a6c4b60ca05872c772

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17486 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18558 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21354 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17902 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12937 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14492 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3850 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->