### PR TITLE
textWidth() uses GlyphOverflow unnecessarily

### DIFF
--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -540,10 +540,9 @@ ALWAYS_INLINE float textWidth(RenderText& text, unsigned from, unsigned len, con
 {
     const RenderStyle& style = text.style();
 
-    GlyphOverflow glyphOverflow;
     // FIXME: This is not the right level of abstraction for isFixedPitch. Font fallback may make it such that the fixed pitch font is never actually used!
     if (isFixedPitch || (!from && len == text.text().length()) || style.hasTextCombine())
-        return text.width(from, len, font, xPos, &fallbackFonts, &glyphOverflow);
+        return text.width(from, len, font, xPos, &fallbackFonts);
 
     if (layout)
         return FontCascade::width(*layout, from, len, &fallbackFonts);
@@ -552,7 +551,7 @@ ALWAYS_INLINE float textWidth(RenderText& text, unsigned from, unsigned len, con
     run.setCharacterScanForCodePath(!text.canUseSimpleFontCodePath());
     run.setTabSize(!collapseWhiteSpace, style.tabSize());
     run.setXPos(xPos);
-    return font.width(run, &fallbackFonts, &glyphOverflow);
+    return font.width(run, &fallbackFonts);
 }
 
 // Adding a pair of whitespace collapsing transitions before a character will split it out into a new line box.


### PR DESCRIPTION
#### ece3337fe95e5f9ccb33f9dd51c38e58dcb70c38
<pre>
textWidth() uses GlyphOverflow unnecessarily
<a href="https://bugs.webkit.org/show_bug.cgi?id=260686">https://bugs.webkit.org/show_bug.cgi?id=260686</a>
rdar://114415633

Reviewed by NOBODY (OOPS!).

It passes the GlyphOverflow into the text routines, but it doesn&apos;t do anything
with the result. Let&apos;s just avoid all GlyphOverflow processing, instead.

No test because there is no behavior change.

* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::textWidth):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ece3337fe95e5f9ccb33f9dd51c38e58dcb70c38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16551 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16319 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16780 "Exiting early after 60 failures. 16112 tests run. 1 flakes 60 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18652 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14023 "Exiting early after 60 failures. 16762 tests run. 60 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14592 "9 flakes 5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21429 "7 flakes 64 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15012 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14757 "15 flakes 5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17986 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15346 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13013 "17 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->