### PR TITLE
[GStreamer] registerAppsinkWithWorkaroundsIfNeededCallOnce() should be callable from non-main threads

### DIFF
--- a/Source/WebCore/platform/AudioDecoder.cpp
+++ b/Source/WebCore/platform/AudioDecoder.cpp
@@ -34,7 +34,6 @@
 #include "GStreamerRegistryScanner.h"
 #endif
 
-#include <wtf/MainThread.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/text/WTFString.h>
 
@@ -52,11 +51,8 @@ bool AudioDecoder::isCodecSupported(const StringView& codec)
 
     bool result = false;
 #if USE(GSTREAMER)
-    // FIXME: Workaround for the "GStreamerSinksWorkarounds" quirks expecting to run in the main thread...
-    callOnMainThreadAndWait([&] {
-        auto& scanner = GStreamerRegistryScanner::singleton();
-        result = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codec.toString());
-    });
+    auto& scanner = GStreamerRegistryScanner::singleton();
+    result = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, codec.toString());
 #endif
 
     return result;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -263,6 +263,8 @@ Vector<String> extractGStreamerOptionsFromCommandLine()
 
 bool ensureGStreamerInitialized()
 {
+    // WARNING: Please note this function can be called from any thread, for instance when creating
+    // a WebCodec element from a JS Worker.
     RELEASE_ASSERT(isInWebProcess());
     static std::once_flag onceFlag;
     static bool isGStreamerInitialized;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -280,7 +280,6 @@ bool AppSinkFlushCapsWorkaroundProbe::s_isNeeded;
 
 static void registerAppsinkWithWorkaroundsIfNeededCallOnce()
 {
-    ASSERT(isMainThread());
     // If any workarounds are needed in this system, override GStreamer appsink for a version containing any needed workarounds.
     GST_DEBUG_CATEGORY_INIT(webkit_workarounds_debug, "webkitworkarounds", 0, "WebKit GStreamer Workarounds");
     GST_DEBUG("Checking for potentially needed GStreamer workarounds...");


### PR DESCRIPTION
#### c760465095dda52270369a1f4f620a253bc320d8
<pre>
[GStreamer] registerAppsinkWithWorkaroundsIfNeededCallOnce() should be callable from non-main threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=260711">https://bugs.webkit.org/show_bug.cgi?id=260711</a>

Reviewed by Alicia Boya Garcia.

Remove un-needed ASSERT, nothing should prevent to call gst_element_register() from a non-main thread.

* Source/WebCore/platform/AudioDecoder.cpp:
(WebCore::AudioDecoder::isCodecSupported):
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
(WebCore::registerAppsinkWithWorkaroundsIfNeededCallOnce):

Canonical link: <a href="https://commits.webkit.org/267550@main">https://commits.webkit.org/267550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab46ad29fefe4ce76668675244182dda64372dec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17405 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19539 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22089 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19851 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15303 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4057 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->