### PR TITLE
fast/dom/selectorAPI/caseID.html is a constant text failure (when repro steps are followed).

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6629,4 +6629,3 @@ webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/
 # We only support import-attributes and do not support import-assertions.
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/import-assertions
 
-webkit.org/b/260556 fast/dom/selectorAPI/caseID.html [ Pass Failure ]

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -61,14 +61,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
 {
 }
 
-bool CSSSelectorParserContext::operator==(const CSSSelectorParserContext& other) const
-{
-    return mode == other.mode
-        || cssNestingEnabled == other.cssNestingEnabled
-        || focusVisibleEnabled == other.focusVisibleEnabled
-        || hasPseudoClassEnabled == other.hasPseudoClassEnabled;
-}
-
 void add(Hasher& hasher, const CSSSelectorParserContext& context)
 {
     add(hasher,

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -57,7 +57,7 @@ struct CSSSelectorParserContext {
     CSSSelectorParserContext(const CSSParserContext&);
     explicit CSSSelectorParserContext(const Document&);
 
-    bool operator==(const CSSSelectorParserContext&) const;
+    bool operator==(const CSSSelectorParserContext&) const = default;
 };
 
 class CSSSelectorParser {


### PR DESCRIPTION
#### 727dbe30fe5ffaa2a2370b91eb551d3834a89419
<pre>
fast/dom/selectorAPI/caseID.html is a constant text failure (when repro steps are followed).
<a href="https://bugs.webkit.org/show_bug.cgi?id=260556">https://bugs.webkit.org/show_bug.cgi?id=260556</a>
rdar://114287946

Reviewed by Antti Koivisto.

The CSSSelectorParserContext&apos;s operator==() was wrong, it was using `||` instead
of `&amp;&amp;` between the data member checks. Fix the issue by using the default
operator==().

* LayoutTests/TestExpectations:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParserContext::operator== const): Deleted.

Canonical link: <a href="https://commits.webkit.org/267237@main">https://commits.webkit.org/267237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c961c2a897d24d172a61bbbf36ab21cd69053a35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18585 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14508 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14507 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3828 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->