### PR TITLE
Suppress HeapSnapshot logging in some JSC stress tests.

### DIFF
--- a/JSTests/stress/collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js
+++ b/JSTests/stress/collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js
@@ -1,4 +1,4 @@
-//@ runDefault("--maxPerThreadStackUsage=1572864", "--forceMiniVMMode=1", "--stealEmptyBlocksFromOtherAllocators=0", "--collectContinuously=1", "--watchdog=3000", "--watchdog-exception-ok")
+//@ runDefault("--maxPerThreadStackUsage=1572864", "--forceMiniVMMode=1", "--stealEmptyBlocksFromOtherAllocators=0", "--collectContinuously=1", "--watchdog=3000", "--watchdog-exception-ok", "--verboseHeapSnapshotLogging=0")
 // Reproducing the crash with this test is very hard. You should execute something like this.
 // while true; do for x in {0..4}; do DYLD_FRAMEWORK_PATH=$VM $VM/jsc --maxPerThreadStackUsage=1572864 --forceMiniVMMode=1 --stealEmptyBlocksFromOtherAllocators=0 --collectContinuously=1 collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js --watchdog=3000&; done; wait; sleep 0.1; done
 

--- a/JSTests/stress/heap-analyzer-taking-lock.js
+++ b/JSTests/stress/heap-analyzer-taking-lock.js
@@ -1,3 +1,5 @@
+//@ requireOptions("--verboseHeapSnapshotLogging=0")
+
 // Should not crash.
 let array = [];
 for (let i = 0; i < 10000; i++) {

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,8 +109,10 @@ void HeapSnapshotBuilder::analyzeEdge(JSCell* from, JSCell* to, RootMarkReason r
     Locker locker { m_buildingEdgeMutex };
 
     if (m_snapshotType == SnapshotType::GCDebuggingSnapshot && !from) {
-        if (rootMarkReason == RootMarkReason::None && m_snapshotType == SnapshotType::GCDebuggingSnapshot)
-            WTFLogAlways("Cell %p is a root but no root marking reason was supplied", to);
+        if (rootMarkReason == RootMarkReason::None && m_snapshotType == SnapshotType::GCDebuggingSnapshot) {
+            if (Options::verboseHeapSnapshotLogging())
+                WTFLogAlways("Cell %p is a root but no root marking reason was supplied", to);
+        }
 
         m_rootData.ensure(to, [] () -> RootData {
             return { };
@@ -499,8 +501,10 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
         else {
             auto fromLookup = allowedNodeIdentifiers.find(edge.from.cell);
             if (fromLookup == allowedNodeIdentifiers.end()) {
-                if (m_snapshotType == SnapshotType::GCDebuggingSnapshot)
-                    WTFLogAlways("Failed to find node for from-edge cell %p", edge.from.cell);
+                if (m_snapshotType == SnapshotType::GCDebuggingSnapshot) {
+                    if (Options::verboseHeapSnapshotLogging())
+                        WTFLogAlways("Failed to find node for from-edge cell %p", edge.from.cell);
+                }
                 return true;
             }
             edge.from.identifier = fromLookup->value;
@@ -511,8 +515,10 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
         else {
             auto toLookup = allowedNodeIdentifiers.find(edge.to.cell);
             if (toLookup == allowedNodeIdentifiers.end()) {
-                if (m_snapshotType == SnapshotType::GCDebuggingSnapshot)
-                    WTFLogAlways("Failed to find node for to-edge cell %p", edge.to.cell);
+                if (m_snapshotType == SnapshotType::GCDebuggingSnapshot) {
+                    if (Options::verboseHeapSnapshotLogging())
+                        WTFLogAlways("Failed to find node for to-edge cell %p", edge.to.cell);
+                }
                 return true;
             }
             edge.to.identifier = toLookup->value;
@@ -563,7 +569,8 @@ String HeapSnapshotBuilder::json(Function<bool (const HeapSnapshotNode&)> allowN
         for (auto it : m_rootData) {
             auto snapshotNode = snapshot->nodeForCell(it.key);
             if (!snapshotNode) {
-                WTFLogAlways("Failed to find snapshot node for cell %p", it.key);
+                if (Options::verboseHeapSnapshotLogging())
+                    WTFLogAlways("Failed to find snapshot node for cell %p", it.key);
                 continue;
             }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -197,6 +197,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, forceFencedBarrier, false, Normal, nullptr) \
     v(Bool, verboseVisitRace, false, Normal, nullptr) \
     v(Bool, optimizeParallelSlotVisitorsForStoppedMutator, false, Normal, nullptr) \
+    v(Bool, verboseHeapSnapshotLogging, true, Normal, nullptr) \
     v(Unsigned, largeHeapSize, 32 * 1024 * 1024, Normal, nullptr) \
     v(Unsigned, smallHeapSize, 1 * 1024 * 1024, Normal, nullptr) \
     v(Double, smallHeapRAMFraction, 0.25, Normal, nullptr) \


### PR DESCRIPTION
#### 12ec99a12155a439d026d768a68a4be3f5f61de2
<pre>
Suppress HeapSnapshot logging in some JSC stress tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260743">https://bugs.webkit.org/show_bug.cgi?id=260743</a>
rdar://114474559

Reviewed by Justin Michaud.

Specifically, heap-analyzer-taking-lock.js and collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js.
The logging is not needed for the tests, and the verbosity of the logging makes it hard to see real failures when running the JSC stress tests.

* JSTests/stress/collect-continuously-should-not-wake-concurrent-collector-after-prevent-collection-is-called.js:
* JSTests/stress/heap-analyzer-taking-lock.js:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::HeapSnapshotBuilder::analyzeEdge):
(JSC::HeapSnapshotBuilder::json):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/267306@main">https://commits.webkit.org/267306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/870b7de85cfa56a4f70a4aa5d8db6b13802104ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15238 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16670 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16881 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18771 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14704 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13988 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15113 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/18123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15476 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15460 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16442 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14685 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4092 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/3879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17608 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1993 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15283 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3885 "Passed tests") | 
<!--EWS-Status-Bubble-End-->