### PR TITLE
pointerevent_movementxy.html?mouse WPT is failing on safaridriver after 265730@main

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -263,7 +263,7 @@ private:
 
     // Platform-dependent implementations.
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-    void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime, int maxDistance);
+    void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime = 1_s, int maxDistance = 0);
     void resetClickCount();
     void platformSimulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInViewport, OptionSet<WebEventModifier>, const String& pointerType);
     static OptionSet<WebEventModifier> platformWebModifiersFromRaw(unsigned modifiers);


### PR DESCRIPTION
#### 7d047e3205feb6753e591c4e3887059bd0b11ed8
<pre>
pointerevent_movementxy.html?mouse WPT is failing on safaridriver after 265730@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=260633">https://bugs.webkit.org/show_bug.cgi?id=260633</a>
rdar://114350545

Reviewed by Aditya Keerthi.

The pointerevent_movementxy.html?mouse WPT was made to pass on WKTR in
265730@main, but this test continued to fail when run through the WPT +
safaridriver tooling.

It turns out that we&apos;re just never propagating the mousemove event
deltas before sending NSEvent instances in
WebAutomationSession::platformSimulateMouseInteraction. To fix this, we
make two changes:

1. Keep track of the previous mouse click by calling into
WebAutomationSession::updateClickCount().
2. Follow the precedent set by EventSenderProxy in WKTR and assign the
deltaX/Y fields of a CGEvent, finally initializing an NSEvent from it.

No new tests because we do not expect WebKit behavior to change.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:

Provide default values to the maxTime and maxDistance arguments in
WebAutomationSession::updateClickCount(). This matches the time and
distance heuristics used in EventSenderProxy::updateClickCountForButton.

* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):

Canonical link: <a href="https://commits.webkit.org/267367@main">https://commits.webkit.org/267367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2ea2eb9bfcb731d701adfaac4cd48642a4aadc6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15244 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18779 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14130 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21536 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14873 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18127 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13110 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14691 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3932 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->