### PR TITLE
Simplify Quirks for shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -292,14 +292,19 @@ bool Quirks::isNeverRichlyEditableForTouchBar() const
 }
 
 // docs.google.com rdar://49864669
-static bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasForHost(StringView host)
+// FIXME https://bugs.webkit.org/show_bug.cgi?id=260698
+bool Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const
 {
+
 #if PLATFORM(IOS_FAMILY)
-    return equalLettersIgnoringASCIICase(host, "docs.google.com"_s);
-#else
-    UNUSED_PARAM(host);
-    return false;
+    if (!needsQuirks())
+        return false;
+
+    auto host = m_document->topDocument().url().host();
+    if (equalLettersIgnoringASCIICase(host, "docs.google.com"_s))
+        return true;
 #endif
+    return false;
 }
 
 // weebly.com rdar://48003980
@@ -350,15 +355,6 @@ bool Quirks::shouldAvoidUsingIOS13ForGmail() const
 #else
     return false;
 #endif
-}
-
-// rdar://49864669
-bool Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const
-{
-    if (!needsQuirks())
-        return false;
-
-    return shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasForHost(m_document->topDocument().url().host());
 }
 
 #if ENABLE(TOUCH_EVENTS)


### PR DESCRIPTION
#### 2ec1a7e6b1cae309a91cd6a4216bb51f0e50a7b6
<pre>
Simplify Quirks for shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas
<a href="https://bugs.webkit.org/show_bug.cgi?id=260695">https://bugs.webkit.org/show_bug.cgi?id=260695</a>
rdar://49864669

Reviewed by Wenson Hsieh.

Refactor a bit the two functions in one function.
Also add a reference to a bug with steps to reproduce to remove later.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas const):
(WebCore::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasForHost): Deleted.

Canonical link: <a href="https://commits.webkit.org/267288@main">https://commits.webkit.org/267288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d63bd8cca8e2d45c81aedb03b661059302b5ff72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18673 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21447 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14774 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18006 "4 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13027 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14592 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3868 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->