### PR TITLE
Add generated messages that can work without using IPC::Connection

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -472,6 +472,9 @@ public:
 
     CompletionHandler<void(Decoder*)> takeAsyncReplyHandler(AsyncReplyID);
 
+    template<typename T, typename C> static void callReply(IPC::Decoder&, C&& completionHandler);
+    template<typename T, typename C> static void cancelReply(C&& completionHandler);
+
 private:
     Connection(Identifier, bool isServer);
     void platformInitialize(Identifier);
@@ -531,9 +534,6 @@ private:
 
     // Only valid between open() and invalidate().
     SerialFunctionDispatcher& dispatcher();
-
-    template<typename T, typename C> static void callReply(IPC::Decoder&, C&& completionHandler);
-    template<typename T, typename C> static void cancelReply(C&& completionHandler);
 
     class SyncMessageState;
     struct SyncMessageStateRelease {

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -44,6 +44,8 @@ using EncodedMessage = Vector<uint8_t>;
 class Connection : public CanMakeWeakPtr<Connection> {
 public:
     Connection() = default;
+    virtual ~Connection() = default;
+
 #if PLATFORM(COCOA)
     explicit Connection(RetainPtr<xpc_connection_t>&& connection)
         : m_connection(WTFMove(connection)) { }
@@ -53,6 +55,7 @@ public:
 protected:
     mutable RetainPtr<xpc_connection_t> m_connection;
 #endif
+    virtual void initializeConnectionIfNeeded() const { }
 };
 
 template<typename Traits>
@@ -74,7 +77,7 @@ public:
     const CString& machServiceName() const { return m_machServiceName; }
 
 private:
-    void initializeConnectionIfNeeded() const;
+    void initializeConnectionIfNeeded() const override;
 
     const CString m_machServiceName;
 };

--- a/Source/WebKit/Platform/IPC/MessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiver.h
@@ -46,6 +46,11 @@ public:
         ASSERT_NOT_REACHED();
     }
 
+    virtual void didReceiveMessageWithReplyHandler(Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&)
+    {
+        ASSERT_NOT_REACHED();
+    }
+
     virtual bool didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&)
     {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -48,4 +48,16 @@ bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, Asyn
     return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions) == Error::NoError;
 }
 
+bool MessageSender::performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&)
+{
+    // Senders that use sendWithoutUsingIPCConnection(T&& message) must also override this.
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+bool MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>)
+{
+    // Senders that use sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler) must also override this.
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -30,6 +30,7 @@
 namespace IPC {
 
 class Connection;
+class Decoder;
 class Encoder;
 class Timeout;
 enum class SendOption : uint8_t;
@@ -68,6 +69,12 @@ public:
     template<typename T, typename C> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption>);
     template<typename T, typename C, typename U, typename V> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V> destinationID);
     template<typename T, typename C, typename U, typename V> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V> destinationID, OptionSet<SendOption>);
+
+    template<typename T> inline bool sendWithoutUsingIPCConnection(T&& message);
+    virtual bool performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&);
+
+    template<typename T, typename C> inline bool sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler);
+    virtual bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>);
 
     virtual bool sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption>);
 

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -47,6 +47,8 @@ void Connection::send(xpc_object_t message) const
 void Connection::sendWithReply(xpc_object_t message, CompletionHandler<void(xpc_object_t)>&& completionHandler) const
 {
     ASSERT(RunLoop::isMain());
+    initializeConnectionIfNeeded();
+
     ASSERT(m_connection.get());
     ASSERT(xpc_get_type(message) == XPC_TYPE_DICTIONARY);
     xpc_connection_send_message_with_reply(m_connection.get(), message, dispatch_get_main_queue(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
@@ -79,7 +81,7 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
         weakThis->connectionReceivedEvent(event);
     });
     xpc_connection_activate(m_connection.get());
-    
+
     newConnectionWasInitialized();
 }
 

--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -44,6 +44,7 @@ _test_receiver_names = [
     'TestWithSuperclass',
     'TestWithLegacyReceiver',
     'TestWithoutAttributes',
+    'TestWithoutUsingIPCConnection',
     'TestWithIfMessage',
     'TestWithSemaphore',
     'TestWithImageData',

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -33,12 +33,14 @@ SYNCHRONOUS_ATTRIBUTE = 'Synchronous'
 STREAM_ATTRIBUTE = "Stream"
 
 class MessageReceiver(object):
-    def __init__(self, name, superclass, attributes, messages, condition):
+    def __init__(self, name, superclass, attributes, messages, condition, namespace):
         self.name = name
         self.superclass = superclass
         self.attributes = frozenset(attributes or [])
         self.messages = messages
         self.condition = condition
+        self.namespace = namespace
+
 
     def iterparameters(self):
         return itertools.chain((parameter for message in self.messages for parameter in message.parameters),
@@ -80,7 +82,7 @@ ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_
     Message('LegacySessionState', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('SetStreamDestinationID', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('ProcessOutOfStreamMessage', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-], condition=None)
+], condition=None, namespace="WebKit")
 
 
 def check_global_model_inputs(receivers):
@@ -114,5 +116,6 @@ def generate_global_model(receivers):
         for message in receiver.messages:
             if message.reply_parameters is not None and not message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
                 async_reply_messages.append(Message(name='%s_%sReply' % (receiver.name, message.name), parameters=message.reply_parameters, reply_parameters=[], attributes=None, condition=message.condition))
-    async_reply_receiver = MessageReceiver(name='AsyncReply', superclass='None', attributes=[BUILTIN_ATTRIBUTE], messages=async_reply_messages, condition=None)
+    async_reply_receiver = MessageReceiver(name='AsyncReply', superclass='None', attributes=[BUILTIN_ATTRIBUTE], messages=async_reply_messages, condition=None, namespace='WebKit')
+
     return [ipc_receiver, async_reply_receiver] + receivers

--- a/Source/WebKit/Scripts/webkit/parser.py
+++ b/Source/WebKit/Scripts/webkit/parser.py
@@ -49,9 +49,15 @@ def parse(file):
     conditions = []
     master_condition = None
     superclass = []
+    namespace = "WebKit"
     for line in file:
         line = line.strip()
-        match = re.search(r'messages -> (?P<destination>[A-Za-z_0-9]+) \s*(?::\s*(?P<superclass>.*?) \s*)?(?:(?P<attributes>.*?)\s+)?{', line)
+        match = re.search(r'messages -> (?P<namespace>[A-Za-z]+)::(?P<destination>[A-Za-z_0-9]+) \s*(?::\s*(?P<superclass>.*?) \s*)?(?:(?P<attributes>.*?)\s+)?{', line)
+        if not match:
+            match = re.search(r'messages -> (?P<destination>[A-Za-z_0-9]+) \s*(?::\s*(?P<superclass>.*?) \s*)?(?:(?P<attributes>.*?)\s+)?{', line)
+        else:
+            if match.group('namespace'):
+                namespace = match.group('namespace')
         if match:
             receiver_attributes = parse_attributes_string(match.group('attributes'))
             if match.group('superclass'):
@@ -97,7 +103,7 @@ def parse(file):
                 reply_parameters = None
 
             messages.append(model.Message(name, parameters, reply_parameters, attributes, combine_condition(conditions), runtime_enablement))
-    return model.MessageReceiver(destination, superclass, receiver_attributes, messages, combine_condition(master_condition))
+    return model.MessageReceiver(destination, superclass, receiver_attributes, messages, combine_condition(master_condition), namespace)
 
 
 def parse_attributes_string(attributes_string):

--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -3,6 +3,7 @@ TESTS = \
     TestWithSuperclass \
     TestWithLegacyReceiver \
     TestWithoutAttributes \
+    TestWithoutUsingIPCConnection \
     TestWithIfMessage \
     TestWithSemaphore \
     TestWithImageData \

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -127,6 +127,7 @@
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
 #include "TestWithoutAttributesMessages.h" // NOLINT
 #endif
+#include "TestWithoutUsingIPCConnectionMessages.h" // NOLINT
 #include "TestWithIfMessageMessages.h" // NOLINT
 #include "TestWithSemaphoreMessages.h" // NOLINT
 #include "TestWithImageDataMessages.h" // NOLINT
@@ -280,6 +281,18 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_ExperimentalOperation>(globalObject, decoder);
 #endif
 #endif
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument:
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply:
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgument:
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgument>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, decoder);
 #if PLATFORM(COCOA)
     case MessageName::TestWithIfMessage_LoadURL:
         return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
@@ -383,6 +396,14 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
         return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_InterpretKeyEvent>(globalObject, decoder);
 #endif
 #endif
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply:
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, decoder);
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, decoder);
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
         return jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, decoder);
     case MessageName::TestWithImageData_ReceiveImageData:
@@ -856,6 +877,24 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         };
 #endif
 #endif
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgument:
+        return Vector<ArgumentDescription> {
+            { "argument", "String", nullptr, false },
+        };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
+        return Vector<ArgumentDescription> {
+            { "argument", "String", nullptr, false },
+        };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
+        return Vector<ArgumentDescription> {
+            { "argument", "String", nullptr, false },
+        };
 #if PLATFORM(COCOA)
     case MessageName::TestWithIfMessage_LoadURL:
         return Vector<ArgumentDescription> {
@@ -1017,6 +1056,18 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
         };
 #endif
 #endif
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
+        return Vector<ArgumentDescription> {
+            { "reply", "String", nullptr, false },
+        };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
+        return Vector<ArgumentDescription> { };
+    case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
+        return Vector<ArgumentDescription> {
+            { "reply", "String", nullptr, false },
+        };
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
         return Vector<ArgumentDescription> {
             { "r0", "IPC::Semaphore", nullptr, false },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -125,6 +125,12 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
     { "TestWithoutAttributes_TouchEvent", ReceiverName::TestWithoutAttributes, false, false },
 #endif
+    { "TestWithoutUsingIPCConnection_MessageWithArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply", ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply", ReceiverName::TestWithoutUsingIPCConnection, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument", ReceiverName::TestWithoutUsingIPCConnection, false, false },
 #if PLATFORM(COCOA)
     { "InitializeConnection", ReceiverName::IPC, false, false },
 #endif
@@ -157,6 +163,10 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithoutAttributes_InterpretKeyEventReply", ReceiverName::AsyncReply, false, false },
 #endif
     { "TestWithoutAttributes_RunJavaScriptAlertReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply", ReceiverName::AsyncReply, false, false },
+    { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply", ReceiverName::AsyncReply, false, false },
     { "TestWithLegacyReceiver_GetPluginProcessConnection", ReceiverName::TestWithLegacyReceiver, true, false },
     { "TestWithLegacyReceiver_TestMultipleAttributes", ReceiverName::TestWithLegacyReceiver, true, false },
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -42,9 +42,10 @@ enum class ReceiverName : uint8_t {
     , TestWithStreamServerConnectionHandle = 10
     , TestWithSuperclass = 11
     , TestWithoutAttributes = 12
-    , IPC = 13
-    , AsyncReply = 14
-    , Invalid = 15
+    , TestWithoutUsingIPCConnection = 13
+    , IPC = 14
+    , AsyncReply = 15
+    , Invalid = 16
 };
 
 enum class MessageName : uint16_t {
@@ -145,6 +146,12 @@ enum class MessageName : uint16_t {
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
     TestWithoutAttributes_TouchEvent,
 #endif
+    TestWithoutUsingIPCConnection_MessageWithArgument,
+    TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply,
+    TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument,
+    TestWithoutUsingIPCConnection_MessageWithoutArgument,
+    TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply,
+    TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument,
 #if PLATFORM(COCOA)
     InitializeConnection,
 #endif
@@ -177,6 +184,10 @@ enum class MessageName : uint16_t {
     TestWithoutAttributes_InterpretKeyEventReply,
 #endif
     TestWithoutAttributes_RunJavaScriptAlertReply,
+    TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply,
+    TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply,
+    TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply,
+    TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply,
     FirstSynchronous,
     LastAsynchronous = FirstSynchronous - 1,
     TestWithLegacyReceiver_GetPluginProcessConnection,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnection.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnection.messages.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Tests various parts of generating message handlers that work with custom transport (e.g. not an IPC Conneciton)
+
+messages -> TestWithoutUsingIPCConnection NotUsingIPCConnection {
+    void MessageWithoutArgument()
+    void MessageWithoutArgumentAndEmptyReply() -> ()
+    void MessageWithoutArgumentAndReplyWithArgument() -> (String reply)
+    void MessageWithArgument(String argument)
+    void MessageWithArgumentAndEmptyReply(String argument) -> ()
+    void MessageWithArgumentAndReplyWithArgument(String argument) -> (String reply)
+}

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithoutUsingIPCConnection.h"
+
+#include "ArgumentCoders.h" // NOLINT
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithoutUsingIPCConnectionMessages.h" // NOLINT
+#include <wtf/text/WTFString.h> // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decoder& decoder, Function<void(UniqueRef<IPC::Encoder>&&)>&& replyHandler)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::name())
+        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithoutArgument);
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name())
+        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithArgument);
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
+    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
+    UNUSED_PARAM(decoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgument::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::ReplyArguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
+
+
+namespace Messages {
+namespace TestWithoutUsingIPCConnection {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithoutUsingIPCConnection;
+}
+
+class MessageWithoutArgument {
+public:
+    using Arguments = std::tuple<>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<> m_arguments;
+};
+
+class MessageWithoutArgumentAndEmptyReply {
+public:
+    using Arguments = std::tuple<>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<>;
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<> m_arguments;
+};
+
+class MessageWithoutArgumentAndReplyWithArgument {
+public:
+    using Arguments = std::tuple<>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<String>;
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<> m_arguments;
+};
+
+class MessageWithArgument {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgument; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    explicit MessageWithArgument(const String& argument)
+        : m_arguments(argument)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+class MessageWithArgumentAndEmptyReply {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<>;
+    explicit MessageWithArgumentAndEmptyReply(const String& argument)
+        : m_arguments(argument)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+class MessageWithArgumentAndReplyWithArgument {
+public:
+    using Arguments = std::tuple<String>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<String>;
+    explicit MessageWithArgumentAndReplyWithArgument(const String& argument)
+        : m_arguments(argument)
+    {
+    }
+
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+private:
+    std::tuple<const String&> m_arguments;
+};
+
+} // namespace TestWithoutUsingIPCConnection
+} // namespace Messages


### PR DESCRIPTION
#### 961097c5d0de061794d8ee19cb8151804c974bb5
<pre>
Add generated messages that can work without using IPC::Connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=260660">https://bugs.webkit.org/show_bug.cgi?id=260660</a>

Reviewed by Alex Christensen and Chris Dumez.

We want to auto generated messages to our daemons, but they don&apos;t use IPC::Connection.

This patch gives generated messages and message handlers the ability to bypass using IPC::Connection.

The MessageSender implements a few new custom methods to take a completed Encoder and ship it across its
own transport, as well as create a Decoder for replies.
The MessageReceiver implements a custom method to create its own Encoder from tranport and its own reply
handler that will be called by automatically generated code.

This just lays the groundwork and exercises it using the script tests.

Coming up next will be generating messages for webpushd

* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/DaemonConnection.h:
(WebKit::Daemon::Connection::initializeConnectionIfNeeded const):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageWithoutUsingIPCConnection):
(IPC::handleMessageAsyncWithoutUsingIPCConnection):
* Source/WebKit/Platform/IPC/MessageReceiver.h:
(IPC::MessageReceiver::didReceiveMessageWithReplyHandler):
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::performSendWithoutUsingIPCConnection):
(IPC::MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection):
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithoutUsingIPCConnection):
(IPC::MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::Connection::sendWithReply const):
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
* Source/WebKit/Scripts/webkit/messages.py:
(async_message_statement):
(generate_message_handler):
* Source/WebKit/Scripts/webkit/model.py:
(MessageReceiver.__init__):
(generate_global_model):
* Source/WebKit/Scripts/webkit/parser.py:
(parse):
* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::jsValueForReplyArguments):
(IPC::messageArgumentDescriptions):
(IPC::messageReplyArgumentDescriptions):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnection.messages.in: Added.
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp: Added.
(WebKit::TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgument&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h: Added.
(Messages::TestWithoutUsingIPCConnection::messageReceiverName):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::name):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::arguments):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::asyncMessageReplyName):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::arguments):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::asyncMessageReplyName):
(Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::arguments):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgument::MessageWithArgument):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgument::arguments):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::asyncMessageReplyName):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::MessageWithArgumentAndEmptyReply):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::arguments):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::asyncMessageReplyName):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::MessageWithArgumentAndReplyWithArgument):
(Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::arguments):

Canonical link: <a href="https://commits.webkit.org/267262@main">https://commits.webkit.org/267262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/938527e080a80453468d3fb3dedd0f42068ab34f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15146 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18667 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/16261 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14036 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13897 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18000 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16340 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14587 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4070 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3847 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18956 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17507 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15182 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3863 "Passed tests") | 
<!--EWS-Status-Bubble-End-->