### PR TITLE
Avoid constructing a DocumentFragment unnecessarily in DOMParser::parseFromString()

### DIFF
--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -95,7 +95,9 @@ void DocumentFragment::parseHTML(const String& source, Element& contextElement, 
         ASSERT(serializeFragment(*this, SerializedNodes::SubtreesOfChildren) == serializeFragment(referenceFragment, SerializedNodes::SubtreesOfChildren));
 #endif
         return;
-    }
+    } else if (hasChildNodes())
+        removeChildren();
+
     HTMLDocumentParser::parseDocumentFragment(source, *this, contextElement, parserContentPolicy);
 }
 

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
@@ -35,13 +35,13 @@
 
 namespace WebCore {
 
+class ContainerNode;
 class Document;
-class DocumentFragment;
 class Element;
 
 enum class ParserContentPolicy : uint8_t;
 
-WEBCORE_EXPORT bool tryFastParsingHTMLFragment(const String& source, Document&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy>);
+WEBCORE_EXPORT bool tryFastParsingHTMLFragment(const String& source, Document&, ContainerNode&, Element& contextElement, OptionSet<ParserContentPolicy>);
 
 } // namespace WebCore
 

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -59,18 +59,14 @@ ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, cons
     document->setParserContentPolicy(parsingOptions);
     bool usedFastPath = false;
     if (contentType == "text/html"_s) {
-        auto fragment = DocumentFragment::create(document);
         auto body = HTMLBodyElement::create(document);
-        usedFastPath = tryFastParsingHTMLFragment(string, document, fragment, body, parsingOptions);
+        usedFastPath = tryFastParsingHTMLFragment(string, document, body, body, parsingOptions);
         if (LIKELY(usedFastPath)) {
             auto html = HTMLHtmlElement::create(document);
             document->appendChild(html);
             auto head = HTMLHeadElement::create(document);
             html->appendChild(head);
             html->appendChild(body);
-            auto result = body->appendChild(fragment);
-            if (UNLIKELY(result.hasException()))
-                return result.releaseException();
         }
     }
     if (!usedFastPath)


### PR DESCRIPTION
#### 903209cb2740be645ffee7bd740aa4553e59e3d8
<pre>
Avoid constructing a DocumentFragment unnecessarily in DOMParser::parseFromString()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260665">https://bugs.webkit.org/show_bug.cgi?id=260665</a>

Reviewed by Yusuke Suzuki.

Avoid constructing a DocumentFragment unnecessarily in DOMParser::parseFromString().
Have the HTML fast parser construct the subtree under the &lt;body&gt; element directly
instead.

* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::parseHTML):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::HTMLFastPathParser):
(WebCore::HTMLFastPathParser::parseCompleteInput):
(WebCore::tryFastParsingHTMLFragmentImpl):
(WebCore::tryFastParsingHTMLFragment):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.h:
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):

Canonical link: <a href="https://commits.webkit.org/267242@main">https://commits.webkit.org/267242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79f4649f7eafa02e61acf6724e8ff160f55d3abd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16485 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18587 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21378 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17927 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15286 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14520 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3832 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->