### PR TITLE
Deploy more smart pointers in RemoteResourceCache

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -362,13 +362,13 @@ void RemoteRenderingBackend::cacheFont(const Font::Attributes& fontAttributes, F
 {
     ASSERT(!RunLoop::isMain());
 
-    FontCustomPlatformData* customPlatformData = nullptr;
+    RefPtr<FontCustomPlatformData> customPlatformData = nullptr;
     if (fontCustomPlatformDataIdentifier) {
         customPlatformData = m_remoteResourceCache.cachedFontCustomPlatformData(*fontCustomPlatformDataIdentifier);
         MESSAGE_CHECK(customPlatformData, "CacheFont without caching custom data");
     }
 
-    FontPlatformData platform = FontPlatformData::create(platformData, customPlatformData);
+    FontPlatformData platform = FontPlatformData::create(platformData, customPlatformData.get());
 
     Ref<Font> font = Font::create(platform, fontAttributes.origin, fontAttributes.isInterstitial, fontAttributes.visibility, fontAttributes.isTextOrientationFallback, fontAttributes.renderingResourceIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -72,7 +72,7 @@ void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter)
     m_resourceHeap.add(WTFMove(filter));
 }
 
-NativeImage* RemoteResourceCache::cachedNativeImage(RenderingResourceIdentifier renderingResourceIdentifier) const
+RefPtr<NativeImage> RemoteResourceCache::cachedNativeImage(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getNativeImage(renderingResourceIdentifier);
 }
@@ -87,7 +87,7 @@ void RemoteResourceCache::cacheFont(Ref<Font>&& font)
     m_resourceHeap.add(WTFMove(font));
 }
 
-Font* RemoteResourceCache::cachedFont(RenderingResourceIdentifier renderingResourceIdentifier) const
+RefPtr<Font> RemoteResourceCache::cachedFont(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getFont(renderingResourceIdentifier);
 }
@@ -97,22 +97,22 @@ void RemoteResourceCache::cacheFontCustomPlatformData(Ref<FontCustomPlatformData
     m_resourceHeap.add(WTFMove(customPlatformData));
 }
 
-FontCustomPlatformData* RemoteResourceCache::cachedFontCustomPlatformData(RenderingResourceIdentifier renderingResourceIdentifier) const
+RefPtr<FontCustomPlatformData> RemoteResourceCache::cachedFontCustomPlatformData(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getFontCustomPlatformData(renderingResourceIdentifier);
 }
 
-DecomposedGlyphs* RemoteResourceCache::cachedDecomposedGlyphs(RenderingResourceIdentifier renderingResourceIdentifier) const
+RefPtr<DecomposedGlyphs> RemoteResourceCache::cachedDecomposedGlyphs(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getDecomposedGlyphs(renderingResourceIdentifier);
 }
 
-Gradient* RemoteResourceCache::cachedGradient(RenderingResourceIdentifier renderingResourceIdentifier) const
+RefPtr<Gradient> RemoteResourceCache::cachedGradient(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getGradient(renderingResourceIdentifier);
 }
 
-Filter* RemoteResourceCache::cachedFilter(RenderingResourceIdentifier renderingResourceIdentifier) const
+RefPtr<Filter> RemoteResourceCache::cachedFilter(RenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getFilter(renderingResourceIdentifier);
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -49,12 +49,12 @@ public:
 
     RefPtr<RemoteImageBuffer> cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
     RefPtr<RemoteImageBuffer> takeImageBuffer(WebCore::RenderingResourceIdentifier);
-    WebCore::NativeImage* cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
-    WebCore::Font* cachedFont(WebCore::RenderingResourceIdentifier) const;
-    WebCore::DecomposedGlyphs* cachedDecomposedGlyphs(WebCore::RenderingResourceIdentifier) const;
-    WebCore::Gradient* cachedGradient(WebCore::RenderingResourceIdentifier) const;
-    WebCore::Filter* cachedFilter(WebCore::RenderingResourceIdentifier) const;
-    WebCore::FontCustomPlatformData* cachedFontCustomPlatformData(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::NativeImage> cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::Font> cachedFont(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::DecomposedGlyphs> cachedDecomposedGlyphs(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::Gradient> cachedGradient(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::Filter> cachedFilter(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::FontCustomPlatformData> cachedFontCustomPlatformData(WebCore::RenderingResourceIdentifier) const;
 
     std::optional<WebCore::SourceImage> cachedSourceImage(WebCore::RenderingResourceIdentifier) const;
 


### PR DESCRIPTION
#### 3d24de6874f0a0ceb27512256c9896b1d5ed71e1
<pre>
Deploy more smart pointers in RemoteResourceCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=260683">https://bugs.webkit.org/show_bug.cgi?id=260683</a>
rdar://problem/114413095

Reviewed by Ryosuke Niwa.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheFont):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cachedNativeImage const):
(WebKit::RemoteResourceCache::cachedFont const):
(WebKit::RemoteResourceCache::cachedFontCustomPlatformData const):
(WebKit::RemoteResourceCache::cachedDecomposedGlyphs const):
(WebKit::RemoteResourceCache::cachedGradient const):
(WebKit::RemoteResourceCache::cachedFilter const):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:

Canonical link: <a href="https://commits.webkit.org/267256@main">https://commits.webkit.org/267256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/120235380175b02d150a62c73d3d757f02d917ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16120 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16545 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18646 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14016 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15340 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/18937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1976 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->