### PR TITLE
CSS @imports in HTML missing semi-colon and space are mistakenly hidden from CSSPreload Scanner

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Imported inline CSS with no semicolon is not blocked on pending CSS
+

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var t = async_test('Imported inline CSS with no semicolon is not blocked on pending CSS');
+</script>
+<link rel=stylesheet href="resources/dummy.css?first-preloader-css-import-no-semicolon&pipe=trickle(d1)">
+<script>
+    var this_script_is_necessary_to_block_the_inline_style_processing = true;
+</script>
+<style>
+@import url("resources/dummy.css?second-preloader-css-import-no-semicolon")
+</style>
+<script>
+    window.addEventListener("load", t.step_func_done(() => {
+        let entries = performance.getEntriesByType('resource');
+        let first;
+        let second;
+        for (entry of entries) {
+            if (entry.name.includes("first")) {
+                first = entry;
+            }
+            if (entry.name.includes("second")) {
+                second = entry;
+            }
+        }
+        assert_true(first.responseEnd > second.startTime, "The second resource start time should not be blocked on the first resource response");
+    }));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Imported inline CSS with no space is not blocked on pending CSS
+

--- a/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var t = async_test('Imported inline CSS with no space is not blocked on pending CSS');
+</script>
+<link rel=stylesheet href="resources/dummy.css?first-preloader-css-import-no-space&pipe=trickle(d1)">
+<script>
+    var this_script_is_necessary_to_block_the_inline_style_processing = true;
+</script>
+<style>@import url("resources/dummy.css?second-preloader-css-import-no-space")</style>
+<script>
+    window.addEventListener("load", t.step_func_done(() => {
+        let entries = performance.getEntriesByType('resource');
+        let first;
+        let second;
+        for (entry of entries) {
+            if (entry.name.includes("first")) {
+                first = entry;
+            }
+            if (entry.name.includes("second")) {
+                second = entry;
+            }
+        }
+        assert_true(first.responseEnd > second.startTime, "The second resource start time should not be blocked on the first resource response");
+    }));
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1500,6 +1500,9 @@ imported/w3c/web-platform-tests/fetch/private-network-access/resources/xhr-sende
 imported/w3c/web-platform-tests/fetch/private-network-access/resources/iframed.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/resources/iframer.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/shared-worker.window.html [ DumpJSConsoleLogInStdErr ]
+webkit.org/b/260731 imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative.html [ Failure ]
+webkit.org/b/260731 imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative.html [ Failure ]
+webkit.org/b/260731 imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative.html [ Failure ]
 
 # The tests are crashing, timing out and passing. Mark as Skip for now.
 webkit.org/b/177940 workers/wasm-hashset-many-2.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -173,6 +173,9 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-destinationnode-inter
 # Avoid libsoup console messages as suggested in bug185254
 http/tests/cache/network-error-during-revalidation.html [ DumpJSConsoleLogInStdErr ]
 http/tests/xmlhttprequest/state-after-network-error.html [ DumpJSConsoleLogInStdErr ]
+webkit.org/b/260731 imported/w3c/web-platform-tests/loading/preloader-css-import-no-quote.tentative.html [ Failure ]
+webkit.org/b/260731 imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative.html [ Failure ]
+webkit.org/b/260731 imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative.html [ Failure ]
 
 # WPE passing since (237579@main - 237582@main]. GTK back failing after revert.
 imported/w3c/web-platform-tests/css/css-contain/contain-size-block-003.html [ Pass ]

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  * Copyright (C) 2009 Torch Mobile, Inc. http://www.torchmobile.com/
- * Copyright (C) 2010-2018 Google Inc. All Rights Reserved.
+ * Copyright (C) 2010-2020 Google Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,20 @@ void CSSPreloadScanner::scan(const HTMLToken::DataVector& data, PreloadRequestSt
 
         tokenize(c);
     }
+
+    if (m_state == RuleValue || m_state == AfterRuleValue)
+        emitRule();
+}
+
+bool CSSPreloadScanner::hasFinishedRuleValue() const
+{
+    if (m_ruleValue.size() < 2 || m_ruleValue[m_ruleValue.size() - 2] == '\\')
+        return false;
+    // String
+    if (m_ruleValue[0] == '\'' || m_ruleValue[0] == '"')
+        return m_ruleValue[0] == m_ruleValue[m_ruleValue.size()  - 1];
+    // url()
+    return m_ruleValue[m_ruleValue.size() - 1] == ')';
 }
 
 inline void CSSPreloadScanner::tokenize(UChar c)
@@ -126,10 +140,10 @@ inline void CSSPreloadScanner::tokenize(UChar c)
     case RuleValue:
         if (isASCIIWhitespace(c))
             m_state = AfterRuleValue;
-        else if (c == ';')
-            emitRule();
         else
             m_ruleValue.append(c);
+        if (hasFinishedRuleValue())
+            m_state = AfterRuleValue;
         break;
     case AfterRuleValue:
         if (isASCIIWhitespace(c))

--- a/Source/WebCore/html/parser/CSSPreloadScanner.h
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008, 2013 Apple Inc. All Rights Reserved.
- * Copyright (C) 2010 Google Inc. All Rights Reserved.
+ * Copyright (C) 2010-2020 Google Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,6 +59,7 @@ private:
 
     inline void tokenize(UChar);
     void emitRule();
+    bool hasFinishedRuleValue() const;
 
     State m_state;
     Vector<UChar> m_rule;


### PR DESCRIPTION
#### af134e645543841f47f56df5620d9fb742ef9426
<pre>
CSS @imports in HTML missing semi-colon and space are mistakenly hidden from CSSPreload Scanner

<a href="https://bugs.webkit.org/show_bug.cgi?id=253462">https://bugs.webkit.org/show_bug.cgi?id=253462</a>
rdar://problem/106666050

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/60092ea1a78a62ab84983e321b95415a358b07eb">https://chromium.googlesource.com/chromium/src.git/+/60092ea1a78a62ab84983e321b95415a358b07eb</a>

When scanning for @import rules to preload, CSSPreloadScanner terminates
a URL at &apos;;&apos; unconditionally. This is wrong as there might be &apos;;&apos; in a
URL, in which case we make a preload of a broken URL.

This patch scans URLs in a saner way:
- For urls given as a raw string, terminate at the ending quote
- Other those wrapped in a &apos;url()&apos;, terminate at the closing parenthesis

Note: We do not intend to write a full parser here, so it&apos;s still broken
in some cases (e.g., when the url contains &apos; &apos; or &apos;)&apos;). It&apos;s out of the
scope of this patch to fix them and already broken in current parser.

* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(CSSPreloadScanner::scan):
(CSSPreloadScanner::tokenize):
(CSSPreloadScanner::hasFinishedRuleValue):
* Source/WebCore/html/parser/CSSPreloadScanner.h: New bool function &apos;hasFinishedRuleValue&apos;
* LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-space.tentative-expected.txt: Add Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/loading/preloader-css-import-no-semicolon.tentative-expected.txt: Add Test Case Expectation
* LayoutTests/platform/glib/TestExpectations: Add Platform Specific Expectation (for GTK-WK2) with bug reference due to &apos;libsoup&apos; issue
* LayoutTests/platform/wpe/TestExpectations: Add Platform Specific Expectation (for WPE-WK2) with bug reference due to &apos;libsoup&apos; issue

Canonical link: <a href="https://commits.webkit.org/267322@main">https://commits.webkit.org/267322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7432b6601ec0ad804d19b58bb7645fbcb8286a65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18821 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21557 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18209 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13135 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14583 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3894 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->