### PR TITLE
[css-values] Implement rcap / rex / ric / rch units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt
@@ -2,13 +2,13 @@
 PASS em units respond to changes
 PASS rem units respond to changes
 PASS ex units respond to changes
-FAIL rex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS rex units respond to changes
 PASS ch units respond to changes
 FAIL cap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL rch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS rch units respond to changes
 PASS lh units respond to changes
 PASS rlh units respond to changes
 PASS ic units respond to changes
-FAIL ric units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS ric units respond to changes
 FAIL rcap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-expected.txt
@@ -2,13 +2,13 @@
 PASS em relative inline-size
 PASS rem relative inline-size
 PASS ex relative inline-size
-FAIL rex relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS rex relative inline-size
 PASS ch relative inline-size
-FAIL rch relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS rch relative inline-size
 PASS ic relative inline-size
-FAIL ric relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS ric relative inline-size
 PASS lh relative inline-size
 PASS rlh relative inline-size
 PASS cap relative inline-size
-FAIL rcap relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS rcap relative inline-size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+
+<style>
+  :root {
+    font-family: Ahem;
+    font-size: 16px;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-size: 1cap;">
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+
+<style>
+  :root {
+    font-family: Ahem;
+    font-size: 16px;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-size: 1cap;">
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-size-prop">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="rcap-in-monospace-ref.html">
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+
+<style>
+  :root {
+    font-family: Ahem;
+    font-size: 16px;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-family: monospace; font-size: 1.5em">
+  <div style="font-family: sans-serif; font-size: 1rcap">
+    Text.
+  </div>
+</div>
+
+<div style="font-family: sans-serif; font-size: 1rcap">
+  Text.
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<p>The following two lines should look exactly the same.</p>
+
+<div style="font-family: sans-serif; font-size: 1rch">
+  Text.
+</div>
+
+<div style="font-family: sans-serif; font-size: 1rch">
+  Text.
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<p>The following two lines should look exactly the same.</p>
+
+<div style="font-family: sans-serif; font-size: 1rch">
+  Text.
+</div>
+
+<div style="font-family: sans-serif; font-size: 1rch">
+  Text.
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-size-prop">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="rch-in-monospace-ref.html">
+
+<p>The following two lines should look exactly the same.</p>
+
+<div style="font-family: monospace; font-size: 1.5em">
+  <div style="font-family: sans-serif; font-size: 1rch">
+    Text.
+  </div>
+</div>
+
+<div style="font-family: sans-serif; font-size: 1rch">
+  Text.
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<style>
+  @font-face {
+    font-family: ExTest;
+    src: url(../css-values/resources/ExTest.woff);
+  }
+  :root {
+    font-family: ExTest;
+    font-size: 20px;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-size: 1ex;">
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<style>
+  @font-face {
+    font-family: ExTest;
+    src: url(../css-values/resources/ExTest.woff);
+  }
+  :root {
+    font-family: ExTest;
+    font-size: 20px;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-size: 1ex;">
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-size-prop">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="rex-in-monospace-ref.html">
+
+<style>
+  @font-face {
+    font-family: ExTest;
+    src: url(../css-values/resources/ExTest.woff);
+  }
+  :root {
+    font-family: ExTest;
+    font-size: 20px;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-family: monospace; font-size: 1.5em">
+  <div style="font-family: sans-serif; font-size: 1rex">
+    Text.
+  </div>
+</div>
+
+<div style="font-family: sans-serif; font-size: 1rex">
+  Text.
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<style>
+  @font-face {
+    font-family: IcTestFullWidth;
+    src: url(../css-values/resources/IcTestFullWidth.woff2);
+  }
+  :root {
+    font-family: IcTestFullWidth;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-size: 1ic">
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<style>
+  @font-face {
+    font-family: IcTestFullWidth;
+    src: url(../css-values/resources/IcTestFullWidth.woff2);
+  }
+  :root {
+    font-family: IcTestFullWidth;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-size: 1ic">
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+
+  <div style="font-family: sans-serif;">
+    Text.
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-size-prop">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="ric-in-monospace-ref.html">
+
+<style>
+  @font-face {
+    font-family: IcTestFullWidth;
+    src: url(../css-values/resources/IcTestFullWidth.woff2);
+  }
+  :root {
+    font-family: IcTestFullWidth;
+  }
+</style>
+
+<p style="font-family: sans-serif">The following two lines should look exactly the same.</p>
+
+<div style="font-family: monospace; font-size: 1.5em">
+  <div style="font-family: sans-serif; font-size: 1ric">
+    Text.
+  </div>
+</div>
+
+<div style="font-family: sans-serif; font-size: 1ric">
+  Text.
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rcap-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rcap-invalidation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_not_equals: expect the capital height of Ahem and sans-serif to be different got disallowed value 784
 
-FAIL CSS Values and Units Test: rcap invalidation Error: assert_not_equals: expect the capital height of Ahem and sans-serif to be different got disallowed value 784
+PASS CSS Values and Units Test: rcap invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rch-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rch-invalidation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_not_equals: expect the width of zero of Ahem and sans-serif to be different got disallowed value 784
 
-FAIL CSS Values and Units Test: rch invalidation Error: assert_not_equals: expect the width of zero of Ahem and sans-serif to be different got disallowed value 784
+PASS CSS Values and Units Test: rch invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rex-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rex-invalidation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_not_equals: expect the x-height of Ahem and sans-serif to be different got disallowed value 784
 
-FAIL CSS Values and Units Test: rex invalidation Error: assert_not_equals: expect the x-height of Ahem and sans-serif to be different got disallowed value 784
+PASS CSS Values and Units Test: rex invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/ric-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/ric-invalidation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_not_equals: expect update of ric units with font size change got disallowed value 784
 
-FAIL CSS Values and Units Test: ric invalidation Error: assert_not_equals: expect update of ric units with font size change got disallowed value 784
+PASS CSS Values and Units Test: ric invalidation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rlh-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/rlh-invalidation-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_not_equals: expect rlh units to update on line-height update got disallowed value 800
 
-FAIL CSS Values and Units Test: rlh invalidation Error: assert_not_equals: expect rlh units to update on line-height update got disallowed value 800
+PASS CSS Values and Units Test: rlh invalidation
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -94,7 +94,11 @@ static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
     case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
     case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
     case CSSUnitType::CSS_SVH:
@@ -199,7 +203,11 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
     case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_RGBCOLOR:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
@@ -379,10 +387,14 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_EM:
     case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_EX:
-    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_MM:
@@ -680,10 +692,6 @@ static double lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis logicalA
 
 double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primitiveType, double value, CSSPropertyID propertyToCompute, const FontCascade* fontCascadeForUnit, const RenderView* renderView)
 {
-    // FIXME: Figure out where we don't initialize the root style in BuilderContext and check if this matters.
-    if (isRootFontRelativeLength(primitiveType) && !fontCascadeForUnit)
-        return value;
-
     switch (primitiveType) {
     case CSSUnitType::CSS_EM:
     case CSSUnitType::CSS_QUIRKY_EM:
@@ -692,7 +700,8 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         auto& fontDescription = fontCascadeForUnit->fontDescription();
         return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSize()) * value;
     }
-    case CSSUnitType::CSS_EX: {
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_REX: {
         ASSERT(fontCascadeForUnit);
         auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
         if (fontMetrics.hasXHeight())
@@ -700,7 +709,8 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         auto& fontDescription = fontCascadeForUnit->fontDescription();
         return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSize()) / 2.0 * value;
     }
-    case CSSUnitType::CSS_CAP: {
+    case CSSUnitType::CSS_CAP:
+    case CSSUnitType::CSS_RCAP: {
         ASSERT(fontCascadeForUnit);
         auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
         if (fontMetrics.hasCapHeight())
@@ -708,9 +718,11 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         return fontMetrics.ascent() * value;
     }
     case CSSUnitType::CSS_CH:
+    case CSSUnitType::CSS_RCH:
         ASSERT(fontCascadeForUnit);
         return fontCascadeForUnit->metricsOfPrimaryFont().zeroWidth().value_or(fontCascadeForUnit->fontDescription().computedSize() / 2) * value;
     case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RIC:
         ASSERT(fontCascadeForUnit);
         return fontCascadeForUnit->metricsOfPrimaryFont().ideogramWidth() * value;
     case CSSUnitType::CSS_PX:
@@ -831,8 +843,12 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
         value = computeUnzoomedNonCalcLengthDouble(primitiveType, value, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits());
         break;
 
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
     case CSSUnitType::CSS_REM:
-        value = computeUnzoomedNonCalcLengthDouble(primitiveType, value, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : nullptr);
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
+        value = computeUnzoomedNonCalcLengthDouble(primitiveType, value, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : &conversionData.fontCascadeForFontUnits());
         break;
 
     case CSSUnitType::CSS_PX:
@@ -1257,7 +1273,11 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_PX: return "px"_s;
     case CSSUnitType::CSS_Q: return "q"_s;
     case CSSUnitType::CSS_RAD: return "rad"_s;
+    case CSSUnitType::CSS_RCAP: return "rcap"_s;
+    case CSSUnitType::CSS_RCH: return "rch"_s;
     case CSSUnitType::CSS_REM: return "rem"_s;
+    case CSSUnitType::CSS_REX: return "rex"_s;
+    case CSSUnitType::CSS_RIC: return "ric"_s;
     case CSSUnitType::CSS_RLH: return "rlh"_s;
     case CSSUnitType::CSS_S: return "s"_s;
     case CSSUnitType::CSS_SVB: return "svb"_s;
@@ -1347,7 +1367,11 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_Q:
     case CSSUnitType::CSS_RAD:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
     case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
@@ -1442,10 +1466,14 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CSS_EM:
     case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_EX:
-    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_DPPX:
@@ -1540,10 +1568,14 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
     case CSSUnitType::CSS_EM:
     case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_EX:
-    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_DPPX:
@@ -1635,6 +1667,10 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
 void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     switch (primitiveUnitType()) {
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_REM:
         dependencies.rootProperties.appendIfNotContains(CSSPropertyFontSize);
         break;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -255,8 +255,12 @@ constexpr bool CSSPrimitiveValue::isFontIndependentLength(CSSUnitType type)
 
 constexpr bool CSSPrimitiveValue::isRootFontRelativeLength(CSSUnitType type)
 {
-    return type == CSSUnitType::CSS_RLH
-        || type == CSSUnitType::CSS_REM;
+    return type == CSSUnitType::CSS_RCAP
+        || type == CSSUnitType::CSS_RCH
+        || type == CSSUnitType::CSS_REM
+        || type == CSSUnitType::CSS_REX
+        || type == CSSUnitType::CSS_RIC
+        || type == CSSUnitType::CSS_RLH;
 }
 
 constexpr bool CSSPrimitiveValue::isFontRelativeLength(CSSUnitType type)
@@ -264,12 +268,11 @@ constexpr bool CSSPrimitiveValue::isFontRelativeLength(CSSUnitType type)
     return type == CSSUnitType::CSS_EM
         || type == CSSUnitType::CSS_EX
         || type == CSSUnitType::CSS_LH
-        || type == CSSUnitType::CSS_RLH
-        || type == CSSUnitType::CSS_REM
         || type == CSSUnitType::CSS_CAP
         || type == CSSUnitType::CSS_CH
         || type == CSSUnitType::CSS_IC
-        || type == CSSUnitType::CSS_QUIRKY_EM;
+        || type == CSSUnitType::CSS_QUIRKY_EM
+        || isRootFontRelativeLength(type);
 }
 
 constexpr bool CSSPrimitiveValue::isLength(CSSUnitType type)
@@ -282,19 +285,14 @@ constexpr bool CSSPrimitiveValue::isLength(CSSUnitType type)
         || type == CSSUnitType::CSS_IN
         || type == CSSUnitType::CSS_PT
         || type == CSSUnitType::CSS_PC
-        || type == CSSUnitType::CSS_REM
-        || type == CSSUnitType::CSS_CAP
-        || type == CSSUnitType::CSS_CH
-        || type == CSSUnitType::CSS_IC
         || type == CSSUnitType::CSS_Q
-        || type == CSSUnitType::CSS_LH
-        || type == CSSUnitType::CSS_RLH
         || type == CSSUnitType::CSS_CQW
         || type == CSSUnitType::CSS_CQH
         || type == CSSUnitType::CSS_CQI
         || type == CSSUnitType::CSS_CQB
         || type == CSSUnitType::CSS_CQMIN
         || type == CSSUnitType::CSS_CQMAX
+        || isFontRelativeLength(type)
         || isViewportPercentageLength(type)
         || type == CSSUnitType::CSS_QUIRKY_EM;
 }

--- a/Source/WebCore/css/CSSUnits.cpp
+++ b/Source/WebCore/css/CSSUnits.cpp
@@ -44,12 +44,16 @@ CSSUnitCategory unitCategory(CSSUnitType type)
         return CSSUnitCategory::AbsoluteLength;
     // https://drafts.csswg.org/css-values-4/#font-relative-lengths
     case CSSUnitType::CSS_EM:
-    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_RLH:
         return CSSUnitCategory::FontRelativeLength;
     // https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
@@ -248,7 +252,11 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_CQMAX: ts << "cqmax"; break;
     case CSSUnitType::CSS_CQMIN: ts << "cqmin"; break;
     case CSSUnitType::CSS_TURN: ts << "turn"; break;
+    case CSSUnitType::CSS_RCAP: ts << "rcap"; break;
+    case CSSUnitType::CSS_RCH: ts << "rch"; break;
     case CSSUnitType::CSS_REM: ts << "rem"; break;
+    case CSSUnitType::CSS_REX: ts << "rex"; break;
+    case CSSUnitType::CSS_RIC: ts << "ric"; break;
     case CSSUnitType::CSS_CAP: ts << "cap"; break;
     case CSSUnitType::CSS_CH: ts << "ch"; break;
     case CSSUnitType::CSS_IC: ts << "ic"; break;

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -102,9 +102,13 @@ enum class CSSUnitType : uint8_t {
 
     CSS_TURN,
     CSS_REM,
+    CSS_REX,
     CSS_CAP,
+    CSS_RCAP,
     CSS_CH,
+    CSS_RCH,
     CSS_IC,
+    CSS_RIC,
 
     CSS_COUNTER_NAME,
 

--- a/Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp
+++ b/Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp
@@ -47,11 +47,15 @@ CalculationCategory calcUnitCategory(CSSUnitType type)
     case CSSUnitType::CSS_PC:
     case CSSUnitType::CSS_Q:
     case CSSUnitType::CSS_LH:
-    case CSSUnitType::CSS_RLH:
-    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_VH:
     case CSSUnitType::CSS_VMIN:
@@ -141,11 +145,15 @@ CalculationCategory calculationCategoryForCombination(CSSUnitType type)
     case CSSUnitType::CSS_EM:
     case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_LH:
-    case CSSUnitType::CSS_REM:
-    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_VH:
     case CSSUnitType::CSS_VMIN:
@@ -211,7 +219,6 @@ bool hasDoubleValue(CSSUnitType type)
     case CSSUnitType::CSS_CAP:
     case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
-    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_MM:
@@ -258,6 +265,11 @@ bool hasDoubleValue(CSSUnitType type)
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_Q:
     case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RCAP:
+    case CSSUnitType::CSS_RCH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_REX:
+    case CSSUnitType::CSS_RIC:
     case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_CQW:
     case CSSUnitType::CSS_CQH:

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -194,9 +194,19 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
                 if (toASCIILower(data[2]) == 'd')
                     return CSSUnitType::CSS_RAD;
                 break;
+            case 'c':
+                if (toASCIILower(data[2]) == 'h')
+                    return CSSUnitType::CSS_RCH;
+                break;
             case 'e':
                 if (toASCIILower(data[2]) == 'm')
                     return CSSUnitType::CSS_REM;
+                if (toASCIILower(data[2]) == 'x')
+                    return CSSUnitType::CSS_REX;
+                break;
+            case 'i':
+                if (toASCIILower(data[2]) == 'c')
+                    return CSSUnitType::CSS_RIC;
                 break;
             case 'l':
                 if (toASCIILower(data[2]) == 'h' && DeprecatedGlobalSettings::lineHeightUnitsEnabled())
@@ -241,6 +251,10 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
         case 'g':
             if (toASCIILower(data[1]) == 'r' && toASCIILower(data[2]) == 'a' && toASCIILower(data[3]) == 'd')
                 return CSSUnitType::CSS_GRAD;
+            break;
+        case 'r':
+            if (toASCIILower(data[1]) == 'c' && toASCIILower(data[2]) == 'a' && toASCIILower(data[3]) == 'p')
+                return CSSUnitType::CSS_RCAP;
             break;
         case 't':
             if (toASCIILower(data[1]) == 'u' && toASCIILower(data[2]) == 'r' && toASCIILower(data[3]) == 'n')

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -548,9 +548,13 @@ struct LengthRawKnownTokenTypeDimensionConsumer {
         case CSSUnitType::CSS_LH:
         case CSSUnitType::CSS_RLH:
         case CSSUnitType::CSS_CAP:
+        case CSSUnitType::CSS_RCAP:
         case CSSUnitType::CSS_CH:
+        case CSSUnitType::CSS_RCH:
         case CSSUnitType::CSS_IC:
+        case CSSUnitType::CSS_RIC:
         case CSSUnitType::CSS_EX:
+        case CSSUnitType::CSS_REX:
         case CSSUnitType::CSS_PX:
         case CSSUnitType::CSS_CM:
         case CSSUnitType::CSS_MM:

--- a/Source/WebCore/css/typedom/CSSNumericFactory.h
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.h
@@ -49,11 +49,15 @@ public:
 
     // <length>
     static Ref<CSSUnitValue> em(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EM); }
-    static Ref<CSSUnitValue> ex(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EX); }
-    static Ref<CSSUnitValue> cap(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CAP); }
-    static Ref<CSSUnitValue> ch(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CH); }
-    static Ref<CSSUnitValue> ic(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_IC); }
     static Ref<CSSUnitValue> rem(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_REM); }
+    static Ref<CSSUnitValue> ex(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EX); }
+    static Ref<CSSUnitValue> rex(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_REX); }
+    static Ref<CSSUnitValue> cap(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CAP); }
+    static Ref<CSSUnitValue> rcap(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_RCAP); }
+    static Ref<CSSUnitValue> ch(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CH); }
+    static Ref<CSSUnitValue> rch(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_RCH); }
+    static Ref<CSSUnitValue> ic(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_IC); }
+    static Ref<CSSUnitValue> ric(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_RIC); }
     static Ref<CSSUnitValue> lh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LH); }
     static Ref<CSSUnitValue> rlh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_RLH); }
     static Ref<CSSUnitValue> vw(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_VW); }

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -194,16 +194,22 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
             return Ref<CSSStyleValue> { CSSNumericFactory::percent(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_EM:
             return Ref<CSSStyleValue> { CSSNumericFactory::em(primitiveValue->doubleValue()) };
+        case CSSUnitType::CSS_REM:
+            return Ref<CSSStyleValue> { CSSNumericFactory::rem(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_EX:
             return Ref<CSSStyleValue> { CSSNumericFactory::ex(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_CAP:
             return Ref<CSSStyleValue> { CSSNumericFactory::cap(primitiveValue->doubleValue()) };
+        case CSSUnitType::CSS_RCAP:
+            return Ref<CSSStyleValue> { CSSNumericFactory::rcap(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_CH:
             return Ref<CSSStyleValue> { CSSNumericFactory::ch(primitiveValue->doubleValue()) };
+        case CSSUnitType::CSS_RCH:
+            return Ref<CSSStyleValue> { CSSNumericFactory::rch(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_IC:
             return Ref<CSSStyleValue> { CSSNumericFactory::ic(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_REM:
-            return Ref<CSSStyleValue> { CSSNumericFactory::rem(primitiveValue->doubleValue()) };
+        case CSSUnitType::CSS_RIC:
+            return Ref<CSSStyleValue> { CSSNumericFactory::ric(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_LH:
             return Ref<CSSStyleValue> { CSSNumericFactory::lh(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_RLH:

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -215,7 +215,8 @@ static bool styleChangeAffectsRelativeUnits(const RenderStyle& style, const Rend
 {
     if (!existingStyle)
         return true;
-    return style.computedFontSize() != existingStyle->computedFontSize();
+    return existingStyle->fontCascade() != style.fontCascade()
+        || existingStyle->computedLineHeight() != style.computedLineHeight();
 }
 
 auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingStyle, ResolutionType resolutionType) -> std::pair<ElementUpdate, DescendantsToResolve>


### PR DESCRIPTION
#### 424dee4815091e03fcc4c9035af6e7a9a8128184
<pre>
[css-values] Implement rcap / rex / ric / rch units
<a href="https://bugs.webkit.org/show_bug.cgi?id=260648">https://bugs.webkit.org/show_bug.cgi?id=260648</a>
rdar://114367871

Reviewed by Cameron McCormack.

Implement new units as per <a href="https://drafts.csswg.org/css-values/#font-relative-lengths">https://drafts.csswg.org/css-values/#font-relative-lengths</a>

Invalidation support is also added by invalidating when the root font cascade / line height changes.

Also add a bunch of tests for root font units in monospace.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/font-relative-units-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rcap-in-monospace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rch-in-monospace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/rex-in-monospace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/ric-in-monospace.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/rcap-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/rch-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/rex-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/ric-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/rlh-invalidation-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::isValidCSSUnitTypeForDoubleConversion):
(WebCore::isStringType):
(WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble):
(WebCore::CSSPrimitiveValue::computeNonCalcLengthDouble):
(WebCore::CSSPrimitiveValue::unitTypeString):
(WebCore::CSSPrimitiveValue::serializeInternal const):
(WebCore::CSSPrimitiveValue::equals const):
(WebCore::CSSPrimitiveValue::addDerivedHash const):
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const):
* Source/WebCore/css/CSSPrimitiveValue.h:
(WebCore::CSSPrimitiveValue::isRootFontRelativeLength):
(WebCore::CSSPrimitiveValue::isFontRelativeLength):
(WebCore::CSSPrimitiveValue::isLength):
* Source/WebCore/css/CSSUnits.cpp:
(WebCore::unitCategory):
(WebCore::operator&lt;&lt;):
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp:
(WebCore::calcUnitCategory):
(WebCore::calculationCategoryForCombination):
(WebCore::hasDoubleValue):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::cssPrimitiveValueUnitFromTrie):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::LengthRawKnownTokenTypeDimensionConsumer::consume):
* Source/WebCore/css/typedom/CSSNumericFactory.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::styleChangeAffectsRelativeUnits):

Canonical link: <a href="https://commits.webkit.org/267321@main">https://commits.webkit.org/267321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fd5fb2050a30949b7b37bebc11c7b8ec3f5139f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16293 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16725 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18828 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15159 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15507 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14590 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/3893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19091 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1999 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->