### PR TITLE
Support <svg:image crossorigin>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1300,7 +1300,7 @@ PASS SVGImageElement interface: attribute y
 PASS SVGImageElement interface: attribute width
 PASS SVGImageElement interface: attribute height
 PASS SVGImageElement interface: attribute preserveAspectRatio
-FAIL SVGImageElement interface: attribute crossOrigin assert_true: The prototype object must have a property "crossOrigin" expected true got false
+PASS SVGImageElement interface: attribute crossOrigin
 PASS SVGImageElement interface: attribute href
 PASS SVGImageElement must be primary interface of objects.image
 PASS Stringification of objects.image
@@ -1309,7 +1309,7 @@ PASS SVGImageElement interface: objects.image must inherit property "y" with the
 PASS SVGImageElement interface: objects.image must inherit property "width" with the proper type
 PASS SVGImageElement interface: objects.image must inherit property "height" with the proper type
 PASS SVGImageElement interface: objects.image must inherit property "preserveAspectRatio" with the proper type
-FAIL SVGImageElement interface: objects.image must inherit property "crossOrigin" with the proper type assert_inherits: property "crossOrigin" not found in prototype chain
+PASS SVGImageElement interface: objects.image must inherit property "crossOrigin" with the proper type
 PASS SVGImageElement interface: objects.image must inherit property "href" with the proper type
 PASS SVGGraphicsElement interface: objects.image must inherit property "transform" with the proper type
 PASS SVGGraphicsElement interface: objects.image must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html
@@ -1,222 +1,219 @@
-
 <!DOCTYPE html>
 <html>
+
 <head>
   <script src='/resources/testharness.js'></script>
   <script src='/resources/testharnessreport.js'></script>
   <script src="/common/get-host-info.sub.js"></script>
 </head>
+
 <body>
-<svg id="svg" width="200" height="200" xmlns="http://www.w3.org/2000/svg">
-</svg>
-<script>
-const SAMEORIGIN_BASE = get_host_info().HTTP_ORIGIN;
-const CROSSORIGIN_BASE = get_host_info().HTTP_NOTSAMESITE_ORIGIN;
+  <svg id="svg" width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+  </svg>
+  <script>
+    const SAMEORIGIN_BASE = get_host_info().HTTP_ORIGIN;
+    const CROSSORIGIN_BASE = get_host_info().HTTP_NOTSAMESITE_ORIGIN;
 
-async function getVideoFilename()
-{
-     const videoConfiguration = {
-       type: 'file',
-       video: {
-           contentType: 'video/mp4; codecs=avc1',
-           width: 640,
-           height: 480,
-           bitrate: 800,
-           framerate: 30
-         }
-     };
-     const result = await navigator.mediaCapabilities.decodingInfo(videoConfiguration);
-     if (result.supported)
-         return '/webcodecs/h264.mp4';
-     return '/webcodecs/av1.mp4';
-}
-
-const TESTS = [
-  // HTMLImageElement
-  {
-    title: 'Test creating a VideoFrame with a same-origin HTMLImageElement',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.src = SAMEORIGIN_BASE + '/webcodecs/four-colors.jpg';
-      });
-    },
-    should_throw: false,
-  },
-  {
-    title: 'Test creating a VideoFrame with a cross-origin HTMLImageElement',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.src = CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg';
-      });
-    },
-    should_throw: true,
-  },
-  {
-    title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLImageElement without setting crossorigin',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.src = CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)';
-      });
-    },
-    should_throw: true,
-  },
-  {
-    title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLImageElement with crossorigin="anonymous"',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.crossOrigin = 'anonymous';
-        image.src = CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)';
-      });
-    },
-    should_throw: false,
-  },
-  // SVGImageElement
-  {
-    title: 'Test creating a VideoFrame with a same-origin SVGImageElement',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = document.createElementNS('http://www.w3.org/2000/svg','image');
-        svg.appendChild(image);
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.setAttribute('href', SAMEORIGIN_BASE + '/webcodecs/four-colors.jpg');
-      });
-    },
-    should_throw: false,
-  },
-  {
-    title: 'Test creating a VideoFrame with a cross-origin SVGImageElement',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = document.createElementNS('http://www.w3.org/2000/svg','image');
-        svg.appendChild(image);
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg');
-      });
-    },
-    should_throw: true,
-  },
-  {
-    title: 'Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement without setting crossorigin',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = document.createElementNS('http://www.w3.org/2000/svg','image');
-        svg.appendChild(image);
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)');
-      });
-    },
-    should_throw: true,
-  },
-  {
-    title: 'Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement with crossorigin="anonymous"',
-    factory: () => {
-      return new Promise((resolve, reject) => {
-        const image = document.createElementNS('http://www.w3.org/2000/svg','image');
-        svg.appendChild(image);
-        image.onload = () => resolve(image);
-        image.onerror = reject;
-        image.crossOrigin = 'anonymous';
-        image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)');
-      });
-    },
-    should_throw: () => {
-      // SVGImageElement.crossOrigin is not standardized.
-      const image = document.createElementNS('http://www.w3.org/2000/svg','image');
-      return !('crossOrigin' in image);
-    },
-  },
-  // HTMLVideoElement
-  {
-    title: 'Test creating a VideoFrame with a same-origin HTMLVideoElement',
-    factory: () => {
-      return new Promise(async (resolve, reject) => {
-        const video = document.createElement('video');
-        on_frame_available(video, () => resolve(video));
-        video.onerror = reject;
-        video.src = SAMEORIGIN_BASE + await getVideoFilename();
-      });
-    },
-    should_throw: false,
-  },
-  {
-    title: 'Test creating a VideoFrame with a cross-origin HTMLVideoElement',
-    factory: () => {
-      return new Promise(async (resolve, reject) => {
-        const video = document.createElement('video');
-        on_frame_available(video, () => resolve(video));
-        video.onerror = reject;
-        video.src = CROSSORIGIN_BASE + await getVideoFilename();
-      });
-    },
-    should_throw: true,
-  },
-  {
-    title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement without setting crossorigin',
-    factory: () => {
-      return new Promise(async (resolve, reject) => {
-        const video = document.createElement('video');
-        on_frame_available(video, () => resolve(video));
-        video.onerror = reject;
-        video.src = CROSSORIGIN_BASE + await getVideoFilename() + '?pipe=header(Access-Control-Allow-Origin,*)';
-      });
-    },
-    should_throw: true,
-  },
-  {
-    title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement with crossorigin="anonymous"',
-    factory: () => {
-      return new Promise(async (resolve, reject) => {
-        const video = document.createElement('video');
-        on_frame_available(video, () => resolve(video));
-        video.onerror = reject;
-        video.crossOrigin = 'anonymous';
-        video.src = CROSSORIGIN_BASE + await getVideoFilename() +'?pipe=header(Access-Control-Allow-Origin,*)';
-      });
-    },
-    should_throw: false,
-  },
-];
-
-TESTS.forEach(test => run_test(test));
-
-function run_test(test) {
-  promise_test(async t => {
-    const source = await test.factory();
-    if (test.should_throw) {
-      assert_throws_dom('SecurityError', () => { create_frame(source); });
-    } else {
-      create_frame(source);
+    async function getVideoFilename() {
+      const videoConfiguration = {
+        type: 'file',
+        video: {
+          contentType: 'video/mp4; codecs=avc1',
+          width: 640,
+          height: 480,
+          bitrate: 800,
+          framerate: 30
+        }
+      };
+      const result = await navigator.mediaCapabilities.decodingInfo(videoConfiguration);
+      if (result.supported)
+        return '/webcodecs/h264.mp4';
+      return '/webcodecs/av1.mp4';
     }
-  }, test.title);
-}
 
-function create_frame(img) {
-  let frame = new VideoFrame(img, {timestamp: 0});
-  frame.close();
-}
+    const TESTS = [
+      // HTMLImageElement
+      {
+        title: 'Test creating a VideoFrame with a same-origin HTMLImageElement',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.src = SAMEORIGIN_BASE + '/webcodecs/four-colors.jpg';
+          });
+        },
+        should_throw: false,
+      },
+      {
+        title: 'Test creating a VideoFrame with a cross-origin HTMLImageElement',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.src = CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg';
+          });
+        },
+        should_throw: true,
+      },
+      {
+        title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLImageElement without setting crossorigin',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.src = CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)';
+          });
+        },
+        should_throw: true,
+      },
+      {
+        title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLImageElement with crossorigin="anonymous"',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.crossOrigin = 'anonymous';
+            image.src = CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)';
+          });
+        },
+        should_throw: false,
+      },
+      // SVGImageElement
+      {
+        title: 'Test creating a VideoFrame with a same-origin SVGImageElement',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+            svg.appendChild(image);
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.setAttribute('href', SAMEORIGIN_BASE + '/webcodecs/four-colors.jpg');
+          });
+        },
+        should_throw: false,
+      },
+      {
+        title: 'Test creating a VideoFrame with a cross-origin SVGImageElement',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+            svg.appendChild(image);
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg');
+          });
+        },
+        should_throw: true,
+      },
+      {
+        title: 'Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement without setting crossorigin',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+            svg.appendChild(image);
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)');
+          });
+        },
+        should_throw: true,
+      },
+      {
+        title: 'Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement with crossorigin="anonymous"',
+        factory: () => {
+          return new Promise((resolve, reject) => {
+            const image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+            svg.appendChild(image);
+            image.onload = () => resolve(image);
+            image.onerror = reject;
+            image.crossOrigin = 'anonymous';
+            image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)');
+          });
+        },
+        should_throw: false,
+      },
+      // HTMLVideoElement
+      {
+        title: 'Test creating a VideoFrame with a same-origin HTMLVideoElement',
+        factory: () => {
+          return new Promise(async (resolve, reject) => {
+            const video = document.createElement('video');
+            on_frame_available(video, () => resolve(video));
+            video.onerror = reject;
+            video.src = SAMEORIGIN_BASE + await getVideoFilename();
+          });
+        },
+        should_throw: false,
+      },
+      {
+        title: 'Test creating a VideoFrame with a cross-origin HTMLVideoElement',
+        factory: () => {
+          return new Promise(async (resolve, reject) => {
+            const video = document.createElement('video');
+            on_frame_available(video, () => resolve(video));
+            video.onerror = reject;
+            video.src = CROSSORIGIN_BASE + await getVideoFilename();
+          });
+        },
+        should_throw: true,
+      },
+      {
+        title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement without setting crossorigin',
+        factory: () => {
+          return new Promise(async (resolve, reject) => {
+            const video = document.createElement('video');
+            on_frame_available(video, () => resolve(video));
+            video.onerror = reject;
+            video.src = CROSSORIGIN_BASE + await getVideoFilename() + '?pipe=header(Access-Control-Allow-Origin,*)';
+          });
+        },
+        should_throw: true,
+      },
+      {
+        title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement with crossorigin="anonymous"',
+        factory: () => {
+          return new Promise(async (resolve, reject) => {
+            const video = document.createElement('video');
+            on_frame_available(video, () => resolve(video));
+            video.onerror = reject;
+            video.crossOrigin = 'anonymous';
+            video.src = CROSSORIGIN_BASE + await getVideoFilename() + '?pipe=header(Access-Control-Allow-Origin,*)';
+          });
+        },
+        should_throw: false,
+      },
+    ];
 
-function on_frame_available(video, callback) {
-  if ('requestVideoFrameCallback' in video)
-    video.requestVideoFrameCallback(callback);
-  else
-    video.onloadeddata = callback;
-}
+    TESTS.forEach(test => run_test(test));
 
-</script>
+    function run_test(test) {
+      promise_test(async t => {
+        const source = await test.factory();
+        if (test.should_throw) {
+          assert_throws_dom('SecurityError', () => { create_frame(source); });
+        } else {
+          create_frame(source);
+        }
+      }, test.title);
+    }
+
+    function create_frame(img) {
+      let frame = new VideoFrame(img, { timestamp: 0 });
+      frame.close();
+    }
+
+    function on_frame_available(video, callback) {
+      if ('requestVideoFrameCallback' in video)
+        video.requestVideoFrameCallback(callback);
+      else
+        video.onloadeddata = callback;
+    }
+
+  </script>
 </body>
+
 </html>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -344,14 +344,6 @@ bool HTMLImageElement::hasLazyLoadableAttributeValue(StringView attributeValue)
     return equalLettersIgnoringASCIICase(attributeValue, "lazy"_s);
 }
 
-enum CrossOriginState { NotSet, UseCredentials, Anonymous };
-static CrossOriginState parseCrossoriginState(const AtomString& crossoriginValue)
-{
-    if (crossoriginValue.isNull())
-        return NotSet;
-    return equalLettersIgnoringASCIICase(crossoriginValue, "use-credentials"_s) ? UseCredentials : Anonymous;
-}
-
 void HTMLImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
@@ -394,7 +386,7 @@ void HTMLImageElement::attributeChanged(const QualifiedName& name, const AtomStr
         }
         break;
     case AttributeNames::crossoriginAttr:
-        if (parseCrossoriginState(oldValue) != parseCrossoriginState(newValue))
+        if (parseCORSSettingsAttribute(oldValue) != parseCORSSettingsAttribute(newValue))
             m_imageLoader->updateFromElementIgnoringPreviousError(RelevantMutation::Yes);
         break;
     case AttributeNames::nameAttr: {

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -25,6 +25,7 @@
 #include "SVGImageElement.h"
 
 #include "CSSPropertyNames.h"
+#include "HTMLParserIdioms.h"
 #include "LegacyRenderSVGImage.h"
 #include "NodeName.h"
 #include "RenderImageResource.h"
@@ -104,6 +105,10 @@ void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomStri
         break;
     case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        break;
+    case AttributeNames::crossoriginAttr:
+        if (parseCORSSettingsAttribute(oldValue) != parseCORSSettingsAttribute(newValue))
+            m_imageLoader.updateFromElementIgnoringPreviousError(RelevantMutation::Yes);
         break;
     default:
         break;
@@ -192,6 +197,16 @@ Node::InsertedIntoAncestorResult SVGImageElement::insertedIntoAncestor(Insertion
 const AtomString& SVGImageElement::imageSourceURL() const
 {
     return getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr);
+}
+
+void SVGImageElement::setCrossOrigin(const AtomString& value)
+{
+    setAttributeWithoutSynchronization(HTMLNames::crossoriginAttr, value);
+}
+
+String SVGImageElement::crossOrigin() const
+{
+    return parseCORSSettingsAttribute(attributeWithoutSynchronization(HTMLNames::crossoriginAttr));
 }
 
 void SVGImageElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -42,6 +42,9 @@ public:
     const SVGLengthValue& height() const { return m_height->currentValue(); }
     const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
 
+    void setCrossOrigin(const AtomString&);
+    String crossOrigin() const;
+
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }
     SVGAnimatedLength& widthAnimated() { return m_width; }

--- a/Source/WebCore/svg/SVGImageElement.idl
+++ b/Source/WebCore/svg/SVGImageElement.idl
@@ -32,6 +32,7 @@
     readonly attribute SVGAnimatedLength width;
     readonly attribute SVGAnimatedLength height;
     readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;
+    attribute [AtomString] DOMString? crossOrigin;
 };
 
 SVGImageElement includes SVGURIReference;


### PR DESCRIPTION
#### 504cb3567c094a4118abbe6812443cdd431fb374
<pre>
Support &lt;svg:image crossorigin&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=260724">https://bugs.webkit.org/show_bug.cgi?id=260724</a>
rdar://114462749

Reviewed by Youenn Fablet.

Add support for the crossorigin attribute to SVGImageElement in a
manner analogous to HTMLImageElement.

Also remove a duplicate parser for the crossorigin attribute in
HTMLImageElement.

* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::attributeChanged):
(): Deleted.
(WebCore::parseCrossoriginState): Deleted.
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::attributeChanged):
(WebCore::SVGImageElement::setCrossOrigin):
(WebCore::SVGImageElement::crossOrigin const):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGImageElement.idl:

Canonical link: <a href="https://commits.webkit.org/267349@main">https://commits.webkit.org/267349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c628a28904c290b790f9ddec2a14077658ba630

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17651 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18819 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21559 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18214 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13134 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3914 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->