### PR TITLE
Back button needs to be pressed twice to go back on https://www.liveilpalazzoapartments.com

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -892,8 +892,8 @@ void FrameLoader::HistoryController::pushState(RefPtr<SerializedScriptValue>&& s
 
     auto* document = m_frame.document();
     if (document && !document->hasRecentUserInteractionForNavigationFromJS())
-        m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
-    
+        topItem->setWasCreatedByJSWithoutUserInteraction(true);
+
     // Override data in the current item (created by createItemTree) to reflect
     // the pushState() arguments.
     m_currentItem->setTitle(title);


### PR DESCRIPTION
#### 6fb0e85b7be0f97a9adf9d9051eba6b9561fbab0
<pre>
Back button needs to be pressed twice to go back on <a href="https://www.liveilpalazzoapartments.com">https://www.liveilpalazzoapartments.com</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=260682">https://bugs.webkit.org/show_bug.cgi?id=260682</a>
rdar://113772385

Reviewed by Brent Fulgham.

WebKit normally ignores history entries added by the JavaScript without user
interaction when navigating back or forward.

Here, the site is adding a history entry using `history.pushState()`, without
user interaction but it was incorrectly not getting ignored when navigating
back.

The reason for this is that they are calling `history.pushState()` from a
subframe. Navigations in subframes still create a top-level back/forward
list item. However, we had a bug in HistoryController::pushState() where
we would set the `wasCreatedByJSWithoutUserInteraction` flag on m_currentItem
instead of topItem. topItem and m_currentItem are the same when
`history.pushState()` gets called on the main frame but not in this case.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::FrameLoader::HistoryController::pushState):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/267287@main">https://commits.webkit.org/267287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2458ec5c7a84f79b9c0695e2d8aec24c88ce6260

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17538 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18645 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21421 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13005 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14567 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18936 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->