### PR TITLE
Deploy more smart pointers in Source/WebKit/Platform/IPC and Source/WebKit/Shared/API/Cocoa

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -684,7 +684,7 @@ template<typename T>
 Error Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
     Locker locker { s_connectionMapLock };
-    auto* connection = connectionMap().get(connectionID);
+    RefPtr connection = connectionMap().get(connectionID);
     if (!connection)
         return Error::NoConnectionForIdentifier;
     return connection->send(WTFMove(message), destinationID, sendOptions, qos);

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -34,7 +34,7 @@ MessageSender::~MessageSender() = default;
 
 bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOption> sendOptions)
 {
-    auto* connection = messageSenderConnection();
+    RefPtr connection = messageSenderConnection();
     ASSERT(connection);
     // FIXME: Propagate errors out.
     return connection->sendMessage(WTFMove(encoder), sendOptions) == Error::NoError;
@@ -42,7 +42,7 @@ bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOpti
 
 bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncReplyHandler replyHandler, OptionSet<SendOption> sendOptions)
 {
-    auto* connection = messageSenderConnection();
+    RefPtr connection = messageSenderConnection();
     ASSERT(connection);
     // FIXME: Propagate errors out.
     return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions) == Error::NoError;

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -772,9 +772,9 @@ static id decodeObjectFromObjectStream(WKRemoteObjectDecoder *decoder, const Has
     if (decoder->_objectStreamPosition == decoder->_objectStream->size())
         return nil;
 
-    const API::Dictionary* dictionary = decoder->_objectStream->at<API::Dictionary>(decoder->_objectStreamPosition++);
+    RefPtr dictionary = decoder->_objectStream->at<API::Dictionary>(decoder->_objectStreamPosition++);
 
-    return decodeObject(decoder, dictionary, allowedClasses);
+    return decodeObject(decoder, dictionary.get(), allowedClasses);
 }
 
 static const HashSet<CFTypeRef> alwaysAllowedClasses()
@@ -1014,7 +1014,7 @@ static NSInvocation *decodeInvocation(WKRemoteObjectDecoder *decoder)
 
 static RetainPtr<NSString> decodeString(WKRemoteObjectDecoder *decoder)
 {
-    API::String* string = decoder->_currentDictionary->get<API::String>(stringKey);
+    RefPtr string = decoder->_currentDictionary->get<API::String>(stringKey);
     if (!string)
         [NSException raise:NSInvalidUnarchiveOperationException format:@"String missing"];
 
@@ -1023,7 +1023,7 @@ static RetainPtr<NSString> decodeString(WKRemoteObjectDecoder *decoder)
 
 static id decodeObject(WKRemoteObjectDecoder *decoder)
 {
-    API::String* classNameString = decoder->_currentDictionary->get<API::String>(classNameKey);
+    RefPtr classNameString = decoder->_currentDictionary->get<API::String>(classNameKey);
     if (!classNameString)
         [NSException raise:NSInvalidUnarchiveOperationException format:@"Class name missing"];
 
@@ -1067,7 +1067,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (BOOL)decodeBoolForKey:(NSString *)key
 {
-    const API::Boolean* value = _currentDictionary->get<API::Boolean>(escapeKey(key));
+    RefPtr value = _currentDictionary->get<API::Boolean>(escapeKey(key));
     if (!value)
         return false;
     return value->value();
@@ -1075,7 +1075,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (int)decodeIntForKey:(NSString *)key
 {
-    const API::UInt64* value = _currentDictionary->get<API::UInt64>(escapeKey(key));
+    RefPtr value = _currentDictionary->get<API::UInt64>(escapeKey(key));
     if (!value)
         return 0;
     return static_cast<int>(value->value());
@@ -1083,7 +1083,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (int32_t)decodeInt32ForKey:(NSString *)key
 {
-    const API::UInt64* value = _currentDictionary->get<API::UInt64>(escapeKey(key));
+    RefPtr value = _currentDictionary->get<API::UInt64>(escapeKey(key));
     if (!value)
         return 0;
     return static_cast<int32_t>(value->value());
@@ -1091,7 +1091,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (int64_t)decodeInt64ForKey:(NSString *)key
 {
-    const API::UInt64* value = _currentDictionary->get<API::UInt64>(escapeKey(key));
+    RefPtr value = _currentDictionary->get<API::UInt64>(escapeKey(key));
     if (!value)
         return 0;
     return value->value();
@@ -1104,7 +1104,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (float)decodeFloatForKey:(NSString *)key
 {
-    const API::Double* value = _currentDictionary->get<API::Double>(escapeKey(key));
+    RefPtr value = _currentDictionary->get<API::Double>(escapeKey(key));
     if (!value)
         return 0;
     return value->value();
@@ -1112,7 +1112,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (double)decodeDoubleForKey:(NSString *)key
 {
-    const API::Double* value = _currentDictionary->get<API::Double>(escapeKey(key));
+    RefPtr value = _currentDictionary->get<API::Double>(escapeKey(key));
     if (!value)
         return 0;
     return value->value();
@@ -1120,7 +1120,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (const uint8_t *)decodeBytesForKey:(NSString *)key returnedLength:(NSUInteger *)length
 {
-    auto* data = _currentDictionary->get<API::Data>(escapeKey(key));
+    RefPtr data = _currentDictionary->get<API::Data>(escapeKey(key));
     if (!data || !data->size()) {
         *length = 0;
         return nullptr;
@@ -1141,7 +1141,8 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
     for (Class allowedClass in classes)
         allowedClasses.add((__bridge CFTypeRef)allowedClass);
 
-    return decodeObject(self, _currentDictionary->get<API::Dictionary>(escapeKey(key)), allowedClasses);
+    RefPtr dictionary = _currentDictionary->get<API::Dictionary>(escapeKey(key));
+    return decodeObject(self, dictionary.get(), allowedClasses);
 }
 
 - (NSSet *)allowedClasses

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -210,7 +210,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 - (void)_invokeMethod:(const WebKit::RemoteObjectInvocation&)remoteObjectInvocation
 {
     auto& interfaceIdentifier = remoteObjectInvocation.interfaceIdentifier();
-    auto* encodedInvocation = remoteObjectInvocation.encodedInvocation();
+    RefPtr encodedInvocation = remoteObjectInvocation.encodedInvocation();
 
     auto interfaceAndObject = _exportedObjects.get(interfaceIdentifier);
     if (!interfaceAndObject.second) {
@@ -220,7 +220,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 
     RetainPtr<_WKRemoteObjectInterface> interface = interfaceAndObject.second;
 
-    auto decoder = adoptNS([[WKRemoteObjectDecoder alloc] initWithInterface:interface.get() rootObjectDictionary:encodedInvocation replyToSelector:nullptr]);
+    auto decoder = adoptNS([[WKRemoteObjectDecoder alloc] initWithInterface:interface.get() rootObjectDictionary:encodedInvocation.get() replyToSelector:nullptr]);
 
     NSInvocation *invocation = [decoder decodeObjectOfClass:[NSInvocation class] forKey:invocationKey];
 
@@ -321,7 +321,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 
 - (void)_callReplyWithID:(uint64_t)replyID blockInvocation:(const WebKit::UserData&)blockInvocation
 {
-    auto encodedInvocation = blockInvocation.object();
+    RefPtr encodedInvocation = blockInvocation.object();
     if (!encodedInvocation || encodedInvocation->type() != API::Object::Type::Dictionary)
         return;
 
@@ -332,7 +332,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
     auto pendingReply = it->value;
     _pendingReplies.remove(it);
 
-    auto decoder = adoptNS([[WKRemoteObjectDecoder alloc] initWithInterface:pendingReply.interface.get() rootObjectDictionary:static_cast<API::Dictionary*>(encodedInvocation) replyToSelector:pendingReply.selector]);
+    auto decoder = adoptNS([[WKRemoteObjectDecoder alloc] initWithInterface:pendingReply.interface.get() rootObjectDictionary:static_cast<API::Dictionary*>(encodedInvocation.get()) replyToSelector:pendingReply.selector]);
 
     NSInvocation *replyInvocation = [decoder decodeObjectOfClass:[NSInvocation class] forKey:invocationKey];
 


### PR DESCRIPTION
#### f46ead2d46ea966ca9ef3677d2351c72354dbc14
<pre>
Deploy more smart pointers in Source/WebKit/Platform/IPC and Source/WebKit/Shared/API/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=260701">https://bugs.webkit.org/show_bug.cgi?id=260701</a>

Reviewed by Chris Dumez.

Deployed more smart pointers in these files.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::send):
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::sendMessage):
(IPC::MessageSender::sendMessageWithAsyncReply):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(decodeObjectFromObjectStream):
(decodeString):
(decodeObject):
(-[WKRemoteObjectDecoder decodeBoolForKey:]):
(-[WKRemoteObjectDecoder decodeIntForKey:]):
(-[WKRemoteObjectDecoder decodeInt32ForKey:]):
(-[WKRemoteObjectDecoder decodeInt64ForKey:]):
(-[WKRemoteObjectDecoder decodeFloatForKey:]):
(-[WKRemoteObjectDecoder decodeDoubleForKey:]):
(-[WKRemoteObjectDecoder decodeBytesForKey:returnedLength:]):
(-[WKRemoteObjectDecoder decodeObjectOfClasses:forKey:]):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _invokeMethod:]):
(-[_WKRemoteObjectRegistry _callReplyWithID:blockInvocation:]):

Canonical link: <a href="https://commits.webkit.org/267295@main">https://commits.webkit.org/267295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04c759c7d73a775baa75a31b772ac7e800fc9a22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15157 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17561 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18680 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14047 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21452 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18967 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1985 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->