### PR TITLE
REGRESSION (267279@main): [ macOS Debug ] ASSERTION FAILED: WebCore::MediaSource::completeSeek()::SeeksCallbackAggregator::SeeksCallbackAggregator

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2862,6 +2862,3 @@ webkit.org/b/260224 [ Ventura+ ] imported/w3c/web-platform-tests/css/css-transfo
 webkit.org/b/130490 media/video-remote-control-playpause.html [ Pass Timeout Crash ]
 
 webkit.org/b/260529 [ Ventura+ x86_64 ] animations/suspend-resume-animation-events.html [ Pass Failure ]
-
-webkit.org/b/260742 [ Monterey+ Debug ] fast/canvas/webgl/texImage2D-mse-flipY-false.html [ Crash ]
-webkit.org/b/260742 [ Monterey+ Debug ] fast/canvas/webgl/texImage2D-mse-flipY-true.html [ Crash ]

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -249,7 +249,7 @@ void MediaSource::completeSeek()
             , mediaSource(source)
             , completionHandler(WTFMove(completionHandler))
         {
-            ASSERT(completionHandler);
+            ASSERT(this->completionHandler);
         }
 
         ~SeeksCallbackAggregator()


### PR DESCRIPTION
#### f005b556a611f06b9b8c5832e24a6c33bcffb6b7
<pre>
REGRESSION (267279@main): [ macOS Debug ] ASSERTION FAILED: WebCore::MediaSource::completeSeek()::SeeksCallbackAggregator::SeeksCallbackAggregator
<a href="https://bugs.webkit.org/show_bug.cgi?id=260742">https://bugs.webkit.org/show_bug.cgi?id=260742</a>
rdar://114472398

Reviewed by Richard Robinson and Alan Baradlay.

Fix incorrect assertion.

Covered by tests.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::completeSeek):

Canonical link: <a href="https://commits.webkit.org/267314@main">https://commits.webkit.org/267314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8aa86a810cf218e9b49193bf9eeeca40ac5c412

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16697 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16905 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18799 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15137 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/18151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14704 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3887 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->