### PR TITLE
Add some accessors to WidthIterator's internal iterators

### DIFF
--- a/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
+++ b/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
@@ -63,8 +63,6 @@ public:
         m_currentIndex += advanceLength;
     }
 
-    unsigned currentIndex() const { return m_currentIndex; }
-
     void reset(unsigned index)
     {
         ASSERT(index >= m_originalIndex);
@@ -73,12 +71,21 @@ public:
         m_currentIndex = index;
     }
 
+    const UChar* remainingCharacters() const
+    {
+        auto relativeIndex = m_currentIndex - m_originalIndex;
+        return m_characters + relativeIndex;
+    }
+
+    unsigned currentIndex() const { return m_currentIndex; }
+    const UChar* characters() const { return m_characters; }
+
 private:
     CachedTextBreakIterator m_iterator;
-    const UChar* m_characters;
-    unsigned m_originalIndex { 0 };
+    const UChar* const m_characters;
+    const unsigned m_originalIndex { 0 };
     unsigned m_currentIndex { 0 };
-    unsigned m_lastIndex { 0 };
+    const unsigned m_lastIndex { 0 };
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/Latin1TextIterator.h
+++ b/Source/WebCore/platform/graphics/Latin1TextIterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -19,8 +19,7 @@
  *
  */
 
-#ifndef Latin1TextIterator_h
-#define Latin1TextIterator_h
+#pragma once
 
 #include <wtf/text/WTFString.h>
 
@@ -61,16 +60,20 @@ public:
         m_currentIndex = index;
     }
 
+    const LChar* remainingCharacters() const
+    {
+        auto relativeIndex = m_currentIndex - m_originalIndex;
+        return m_characters + relativeIndex;
+    }
+
     unsigned currentIndex() const { return m_currentIndex; }
     const LChar* characters() const { return m_characters; }
 
 private:
-    const LChar* m_characters;
+    const LChar* const m_characters;
     unsigned m_currentIndex;
-    unsigned m_originalIndex;
-    unsigned m_lastIndex;
+    const unsigned m_originalIndex;
+    const unsigned m_lastIndex;
 };
 
-}
-
-#endif
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
+++ b/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
@@ -54,8 +54,6 @@ public:
         m_currentIndex += advanceLength;
     }
 
-    unsigned currentIndex() const { return m_currentIndex; }
-
     void reset(unsigned index)
     {
         if (index >= m_lastIndex)
@@ -63,12 +61,21 @@ public:
         m_currentIndex = index;
     }
 
+    const UChar* remainingCharacters() const
+    {
+        auto relativeIndex = m_currentIndex - m_originalIndex;
+        return m_characters + relativeIndex;
+    }
+
+    unsigned currentIndex() const { return m_currentIndex; }
+    const UChar* characters() const { return m_characters; }
+
 private:
-    const UChar* m_characters { nullptr };
+    const UChar* const m_characters { nullptr };
     unsigned m_currentIndex { 0 };
-    unsigned m_originalIndex { 0 };
-    unsigned m_lastIndex { 0 };
-    unsigned m_endIndex { 0 };
+    const unsigned m_originalIndex { 0 };
+    const unsigned m_lastIndex { 0 };
+    const unsigned m_endIndex { 0 };
 };
 
-}
+} // namespace WebCore


### PR DESCRIPTION
#### 7f5ccd87b5c428c990a92a81ff3add2a17e7a2c4
<pre>
Add some accessors to WidthIterator&apos;s internal iterators
<a href="https://bugs.webkit.org/show_bug.cgi?id=260671">https://bugs.webkit.org/show_bug.cgi?id=260671</a>
rdar://114400737

Reviewed by Cameron McCormack.

This is in preparation for removing the complex text codepath. These accessors will be
necessary when we actually make WidthIterator understand character clusters. For now,
they are unused.

No tests because there is no behavior change.

* Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h:
(WebCore::ComposedCharacterClusterTextIterator::remainingCharacters const):
(WebCore::ComposedCharacterClusterTextIterator::currentIndex const):
(WebCore::ComposedCharacterClusterTextIterator::characters const):
* Source/WebCore/platform/graphics/Latin1TextIterator.h:
(WebCore::Latin1TextIterator::remainingCharacters const):
* Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h:
(WebCore::SurrogatePairAwareTextIterator::remainingCharacters const):
(WebCore::SurrogatePairAwareTextIterator::currentIndex const):
(WebCore::SurrogatePairAwareTextIterator::characters const):

Canonical link: <a href="https://commits.webkit.org/267254@main">https://commits.webkit.org/267254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42833e2128a17cc0eb2aab8e1dac621d7e642d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16510 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18613 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21399 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17951 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12981 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14541 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3842 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->