### PR TITLE
[Cocoa] ImageDecoderAVFObjC::storeSampleBuffer can leak a CGImage

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -427,6 +427,10 @@ bool ImageDecoderAVFObjC::storeSampleBuffer(CMSampleBufferRef sampleBuffer)
 
     auto presentationTime = PAL::toMediaTime(PAL::CMSampleBufferGetOutputPresentationTimeStamp(sampleBuffer));
     auto iter = m_sampleData.presentationOrder().findSampleWithPresentationTime(presentationTime);
+    if (iter == m_sampleData.presentationOrder().end()) {
+        RELEASE_LOG_ERROR(Images, "ImageDecoderAVFObjC::storeSampleBuffer(%p) - could not find sample buffer entry with specified presentation time", this);
+        return false;
+    }
 
     if (m_imageRotationSession)
         pixelBuffer = m_imageRotationSession->rotate(pixelBuffer.get());
@@ -434,11 +438,6 @@ bool ImageDecoderAVFObjC::storeSampleBuffer(CMSampleBufferRef sampleBuffer)
     CGImageRef rawImage = nullptr;
     if (noErr != VTCreateCGImageFromCVPixelBuffer(pixelBuffer.get(), nullptr, &rawImage)) {
         RELEASE_LOG_ERROR(Images, "ImageDecoderAVFObjC::storeSampleBuffer(%p) - could not create CGImage from pixelBuffer", this);
-        return false;
-    }
-
-    if (iter == m_sampleData.presentationOrder().end()) {
-        RELEASE_LOG_ERROR(Images, "ImageDecoderAVFObjC::storeSampleBuffer(%p) - could not find sample buffer entry with specified presentation time", this);
         return false;
     }
 


### PR DESCRIPTION
#### 34880c26a151cfc9546a16b0575da05da2b59325
<pre>
[Cocoa] ImageDecoderAVFObjC::storeSampleBuffer can leak a CGImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=260681">https://bugs.webkit.org/show_bug.cgi?id=260681</a>
rdar://114411564

Reviewed by Eric Carlson.

ImageDecoderAVFObjC::storeSampleBuffer creates a CGImage from a sample decoded from the passed-in
CMSampleBuffer, then sets its as that sample&apos;s image. However, if an iterator to the decoded sample
cannot be found in m_sampleData then the created CGImage would not be adopted and would therefore be
leaked.

Fixed this by moving the check of the sample iterator to before we create the CGImage. This prevents
us from early-returning prior to adopting the image, and has the side effect of avoiding the image
creation (and rotation) alltogether if there is no sample on which to attach it.

* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::storeSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/267259@main">https://commits.webkit.org/267259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3470fb32b94339cc7e2887bf6a984b882dd8ecd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16538 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18639 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21416 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17989 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14562 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3846 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->