### PR TITLE
Various cleanups after 267095@main

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -509,7 +509,7 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=150791: @font-face features should also cause this to be complex.
 
-#if (!USE(FONT_VARIANT_VIA_FEATURES) && !USE(FREETYPE))
+#if !USE(FONT_VARIANT_VIA_FEATURES) && !USE(FREETYPE)
     if (run.length() > 1 && (enableKerning() || requiresShaping()))
         return CodePath::Complex;
 #endif

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -207,13 +207,7 @@ static void addToGlyphBuffer(GlyphBuffer& glyphBuffer, Glyph glyph, const Font& 
 }
 
 struct SmallCapsState {
-    SmallCapsState(const FontCascadeDescription& fontDescription)
-    {
-        fontVariantCaps = fontDescription.variantCaps();
-        dontSynthesizeSmallCaps = !fontDescription.hasAutoFontSynthesisSmallCaps();
-        engageAllSmallCapsProcessing = fontVariantCaps == FontVariantCaps::AllSmall || fontVariantCaps == FontVariantCaps::AllPetite;
-    }
-    const Font* font;
+    const Font* font { nullptr };
     const Font* synthesizedFont { nullptr };
     const Font* smallSynthesizedFont { nullptr };
     bool isSmallCaps { false };
@@ -224,6 +218,13 @@ struct SmallCapsState {
     bool dontSynthesizeSmallCaps { false };
     bool engageAllSmallCapsProcessing { false };
 
+    SmallCapsState(const FontCascadeDescription& fontDescription)
+    {
+        fontVariantCaps = fontDescription.variantCaps();
+        dontSynthesizeSmallCaps = !fontDescription.hasAutoFontSynthesisSmallCaps();
+        engageAllSmallCapsProcessing = fontVariantCaps == FontVariantCaps::AllSmall || fontVariantCaps == FontVariantCaps::AllPetite;
+    }
+
     void setSmallCapsData(const Font* font, bool isSmallCaps, const FontDescription& fontDescription)
     {
         ASSERT(font);
@@ -233,17 +234,20 @@ struct SmallCapsState {
         this->isLastSmallCaps = this->isSmallCaps;
         this->isSmallCaps = isSmallCaps;
     }
+
     void clear()
     {
         synthesizedFont = nullptr;
         smallSynthesizedFont = nullptr;
         isSmallCaps = false;
     }
+
     void setIsSmallCaps(bool isSmallCaps)
     {
         isLastSmallCaps = this->isSmallCaps;
         this->isSmallCaps = isSmallCaps;
     }
+
     bool skipSmallCapsProcessing() const
     {
         return fontVariantCaps == FontVariantCaps::Normal;
@@ -251,24 +255,24 @@ struct SmallCapsState {
 };
 
 struct AdvanceInternalState {
-    const Font* font;
-    const Font* lastFont;
+    const Font* font { nullptr };
+    const Font* lastFont { nullptr };
     // rangeFont and font are not necessarily the same, since small-caps might change the range fot for a synthesized font, or a small-caps-synthesized font.
-    const Font* rangeFont;
-    const Font* nextRangeFont;
+    const Font* rangeFont { nullptr };
+    const Font* nextRangeFont { nullptr };
     GlyphBuffer& glyphBuffer;
-    unsigned lastGlyphCount;
+    unsigned lastGlyphCount { 0 };
     const Font& primaryFont;
-    float widthOfCurrentFontRange { 0.0 };
+    float widthOfCurrentFontRange { 0 };
     CharactersTreatedAsSpace charactersTreatedAsSpace;
     unsigned currentCharacterIndex { 0 };
     unsigned indexOfFontTransition { 0 };
 
     AdvanceInternalState(GlyphBuffer& glyphBuffer, const Font& primaryFont, unsigned currentCharacterIndex)
-    : glyphBuffer { glyphBuffer }
-    , primaryFont { primaryFont }
-    , currentCharacterIndex { currentCharacterIndex }
-    , indexOfFontTransition { currentCharacterIndex }
+        : glyphBuffer { glyphBuffer }
+        , primaryFont { primaryFont }
+        , currentCharacterIndex { currentCharacterIndex }
+        , indexOfFontTransition { currentCharacterIndex }
     {
         lastGlyphCount = glyphBuffer.size();
         lastFont = &primaryFont;
@@ -276,10 +280,12 @@ struct AdvanceInternalState {
         rangeFont = &primaryFont;
         nextRangeFont = &primaryFont;
     }
+
     bool fontChanged() const
     {
         return font != lastFont;
     }
+
     void updateFont(const Font* font)
     {
         this->lastFont = this->font;
@@ -813,6 +819,7 @@ void WidthIterator::advance(unsigned offset, GlyphBuffer& glyphBuffer)
     applyCSSVisibilityRules(glyphBuffer, glyphBufferStartIndex);
 }
 
+// FIXME: It's pretty much never right to advance just one character.
 bool WidthIterator::advanceOneCharacter(float& width, GlyphBuffer& glyphBuffer)
 {
     unsigned oldSize = glyphBuffer.size();
@@ -824,4 +831,4 @@ bool WidthIterator::advanceOneCharacter(float& width, GlyphBuffer& glyphBuffer)
     return glyphBuffer.size() > oldSize;
 }
 
-}
+} // namespace WebCore


### PR DESCRIPTION
#### e67d582edd3d1ca5c75c80220b030e2c34e4cd1c
<pre>
Various cleanups after 267095@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=260670">https://bugs.webkit.org/show_bug.cgi?id=260670</a>
rdar://114400262

Reviewed by Cameron McCormack.

This is a bunch of style-related cleanups in WidthIterator.

No test because there is no behavior change.

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::SmallCapsState::SmallCapsState):
(WebCore::AdvanceInternalState::AdvanceInternalState):
(WebCore::resetFontRangeIfNeeded):

Canonical link: <a href="https://commits.webkit.org/267297@main">https://commits.webkit.org/267297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a4879584308299203ccffb8d6a28078ea46aea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17544 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18653 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21430 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17987 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13011 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14574 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3876 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->