### PR TITLE
LibWebRTC TCPConnection might receive packets while its port is nullptr

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/tcp_port.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/tcp_port.cc
@@ -564,6 +564,14 @@ void TCPConnection::OnReadPacket(rtc::AsyncPacketSocket* socket,
                                  const rtc::SocketAddress& remote_addr,
                                  const int64_t& packet_time_us) {
   RTC_DCHECK_EQ(socket, socket_.get());
+
+#if defined(WEBRTC_WEBKIT_BUILD)
+  if (!port()) {
+    RTC_LOG(LS_WARNING) << "TCPConnection: Port has been deleted.";
+    return;
+  }
+#endif
+
   Connection::OnReadPacket(data, size, packet_time_us);
 }
 


### PR DESCRIPTION
#### 277cc3e4b924b487ff3f17f03bf44bd25a269b05
<pre>
LibWebRTC TCPConnection might receive packets while its port is nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=260705">https://bugs.webkit.org/show_bug.cgi?id=260705</a>
rdar://113531400

Reviewed by Jean-Yves Avenard.

According logs, we have a nullptr crash in Connection::OnReadPacket when calling Port::GetStunMessage.
The current explanation is this one:
1. The connection is live and connected to the socket (which means it is a TCPConnection).
2. The connection&apos;s port is dead, which can happen if Port::DestroyConnectionAsync is called.

To prevent the nullptr crash, we add a nullptr check in TCPConnection::OnReadPacket.

* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/tcp_port.cc:

Canonical link: <a href="https://commits.webkit.org/267275@main">https://commits.webkit.org/267275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fce3a4f48bb6ccd1e5bae21771a0cf0dab55630

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15167 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18692 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21468 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18025 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14611 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3858 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->