### PR TITLE
Simplify frame scheduling logic in RemoteLayerTreeDrawingArea.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -125,8 +125,13 @@ public:
     virtual void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) = 0;
     virtual void addRootFrame(WebCore::FrameIdentifier) { }
     // FIXME: Add a corresponding removeRootFrame.
+
+    // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;
+    // Cause a rendering update to happen at the next suitable time,
+    // as determined by the drawing area.
     virtual bool scheduleRenderingUpdate() { return false; }
+
     virtual void renderingUpdateFramesPerSecondChanged() { }
 
     virtual void willStartRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -56,12 +56,23 @@ public:
     TransactionID nextTransactionID() const { return m_currentTransactionID.next(); }
     TransactionID lastCommittedTransactionID() const { return m_currentTransactionID; }
 
-    bool displayDidRefreshIsPending() const { return m_waitingForBackingStoreSwap; }
-
 protected:
-    void updateRendering();
+    enum class ScheduleRenderingUrgency {
+        // FIXME: There are many consumers of this (and triggerRenderingUpdate), do they all actually need the ASAP behaviour?
+        AsSoonAsPossible,
+        NextSuitableTime,
+    };
+    void scheduleRenderingUpdate(ScheduleRenderingUrgency);
 
 private:
+    enum class State {
+        Idle,
+        WaitingForDisplayDidRefresh,
+        WaitingForUpdateRenderingTimer,
+        WaitingForCallOnMainRunLoop,
+        WaitingForScheduleRenderingTimer,
+    };
+
     // DrawingArea
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const WebCore::IntRect&) override;
@@ -71,8 +82,11 @@ private:
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void addRootFrame(WebCore::FrameIdentifier) final;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
+
+    void updateRendering();
+
     void renderingUpdateFramesPerSecondChanged() final;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
 
@@ -162,13 +176,12 @@ private:
 
     std::optional<WebCore::FloatRect> m_viewExposedRect;
 
+    State m_state { State::Idle };
+
     WebCore::Timer m_updateRenderingTimer;
     bool m_isRenderingSuspended { false };
     bool m_hasDeferredRenderingUpdate { false };
     bool m_inUpdateRendering { false };
-
-    bool m_waitingForBackingStoreSwap { false };
-    bool m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap { false };
 
     OSObjectPtr<dispatch_queue_t> m_commitQueue;
     RefPtr<BackingStoreFlusher> m_pendingBackingStoreFlusher;
@@ -182,7 +195,8 @@ private:
     WebCore::Timer m_scheduleRenderingTimer;
     std::optional<WebCore::FramesPerSecond> m_preferredFramesPerSecond;
     Seconds m_preferredRenderingUpdateInterval;
-    bool m_isScheduled { false };
+
+    bool m_updateRenderingIsPending { false };
 };
 
 inline bool RemoteLayerTreeDrawingArea::addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone> paintMilestones)

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -79,8 +79,8 @@ void RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage(double scale, Float
     auto unscrolledOrigin = origin;
     FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     unscrolledOrigin.moveBy(-unobscuredContentRect.location());
-    webPage->scalePage(scale / webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
-    updateRendering();
+    m_webPage->scalePage(scale / m_webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
+    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
 }
 
 void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::FloatPoint origin)


### PR DESCRIPTION
#### 192aff7ffe916c00c66a7cb850bb8e4deba3a4a1
<pre>
Simplify frame scheduling logic in RemoteLayerTreeDrawingArea.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259999">https://bugs.webkit.org/show_bug.cgi?id=259999</a>
&lt;rdar://113657855&gt;

Reviewed by Simon Fraser.

Previously, both scheduleRenderingUpdate and external calls to triggerRenderingUpdate would wait for the next displayDidRefresh
if one was pending. scheduleRenderingUpdate would check for this explicitly at call time. TriggerRenderingUpdate would
always run updateRendering on a 0ms timer, and then check at that point and reschedule (by setting m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap=true).

This reverses the logic of triggerRenderingUpdate to be the same as scheduleRenderingUpdate by making them use the same code (a new scheduleRenderingUpdate function
with an enum to specify the exact behaviour). In very rare cases this could be a behaviour change (since we&apos;re checking state at a different point).

The difference between these two is now more clear, in the case where there isn&apos;t a displayDidRefresh pending, schedule has an extra async task dispatch that trigger
does not. This difference affects performance benchmark results, so trying to remove it is outside the scope of this patch.

It should now never be possible for displayDidRefresh to be pending when updateRendering is called, so m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap is removed.
Setting of m_displayDidRefreshIsPending=true happens earlier, since we can sometimes recurse back in to trigger rendering during a rendering update.

Existing internal callers of triggerRenderingUpdate (and startRenderingUpdateTimer) have been changed to use the enum version of scheduleRenderingUpdate to make it clearer. Most
of these are using the as soon as possible variant, but almost certainly don&apos;t need to and could be changed.

The two call sites that synchronously called updateRendering have also been changed to scheduleRenderingUpdate(AsSoonAsPossible). These likely weren&apos;t synchronous previously (since
updateRendering aborted and rescheduled if displayDidRefresh was pending), but it was non-deterministic. Making them always just schedule seems a lot safer and easier to understand.

Renames m_waitingForBackingStoreSwap to m_displayDidRefreshIsPending since that&apos;s the name of the message
we&apos;re actually waiting for.

The logic in ::displayDidRefresh cleaned up in response to the above changes, since most of the complexity it checked for no longer exists.

* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefreshIsPending const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer):
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::RemoteLayerTreeDrawingArea::forceRepaint):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):

Canonical link: <a href="https://commits.webkit.org/267274@main">https://commits.webkit.org/267274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34bf9023f71a9e5db65d2dea04886f761ab4c136

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15172 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16596 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18697 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14061 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13047 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14616 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3857 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->