### PR TITLE
Sync 'Track' and 'WebVTT' IDL files with Web-Spec

### DIFF
--- a/Source/WebCore/html/track/AudioTrack.idl
+++ b/Source/WebCore/html/track/AudioTrack.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/multipage/media.html#audiotrack
+
 [
     Conditional=VIDEO,
     ExportMacro=WEBCORE_EXPORT,
@@ -33,7 +35,7 @@
     [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString kind;
     readonly attribute DOMString label;
     [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString language;
-    [EnabledBySetting=TrackConfigurationEnabled] readonly attribute AudioTrackConfiguration configuration;
-
     attribute boolean enabled;
+
+    [EnabledBySetting=TrackConfigurationEnabled] readonly attribute AudioTrackConfiguration configuration;
 };

--- a/Source/WebCore/html/track/AudioTrackList.idl
+++ b/Source/WebCore/html/track/AudioTrackList.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/multipage/media.html#audiotracklist
+
 [
     ActiveDOMObject,
     Conditional=VIDEO,
@@ -31,8 +33,10 @@
     Exposed=Window
 ] interface AudioTrackList : EventTarget {
     readonly attribute unsigned long length;
+
+    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
     getter AudioTrack item(unsigned long index);
-    AudioTrack getTrackById([AtomString] DOMString id);
+    AudioTrack? getTrackById([AtomString] DOMString id);
 
     attribute EventHandler onchange;
     attribute EventHandler onaddtrack;

--- a/Source/WebCore/html/track/DataCue.idl
+++ b/Source/WebCore/html/track/DataCue.idl
@@ -24,11 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://wicg.github.io/datacue/#datacue-interface
+
 [
     Conditional=VIDEO,
     Exposed=Window
 ] interface DataCue : TextTrackCue {
     [CallWith=CurrentDocument] constructor(unrestricted double startTime, unrestricted double endTime, ArrayBuffer data);
+    // FIXME: Remove 'unrestricted' from 'startTime' to align with the specification: See: https://bugs.webkit.org/show_bug.cgi?id=260764
     [CallWith=CurrentDocument] constructor(unrestricted double startTime, unrestricted double endTime, any value, optional DOMString type);
 
     attribute ArrayBuffer data;

--- a/Source/WebCore/html/track/TextTrack.idl
+++ b/Source/WebCore/html/track/TextTrack.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/#texttrack
+
 enum TextTrackMode { "disabled", "hidden", "showing" };
 enum TextTrackKind { "subtitles", "captions", "descriptions", "chapters", "metadata", "forced" };
 
@@ -35,10 +37,11 @@ enum TextTrackKind { "subtitles", "captions", "descriptions", "chapters", "metad
     SkipVTableValidation,
     Exposed=Window
 ] interface TextTrack : EventTarget {
-    readonly attribute DOMString id;
     [ImplementedAs=kindForBindings] attribute TextTrackKind kind;
     readonly attribute DOMString label;
     [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString language;
+
+    readonly attribute DOMString id;
     readonly attribute DOMString inBandMetadataTrackDispatchType;
 
     attribute TextTrackMode mode;
@@ -51,6 +54,7 @@ enum TextTrackKind { "subtitles", "captions", "descriptions", "chapters", "metad
 
     attribute EventHandler oncuechange;
 
+    // FIXME: Remove 'non-standard'. See: https://bugs.webkit.org/show_bug.cgi?id=260767 
     readonly attribute VTTRegionList regions;
     undefined addRegion(VTTRegion region);
     undefined removeRegion(VTTRegion region);

--- a/Source/WebCore/html/track/TextTrackCue.idl
+++ b/Source/WebCore/html/track/TextTrackCue.idl
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/#texttrackcue
+
 [
     Conditional=VIDEO,
     CustomIsReachable,
@@ -33,17 +35,18 @@
     LegacyFactoryFunctionEnabledBySetting=GenericCueAPIEnabled,
     Exposed=Window
 ] interface TextTrackCue : EventTarget {
-    [CallWith=CurrentDocument] constructor(double startTime, double endTime, DocumentFragment cueNode);
-
-    readonly attribute TextTrack track;
+    readonly attribute TextTrack? track;
 
     attribute [AtomString] DOMString id;
     attribute double startTime;
+    // FIXME: Add 'unrestricted' to 'endTime' to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260765
     attribute double endTime;
     attribute boolean pauseOnExit;
 
     attribute EventHandler onenter;
     attribute EventHandler onexit;
 
+    // FIXME: Add 'unrestricted' to 'endTime' to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260765
+    [CallWith=CurrentDocument] constructor(double startTime, double endTime, DocumentFragment cueNode);
     [EnabledBySetting=GenericCueAPIEnabled] DocumentFragment getCueAsHTML();
 };

--- a/Source/WebCore/html/track/TextTrackCueList.idl
+++ b/Source/WebCore/html/track/TextTrackCueList.idl
@@ -23,12 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/#texttrackcuelist
+
 [
     Conditional=VIDEO,
     Exposed=Window
 ] interface TextTrackCueList {
     readonly attribute unsigned long length;
+    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
     getter TextTrackCue item(unsigned long index);
-    TextTrackCue getCueById(DOMString id);
+    TextTrackCue? getCueById(DOMString id);
 };
 

--- a/Source/WebCore/html/track/TextTrackList.idl
+++ b/Source/WebCore/html/track/TextTrackList.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/#texttracklist
+
 [
     ActiveDOMObject,
     Conditional=VIDEO,
@@ -31,8 +33,9 @@
     Exposed=Window
 ] interface TextTrackList : EventTarget {
     readonly attribute unsigned long length;
+    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
     getter TextTrack item(unsigned long index);
-    TextTrack getTrackById([AtomString] DOMString id);
+    TextTrack? getTrackById([AtomString] DOMString id);
 
     attribute EventHandler onaddtrack;
     attribute EventHandler onchange;

--- a/Source/WebCore/html/track/TrackEvent.idl
+++ b/Source/WebCore/html/track/TrackEvent.idl
@@ -23,11 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/multipage/media.html#the-trackevent-interface
+
 [
     Conditional=VIDEO,
     Exposed=Window
 ] interface TrackEvent : Event {
-    constructor([AtomString] DOMString type, optional TrackEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional TrackEventInit eventInitDict = {});
 
     readonly attribute (VideoTrack or AudioTrack or TextTrack)? track;
 };

--- a/Source/WebCore/html/track/VTTCue.idl
+++ b/Source/WebCore/html/track/VTTCue.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://www.w3.org/TR/webvtt1/#the-vttcue-interface
+
 enum AutoKeyword { "auto" };
 typedef (double or AutoKeyword) LineAndPositionSetting;
 
@@ -40,6 +42,7 @@ enum AlignSetting { "start", "center", "end", "left", "right" };
 ] interface VTTCue : TextTrackCue {
     [CallWith=CurrentDocument] constructor(double startTime, double endTime, DOMString text);
 
+    attribute VTTRegion? region;
     attribute DirectionSetting vertical;
     attribute boolean snapToLines;
     attribute LineAndPositionSetting line;
@@ -50,6 +53,4 @@ enum AlignSetting { "start", "center", "end", "left", "right" };
     attribute AlignSetting align;
     attribute DOMString text;
     DocumentFragment getCueAsHTML();
-
-    attribute VTTRegion? region;
 };

--- a/Source/WebCore/html/track/VTTRegion.idl
+++ b/Source/WebCore/html/track/VTTRegion.idl
@@ -24,14 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://www.w3.org/TR/webvtt1/#the-vttregion-interface
+
+ // FIXME: Add 'enum' for 'ScrollSetting' to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260766
+
 [
     Conditional=VIDEO,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface VTTRegion {
     [CallWith=CurrentScriptExecutionContext] constructor();
-
-    readonly attribute TextTrack track;
 
     attribute DOMString id;
     attribute double width;
@@ -40,5 +42,7 @@
     attribute double regionAnchorY;
     attribute double viewportAnchorX;
     attribute double viewportAnchorY;
+    // FIXME: Use 'enum' 'ScrollSetting' for 'scroll'. See: https://bugs.webkit.org/show_bug.cgi?id=260766
     attribute [AtomString] DOMString scroll;
+    readonly attribute TextTrack track;
 };

--- a/Source/WebCore/html/track/VideoTrack.idl
+++ b/Source/WebCore/html/track/VideoTrack.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/#videotrack
+
 [
     Conditional=VIDEO,
     GenerateIsReachable,
@@ -32,7 +34,6 @@
     [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString kind;
     readonly attribute DOMString label;
     [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString language;
-
     attribute boolean selected;
 
     [EnabledBySetting=TrackConfigurationEnabled] readonly attribute VideoTrackConfiguration configuration;

--- a/Source/WebCore/html/track/VideoTrackList.idl
+++ b/Source/WebCore/html/track/VideoTrackList.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/#videotracklist
+
 [
     ActiveDOMObject,
     Conditional=VIDEO,
@@ -31,8 +33,9 @@
     Exposed=Window
 ] interface VideoTrackList : EventTarget {
     readonly attribute unsigned long length;
+    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
     getter VideoTrack item(unsigned long index);
-    VideoTrack getTrackById([AtomString] DOMString id);
+    VideoTrack? getTrackById([AtomString] DOMString id);
     readonly attribute long selectedIndex;
 
     attribute EventHandler onchange;


### PR DESCRIPTION
#### 08c40bd4fc5a5aef8bc5e2a3c8f9989007e575e1
<pre>
Sync &apos;Track&apos; and &apos;WebVTT&apos; IDL files with Web-Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=260734">https://bugs.webkit.org/show_bug.cgi?id=260734</a>

Reviewed by Eric Carlson.

This patch is to add &apos;interface&apos; web-spec links to relevant &apos;track&apos; and &apos;VTT&apos; files
and do minor sync-up (i.e., adding missing ?) and add &apos;FIXME&apos; where applicable for future work.

* Source/WebCore/html/track/AudioTrack.idl:
* Source/WebCore/html/track/AudioTrackList.idl:
* Source/WebCore/html/track/DataCue.idl:
* Source/WebCore/html/track/TextTrack.idl:
* Source/WebCore/html/track/TextTrackCue.idl:
* Source/WebCore/html/track/TextTrackCueList.idl:
* Source/WebCore/html/track/TextTrackList.idl:
* Source/WebCore/html/track/TrackEvent.idl:
* Source/WebCore/html/track/VideoTrack.idl:
* Source/WebCore/html/track/VideoTrackList.idl:
* Source/WebCore/html/track/VTTCue.idl:
* Source/WebCore/html/track/VTTRegion.idl:

Canonical link: <a href="https://commits.webkit.org/267323@main">https://commits.webkit.org/267323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/855d6982f3159250949ddb36f86e5606be90d816

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18824 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21562 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18222 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13136 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14722 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3895 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->