### PR TITLE
[CSS] Always serialize implicit nesting selector/rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -3,10 +3,10 @@ PASS .foo { & { color: green; }}
 PASS .foo { &.bar { color: green; }}
 PASS .foo { & .bar { color: green; }}
 PASS .foo { & > .bar { color: green; }}
-FAIL .foo { > .bar { color: green; }} assert_equals: Inner rule's selector should be "& > .bar". expected "& > .bar" but got "> .bar"
-FAIL .foo { > & .bar { color: green; }} assert_equals: Inner rule's selector should be "& > & .bar". expected "& > & .bar" but got "> & .bar"
-FAIL .foo { + .bar & { color: green; }} assert_equals: Inner rule's selector should be "& + .bar &". expected "& + .bar &" but got "+ .bar &"
-FAIL .foo { + .bar, .foo, > .baz { color: green; }} assert_equals: Inner rule's selector should be "& + .bar, .foo, & > .baz". expected "& + .bar, .foo, & > .baz" but got "+ .bar, .foo, > .baz"
+PASS .foo { > .bar { color: green; }}
+PASS .foo { > & .bar { color: green; }}
+PASS .foo { + .bar & { color: green; }}
+PASS .foo { + .bar, .foo, > .baz { color: green; }}
 PASS .foo { .foo { color: green; }}
 PASS .foo { .test > & .bar { color: green; }}
 PASS .foo { .foo, .foo & { color: green; }}

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
@@ -47,15 +47,15 @@
 
   // relative selector
   testNestedSelector("> .bar", {expected:"& > .bar"});
-  testNestedSelector("> & .bar", {expected: "& > & .bar"});
+  testNestedSelector("> & .bar", {expected:"& > & .bar"});
   testNestedSelector("+ .bar &", {expected:"& + .bar &"});
-  testNestedSelector("+ .bar, .foo, > .baz", {expected:"& + .bar, .foo, & > .baz"});
+  testNestedSelector("+ .bar, .foo, > .baz", {expected:"& + .bar, & .foo, & > .baz"});
 
   // implicit relative (and not)
-  testNestedSelector(".foo");
+  testNestedSelector(".foo", {expected:"& .foo"});
   testNestedSelector(".test > & .bar");
-  testNestedSelector(".foo, .foo &");
-  testNestedSelector(":is(.bar, .baz)");
+  testNestedSelector(".foo, .foo &", {expected:"& .foo, .foo &"});
+  testNestedSelector(":is(.bar, .baz)", {expected:"& :is(.bar, .baz)"});
   testNestedSelector("&:is(.bar, .baz)");
   testNestedSelector(":is(.bar, &.baz)");
   testNestedSelector("&:is(.bar, &.baz)");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Declarations are serialized on one line, rules on two.
-FAIL Mixed declarations/rules are on two lines. assert_equals: Mixed declarations/rules are on two lines. expected "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}" but got "div {\n  @media screen { color: red; background-color: green; }\n}"
-FAIL Implicit rule is serialized assert_equals: Implicit rule is serialized expected "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n}\n  &:hover { color: navy; }\n}" but got "div {\n  @supports selector(&) { color: red; background-color: green; }\n  &:hover { color: navy; }\n}"
-FAIL Implicit rule not removed assert_equals: Implicit rule not removed expected "div {\n  @media screen {\n  & { color: red; }\n}\n}" but got "div {\n  @media screen { color: red; }\n}"
+PASS Mixed declarations/rules are on two lines.
+PASS Implicit rule is serialized
+PASS Implicit rule not removed
 PASS Implicit + empty hover rule
 PASS Implicit like rule not in first position
-FAIL Two implicit-like rules assert_equals: Two implicit-like rules expected "div {\n  @media screen {\n  & { color: red; }\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\n  color: red;\n  & { color: red; }\n}\n}"
-FAIL Implicit like rule after decls assert_equals: Implicit like rule after decls expected "div {\n  @media screen {\n  & { color: red; }\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\n  color: red;\n  & { color: red; }\n}\n}"
-FAIL Implicit like rule after decls, missing closing braces assert_equals: Implicit like rule after decls, missing closing braces expected "div {\n  @media screen {\n  & { color: red; }\n  & { color: blue; }\n}\n}" but got "div {\n  @media screen {\n  color: red;\n  & { color: blue; }\n}\n}"
+PASS Two implicit-like rules
+PASS Implicit like rule after decls
+PASS Implicit like rule after decls, missing closing braces
 PASS Implicit like rule with other selectors
 PASS Implicit-like rule in style rule
 PASS Empty conditional rule

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping-expected.txt
@@ -31,7 +31,9 @@ PASS: Rule should have no groupings.
 -- Running test case: CSS.getMatchedStyleForNode.NestingStyleGrouping.NestedRulePropertyWithImplicitAmpersand
 PASS: Should have 4 authored rules.
 - Testing rule #0
-PASS: Selector text should be ".innerA".
+FAIL: Selector text should be ".innerA".
+    Expected: ".innerA"
+    Actual: "& .innerA"
 PASS: Rule should not be an implicitly nested rule.
 PASS: "color" property value should be "green".
 PASS: Rule should have 1 grouping(s).

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -144,26 +144,10 @@ void CSSGroupingRule::appendCSSTextForItems(StringBuilder& builder) const
     return;
 }
 
-void CSSGroupingRule::cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const
+void CSSGroupingRule::cssTextForDeclsAndRules(StringBuilder&, StringBuilder& rules) const
 {
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0 ; index < childRules.size() ; index++) {
-        // We put the declarations at the upper level when the rule:
-        // - is the first rule
-        // - has just "&" as original selector
-        // - has no child rules
-        if (!index) {
-            // It's the first rule.
-            auto childRule = childRules[index];
-            if (childRule->isStyleRuleWithNesting()) {
-                auto& nestedStyleRule = downcast<StyleRuleWithNesting>(childRule);
-                if (nestedStyleRule.originalSelectorList().hasOnlyNestingSelector() && nestedStyleRule.nestedRules().isEmpty()) {
-                    decls.append(nestedStyleRule.properties().asText());
-                    continue;
-                }
-            }
-        }
-        // Otherwise we print the child rule
         auto wrappedRule = item(index);
         rules.append("\n  ", wrappedRule->cssText());
     }

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -702,7 +702,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         return false;
 
     if (selector.match() == CSSSelector::Match::NestingParent) {
-        ASSERT_NOT_REACHED();
         return false;
     }
 

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -152,6 +152,18 @@ CSSParserSelector* CSSParserSelector::leftmostSimpleSelector()
     return selector;
 }
 
+bool CSSParserSelector::hasExplicitNestingParent() const
+{
+    auto selector = this;
+    while (selector) {
+        if (selector->selector()->hasExplicitNestingParent())
+            return true;
+
+        selector = selector->tagHistory();
+    }
+    return false;
+}
+
 static bool selectorListMatchesPseudoElement(const CSSSelectorList* selectorList)
 {
     if (!selectorList)

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -49,6 +49,7 @@ public:
     ~CSSParserSelector();
 
     std::unique_ptr<CSSSelector> releaseSelector() { return WTFMove(m_selector); }
+    const CSSSelector* selector() const { return m_selector.get(); };
     CSSSelector* selector() { return m_selector.get(); }
 
     void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector->setValue(value, matchLowerCase); }
@@ -80,6 +81,8 @@ public:
     bool matchesPseudoElement() const;
 
     bool isHostPseudoSelector() const;
+
+    bool hasExplicitNestingParent() const;
 
     // FIXME-NEWPARSER: "slotted" was removed here for now, since it leads to a combinator
     // connection of ShadowDescendant, and the current shadow DOM code doesn't expect this. When

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -30,6 +30,8 @@
 #include "config.h"
 #include "CSSSelectorParser.h"
 
+#include "CSSParserSelector.h"
+#include "CSSSelector.h"
 #include "CommonAtomStrings.h"
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
@@ -307,12 +309,41 @@ static bool isDescendantCombinator(CSSSelector::RelationType relation)
 
 std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeNestedComplexSelector(CSSParserTokenRange& range)
 {
+    auto appendNestingSelector = [] (auto& parserSelector) {
+        // https://drafts.csswg.org/css-nesting/#cssom
+        // Relative selector should be absolutized (only when not "nest-containing" for the descendant one),
+        // with the implied nesting selector inserted.
+
+        auto lastSelector = parserSelector->leftmostSimpleSelector()->selector();
+        ASSERT(lastSelector);
+
+        // Relation is Descendant by default.
+        auto relation = lastSelector->relation();
+        if (relation == CSSSelector::RelationType::Subselector)
+            relation = CSSSelector::RelationType::DescendantSpace;
+
+        auto nestingSelector = makeUnique<CSSParserSelector>();
+        nestingSelector->setMatch(CSSSelector::Match::NestingParent);
+        // We add the implicit parent selector at the beginning of the selector.
+        parserSelector->appendTagHistory(relation, WTFMove(nestingSelector));
+    };
+
     auto selector = consumeComplexSelector(range);
-    if (selector)
+    if (selector) {
+        if (selector->hasExplicitNestingParent())
+            return selector;
+
+        appendNestingSelector(selector);
         return selector;
+    }
 
     selector = consumeRelativeNestedSelector(range);
-    return selector;
+    if (selector) {
+        appendNestingSelector(selector);
+        return selector;
+    }
+
+    return nullptr;
 }
 
 std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeComplexSelector(CSSParserTokenRange& range)
@@ -1240,47 +1271,15 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
     CSSSelectorList copiedSelectorList { nestedSelectorList };
     auto selector = copiedSelectorList.first();
     while (selector) {
-        if (selector->hasExplicitNestingParent()) {
-            if (parentResolvedSelectorList) {
-                // FIXME: We should build a new CSSParserSelector from this selector and resolve it
-                const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(*parentResolvedSelectorList);
-            } else {
-                // It's top-level, the nesting parent selector should be replace by :scope
-                const_cast<CSSSelector*>(selector)->replaceNestingParentByPseudoClassScope();
-            }
-            auto parserSelector = makeUnique<CSSParserSelector>(*selector);
-            result.append(WTFMove(parserSelector));
+        if (parentResolvedSelectorList) {
+            // FIXME: We should build a new CSSParserSelector from this selector and resolve it
+            const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(*parentResolvedSelectorList);
         } else {
-            auto parserSelector = makeUnique<CSSParserSelector>(*selector);
-            if (parentResolvedSelectorList) {
-                // We add the implicit parent selector at the beginning of the selector.
-                auto lastSelector = parserSelector->leftmostSimpleSelector()->selector();
-                ASSERT(lastSelector);
-                bool isLastInSelectorList = lastSelector->isLastInSelectorList();
-
-                // Relation is Descendant by default.
-                auto relation = lastSelector->relation();
-                if (relation == CSSSelector::RelationType::Subselector)
-                    relation = CSSSelector::RelationType::DescendantSpace;
-
-                lastSelector->setNotLastInTagHistory();
-                lastSelector->setNotLastInSelectorList();
-                CSSSelector parentIsSelector;
-                parentIsSelector.setMatch(CSSSelector::Match::PseudoClass);
-                parentIsSelector.setPseudoClassType(CSSSelector::PseudoClassType::Is);
-                parentIsSelector.setSelectorList(makeUnique<CSSSelectorList>(*parentResolvedSelectorList));
-                parentIsSelector.setLastInTagHistory();
-                if (isLastInSelectorList)
-                    parentIsSelector.setLastInSelectorList();
-                else
-                    parentIsSelector.setNotLastInSelectorList();
-
-                auto uniqueParentIsSelector = makeUnique<CSSParserSelector>(parentIsSelector);
-                parserSelector->appendTagHistory(relation, WTFMove(uniqueParentIsSelector));
-            }
-            // Otherwise, no nesting parent selector and top-level, do nothing to this selector
-            result.append(WTFMove(parserSelector));
+            // It's top-level, the nesting parent selector should be replace by :scope
+            const_cast<CSSSelector*>(selector)->replaceNestingParentByPseudoClassScope();
         }
+        auto parserSelector = makeUnique<CSSParserSelector>(*selector);
+        result.append(WTFMove(parserSelector));
         selector = copiedSelectorList.next(selector);
     }
 


### PR DESCRIPTION
#### 41f7a301e412e75355904d8aa98393810cd91e3a
<pre>
[CSS] Always serialize implicit nesting selector/rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=260707">https://bugs.webkit.org/show_bug.cgi?id=260707</a>
rdar://112900363

Reviewed by Patrick Angle and Antti Koivisto.

<a href="https://drafts.csswg.org/css-nesting/#cssom">https://drafts.csswg.org/css-nesting/#cssom</a>

&quot;When serializing a relative selector in a nested style rule,
the selector must be absolutized, with the implied nesting selector inserted.
When serializing a nested group rule, it must serialize solely with child rules.&quot;

This patch moves the code which build the selector with the implicit &amp; added
from rule set building time to parsing time.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt:
* LayoutTests/inspector/css/getMatchedStylesForNodeNestingStyleGrouping-expected.txt:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::hasExplicitNestingParent const):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::selector const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeNestedComplexSelector):
(WebCore::CSSSelectorParser::resolveNestingParent):

Canonical link: <a href="https://commits.webkit.org/267531@main">https://commits.webkit.org/267531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d427432840f13dbe15162f641ccdf39c8ef8f86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17277 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19397 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21991 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19726 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13583 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->