### PR TITLE
REGRESSION(266644@main): [wk2] http/tests/security/referrer-policy-header.html is a flaky text failure, crash

### DIFF
--- a/LayoutTests/http/tests/security/referrer-policy-header.html
+++ b/LayoutTests/http/tests/security/referrer-policy-header.html
@@ -8,9 +8,10 @@
 <script>
 description("Tests support for Referrer-Policy HTTP header.");
 jsTestIsAsync = true;
-runTests(false);
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.waitUntilDone();
     testRunner.setStatisticsShouldDowngradeReferrer(false, async () => { await runTests(false /* multipart */); });
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -870,6 +870,4 @@ webkit.org/b/259409 imported/w3c/web-platform-tests/cookies/partitioned-cookies/
 
 webkit.org/b/259482 fast/media/managed-media-source-open-crash.html [ Pass Failure ]
 
-webkit.org/b/260632 http/tests/security/referrer-policy-header.html [ Pass Failure Crash ]
-
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]


### PR DESCRIPTION
#### d4d875b3f05037414daed79a709b33e37c161cfc
<pre>
REGRESSION(266644@main): [wk2] http/tests/security/referrer-policy-header.html is a flaky text failure, crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=260632">https://bugs.webkit.org/show_bug.cgi?id=260632</a>
rdar://114349670

Reviewed by Brent Fulgham.

This test wasn&apos;t waiting for completion of the iframe loads in order to
determine what the referrer was given a referrer policy. There were two
problems: one was I mistakenly added an extra call to runTests so we
were running synchronously once. The other problem was we weren&apos;t
telling the test runner to wait until we were finished loading the
iframe and receiving the messages from it with the results. The former
led to flaky results and the latter led to flaky crashes.

* LayoutTests/http/tests/security/referrer-policy-header.html:
* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/267241@main">https://commits.webkit.org/267241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b640a63c58453bb0daffc0d43d7dc0d14c03a0f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16473 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18576 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21367 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17914 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12953 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14346 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->