### PR TITLE
Deploy even more smart pointers in Source/WebKit/NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -29,6 +29,7 @@
 #include "NetworkProcessSupplement.h"
 #include <pal/SessionID.h>
 #include <stdint.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/WallTime.h>
@@ -66,6 +67,8 @@ public:
     void notifyCookiesDidChange(PAL::SessionID);
 
 private:
+    Ref<NetworkProcess> protectedProcess();
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -91,7 +94,7 @@ private:
     void startObservingCookieChanges(PAL::SessionID);
     void stopObservingCookieChanges(PAL::SessionID);
 
-    NetworkProcess& m_process;
+    CheckedRef<NetworkProcess> m_process;
 };
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
@@ -52,7 +52,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
         break;
     }
 
-    if (auto* storageSession = m_process.storageSession(sessionID))
+    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->setCookieAcceptPolicy(curlPolicy);
 
     completionHandler();

--- a/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
+++ b/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
@@ -58,7 +58,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
 
-    auto* storageSession = m_process.storageSession(sessionID);
+    auto* storageSession = protectedProcess()->storageSession(sessionID);
     if (!storageSession)
         return completionHandler();
 

--- a/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = m_process.storageSession(sessionID))
+    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->setCookieAcceptPolicy(policy);
 
     completionHandler();
@@ -47,13 +47,13 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
 
 void WebCookieManager::setCookiePersistentStorage(PAL::SessionID sessionID, const String& storagePath, SoupCookiePersistentStorageType storageType)
 {
-    if (auto* networkSession = m_process.networkSession(sessionID))
+    if (auto* networkSession = protectedProcess()->networkSession(sessionID))
         static_cast<NetworkSessionSoup&>(*networkSession).setCookiePersistentStorage(storagePath, storageType);
 }
 
 void WebCookieManager::replaceCookies(PAL::SessionID sessionID, const Vector<WebCore::Cookie>& cookies, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = m_process.storageSession(sessionID))
+    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->replaceCookies(cookies);
     completionHandler();
 }


### PR DESCRIPTION
#### 47d14625af7b5cf5166f6a62b1651d896a70e66e
<pre>
Deploy even more smart pointers in Source/WebKit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=260699">https://bugs.webkit.org/show_bug.cgi?id=260699</a>

Reviewed by Chris Dumez.

Deployed more smart pointers.

* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::WebCookieManager):
(WebKit::WebCookieManager::protectedProcess):
(WebKit::WebCookieManager::getHostnamesWithCookies):
(WebKit::WebCookieManager::deleteCookiesForHostnames):
(WebKit::WebCookieManager::deleteAllCookies):
(WebKit::WebCookieManager::deleteCookie):
(WebKit::WebCookieManager::deleteAllCookiesModifiedSince):
(WebKit::WebCookieManager::getAllCookies):
(WebKit::WebCookieManager::getCookies):
(WebKit::WebCookieManager::setCookie):
(WebKit::WebCookieManager::setCookies):
(WebKit::WebCookieManager::notifyCookiesDidChange):
(WebKit::WebCookieManager::startObservingCookieChanges):
(WebKit::WebCookieManager::stopObservingCookieChanges):
(WebKit::WebCookieManager::setHTTPCookieAcceptPolicy):
(WebKit::WebCookieManager::getHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
(WebKit::WebCookieManager::setCookiePersistentStorage):
(WebKit::WebCookieManager::replaceCookies):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::convertToDownload):

Canonical link: <a href="https://commits.webkit.org/267304@main">https://commits.webkit.org/267304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c69e36941ceed58322abe96e960dd8b55818d43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15224 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16653 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18753 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14109 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18082 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19035 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1991 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->