### PR TITLE
Adjust the size limit for Interaction Regions

### DIFF
--- a/LayoutTests/interaction-region/interaction-region-size-limit-expected.txt
+++ b/LayoutTests/interaction-region/interaction-region-size-limit-expected.txt
@@ -1,0 +1,22 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (0,0) width=395 height=295)
+        (borderRadius 0.00),
+        (interaction (0,305) width=395 height=295)
+        (borderRadius 0.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/interaction-region-size-limit.html
+++ b/LayoutTests/interaction-region/interaction-region-size-limit.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<style>
+    section {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        display: flex;
+        flex-direction: row;
+        gap: 10px;
+
+        cursor: pointer;
+
+        background: gray;
+    }
+
+    div {
+        flex-grow: 1;
+
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        background: purple;
+    }
+
+    div > div {
+        background: blue;
+    }
+
+</style>
+<body>
+<section>
+    <div>
+        <div>
+        </div>
+        <div>
+        </div>
+    </div>
+    <div></div>
+</section>
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -252,7 +252,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     // FIXME: Consider also allowing elements that only receive touch events.
     bool hasListener = renderer.style().eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick);
     bool hasPointer = cursorTypeForElement(*matchedElement) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*matchedElement);
-    bool isTooBigForInteraction = checkedRegionArea.value() > frameViewArea / 2;
+    bool isTooBigForInteraction = checkedRegionArea.value() > frameViewArea / 3;
 
     auto elementIdentifier = matchedElement->identifier();
 


### PR DESCRIPTION
#### 05a5d83d68474790c80ce5546b6910162da9e323
<pre>
Adjust the size limit for Interaction Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260659">https://bugs.webkit.org/show_bug.cgi?id=260659</a>
&lt;rdar://114216114&gt;

Reviewed by Tim Horton.

Tweak the maximum size threshold (relative to the frame area) before we
skip Interaction Regions.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Make the maximum 1/3rd instead of half of the frame area.

* LayoutTests/interaction-region/interaction-region-size-limit-expected.txt: Added.
* LayoutTests/interaction-region/interaction-region-size-limit.html: Added.
Add a test with some mockup UI.

Canonical link: <a href="https://commits.webkit.org/267277@main">https://commits.webkit.org/267277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d799cbb57bf75d0825b86dac5545fcb5b086c68f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15169 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17571 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18694 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21460 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18020 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13046 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3861 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->