### PR TITLE
REGRESSION(267278@main) [GStreamer] Stable builds broke with missing include and guard

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -20,8 +20,9 @@
 #include "config.h"
 #include "PlatformRawAudioDataGStreamer.h"
 
-#if USE(GSTREAMER)
+#if ENABLE(WEB_CODECS) && USE(GSTREAMER)
 
+#include "AudioSampleFormat.h"
 #include "GStreamerCommon.h"
 #include "GUniquePtrGStreamer.h"
 #include "SharedBuffer.h"
@@ -230,4 +231,4 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
 
 #undef GST_CAT_DEFAULT
 
-#endif // USE(GSTREAMER)
+#endif // ENABLE(WEB_CODECS) && USE(GSTREAMER)

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h
@@ -21,7 +21,7 @@
 
 #include "PlatformRawAudioData.h"
 
-#if USE(GSTREAMER)
+#if ENABLE(WEB_CODECS) && USE(GSTREAMER)
 
 #include "GRefPtrGStreamer.h"
 #include <gst/audio/audio.h>
@@ -56,4 +56,4 @@ private:
 
 }
 
-#endif // USE(GSTREAMER)
+#endif // ENABLE(WEB_CODECS) && USE(GSTREAMER)


### PR DESCRIPTION
#### 98a84f0a9a6b99d5870f360364c6b361f88dd693
<pre>
REGRESSION(267278@main) [GStreamer] Stable builds broke with missing include and guard
<a href="https://bugs.webkit.org/show_bug.cgi?id=260719">https://bugs.webkit.org/show_bug.cgi?id=260719</a>

Reviewed by Philippe Normand.

Add missing include (as expected in non-unified builds) and guard
PlatformRawAudioDataGStreamer with ENABLE(WEB_CODECS).

* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/267292@main">https://commits.webkit.org/267292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/603ec5fed4aac3ca7dfbc3838e74ca7af39ca000

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16631 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18731 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14665 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15422 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14649 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->