### PR TITLE
[ macOS EWS ] media/video-remove-insert-repaints.html is a flaky crash

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -231,15 +231,23 @@ PlaybackSessionInterfaceContext& PlaybackSessionManager::ensureInterface(Playbac
 
 void PlaybackSessionManager::removeContext(PlaybackSessionContextIdentifier contextId)
 {
-    auto& [model, interface] = ensureModelAndInterface(contextId);
+    auto [model, interface] = m_contextMap.get(contextId);
+    ASSERT(model);
+    ASSERT(interface);
+    if (!model || !interface)
+        return;
 
-    RefPtr<HTMLMediaElement> mediaElement = model->mediaElement();
-    model->setMediaElement(nullptr);
     model->removeClient(*interface);
     interface->invalidate();
-    if (mediaElement)
-        m_mediaElements.remove(*mediaElement);
     m_contextMap.remove(contextId);
+
+    RefPtr mediaElement = model->mediaElement();
+    ASSERT(mediaElement);
+    if (!mediaElement)
+        return;
+
+    model->setMediaElement(nullptr);
+    m_mediaElements.remove(*mediaElement);
 }
 
 void PlaybackSessionManager::addClientForContext(PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -206,16 +206,25 @@ VideoFullscreenInterfaceContext& VideoFullscreenManager::ensureInterface(Playbac
 
 void VideoFullscreenManager::removeContext(PlaybackSessionContextIdentifier contextId)
 {
-    auto [model, interface] = ensureModelAndInterface(contextId);
-
     m_playbackSessionManager->removeClientForContext(contextId);
 
-    RefPtr<HTMLVideoElement> videoElement = model->videoElement();
-    model->setVideoElement(nullptr);
+    auto [model, interface] = m_contextMap.get(contextId);
+    ASSERT(model);
+    ASSERT(interface);
+    if (!model || !interface)
+        return;
+
     model->removeClient(*interface);
     interface->invalidate();
-    m_videoElements.remove(*videoElement);
     m_contextMap.remove(contextId);
+
+    RefPtr videoElement = model->videoElement();
+    ASSERT(videoElement);
+    if (!videoElement)
+        return;
+
+    model->setVideoElement(nullptr);
+    m_videoElements.remove(*videoElement);
 }
 
 void VideoFullscreenManager::addClientForContext(PlaybackSessionContextIdentifier contextId)


### PR DESCRIPTION
#### 8f95bb755716401ffa2af130073742978e126454
<pre>
[ macOS EWS ] media/video-remove-insert-repaints.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=260663">https://bugs.webkit.org/show_bug.cgi?id=260663</a>
rdar://114387091

Reviewed by Jer Noble.

If VideoFullscreenManager::removeContext is called with a contextId that doesn&apos;t exist in
m_contextMap then a new model would be created with a null video element, leading to a crash when
attempting to remove the video element from m_videoElements. Addressed this by returning early in
VideoFullscreenManager::removeContext if no model/interface pair exists for the given contextId.
Assert that this does not occur to help us track down the underlying issue in Debug builds
(removeContext should not be called for a non-existent contextId).

* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::removeContext):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::removeContext):

Canonical link: <a href="https://commits.webkit.org/267257@main">https://commits.webkit.org/267257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17329944009e97dbabe47f08ee826ef3e2cd2165

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15109 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16523 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18623 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13996 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21408 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17960 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14550 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3845 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->