### PR TITLE
python autoinstaller is broken with python 3.12

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -53,12 +53,17 @@ version = Version(0, 16, 3)
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):
     AutoInstall.register(Package('mock', Version(4)))
-    AutoInstall.register(Package('setuptools', Version(56, 0, 0)))
 else:
     AutoInstall.register(Package('mock', Version(3, 0, 5)))
-    AutoInstall.register(Package('setuptools', Version(44, 1, 1)))
     if platform.system() == 'Windows':
         AutoInstall.register(Package('win_inet_pton', Version(1, 1, 0), pypi_name='win-inet-pton'))
+
+if sys.version_info >= (3, 8):
+    AutoInstall.register(Package('setuptools', Version(68, 1, 2)))
+elif sys.version_info >= (3, 0):
+    AutoInstall.register(Package('setuptools', Version(56, 0, 0)))
+else:
+    AutoInstall.register(Package('setuptools', Version(44, 1, 1)))
 
 if sys.version_info >= (3, 6):
     AutoInstall.register(Package('certifi', Version(2022, 12, 7)))
@@ -77,12 +82,22 @@ else:
     AutoInstall.register(Package('packaging', Version(20, 4)))
 
 AutoInstall.register(Package('pyparsing', Version(2, 4, 7)))
-AutoInstall.register(Package('requests', Version(2, 24)))
+
+if sys.version_info >= (3, 12):
+    AutoInstall.register(Package('requests', Version(2, 31, 0)))
+else:
+    AutoInstall.register(Package('requests', Version(2, 24)))
+
 AutoInstall.register(Package('setuptools_scm', Version(5, 0, 2), pypi_name='setuptools-scm'))
 AutoInstall.register(Package('socks', Version(1, 7, 1), pypi_name='PySocks'))
 AutoInstall.register(Package('six', Version(1, 15, 0)))
 AutoInstall.register(Package('tblib', Version(1, 7, 0)))
-AutoInstall.register(Package('urllib3', Version(1, 25, 10)))
+
+if sys.version_info >= (3, 12):
+    AutoInstall.register(Package('urllib3', Version(2, 0, 4)))
+else:
+    AutoInstall.register(Package('urllib3', Version(1, 25, 10)))
+
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))
 AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('cffi', Version(1, 15, 1)))


### PR DESCRIPTION
#### cb4faa2a3ee38601f41c1d60fcac002a83cec4ff
<pre>
python autoinstaller is broken with python 3.12
<a href="https://bugs.webkit.org/show_bug.cgi?id=260726">https://bugs.webkit.org/show_bug.cgi?id=260726</a>

Reviewed by Jonathan Bedard.

Currently git-webkit is broken with python 3.12 due to various problems
with dependencies that are already fixed in newer upstream versions. So,
update a few things.

Unfortunately, the newer library versions are incompatible with other
Python versions, so this means more conditional versions.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:

Canonical link: <a href="https://commits.webkit.org/267415@main">https://commits.webkit.org/267415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6df9e0c671848bfb0e043ac3de6ed247c102a069

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18301 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16985 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19079 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/16645 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14972 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19448 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15734 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/16403 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14934 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->