### PR TITLE
Support filtering in CanvasRenderingContext2D layers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6606,10 +6606,6 @@ webkit.org/b/255970 [ Debug ] fullscreen/exit-full-screen-video-crash.html [ Cra
 [ Debug ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-allow-popups-to-same-origin.https.html?7-8 [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-allow-popups-to-same-origin.https.html?9-last [ Skip ]
 
-# Canvas Layers API not supported yet.
-webkit.org/b/259784 imported/w3c/web-platform-tests/html/canvas/element/layers [ Skip ]
-webkit.org/b/259784 imported/w3c/web-platform-tests/html/canvas/offscreen/layers [ Skip ]
-
 # New failures after re-importing html/canvas
 imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.dropShadow.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/drawing-text-to-the-canvas/canvas.2d.disconnected-font-size-math.html [ ImageOnlyFailure ]
@@ -6645,3 +6641,34 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/im
 
 # webkit.org/b/260546
 [ Debug ] imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html [ Pass Failure ]
+
+# CanvasRenderingContext2D Layers tests that use dictionary filters, which we do not support.
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.alpha.blending.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.alpha.blending.shadow.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.alpha.composite.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.alpha.composite.shadow.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.alpha.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.alpha.shadow.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.blending.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.blending.shadow.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.composite.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.composite.shadow.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.no-global-states.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.global-states.filter.shadow.html [ ImageOnlyFailure ]
+
+# CanvasRenderingContext2D Layers tests that rely on implicitly closing layers on canvas renders, which WebKit does not follow.
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.createImageBitmap.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.drawImage.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.getImageData.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.putImageData.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.requestAnimationFrame.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.toDataURL.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.unclosed-nested.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.unclosed.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.render-opportunities.toBlob.html [ ImageOnlyFailure Timeout ]
+
+# This relies on unimplemented CanvasRenderingContext2D.reset()
+webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.reset.html [ ImageOnlyFailure ]
+
+# Many failing tests on OffscreenCanvas
+webkit.org/b/260748 imported/w3c/web-platform-tests/html/canvas/offscreen/layers [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-reset-endLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-reset-endLayer-expected.txt
@@ -6,5 +6,5 @@ FAIL Raises exception on beginLayer() + reset() + endLayer(). assert_throws_dom:
     ctx.beginLayer();
     ctx.reset();
     ctx.endLayer();
-  }" threw object "TypeError: ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
+  }" threw object "TypeError: ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-restore-expected.txt
@@ -2,8 +2,5 @@
 Raises exception on beginLayer() + restore().
 Actual output:
 
-FAIL Raises exception on beginLayer() + restore(). assert_throws_dom: function "function() {
-    ctx.beginLayer();
-    ctx.restore();
-  }" threw object "TypeError: ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
+PASS Raises exception on beginLayer() + restore().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-save-endLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-save-endLayer-expected.txt
@@ -2,9 +2,5 @@
 Raises exception on beginLayer() + save() + endLayer().
 Actual output:
 
-FAIL Raises exception on beginLayer() + save() + endLayer(). assert_throws_dom: function "function() {
-    ctx.beginLayer();
-    ctx.save();
-    ctx.endLayer();
-  }" threw object "TypeError: ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
+PASS Raises exception on beginLayer() + save() + endLayer().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.endLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.endLayer-expected.txt
@@ -2,7 +2,5 @@
 Raises exception on lone endLayer calls.
 Actual output:
 
-FAIL Raises exception on lone endLayer calls. assert_throws_dom: function "function() {
-    ctx.endLayer();
-  }" threw object "TypeError: ctx.endLayer is not a function. (In 'ctx.endLayer()', 'ctx.endLayer' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
+PASS Raises exception on lone endLayer calls.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.save-beginLayer-restore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.save-beginLayer-restore-expected.txt
@@ -2,9 +2,5 @@
 Raises exception on save() + beginLayer() + restore().
 Actual output:
 
-FAIL Raises exception on save() + beginLayer() + restore(). assert_throws_dom: function "function() {
-    ctx.save();
-    ctx.beginLayer();
-    ctx.restore();
-  }" threw object "TypeError: ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
+PASS Raises exception on save() + beginLayer() + restore().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.save-endLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.save-endLayer-expected.txt
@@ -2,8 +2,5 @@
 Raises exception on save() + endLayer().
 Actual output:
 
-FAIL Raises exception on save() + endLayer(). assert_throws_dom: function "function() {
-    ctx.save();
-    ctx.endLayer();
-  }" threw object "TypeError: ctx.endLayer is not a function. (In 'ctx.endLayer()', 'ctx.endLayer' is undefined)" that is not a DOMException INVALID_STATE_ERR: property "code" is equal to undefined, expected 11
+PASS Raises exception on save() + endLayer().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-endLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-endLayer-expected.txt
@@ -2,5 +2,5 @@
 No exception raised on beginLayer() + endLayer().
 Actual output:
 
-FAIL No exception raised on beginLayer() + endLayer(). ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)
+PASS No exception raised on beginLayer() + endLayer().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-expected.txt
@@ -2,5 +2,5 @@
 No exception raised on lone beginLayer() calls.
 Actual output:
 
-FAIL No exception raised on lone beginLayer() calls. ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)
+PASS No exception raised on lone beginLayer() calls.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-save-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-save-expected.txt
@@ -2,5 +2,5 @@
 No exception raised on beginLayer() + save().
 Actual output:
 
-FAIL No exception raised on beginLayer() + save(). ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)
+PASS No exception raised on beginLayer() + save().
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.save-beginLayer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.save-beginLayer-expected.txt
@@ -2,5 +2,5 @@
 No exception raised on save() + beginLayer().
 Actual output:
 
-FAIL No exception raised on save() + beginLayer(). ctx.beginLayer is not a function. (In 'ctx.beginLayer()', 'ctx.beginLayer' is undefined)
+PASS No exception raised on save() + beginLayer().
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1480,6 +1480,20 @@ CacheAPIEnabled:
     WebCore:
       default: false
 
+Canvas2DLayersEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "CanvasRenderingContext2D Layers API"
+  humanReadableDescription: "Enable support for layers API (beginLayer/endLayer) in CanvasRenderingContext2D"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CanvasColorSpaceEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1209,6 +1209,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/VideoFrameRequestCallback.idl
     html/VoidCallback.idl
 
+    html/canvas/BeginLayerOptions.idl
     html/canvas/CanvasCompositing.idl
     html/canvas/CanvasDirection.idl
     html/canvas/CanvasDrawImage.idl
@@ -1219,6 +1220,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/canvas/CanvasGradient.idl
     html/canvas/CanvasImageData.idl
     html/canvas/CanvasImageSmoothing.idl
+    html/canvas/CanvasLayers.idl
     html/canvas/CanvasLineCap.idl
     html/canvas/CanvasLineJoin.idl
     html/canvas/CanvasPath.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1528,6 +1528,7 @@ $(PROJECT_DIR)/html/VideoFrameRequestCallback.idl
 $(PROJECT_DIR)/html/VoidCallback.idl
 $(PROJECT_DIR)/html/WebKitMediaKeyError.idl
 $(PROJECT_DIR)/html/canvas/ANGLEInstancedArrays.idl
+$(PROJECT_DIR)/html/canvas/BeginLayerOptions.idl
 $(PROJECT_DIR)/html/canvas/CanvasCompositing.idl
 $(PROJECT_DIR)/html/canvas/CanvasDirection.idl
 $(PROJECT_DIR)/html/canvas/CanvasDrawImage.idl
@@ -1538,6 +1539,7 @@ $(PROJECT_DIR)/html/canvas/CanvasFilters.idl
 $(PROJECT_DIR)/html/canvas/CanvasGradient.idl
 $(PROJECT_DIR)/html/canvas/CanvasImageData.idl
 $(PROJECT_DIR)/html/canvas/CanvasImageSmoothing.idl
+$(PROJECT_DIR)/html/canvas/CanvasLayers.idl
 $(PROJECT_DIR)/html/canvas/CanvasLineCap.idl
 $(PROJECT_DIR)/html/canvas/CanvasLineJoin.idl
 $(PROJECT_DIR)/html/canvas/CanvasPath.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -327,6 +327,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBasicCredential.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBasicCredential.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBeforeUnloadEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBeforeUnloadEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBeginLayerOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBeginLayerOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBiquadFilterOptions.cpp
@@ -519,6 +521,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasImageData.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasImageData.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasImageSmoothing.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasImageSmoothing.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasLayers.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasLayers.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasLineCap.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasLineCap.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasLineJoin.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1217,6 +1217,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/VoidCallback.idl \
     $(WebCore)/html/WebKitMediaKeyError.idl \
     $(WebCore)/html/canvas/ANGLEInstancedArrays.idl \
+    $(WebCore)/html/canvas/BeginLayerOptions.idl \
     $(WebCore)/html/canvas/CanvasCompositing.idl \
     $(WebCore)/html/canvas/CanvasDirection.idl \
     $(WebCore)/html/canvas/CanvasDrawImage.idl \
@@ -1227,6 +1228,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/CanvasGradient.idl \
     $(WebCore)/html/canvas/CanvasImageData.idl \
     $(WebCore)/html/canvas/CanvasImageSmoothing.idl \
+    $(WebCore)/html/canvas/CanvasLayers.idl \
     $(WebCore)/html/canvas/CanvasLineCap.idl \
     $(WebCore)/html/canvas/CanvasLineJoin.idl \
     $(WebCore)/html/canvas/CanvasPath.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3193,6 +3193,7 @@ JSBackgroundFetchUpdateUIEvent.cpp
 JSBarcodeDetector.cpp
 JSBarcodeDetectorOptions.cpp
 JSBarcodeFormat.cpp
+JSBeginLayerOptions.cpp
 JSImageResource.cpp
 JSBitrateMode.cpp
 JSBlob.cpp

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -44,6 +44,7 @@
 #include "CSSTokenizer.h"
 #include "CSSUnicodeRangeValue.h"
 #include "Document.h"
+#include "FilterOperationsBuilder.h"
 #include "FontCustomPlatformData.h"
 #include "ParsingUtilities.h"
 #include "ScriptExecutionContext.h"
@@ -629,5 +630,19 @@ RefPtr<CSSValue> consumeVariationTagValue(CSSParserTokenRange& range)
 #endif // ENABLE(VARIATION_FONTS)
 
 } // namespace CSSPropertyParserHelpersWorkerSafe
+
+std::optional<FilterOperations> CSSPropertyParserWorkerSafe::parseFilterString(const Document& document, RenderStyle& style, const String& string, CSSParserMode mode)
+{
+    CSSTokenizer tokenizer(string);
+    CSSParserTokenRange range(tokenizer.tokenRange());
+    range.consumeWhitespace();
+
+    auto parsedValue = CSSPropertyParserHelpers::consumeFilter(range, CSSParserContext(mode), CSSPropertyParserHelpers::AllowedFilterFunctions::PixelFilters);
+    if (!parsedValue)
+        return std::nullopt;
+
+    return Style::createFilterOperations(document, style, CSSToLengthConversionData(), *parsedValue);
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
@@ -28,6 +28,7 @@
 
 #include "CSSParserContext.h"
 #include "CSSPropertyParserHelpers.h"
+#include "FilterOperations.h"
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -44,6 +45,8 @@ class CSSPropertyParserWorkerSafe {
 public:
     static Color parseColor(const String&);
     static std::optional<CSSPropertyParserHelpers::FontRaw> parseFont(const String&, CSSParserMode = HTMLStandardMode);
+
+    static std::optional<FilterOperations> parseFilterString(const Document&, RenderStyle&, const String&, CSSParserMode = HTMLStandardMode);
 
     static RefPtr<CSSValueList> parseFontFaceSrc(const String&, const CSSParserContext&);
     static RefPtr<CSSValue> parseFontFaceStyle(const String&, ScriptExecutionContext&);

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -28,6 +28,7 @@
 
 #include "ByteArrayPixelBuffer.h"
 #include "CanvasRenderingContext.h"
+#include "CanvasRenderingContext2DBase.h"
 #include "Chrome.h"
 #include "Document.h"
 #include "Element.h"
@@ -380,6 +381,20 @@ void CanvasBase::resetGraphicsContextState() const
         m_contextStateSaver->save();
     }
 }
+
+bool CanvasBase::contextIs2DBaseWithUnclosedLayers() const
+{
+    if (!renderingContext())
+        return false;
+    const auto& context = *renderingContext();
+
+    if (!context.is2dBase())
+        return false;
+    const auto& context2DBase = downcast<CanvasRenderingContext2DBase>(context);
+
+    return context2DBase.hasOpenLayers();
+}
+
 
 WebCoreOpaqueRoot root(CanvasBase* canvas)
 {

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -135,6 +135,8 @@ public:
     bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
     void recordLastFillText(const String&);
 
+    bool contextIs2DBaseWithUnclosedLayers() const;
+
 protected:
     explicit CanvasBase(IntSize, const std::optional<NoiseInjectionHashSalt>&);
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -704,6 +704,9 @@ static std::optional<double> qualityFromJSValue(JSC::JSValue qualityValue)
 
 ExceptionOr<UncachedString> HTMLCanvasElement::toDataURL(const String& mimeType, JSC::JSValue qualityValue)
 {
+    if (contextIs2DBaseWithUnclosedLayers())
+        return Exception { InvalidStateError };
+
     if (!originClean())
         return Exception { SecurityError };
 
@@ -738,6 +741,9 @@ ExceptionOr<UncachedString> HTMLCanvasElement::toDataURL(const String& mimeType)
 
 ExceptionOr<void> HTMLCanvasElement::toBlob(Ref<BlobCallback>&& callback, const String& mimeType, JSC::JSValue qualityValue)
 {
+    if (contextIs2DBaseWithUnclosedLayers())
+        return Exception { InvalidStateError };
+
     if (!originClean())
         return Exception { SecurityError };
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -395,6 +395,10 @@ static std::optional<double> qualityFromDouble(double qualityNumber)
 
 void OffscreenCanvas::convertToBlob(ImageEncodeOptions&& options, Ref<DeferredPromise>&& promise)
 {
+    if (contextIs2DBaseWithUnclosedLayers()) {
+        promise->reject(InvalidStateError);
+        return;
+    }
     if (!originClean()) {
         promise->reject(SecurityError);
         return;

--- a/Source/WebCore/html/canvas/BeginLayerOptions.h
+++ b/Source/WebCore/html/canvas/BeginLayerOptions.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct BeginLayerOptions {
+};
+
+}

--- a/Source/WebCore/html/canvas/BeginLayerOptions.h
+++ b/Source/WebCore/html/canvas/BeginLayerOptions.h
@@ -27,7 +27,17 @@
 
 namespace WebCore {
 
+#include <optional>
+
+#include <wtf/text/WTFString.h>
+
+using CanvasFilterPrimitive = String;
+
+// using CanvasFilterInput = std::variant<CanvasFilterPrimitive, Vector<CanvasFilterPrimitive>>;
+using CanvasFilterInput = CanvasFilterPrimitive;
+
 struct BeginLayerOptions {
+    std::optional<CanvasFilterInput> filter;
 };
 
 }

--- a/Source/WebCore/html/canvas/BeginLayerOptions.idl
+++ b/Source/WebCore/html/canvas/BeginLayerOptions.idl
@@ -25,5 +25,12 @@
  * SUCH DAMAGE.
  */
 
+// FIXME: CanvasFilterPrimitive taking a dictionary
+typedef DOMString CanvasFilterPrimitive;
+
+//typedef (CanvasFilterPrimitive or sequence<CanvasFilterPrimitive>) CanvasFilterInput;
+typedef CanvasFilterPrimitive CanvasFilterInput;
+
 dictionary BeginLayerOptions {
+    CanvasFilterInput? filter = null;
 };

--- a/Source/WebCore/html/canvas/BeginLayerOptions.idl
+++ b/Source/WebCore/html/canvas/BeginLayerOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+dictionary BeginLayerOptions {
+};

--- a/Source/WebCore/html/canvas/CanvasLayers.idl
+++ b/Source/WebCore/html/canvas/CanvasLayers.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=Canvas2DLayersEnabled
+]
+interface mixin CanvasLayers {
+    // layers
+    undefined beginLayer(optional BeginLayerOptions options = {});
+    undefined endLayer();
+};

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -33,10 +33,12 @@
 #include "config.h"
 #include "CanvasRenderingContext2D.h"
 
+#include "CSSFilter.h"
 #include "CSSFontSelector.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSPropertyParserWorkerSafe.h"
+#include "Filter.h"
 #include "Gradient.h"
 #include "ImageBuffer.h"
 #include "ImageData.h"

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -248,4 +248,48 @@ void CanvasRenderingContext2D::drawTextInternal(const String& text, double x, do
     drawTextUnchecked(textRun, x, y, fill, maxWidth);
 }
 
+ExceptionOr<Ref<Filter>> CanvasRenderingContext2D::createFilter(const String& filterString)
+{
+    auto& document = canvas().document();
+    if (!document.settings().canvas2DLayersEnabled())
+        return Exception { NotSupportedError };
+
+    document.updateStyleIfNeeded();
+
+    const auto* style = canvas().computedStyle();
+    if (!style)
+        return Exception { InvalidStateError };
+
+    auto parserMode = strictToCSSParserMode(!usesCSSCompatibilityParseMode());
+    auto filterOps = CSSPropertyParserWorkerSafe::parseFilterString(document, const_cast<RenderStyle&>(*style), filterString, parserMode);
+    if (!filterOps)
+        return Exception { SyntaxError };
+
+    auto* context = drawingContext();
+    if (!context)
+        return Exception { InvalidStateError };
+
+    auto* renderer = canvas().renderer();
+    if (!renderer)
+        return Exception { InvalidStateError };
+
+    auto bounds = FloatRect({ }, canvas().size());
+    // FIXME: is this needed?
+    // if (bounds.isEmpty())
+    //    return nullptr;
+
+    auto preferredFilterRenderingModes = renderer->page().preferredFilterRenderingModes();
+    auto filter = CSSFilter::create(*renderer, *filterOps, preferredFilterRenderingModes, { 1, 1 }, bounds, *context);
+    if (!filter)
+        return Exception { UnknownError };
+
+    // TODO: what to do with this
+    auto outsets = CSSFilter::calculateOutsets(*renderer, *filterOps, bounds);
+    (void)(outsets);
+
+    filter->setFilterRegion(bounds);
+    return { filter.releaseNonNull() };
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
@@ -53,6 +53,9 @@ public:
     void strokeText(const String& text, double x, double y, std::optional<double> maxWidth = std::nullopt);
     Ref<TextMetrics> measureText(const String& text);
 
+protected:
+    ExceptionOr<Ref<Filter>> createFilter(const String&) override;
+
 private:
     CanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&, bool usesCSSCompatibilityParseMode);
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -75,6 +75,7 @@
 };
 
 CanvasRenderingContext2D includes CanvasState;
+CanvasRenderingContext2D includes CanvasLayers;
 CanvasRenderingContext2D includes CanvasTransform;
 CanvasRenderingContext2D includes CanvasCompositing;
 CanvasRenderingContext2D includes CanvasImageSmoothing;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -235,14 +235,23 @@ CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, C
 
 void CanvasRenderingContext2DBase::unwindStateStack()
 {
-    // Ensure that the state stack in the ImageBuffer's context
-    // is cleared before destruction, to avoid assertions in the
-    // GraphicsContext dtor.
-    if (size_t stackSize = m_stateStack.size()) {
-        if (auto* context = canvasBase().existingDrawingContext()) {
-            while (--stackSize)
-                context->restore();
+    // Ensure that the state stack in the drawing context is cleared and all transparency layers are closed
+    // before destruction, to avoid assertions in the GraphicsContext dtor.
+
+    auto* context = canvasBase().existingDrawingContext();
+    if (!context)
+        return;
+
+    while (m_stateStack.size() > 1) {
+        auto state = m_stateStack.takeLast();
+
+        if (state.isLayer) {
+            context->endTransparencyLayer();
+            ASSERT(m_layerCount);
+            m_layerCount--;
         }
+
+        context->restore();
     }
 }
 
@@ -266,8 +275,9 @@ bool CanvasRenderingContext2DBase::isAccelerated() const
 void CanvasRenderingContext2DBase::reset()
 {
     unwindStateStack();
-    m_stateStack.resize(1);
+
     m_stateStack.first() = State();
+
     m_path.clear();
     m_unrealizedSaveCount = 0;
     m_cachedImageData = std::nullopt;
@@ -294,6 +304,7 @@ CanvasRenderingContext2DBase::State::State()
     , textAlign(StartTextAlign)
     , textBaseline(AlphabeticTextBaseline)
     , direction(Direction::Inherit)
+    , isLayer(false)
     , unparsedFont(DefaultFont)
 {
 }
@@ -450,29 +461,40 @@ void CanvasRenderingContext2DBase::realizeSavesLoop()
     do {
         if (m_stateStack.size() > MaxSaveCount)
             break;
-        m_stateStack.append(state());
+
+        {
+            State toBeSavedState = state();
+            toBeSavedState.isLayer = false;
+            m_stateStack.append(WTFMove(toBeSavedState));
+        }
+
         if (context)
             context->save();
     } while (--m_unrealizedSaveCount);
 }
 
-void CanvasRenderingContext2DBase::restore()
+ExceptionOr<void> CanvasRenderingContext2DBase::restore()
 {
     if (m_unrealizedSaveCount) {
         --m_unrealizedSaveCount;
-        return;
+        return { };
     }
+
     ASSERT(m_stateStack.size() >= 1);
     if (m_stateStack.size() <= 1)
-        return;
+        return { };
+
+    if (state().isLayer)
+        return Exception { InvalidStateError };
+
     m_path.transform(state().transform);
     m_stateStack.removeLast();
     if (std::optional<AffineTransform> inverse = state().transform.inverse())
         m_path.transform(inverse.value());
-    GraphicsContext* c = drawingContext();
-    if (!c)
-        return;
-    c->restore();
+    if (auto* c = drawingContext())
+        c->restore();
+
+    return { };
 }
 
 void CanvasRenderingContext2DBase::setStrokeStyle(CanvasStyle style)
@@ -1255,6 +1277,7 @@ void CanvasRenderingContext2DBase::clearRect(double x, double y, double width, d
     context->clearRect(rect);
     if (saved)
         context->restore();
+
     didDraw(rect);
 }
 
@@ -1685,6 +1708,9 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     if (!srcCanvasRect.width() || !srcCanvasRect.height())
         return Exception { InvalidStateError };
 
+    if (sourceCanvas.contextIs2DBaseWithUnclosedLayers())
+        return Exception { InvalidStateError };
+
     if (!srcRect.width() || !srcRect.height())
         return { };
 
@@ -2106,8 +2132,12 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(S
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(CanvasBase& canvas, bool repeatX, bool repeatY)
 {
+    if (canvas.contextIs2DBaseWithUnclosedLayers())
+        return Exception { InvalidStateError };
+
     if (!canvas.width() || !canvas.height())
         return Exception { InvalidStateError };
+
     auto* copiedImage = canvas.copiedImage();
 
     if (!copiedImage)
@@ -2180,6 +2210,9 @@ void CanvasRenderingContext2DBase::didDrawEntireCanvas()
 
 void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, OptionSet<DidDrawOption> options)
 {
+    if (hasOpenLayers())
+        return;
+
     if (!options.contains(DidDrawOption::PreserveCachedImageData))
         m_cachedImageData = std::nullopt;
 
@@ -2411,6 +2444,9 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     if (!sw || !sh)
         return Exception { IndexSizeError };
 
+    if (hasOpenLayers())
+        return Exception { InvalidStateError };
+
     if (!canvasBase().originClean()) {
         static NeverDestroyed<String> consoleMessage(MAKE_STATIC_STRING_IMPL("Unable to get image data from canvas because the canvas has been tainted by cross-origin data."));
         canvasBase().scriptExecutionContext()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage);
@@ -2457,19 +2493,22 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     return { { ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull())) } };
 }
 
-void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy)
+ExceptionOr<void> CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy)
 {
-    putImageData(data, dx, dy, 0, 0, data.width(), data.height());
+    return putImageData(data, dx, dy, 0, 0, data.width(), data.height());
 }
 
-void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight)
+ExceptionOr<void> CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight)
 {
     ImageBuffer* buffer = canvasBase().buffer();
     if (!buffer)
-        return;
+        return { };
 
     if (data.data().isDetached())
-        return;
+        return { };
+
+    if (hasOpenLayers())
+        return Exception { InvalidStateError };
 
     if (dirtyWidth < 0) {
         dirtyX += dirtyWidth;
@@ -2496,6 +2535,8 @@ void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy,
         options.add(DidDrawOption::PreserveCachedImageData);
 
     didDraw(FloatRect { destRect }, options);
+
+    return { };
 }
 
 void CanvasRenderingContext2DBase::inflateStrokeRect(FloatRect& rect) const
@@ -2858,6 +2899,57 @@ PixelFormat CanvasRenderingContext2DBase::pixelFormat() const
 DestinationColorSpace CanvasRenderingContext2DBase::colorSpace() const
 {
     return toDestinationColorSpace(m_settings.colorSpace);
+}
+
+ExceptionOr<void> CanvasRenderingContext2DBase::beginLayer(const BeginLayerOptions&)
+{
+    FloatRect boundingBox { { }, canvasBase().size() };
+
+    auto* ctx = drawingContext();
+    if (!ctx)
+        return { };
+
+    save();
+    realizeSaves();
+
+    ctx->beginTransparencyLayer(state().globalAlpha);
+
+    setGlobalAlpha(1.0);
+    setGlobalCompositeOperation("source-over"_s);
+    setShadowOffsetX(0);
+    setShadowOffsetY(0);
+    setShadowBlur(0);
+    setShadowColor("black"_s);
+    modifiableState().isLayer = true;
+
+    m_layerCount++;
+
+    return { };
+}
+
+ExceptionOr<void> CanvasRenderingContext2DBase::endLayer()
+{
+    auto* ctx = drawingContext();
+    if (!ctx)
+        return { };
+
+    realizeSaves();
+
+    ASSERT(!m_stateStack.isEmpty());
+    if (!state().isLayer)
+        return Exception { InvalidStateError };
+
+    ctx->endTransparencyLayer();
+
+    modifiableState().isLayer = false;
+    restore();
+
+    m_layerCount--;
+
+    // FIXME: fix this so we only call didDraw() on the region affected by endLayer()
+    didDrawEntireCanvas();
+
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AffineTransform.h"
+#include "BeginLayerOptions.h"
 #include "CanvasDirection.h"
 #include "CanvasFillRule.h"
 #include "CanvasLineCap.h"
@@ -141,7 +142,11 @@ public:
     void setGlobalCompositeOperation(const String&);
 
     void save() { ++m_unrealizedSaveCount; }
-    void restore();
+    ExceptionOr<void> restore();
+
+    bool hasOpenLayers() const { return m_layerCount; }
+    ExceptionOr<void> beginLayer(const BeginLayerOptions&);
+    ExceptionOr<void> endLayer();
 
     void scale(double sx, double sy);
     void rotate(double angleInRadians);
@@ -208,8 +213,8 @@ public:
     ExceptionOr<Ref<ImageData>> createImageData(ImageData&) const;
     ExceptionOr<Ref<ImageData>> createImageData(int width, int height, std::optional<ImageDataSettings>) const;
     ExceptionOr<Ref<ImageData>> getImageData(int sx, int sy, int sw, int sh, std::optional<ImageDataSettings>) const;
-    void putImageData(ImageData&, int dx, int dy);
-    void putImageData(ImageData&, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight);
+    ExceptionOr<void> putImageData(ImageData&, int dx, int dy);
+    ExceptionOr<void> putImageData(ImageData&, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight);
 
     static constexpr float webkitBackingStorePixelRatio() { return 1; }
 
@@ -290,6 +295,8 @@ public:
         TextAlign textAlign;
         TextBaseline textBaseline;
         Direction direction;
+
+        bool isLayer;
 
         String unparsedFont;
         FontProxy font;
@@ -442,6 +449,8 @@ private:
     HashSet<uint32_t> m_suppliedColors;
     mutable std::optional<CachedImageData> m_cachedImageData;
     CanvasRenderingContext2DSettings m_settings;
+    // FIXME: limit number of layers?
+    uint32_t m_layerCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -27,6 +27,7 @@
 #include "InspectorCanvas.h"
 
 #include "AffineTransform.h"
+#include "BeginLayerOptions.h"
 #include "CSSStyleImageValue.h"
 #include "CachedImage.h"
 #include "CanvasBase.h"
@@ -204,6 +205,12 @@ template<typename T> static Ref<JSON::ArrayOf<JSON::Value>> buildArrayForVector(
     for (auto& item : vector)
         array->addItem(item);
     return array;
+}
+
+std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(BeginLayerOptions)
+{
+    // FIXME(webkit.org/b/260749).
+    return std::nullopt;
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(CanvasDirection argument)

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.h
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BeginLayerOptions.h"
 #include "CanvasRenderingContext2DBase.h"
 #include "WebGL2RenderingContext.h"
 #include "WebGLRenderingContextBase.h"
@@ -136,6 +137,7 @@ enum ImageSmoothingQuality;
 #endif // ENABLE(WEBGL)
 
 #define FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_ARGUMENT(macro) \
+    macro(BeginLayerOptions) \
     macro(CanvasDirection) \
     macro(CanvasFillRule) \
     macro(CanvasImageSource&) \


### PR DESCRIPTION
#### da7903ca75eb39f284c23e7787c48b133e8a365d
<pre>
Support filtering in CanvasRenderingContext2D layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=260691">https://bugs.webkit.org/show_bug.cgi?id=260691</a>
rdar://114420597

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserWorkerSafe::parseFilterString):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h:
* Source/WebCore/html/canvas/BeginLayerOptions.h:
* Source/WebCore/html/canvas/BeginLayerOptions.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::unwindStateStack):
(WebCore::CanvasRenderingContext2DBase::State::State):
(WebCore::CanvasRenderingContext2DBase::realizeSavesLoop):
(WebCore::CanvasRenderingContext2DBase::restore):
(WebCore::CanvasRenderingContext2DBase::drawingContext const):
(WebCore::CanvasRenderingContext2DBase::beginLayer):
(WebCore::CanvasRenderingContext2DBase::endLayer):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::layerCount const):
(WebCore::CanvasRenderingContext2DBase::createFilter):

Originally-landed-as: 574749aa7819. https://bugs.webkit.org/show_bug.cgi?id=260691
</pre>
----------------------------------------------------------------------
#### 69cc99cde3eb5473a077ac51c2c4ea064cbc2a69
<pre>
Implement basic CanvasRenderingContext2D layers support without filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=259784">https://bugs.webkit.org/show_bug.cgi?id=259784</a>
rdar://113343677

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-reset-endLayer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-restore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.beginLayer-save-endLayer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.endLayer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.save-beginLayer-restore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.invalid-calls.save-endLayer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-endLayer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.beginLayer-save-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/layers/2d.layer.valid-calls.save-beginLayer-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::contextIs2DBaseWithUnclosedLayers const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toDataURL):
(WebCore::HTMLCanvasElement::toBlob):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::convertToBlob):
* Source/WebCore/html/canvas/BeginLayerOptions.h: Added.
* Source/WebCore/html/canvas/BeginLayerOptions.idl: Added.
* Source/WebCore/html/canvas/CanvasLayers.idl: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::unwindStateStack):
(WebCore::CanvasRenderingContext2DBase::reset):
(WebCore::CanvasRenderingContext2DBase::State::State):
(WebCore::CanvasRenderingContext2DBase::realizeSavesLoop):
(WebCore::CanvasRenderingContext2DBase::restore):
(WebCore::CanvasRenderingContext2DBase::clearRect):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::createPattern):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
(WebCore::CanvasRenderingContext2DBase::beginLayer):
(WebCore::CanvasRenderingContext2DBase::endLayer):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::hasOpenLayers const):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::processArgument):
* Source/WebCore/inspector/InspectorCanvasCallTracer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da7903ca75eb39f284c23e7787c48b133e8a365d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16998 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18029 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15254 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16694 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/18029 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13912 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18796 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14143 "4 flakes 17 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14722 "1 flakes 5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/18796 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15132 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14887 "6 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/18796 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15497 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15478 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13120 "15 flakes 21 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16464 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14701 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4100 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19067 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17632 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15304 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3893 "Passed tests") | 
<!--EWS-Status-Bubble-End-->