### PR TITLE
Support sending displayDidRefresh at DisplayLink update with site isolation.

### DIFF
--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -52,6 +52,7 @@ using PlatformDisplayID = uint32_t;
 namespace WebKit {
 
 class LayerTreeContext;
+class RemotePageDrawingAreaProxy;
 class WebPageProxy;
 class WebProcessProxy;
 
@@ -131,6 +132,9 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+
+    virtual void addRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy&) { }
+    virtual void removeRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy&) { }
 
 protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -32,6 +32,7 @@
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "RemoteLayerTreeDrawingAreaProxyMessages.h"
+#import "RemotePageDrawingAreaProxy.h"
 #import "RemotePageProxy.h"
 #import "RemoteScrollingCoordinatorProxy.h"
 #import "RemoteScrollingCoordinatorTransaction.h"
@@ -72,6 +73,17 @@ std::span<IPC::ReceiverName> RemoteLayerTreeDrawingAreaProxy::messageReceiverNam
 {
     static std::array<IPC::ReceiverName, 2> names { Messages::DrawingAreaProxy::messageReceiverName(), Messages::RemoteLayerTreeDrawingAreaProxy::messageReceiverName() };
     return { names };
+}
+
+void RemoteLayerTreeDrawingAreaProxy::addRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy& proxy)
+{
+    m_remotePageProcessState.add(proxy, ProcessState { });
+}
+
+void RemoteLayerTreeDrawingAreaProxy::removeRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy& proxy)
+{
+    ASSERT(m_remotePageProcessState.contains(proxy));
+    m_remotePageProcessState.remove(proxy);
 }
 
 std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemoteLayerTreeHost()
@@ -137,26 +149,41 @@ void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
     }, m_identifier);
 }
 
-void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered(TransactionID nextCommitTransactionID)
+RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForConnection(IPC::Connection& connection)
 {
-    if (nextCommitTransactionID <= m_lastLayerTreeTransactionID) {
-        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered nextCommitTransactionID=" << nextCommitTransactionID << ") already obsoleted by m_lastLayerTreeTransactionID=" << m_lastLayerTreeTransactionID);
+    for (auto pair : m_remotePageProcessState) {
+        if (pair.key.process().hasConnection() && pair.key.process().connection() == &connection)
+            return pair.value;
+    }
+
+    ASSERT(m_webPageProxy.process().hasConnection() && &connection == m_webPageProxy.process().connection());
+    return m_webPageProxyProcessState;
+}
+
+void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered(IPC::Connection& connection, TransactionID nextCommitTransactionID)
+{
+    ProcessState& state = processStateForConnection(connection);
+    if (nextCommitTransactionID <= state.lastLayerTreeTransactionID) {
+        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered nextCommitTransactionID=" << nextCommitTransactionID << ") already obsoleted by m_lastLayerTreeTransactionID=" << state.lastLayerTreeTransactionID);
         return;
     }
 
-    m_commitLayerTreeMessageState = Idle;
-    pauseDisplayRefreshCallbacks();
+    state.commitLayerTreeMessageState = Idle;
+
+    maybePauseDisplayRefreshCallbacks();
+
 #if ENABLE(ASYNC_SCROLLING)
     m_webPageProxy.scrollingCoordinatorProxy()->applyScrollingTreeLayerPositionsAfterCommit();
 #endif
 }
 
-void RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree(TransactionID transactionID)
+void RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree(IPC::Connection& connection, TransactionID transactionID)
 {
-    if (transactionID <= m_lastLayerTreeTransactionID)
+    ProcessState& state = processStateForConnection(connection);
+    if (transactionID <= state.lastLayerTreeTransactionID)
         return;
 
-    m_pendingLayerTreeTransactionID = transactionID;
+    state.pendingLayerTreeTransactionID = transactionID;
 }
 
 void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>& transactions)
@@ -182,25 +209,32 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
     // prematurely drop the only reference to them, and `inUse` will be wrong for a brief window.
     if (!sendRights.isEmpty())
         [CATransaction addCommitHandler:[sendRights = WTFMove(sendRights)]() { } forPhase:kCATransactionPhasePostCommit];
+
+    ProcessState& state = processStateForConnection(connection);
+    if (std::exchange(state.commitLayerTreeMessageState, NeedsDisplayDidRefresh) == MissedCommit)
+        didRefreshDisplay(&connection);
+
+    scheduleDisplayRefreshCallbacks();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection& connection, const RemoteLayerTreeTransaction& layerTreeTransaction, const RemoteScrollingCoordinatorTransaction& scrollingTreeTransaction)
 {
     TraceScope tracingScope(CommitLayerTreeStart, CommitLayerTreeEnd);
+    ProcessState& state = processStateForConnection(connection);
 
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree transaction:" << layerTreeTransaction.description());
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree scrolling tree:" << scrollingTreeTransaction.description());
 
-    m_lastLayerTreeTransactionID = layerTreeTransaction.transactionID();
-    if (m_pendingLayerTreeTransactionID < m_lastLayerTreeTransactionID)
-        m_pendingLayerTreeTransactionID = m_lastLayerTreeTransactionID;
+    state.lastLayerTreeTransactionID = layerTreeTransaction.transactionID();
+    if (state.pendingLayerTreeTransactionID < state.lastLayerTreeTransactionID)
+        state.pendingLayerTreeTransactionID = state.lastLayerTreeTransactionID;
 
     bool didUpdateEditorState { false };
     if (layerTreeTransaction.isMainFrameProcessTransaction()) {
-        ASSERT(layerTreeTransaction.transactionID() == m_lastVisibleTransactionID.next());
-        m_transactionIDForPendingCACommit = layerTreeTransaction.transactionID();
-        m_activityStateChangeID = layerTreeTransaction.activityStateChangeID();
-        
+        ASSERT(layerTreeTransaction.transactionID() == state.lastVisibleTransactionID.next());
+        state.transactionIDForPendingCACommit = layerTreeTransaction.transactionID();
+        state.activityStateChangeID = layerTreeTransaction.activityStateChangeID();
+
         didUpdateEditorState = layerTreeTransaction.hasEditorState() && m_webPageProxy.updateEditorState(layerTreeTransaction.editorState(), WebPageProxy::ShouldMergeVisualEditorState::Yes);
     }
 
@@ -213,7 +247,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
             ++m_countOfTransactionsWithNonEmptyLayerChanges;
 
         if (m_remoteLayerTreeHost->updateLayerTree(layerTreeTransaction)) {
-            if (layerTreeTransaction.transactionID() >= m_transactionIDForUnhidingContent)
+            if (layerTreeTransaction.transactionID() >= state.transactionIDForUnhidingContent)
                 m_webPageProxy.setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->rootNode());
             else
                 m_remoteLayerTreeHost->detachRootLayer();
@@ -264,13 +298,6 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     }
 
     m_webPageProxy.layerTreeCommitComplete();
-
-    if (!layerTreeTransaction.isMainFrameProcessTransaction())
-        connection.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
-    else if (std::exchange(m_commitLayerTreeMessageState, NeedsDisplayDidRefresh) == MissedCommit)
-        didRefreshDisplay();
-
-    scheduleDisplayRefreshCallbacks();
 
     if (didUpdateEditorState)
         m_webPageProxy.dispatchDidUpdateEditorState();
@@ -419,30 +446,67 @@ void RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator()
     }
 }
 
+bool RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks()
+{
+    if (m_webPageProxyProcessState.commitLayerTreeMessageState == NeedsDisplayDidRefresh)
+        return false;
+
+    for (auto pair : m_remotePageProcessState) {
+        if (pair.value.commitLayerTreeMessageState == NeedsDisplayDidRefresh)
+            return false;
+    }
+
+    pauseDisplayRefreshCallbacks();
+    return true;
+}
+
 void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()
 {
-    if (!m_webPageProxy.hasRunningProcess())
-        return;
+    didRefreshDisplay(nullptr);
+}
 
-    if (m_commitLayerTreeMessageState != NeedsDisplayDidRefresh) {
-        if (m_commitLayerTreeMessageState == CommitLayerTreePending)
-            m_commitLayerTreeMessageState = MissedCommit;
-        pauseDisplayRefreshCallbacks();
+void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& state, IPC::Connection& connection)
+{
+    if (state.commitLayerTreeMessageState != NeedsDisplayDidRefresh) {
+        if (state.commitLayerTreeMessageState == CommitLayerTreePending)
+            state.commitLayerTreeMessageState = MissedCommit;
         return;
     }
-    
-    m_commitLayerTreeMessageState = CommitLayerTreePending;
 
-    m_webPageProxy.scrollingCoordinatorProxy()->sendScrollingTreeNodeDidScroll();
+    state.commitLayerTreeMessageState = CommitLayerTreePending;
+
+    if (m_webPageProxy.process().connection() == &connection)
+        m_webPageProxy.scrollingCoordinatorProxy()->sendScrollingTreeNodeDidScroll();
 
     // Waiting for CA to commit is insufficient, because the render server can still be
     // using our backing store. We can improve this by waiting for the render server to commit
     // if we find API to do so, but for now we will make extra buffers if need be.
-    m_webPageProxy.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
+    connection.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
 
 #if ASSERT_ENABLED
-    m_lastVisibleTransactionID = m_transactionIDForPendingCACommit;
+    state.lastVisibleTransactionID = state.transactionIDForPendingCACommit;
 #endif
+}
+
+void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connection)
+{
+    if (!m_webPageProxy.hasRunningProcess())
+        return;
+
+    if (maybePauseDisplayRefreshCallbacks())
+        return;
+
+    if (connection) {
+        ProcessState& state = processStateForConnection(*connection);
+        didRefreshDisplay(state, *connection);
+    } else {
+        if (m_webPageProxy.process().hasConnection())
+            didRefreshDisplay(m_webPageProxyProcessState, *m_webPageProxy.process().connection());
+        for (auto pair : m_remotePageProcessState) {
+            if (pair.key.process().hasConnection())
+                didRefreshDisplay(pair.value, *pair.key.process().connection());
+        }
+    }
 
     m_webPageProxy.didUpdateActivityState();
 }
@@ -451,10 +515,15 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 {
     ASSERT(activityStateChangeID != ActivityStateChangeAsynchronous);
 
+    if (!process.hasConnection())
+        return;
+
+    ProcessState& state = processStateForConnection(*process.connection());
+
     // We must send the didUpdate message before blocking on the next commit, otherwise
     // we can be guaranteed that the next commit won't come until after the waitForAndDispatchImmediately times out.
-    if (m_commitLayerTreeMessageState == NeedsDisplayDidRefresh)
-        didRefreshDisplay();
+    if (state.commitLayerTreeMessageState == NeedsDisplayDidRefresh)
+        didRefreshDisplay(process.connection());
 
     static Seconds activityStateUpdateTimeout = [] {
         if (id value = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitOverrideActivityStateUpdateTimeout"])
@@ -465,14 +534,14 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
     WeakPtr weakThis { *this };
     auto startTime = MonotonicTime::now();
     while (process.connection()->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError) {
-        if (!weakThis || activityStateChangeID == ActivityStateChangeAsynchronous || activityStateChangeID <= m_activityStateChangeID)
+        if (!weakThis || activityStateChangeID == ActivityStateChangeAsynchronous || activityStateChangeID <= state.activityStateChangeID)
             return;
     }
 }
 
 void RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate()
 {
-    m_transactionIDForUnhidingContent = nextLayerTreeTransactionID();
+    m_webPageProxyProcessState.transactionIDForUnhidingContent = nextLayerTreeTransactionID();
     m_remoteLayerTreeHost->detachRootLayer();
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -106,7 +106,7 @@ constexpr WebCore::FramesPerSecond DisplayLinkFramesPerSecond = 60;
 - (void)timerFired
 {
     ASSERT(isUIThread());
-    _drawingAreaProxy->didRefreshDisplay();
+    _drawingAreaProxy->didRefreshDisplay(nullptr);
 }
 #endif // ENABLE(TIMER_DRIVEN_DISPLAY_REFRESH_FOR_TESTING)
 

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -40,12 +40,15 @@ RemotePageDrawingAreaProxy::RemotePageDrawingAreaProxy(DrawingAreaProxy& drawing
 {
     for (auto& name : m_names)
         process.addMessageReceiver(name, m_identifier, *this);
+    drawingArea.addRemotePageDrawingAreaProxy(*this);
 }
 
 RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy()
 {
     for (auto& name : m_names)
         m_process->removeMessageReceiver(name, m_identifier);
+    if (m_drawingArea)
+        m_drawingArea->removeRemotePageDrawingAreaProxy(*this);
 }
 
 void RemotePageDrawingAreaProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -40,6 +40,8 @@ public:
     RemotePageDrawingAreaProxy(DrawingAreaProxy&, WebProcessProxy&);
     ~RemotePageDrawingAreaProxy();
 
+    WebProcessProxy& process() { return m_process; }
+
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;


### PR DESCRIPTION
#### f754a3da5ae02423ea73587b1ddc5cd6f3dc9b19
<pre>
Support sending displayDidRefresh at DisplayLink update with site isolation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260674">https://bugs.webkit.org/show_bug.cgi?id=260674</a>
&lt;rdar://problem/114402070&gt;

Reviewed by Alex Christensen.

We currently always send displayDidRefresh for subframes immediately, instead of waiting for the next DisplayLink update.

This keeps a set of remote frames, tracking what the current CommitLayerTreeMessageState is for each of them separately.
When the displayDidRefresh call comes from DisplayLink, we iterate the set, sending the message onto the web process
for each remote frame that is waiting for one.

* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::addRemotePageDrawingAreaProxy):
(WebKit::DrawingAreaProxy::removeRemotePageDrawingAreaProxy):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::nextLayerTreeTransactionID const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::lastCommittedLayerTreeTransactionID const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::addRemotePageDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::removeRemotePageDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::processStateForConnection):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered):
(WebKit::RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::asyncSetLayerContents):
(WebKit::RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler displayLinkFired:]):
(-[WKDisplayLinkHandler timerFired]):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDisplayLinkClient::displayLinkFired):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didRefreshDisplay):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
(WebKit::RemotePageDrawingAreaProxy::RemotePageDrawingAreaProxy):
(WebKit::RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
(WebKit::RemotePageDrawingAreaProxy::process):

Canonical link: <a href="https://commits.webkit.org/267270@main">https://commits.webkit.org/267270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4bf5114ccb9b95d41592f29e6f7eb803b9fe9ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16594 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18695 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14056 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14790 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/18023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15388 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18980 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1979 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->