### PR TITLE
Check implicitly assigned line names in NamedLineCollectionBase::contains.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1605,7 +1605,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-c
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
 
 # Subgrid failures
-imported/w3c/web-platform-tests/css/css-grid/subgrid/line-names-010.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/line-names-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-no-items-on-edges-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/style/GridPositionsResolver.h
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.h
@@ -49,6 +49,9 @@ class NamedLineCollectionBase {
 public:
     NamedLineCollectionBase(const RenderGrid&, const String& name, GridPositionSide, bool nameIsAreaName);
 
+
+    bool hasNamedLines() const;
+    bool hasExplicitNamedLines() const;
     bool contains(unsigned line) const;
 protected:
 
@@ -73,15 +76,11 @@ class NamedLineCollection : public NamedLineCollectionBase {
 public:
     NamedLineCollection(const RenderGrid&, const String& name, GridPositionSide, bool nameIsAreaName = false);
 
-    bool hasNamedLines() const;
     int firstPosition() const;
-
-    bool contains(unsigned line) const;
 
     unsigned lastLine() const;
 
 private:
-    bool hasExplicitNamedLines() const;
     int firstExplicitPosition() const;
 };
 


### PR DESCRIPTION
#### ac15c399013cbb04e8ebea7e35ad09abf2483b4d
<pre>
Check implicitly assigned line names in NamedLineCollectionBase::contains.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260526">https://bugs.webkit.org/show_bug.cgi?id=260526</a>
rdar://114271506

Reviewed by Matt Woodrow.

NamedLineCollection::contains does 3 main things:
1.) Check to see if the line we are looking for is beyond the bounds
of the grid and return false if it is. This can happen when we are
checking to see if a parent grid&apos;s line is within a subgrid.
2.) Checks to see if the line is within the collection of the grid&apos;s
implicitly assigned lines and return true if it is.
3.) Call into NamedLineCollectionBase::contains

Since we already do 1 in NamedLineCollectionBase::contains, the only
difference between the methods is 2. It seems like this contains method
should be checking this anyways since we check to see if the line is
within the collection of other types of grid lines (m_namedLinesIndices
and m_autoRepeatNamedLinesIndices). By moving this logic to the method
in the base class we no longer need to have the version in the subclass.

THis helped fix a bug where items in a subgrid were not being placed
correctly using *-start and *-end line names that were implicitly
created from a grid area in the parent grid.

In the following example the &lt;x&gt; element would get placed into the 8th
grid column when it should be placed inth the 7th.

&lt;style&gt;
i {
      grid-row: 1;
      counter-increment: i;
    }
i::before { content: counter(i, decimal); }
&lt;/style&gt;

&lt;div style=&quot;display:grid; grid-template-areas: &apos;. . . . . . a a a &apos;;&quot;&gt;
  &lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;&lt;i&gt;&lt;/i&gt;
  &lt;div style=&quot;display:grid; grid:auto/subgrid; grid-column:5 / 9;&quot;&gt;
    &lt;x style=&quot;grid-column: a-start / a-end&quot;&gt;x&lt;/x&gt;
  &lt;/div&gt;
&lt;/div&gt;

When we create a NamedLineCollectionBase for the parent grid we will
look and see if any of those lines are within our grid (the subgrid).
However since this uses the base class the parent class was nothing
checking against the implicitly created lines. Now these lines should
be detected and added into the local line collection that subgrid
creates.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::NamedLineCollectionBase::contains const):
(WebCore::NamedLineCollection::NamedLineCollection):
(WebCore::NamedLineCollectionBase::hasExplicitNamedLines const):
(WebCore::NamedLineCollectionBase::hasNamedLines const):
(WebCore::NamedLineCollection::hasExplicitNamedLines const): Deleted.
(WebCore::NamedLineCollection::hasNamedLines const): Deleted.
(WebCore::NamedLineCollection::contains const): Deleted.
* Source/WebCore/rendering/style/GridPositionsResolver.h:

Canonical link: <a href="https://commits.webkit.org/267281@main">https://commits.webkit.org/267281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9c2442602c84639d9172287d76f7ffd27c9233

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18668 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21442 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15330 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14558 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3864 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18927 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->