### PR TITLE
Implement the Cookie Store API get/set/delete functions for Service Workers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL CookieListItem - cookieStore.set defaults with positional name and value promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set defaults with name and value in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with domain set to the current hostname promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with path set to the current directory promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with sameSite set to strict promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with sameSite set to lax promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL CookieListItem - cookieStore.set with sameSite set to none promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
@@ -1,26 +1,16 @@
 
-FAIL cookieStore.delete with positional name promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with name in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete domain starts with "." promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with domain that is not equal current host promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with domain set to the current hostname promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with domain set to a subdomain of the current hostname promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with path set to the current directory promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with path set to subdirectory of the current directory promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with missing / at the end of path promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with path that does not start with / promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with get result promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.delete with positional name
+PASS cookieStore.delete with name in options
+PASS cookieStore.delete domain starts with "."
+PASS cookieStore.delete with domain that is not equal current host
+PASS cookieStore.delete with domain set to the current hostname
+PASS cookieStore.delete with domain set to a subdomain of the current hostname
+PASS cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
+PASS cookieStore.delete with path set to the current directory
+PASS cookieStore.delete with path set to subdirectory of the current directory
+PASS cookieStore.delete with missing / at the end of path
+PASS cookieStore.delete with path that does not start with /
+PASS cookieStore.delete with get result
+FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.delete return type is Promise<void> promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.delete return type is Promise<void>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL cookieStore.getAll with no arguments promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with empty options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with positional name promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with name in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with name in both positional arguments and options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with absolute url in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with relative url in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with invalid url path in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.getAll with invalid url host in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.getAll with no arguments
+PASS cookieStore.getAll with empty options
+PASS cookieStore.getAll with positional name
+PASS cookieStore.getAll with name in options
+PASS cookieStore.getAll with name in both positional arguments and options
+PASS cookieStore.getAll with absolute url in options
+PASS cookieStore.getAll with relative url in options
+FAIL cookieStore.getAll with invalid url path in options assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.getAll with invalid url host in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.getAll returns multiple cookies written by cookieStore.set promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.getAll returns multiple cookies written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.getAll returns the cookie written by cookieStore.set promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.getAll returns the cookie written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.serviceworker-expected.txt
@@ -1,15 +1,11 @@
 
-FAIL cookieStore.get with no arguments returns TypeError promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with empty options returns TypeError promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with positional name promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with name in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with name in both positional arguments and options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with absolute url in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with relative url in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.get with invalid url path in options promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.get with invalid url host in options promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL cookieStore.get with no arguments returns TypeError assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.get with empty options returns TypeError assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.get with positional name
+PASS cookieStore.get with name in options
+PASS cookieStore.get with name in both positional arguments and options
+PASS cookieStore.get with absolute url in options
+PASS cookieStore.get with relative url in options
+FAIL cookieStore.get with invalid url path in options assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.get with invalid url host in options assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.get returns null for a cookie deleted by cookieStore.delete promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.get returns null for a cookie deleted by cookieStore.delete
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'frameCookie.value')"
-FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: The domain must be a part of the current host"
+FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.value')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any.serviceworker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.get returns the cookie written by cookieStore.set promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.get returns the cookie written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any.serviceworker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Set three simple origin session cookies sequentially and ensure they all end up in the cookie jar in order. promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL Set three simple origin session cookies in undefined order using Promise.all and ensure they all end up in the cookie jar in any order.  promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS Set three simple origin session cookies sequentially and ensure they all end up in the cookie jar in order.
+PASS Set three simple origin session cookies in undefined order using Promise.all and ensure they all end up in the cookie jar in any order.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL cookieStore in non-sandboxed iframe should not throw assert_equals: cookieStore ${apiCall} should not throw expected "no exception" but got "TypeError"
+PASS cookieStore in non-sandboxed iframe should not throw
 PASS cookieStore in sandboxed iframe should throw SecurityError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -1,36 +1,24 @@
 
-FAIL cookieStore.set with positional name and value promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with name and value in options promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with empty name and an '=' in value promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with normal name and an '=' in value promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with expires set to a future Date promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with expires set to a past Date promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with expires set to a future timestamp promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with expires set to a past timestamp promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set domain starts with "." promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with domain that is not equal current host promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with domain set to the current hostname promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with domain set to a subdomain of the current hostname promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with domain set to a non-domain-matching suffix of the current hostname promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set default domain is null and differs from current hostname promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with path set to the current directory promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with path set to a subdirectory of the current directory promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set default path is / promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set adds / to path that does not end with / promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with path that does not start with / promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with get result promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set checks if the path is too long promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set checks if the domain is too long promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+PASS cookieStore.set with positional name and value
+PASS cookieStore.set with name and value in options
+PASS cookieStore.set with empty name and an '=' in value
+PASS cookieStore.set with normal name and an '=' in value
+PASS cookieStore.set with expires set to a future Date
+PASS cookieStore.set with expires set to a past Date
+PASS cookieStore.set with expires set to a future timestamp
+PASS cookieStore.set with expires set to a past timestamp
+PASS cookieStore.set domain starts with "."
+PASS cookieStore.set with domain that is not equal current host
+PASS cookieStore.set with domain set to the current hostname
+PASS cookieStore.set with domain set to a subdomain of the current hostname
+PASS cookieStore.set with domain set to a non-domain-matching suffix of the current hostname
+FAIL cookieStore.set default domain is null and differs from current hostname assert_equals: expected 2 but got 1
+PASS cookieStore.set with path set to the current directory
+PASS cookieStore.set with path set to a subdirectory of the current directory
+PASS cookieStore.set default path is /
+PASS cookieStore.set adds / to path that does not end with /
+PASS cookieStore.set with path that does not start with /
+PASS cookieStore.set with get result
+PASS cookieStore.set checks if the path is too long
+PASS cookieStore.set checks if the domain is too long
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
@@ -1,13 +1,11 @@
 
-FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set of expired __Secure- cookie name on secure origin promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set of expired __Host- cookie name on secure origin promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.delete with __Host- name on secure origin promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with __Host- prefix and a domain option promise_rejects_js: function "function() { throw e }" threw object "SecurityError: The operation is insecure." ("SecurityError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL cookieStore.set with malformed name. assert_equals: cookieStore thrown an incorrect exception - expected "TypeError" but got "SecurityError"
+FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set of expired __Secure- cookie name on secure origin
+PASS cookieStore.delete with __Secure- name on secure origin
+FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set of expired __Host- cookie name on secure origin
+PASS cookieStore.delete with __Host- name on secure origin
+FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`__Host-cookie-name`)).value')"
+PASS cookieStore.set with malformed name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any.serviceworker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL BOM not stripped from name promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
-FAIL BOM not stripped from value promise_test: Unhandled rejection with value: object "SecurityError: The operation is insecure."
+FAIL BOM not stripped from name promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.name')"
+FAIL BOM not stripped from value assert_equals: expected "﻿value" but got "ï»¿value"
 

--- a/Source/WebCore/Modules/cookie-store/CookieInit.h
+++ b/Source/WebCore/Modules/cookie-store/CookieInit.h
@@ -33,6 +33,9 @@
 namespace WebCore {
 
 struct CookieInit {
+    CookieInit isolatedCopy() const & { return { name.isolatedCopy(), value.isolatedCopy(), expires, domain.isolatedCopy(), path.isolatedCopy(), sameSite }; }
+    CookieInit isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(value).isolatedCopy(), expires, WTFMove(domain).isolatedCopy(), WTFMove(path).isolatedCopy(), sameSite }; }
+
     String name;
     String value;
     std::optional<DOMHighResTimeStamp> expires { };

--- a/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.h
@@ -30,6 +30,9 @@
 namespace WebCore {
 
 struct CookieStoreGetOptions {
+    CookieStoreGetOptions isolatedCopy() const & { return { name.isolatedCopy(), url.isolatedCopy() }; }
+    CookieStoreGetOptions isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(url).isolatedCopy() }; }
+
     String name;
     String url;
 };

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -35,6 +35,7 @@
 #include "FrameLoader.h"
 #include "HTTPCookieAcceptPolicy.h"
 #include "LocalFrame.h"
+#include "LocalFrameLoaderClient.h"
 #include "NetworkStorageSession.h"
 #include "NetworkingContext.h"
 #include "Page.h"
@@ -65,6 +66,12 @@ IncludeSecureCookies CookieJar::shouldIncludeSecureCookies(const Document& docum
 
 SameSiteInfo CookieJar::sameSiteInfo(const Document& document, IsForDOMCookieAccess isAccessForDOM)
 {
+    RefPtr frame = document.frame();
+    if (frame && frame->loader().client().isRemoteWorkerFrameLoaderClient()) {
+        auto domain = RegistrableDomain(document.securityOrigin().data());
+        return { domain.matches(document.firstPartyForCookies()), false, true };
+    }
+
     if (auto* loader = document.loader())
         return SameSiteInfo::create(loader->request(), isAccessForDOM);
     return { };

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -98,7 +98,7 @@ struct Cookie {
 
     SameSitePolicy sameSite { SameSitePolicy::None };
 
-    Cookie(String&& name, String&& value, String&& domain, String&& path, double created, std::optional<double> expires, bool httpOnly, bool secure, bool session, String&& comment, URL&& commentURL, Vector<uint16_t>&& ports, SameSitePolicy sameSite)
+    Cookie(String&& name, String&& value, String&& domain, String&& path, double created, std::optional<double> expires, bool httpOnly, bool secure, bool session, String&& comment, URL&& commentURL, Vector<uint16_t> ports, SameSitePolicy sameSite)
         : name(WTFMove(name))
         , value(WTFMove(value))
         , domain(WTFMove(domain))
@@ -114,6 +114,9 @@ struct Cookie {
         , sameSite(sameSite)
     {
     }
+
+    Cookie isolatedCopy() const & { return { name.isolatedCopy(), value.isolatedCopy(), domain.isolatedCopy(), path.isolatedCopy(), created, expires, httpOnly, secure, session, comment.isolatedCopy(), commentURL.isolatedCopy(), ports, sameSite }; }
+    Cookie isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(value).isolatedCopy(), WTFMove(domain).isolatedCopy(), WTFMove(path).isolatedCopy(), created, expires, httpOnly, secure, session, WTFMove(comment).isolatedCopy(), WTFMove(commentURL).isolatedCopy(), WTFMove(ports), sameSite }; }
 };
 
 struct CookieHash {

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -237,9 +237,8 @@ void ServiceWorkerGlobalScope::addConsoleMessage(MessageSource source, MessageLe
 
 CookieStore& ServiceWorkerGlobalScope::cookieStore()
 {
-    // FIXME: Should not pass nullptr. Should instead add service worker supported context.
     if (!m_cookieStore)
-        m_cookieStore = CookieStore::create(nullptr);
+        m_cookieStore = CookieStore::create(this);
     return *m_cookieStore;
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -77,6 +77,7 @@
 #include "WebsiteDataStoreParameters.h"
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/Cookie.h>
+#include <WebCore/CookieJar.h>
 #include <WebCore/CookieStoreGetOptions.h>
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/DocumentStorageAccess.h>
@@ -848,7 +849,7 @@ void NetworkConnectionToWebProcess::deleteCookie(const URL& url, const String& c
     networkStorageSession->deleteCookie(url, cookieName, WTFMove(completionHandler));
 }
 
-void NetworkConnectionToWebProcess::cookiesForDOMAsync(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, FrameIdentifier frameID, PageIdentifier pageID, IncludeSecureCookies includeSecureCookies, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::CookieStoreGetOptions&& options, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&& completionHandler)
+void NetworkConnectionToWebProcess::cookiesForDOMAsync(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, IncludeSecureCookies includeSecureCookies, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::CookieStoreGetOptions&& options, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&& completionHandler)
 {
     NETWORK_PROCESS_MESSAGE_CHECK_COMPLETION(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty), completionHandler(std::nullopt));
 
@@ -865,7 +866,7 @@ void NetworkConnectionToWebProcess::cookiesForDOMAsync(const URL& firstParty, co
     completionHandler(WTFMove(result));
 }
 
-void NetworkConnectionToWebProcess::setCookieFromDOMAsync(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, WebCore::FrameIdentifier frameID, PageIdentifier pageID, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::Cookie&& cookie, CompletionHandler<void(bool)>&& completionHandler)
+void NetworkConnectionToWebProcess::setCookieFromDOMAsync(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::Cookie&& cookie, CompletionHandler<void(bool)>&& completionHandler)
 {
     NETWORK_PROCESS_MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty));
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -261,8 +261,8 @@ private:
     void setRawCookie(const WebCore::Cookie&);
     void deleteCookie(const URL&, const String& cookieName, CompletionHandler<void()>&&);
 
-    void cookiesForDOMAsync(const URL&, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::CookieStoreGetOptions&&, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&&);
-    void setCookieFromDOMAsync(const URL&, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::Cookie&&, CompletionHandler<void(bool)>&&);
+    void cookiesForDOMAsync(const URL&, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::CookieStoreGetOptions&&, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&&);
+    void setCookieFromDOMAsync(const URL&, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::Cookie&&, CompletionHandler<void(bool)>&&);
 
     void registerInternalFileBlobURL(const URL&, const String& path, const String& replacementPath, SandboxExtension::Handle&&, const String& contentType);
     void registerInternalBlobURL(const URL&, Vector<WebCore::BlobPart>&&, const String& contentType);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -45,9 +45,9 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     DeleteCookie(URL url, String cookieName) -> ()
     DomCookiesForHost(URL host) -> (Vector<WebCore::Cookie> cookies) Synchronous
 
-    CookiesForDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::CookieStoreGetOptions options) -> (std::optional<Vector<WebCore::Cookie>> cookies)
+    CookiesForDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::CookieStoreGetOptions options) -> (std::optional<Vector<WebCore::Cookie>> cookies)
 
-    SetCookieFromDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::Cookie cookie) -> (bool setSuccessfully)
+    SetCookieFromDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::Cookie cookie) -> (bool setSuccessfully)
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     SubscribeToCookieChangeNotifications(String host) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -42,6 +42,7 @@
 #include "WebBroadcastChannelRegistry.h"
 #include "WebCacheStorageProvider.h"
 #include "WebCompiledContentRuleListData.h"
+#include "WebCookieJar.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebDatabaseProvider.h"
 #include "WebDocumentLoader.h"
@@ -163,6 +164,7 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
         pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();
         pageConfiguration.userContentProvider = m_userContentController;
+        pageConfiguration.cookieJar = WebCookieJar::create();
 #if ENABLE(WEB_RTC)
         pageConfiguration.webRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif


### PR DESCRIPTION
#### 2ecb71d1b38b5f41d1c2cfd7baf45972e01c76d7
<pre>
Implement the Cookie Store API get/set/delete functions for Service Workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=260737">https://bugs.webkit.org/show_bug.cgi?id=260737</a>

Reviewed by Chris Dumez.

The Cookie Store API should be supported for Service Workers. This patch
adds Service Worker support for the get/set/delete cookie functions.
The Cookie Store is now created using a ScriptExecutionContext rather
the CookieJar where needed.

Since get/set/delete are called through the CookieJar, and CookieJar is
a main thread object, we now have a CookieStore::MainThreadBridge which
is used to hop between the main thread and the service worker thread
when needed. This will also be used for cookie change notifications in
a future patch.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any.serviceworker-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieInit.h:
(WebCore::CookieInit::isolatedCopy const):
(WebCore::CookieInit::isolatedCopy):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::create):
(WebCore::CookieStore::MainThreadBridge::MainThreadBridge):
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):
(WebCore::CookieStore::MainThreadBridge::ensureOnContextThread):
(WebCore::CookieStore::MainThreadBridge::get):
(WebCore::CookieStore::MainThreadBridge::getAll):
(WebCore::CookieStore::MainThreadBridge::set):
(WebCore::CookieStore::create):
(WebCore::CookieStore::CookieStore):
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::set):
(WebCore::CookieStore::cookiesAdded):
(WebCore::CookieStore::cookiesDeleted):
(WebCore::CookieStore::stop):
(WebCore::CookieStore::eventListenersDidChange):
(WebCore::CookieStore::takePromise):
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.h:
(WebCore::CookieStoreGetOptions::isolatedCopy const):
(WebCore::CookieStoreGetOptions::isolatedCopy):
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::sameSiteInfo):
* Source/WebCore/platform/Cookie.h:
(WebCore::Cookie::Cookie):
(WebCore::Cookie::isolatedCopy const):
(WebCore::Cookie::isolatedCopy):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::cookieStore):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::cookiesForDOMAsync):
(WebKit::NetworkConnectionToWebProcess::setCookieFromDOMAsync):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::getCookiesAsync const):
(WebKit::WebCookieJar::setCookieAsync const):

Canonical link: <a href="https://commits.webkit.org/268055@main">https://commits.webkit.org/268055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfa34c879a09a5d7584b2a030a5e67d7662e392e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19192 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21233 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23335 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17144 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17046 "9 flakes 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21231 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14940 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16686 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4406 "layout-tests (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21050 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2278 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->