### PR TITLE
Add fine-grained invalidation support for selectors containing :slotted()

### DIFF
--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -45,6 +45,7 @@ static bool isSiblingOrSubject(MatchElement matchElement)
     case MatchElement::AnySibling:
     case MatchElement::HasSibling:
     case MatchElement::Host:
+    case MatchElement::HostChild:
         return true;
     case MatchElement::Parent:
     case MatchElement::Ancestor:
@@ -121,8 +122,7 @@ static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelect
         case CSSSelector::RelationType::ShadowPartDescendant:
             return MatchElement::Host;
         case CSSSelector::RelationType::ShadowSlotted:
-            // FIXME: Implement accurate invalidation.
-            return matchElement;
+            return MatchElement::HostChild;
         };
     }
     switch (relation) {
@@ -138,8 +138,7 @@ static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelect
     case CSSSelector::RelationType::ShadowPartDescendant:
         return MatchElement::Host;
     case CSSSelector::RelationType::ShadowSlotted:
-        // FIXME: Implement accurate invalidation.
-        return matchElement;
+        return MatchElement::HostChild;
     };
     ASSERT_NOT_REACHED();
     return matchElement;
@@ -182,6 +181,7 @@ MatchElement computeHasPseudoClassMatchElement(const CSSSelector& hasSelector)
     case MatchElement::HasSiblingDescendant:
     case MatchElement::HasNonSubjectOrScopeBreaking:
     case MatchElement::Host:
+    case MatchElement::HostChild:
         ASSERT_NOT_REACHED();
         break;
     }
@@ -224,7 +224,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             idsInRules.add(selector->value());
             if (matchElement == MatchElement::Parent || matchElement == MatchElement::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
-            else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling)
+            else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling || matchElement == MatchElement::HostChild)
                 selectorFeatures.ids.append({ selector, matchElement, isNegation });
         } else if (selector->match() == CSSSelector::Match::Class)
             selectorFeatures.classes.append({ selector, matchElement, isNegation });

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -52,9 +52,10 @@ enum class MatchElement : uint8_t {
     HasSibling,
     HasSiblingDescendant,
     HasNonSubjectOrScopeBreaking, // FIXME: This is a catch-all for cases where :has() is in a non-subject position, or may break scope.
-    Host
+    Host,
+    HostChild
 };
-constexpr unsigned matchElementCount = static_cast<unsigned>(MatchElement::Host) + 1;
+constexpr unsigned matchElementCount = static_cast<unsigned>(MatchElement::HostChild) + 1;
 
 enum class IsNegation : bool { No, Yes };
 enum class CanBreakScope : bool { No, Yes }; // :is/not() inside scoped selector can be affected by things outside the scope.

--- a/Source/WebCore/style/StyleInvalidationFunctions.h
+++ b/Source/WebCore/style/StyleInvalidationFunctions.h
@@ -79,8 +79,6 @@ inline void traverseRuleFeatures(Element& element, TraverseFunction&& function)
                 return true;
 #endif
         }
-        if (is<HTMLSlotElement>(element) && ruleSets.hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.slottedPseudoElementRules().isEmpty(); }))
-            return true;
         return false;
     };
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -361,6 +361,12 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
     case MatchElement::Host:
         invalidateInShadowTreeIfNeeded(element);
         break;
+    case MatchElement::HostChild:
+        if (auto* host = element.shadowHost()) {
+            for (auto& hostChild : childrenOfType<Element>(*host))
+                invalidateIfNeeded(hostChild, nullptr);
+        }
+        break;
     }
 }
 


### PR DESCRIPTION
#### 7b40932f6b2a3506f47da91e7cc0ebae2c9294ad
<pre>
Add fine-grained invalidation support for selectors containing :slotted()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260755">https://bugs.webkit.org/show_bug.cgi?id=260755</a>
rdar://114480735

Reviewed by Alan Baradlay.

* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::isSiblingOrSubject):
(WebCore::Style::computeNextMatchElement):

ShadowSlotted shadow-piercing combinator generates HostChild match element for invalidation purposes.

(WebCore::Style::computeHasPseudoClassMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleInvalidationFunctions.h:
(WebCore::Style::traverseRuleFeatures):

Remove now-unnessary slotted test that would lead to large invalidations.

* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Traverse host children for the HostChild match element.

Canonical link: <a href="https://commits.webkit.org/267326@main">https://commits.webkit.org/267326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70793b55d9058f9c862d706902c0aa81da3e6854

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15260 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16700 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18803 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21546 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18152 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15484 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13126 "1 flakes 23 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14707 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->