### PR TITLE
Sync 'audio', 'video' and 'media' element interfaces with WebIDL Spec

### DIFF
--- a/Source/WebCore/html/HTMLAudioElement.idl
+++ b/Source/WebCore/html/HTMLAudioElement.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/multipage/media.html#the-audio-element
+
 [
     Conditional=VIDEO,
     Exposed=Window,

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -23,6 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/multipage/media.html#media-elements
+
+ // FIXME: Add 'enum' for 'CanPlayTypeResult'. See: https://bugs.webkit.org/show_bug.cgi?id=260739
+
 typedef (
 #if defined(ENABLE_MEDIA_STREAM) && ENABLE_MEDIA_STREAM
     MediaStream or
@@ -41,7 +45,7 @@ typedef (
 ] interface HTMLMediaElement : HTMLElement {
 
     // error state
-    readonly attribute MediaError error;
+    readonly attribute MediaError? error;
 
     // network state
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
@@ -59,6 +63,7 @@ typedef (
     readonly attribute TimeRanges buffered;
     undefined load();
 
+    // FIXME: Use 'CanPlayTypeResult' enum for below. See: https://bugs.webkit.org/show_bug.cgi?id=260739
     DOMString canPlayType(DOMString type);
 
     // ready state
@@ -71,7 +76,10 @@ typedef (
     readonly attribute boolean seeking;
 
     // playback state
+    // FIXME: Remove 'unrestricted' from 'currentTime' below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260738
     [ImplementedAs=currentTimeForBindings] attribute unrestricted double currentTime;
+    // FIXME: Remove 'unrestricted' from 'fastSeek' below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260738
+    undefined fastSeek(unrestricted double time);
     readonly attribute unrestricted double duration;
     Date getStartDate();
     readonly attribute boolean paused;
@@ -84,7 +92,6 @@ typedef (
     [CEReactions=NotNeeded, Reflect] attribute boolean loop;
     Promise<undefined> play();
     undefined pause();
-    undefined fastSeek(unrestricted double time);
 
     // controls
     [CEReactions=NotNeeded] attribute boolean controls;
@@ -109,10 +116,11 @@ typedef (
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] attribute EventHandler onwaitingforkey;
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] Promise<undefined> setMediaKeys(MediaKeys? mediaKeys);
 
+    // tracks
     TextTrack addTextTrack([AtomString] DOMString kind, optional [AtomString] DOMString label = "", optional [AtomString] DOMString language = "");
-    [ImplementedAs=ensureAudioTracks] readonly attribute AudioTrackList audioTracks;
-    [ImplementedAs=ensureTextTracks] readonly attribute TextTrackList textTracks;
-    [ImplementedAs=ensureVideoTracks] readonly attribute VideoTrackList videoTracks;
+    [SameObject, ImplementedAs=ensureAudioTracks] readonly attribute AudioTrackList audioTracks;
+    [SameObject, ImplementedAs=ensureTextTracks] readonly attribute TextTrackList textTracks;
+    [SameObject, ImplementedAs=ensureVideoTracks] readonly attribute VideoTrackList videoTracks;
 
     [Reflect] attribute DOMString mediaGroup;
 

--- a/Source/WebCore/html/HTMLVideoElement.idl
+++ b/Source/WebCore/html/HTMLVideoElement.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+ // https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement
+
 [
     Conditional=VIDEO,
     ExportMacro=WEBCORE_EXPORT,
@@ -34,8 +36,9 @@
     readonly attribute unsigned long videoWidth;
     readonly attribute unsigned long videoHeight;
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString poster;
-
     [CEReactions=NotNeeded, Reflect] attribute boolean playsInline;
+
+    // Non-standard
     readonly attribute boolean webkitSupportsFullscreen;
     readonly attribute boolean webkitDisplayingFullscreen;
 


### PR DESCRIPTION
#### e504863ab9a6dc92fa4d25fd14fac58055af07d4
<pre>
Sync &apos;audio&apos;, &apos;video&apos; and &apos;media&apos; element interfaces with WebIDL Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=260740">https://bugs.webkit.org/show_bug.cgi?id=260740</a>

Reviewed by Eric Carlson and Chris Dumez.

This patch is to add &apos;interface&apos; web-spec links to relevant &apos;audio&apos; , &apos;media&apos;
and &apos;video&apos; files. Additionally do minor sync-up (i.e., adding missing ?) and
add &apos;FIXME&apos; where applicable for future work.

* Source/WebCore/html/HTMLAudioElement.idl:
* Source/WebCore/html/HTMLMediaElement.idl:
* Source/WebCore/html/HTMLVideoElement.idl:

Canonical link: <a href="https://commits.webkit.org/267320@main">https://commits.webkit.org/267320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e688e33de35d373fb925d0d18a18c658ff61ee1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16663 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18765 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15453 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14678 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3892 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19044 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->