### PR TITLE
Consider HTMLAnchorElements with no href but click event listeners for Interaction Regions

### DIFF
--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -1,4 +1,4 @@
-This is a link. This is a wiki-style link. This is a link with visible edges.
+This is a link. This is a wiki-style link. This is a link with visible edges. This is a JavaScript link. This link does nothing.
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -19,7 +19,9 @@ This is a link. This is a wiki-style link. This is a link with visible edges.
         (guard (250,-10) width=29 height=39)
         (borderRadius 0.00),
         (interaction (250,0) width=29 height=19)
-        (borderRadius 0.00)])
+        (borderRadius 0.00),
+        (interaction (456,-4) width=38 height=27)
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link.html
+++ b/LayoutTests/interaction-region/inline-link.html
@@ -7,6 +7,8 @@
 <a href="#">This</a> is a link.
 <a href="#" style="border: 0; background: none;">This</a> is a wiki-style link.
 <a href="#" style="background: green;">This</a> is a link with visible edges.
+<a onclick="alert('click!')">This</a> is a JavaScript link.
+<a>This</a> link does nothing.
 
 <pre id="results"></pre>
 <script>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -157,6 +157,9 @@ static bool shouldAllowNonPointerCursorForElement(const Element& element)
     if (is<SliderThumbElement>(element))
         return true;
 
+    if (is<HTMLAnchorElement>(element))
+        return true;
+
     if (shouldAllowAccessibilityRoleAsPointerCursorReplacement(element))
         return true;
 


### PR DESCRIPTION
#### 351891573781afb9625e9cf767eb2331053968a8
<pre>
Consider HTMLAnchorElements with no href but click event listeners for Interaction Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260657">https://bugs.webkit.org/show_bug.cgi?id=260657</a>
&lt;rdar://114215168&gt;

Reviewed by Tim Horton.

HTMLAnchorElements with no `href` don&apos;t have the `isLink` flag set. But
we&apos;re sitll seeing instances of `&lt;a onclick=&quot;...&quot;&gt;`.
Since we already have the `EventListenerRegionType::MouseClick` check,
add HTMLAnchorElement to the list of elements that get
InteractionRegions even without `cursor: pointer`.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowNonPointerCursorForElement):
Add HTMLAnchorElement to the list.

* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link.html:
Update the test to cover the &quot;onclick-only&quot; scenario and the scenario
where a link has neither a href nor a click event listener (and doesn&apos;t
get a region).

Canonical link: <a href="https://commits.webkit.org/267267@main">https://commits.webkit.org/267267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eb7e895a0b4b54c8cd0bf3d758c6c05c5d5a46e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17518 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18603 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21449 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12975 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->