### PR TITLE
[Fonts] systemFallbackForCharacters() only works on individual characters, not clusters

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -551,9 +551,9 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer&, unsigned, unsigned, bool,
 }
 #endif
 
-RefPtr<Font> Font::systemFallbackFontForCharacter(UChar32 character, const FontDescription& description, ResolvedEmojiPolicy resolvedEmojiPolicy, IsForPlatformFont isForPlatformFont) const
+RefPtr<Font> Font::systemFallbackFontForCharacterCluster(StringView characterCluster, const FontDescription& description, ResolvedEmojiPolicy resolvedEmojiPolicy, IsForPlatformFont isForPlatformFont) const
 {
-    return SystemFallbackFontCache::forCurrentThread().systemFallbackFontForCharacter(this, character, description, resolvedEmojiPolicy, isForPlatformFont);
+    return SystemFallbackFontCache::forCurrentThread().systemFallbackFontForCharacterCluster(this, characterCluster, description, resolvedEmojiPolicy, isForPlatformFont);
 }
 
 #if !PLATFORM(COCOA) && !USE(FREETYPE)

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -167,7 +167,7 @@ public:
     bool supportsCodePoint(UChar32) const;
     bool platformSupportsCodePoint(UChar32, std::optional<UChar32> variation = std::nullopt) const;
 
-    RefPtr<Font> systemFallbackFontForCharacter(UChar32, const FontDescription&, ResolvedEmojiPolicy, IsForPlatformFont) const;
+    RefPtr<Font> systemFallbackFontForCharacterCluster(StringView, const FontDescription&, ResolvedEmojiPolicy, IsForPlatformFont) const;
 
     const GlyphPage* glyphPage(unsigned pageNumber) const;
 

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -104,7 +104,7 @@ public:
 
     // These methods are implemented by the platform.
     enum class PreferColoredFont : bool { No, Yes };
-    RefPtr<Font> systemFallbackForCharacters(const FontDescription&, const Font& originalFontData, IsForPlatformFont, PreferColoredFont, const UChar* characters, unsigned length);
+    RefPtr<Font> systemFallbackForCharacterCluster(const FontDescription&, const Font& originalFontData, IsForPlatformFont, PreferColoredFont, StringView);
     Vector<String> systemFontFamilies();
     void platformInit();
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -470,6 +470,13 @@ String FontCascade::normalizeSpaces(const UChar* characters, unsigned length)
     return normalizeSpacesInternal(characters, length);
 }
 
+String FontCascade::normalizeSpaces(StringView stringView)
+{
+    if (stringView.is8Bit())
+        return normalizeSpacesInternal(stringView.characters8(), stringView.length());
+    return normalizeSpacesInternal(stringView.characters16(), stringView.length());
+}
+
 static std::atomic<bool> disableFontSubpixelAntialiasingForTesting = false;
 
 void FontCascade::setDisableFontSubpixelAntialiasingForTesting(bool disable)

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -285,6 +285,7 @@ public:
 
     static String normalizeSpaces(const LChar*, unsigned length);
     static String normalizeSpaces(const UChar*, unsigned length);
+    static String normalizeSpaces(StringView);
 
     bool useBackslashAsYenSymbol() const { return m_useBackslashAsYenSymbol; }
     FontCascadeFonts* fonts() const { return m_fonts.get(); }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -351,7 +351,9 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(UChar32 character, const 
     if (!font)
         font = &realizeFallbackRangesAt(description, 0).fontForFirstRange();
 
-    auto systemFallbackFont = font->systemFallbackFontForCharacter(character, description, resolvedEmojiPolicy, m_isForPlatformFont ? IsForPlatformFont::Yes : IsForPlatformFont::No);
+    StringBuilder stringBuilder;
+    stringBuilder.appendCharacter(character);
+    auto systemFallbackFont = font->systemFallbackFontForCharacterCluster(stringBuilder, description, resolvedEmojiPolicy, m_isForPlatformFont ? IsForPlatformFont::Yes : IsForPlatformFont::No);
     if (!systemFallbackFont)
         return GlyphData();
 

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
@@ -41,27 +41,14 @@ SystemFallbackFontCache& SystemFallbackFontCache::forCurrentThread()
     return FontCache::forCurrentThread().systemFallbackFontCache();
 }
 
-RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacter(const Font* font, UChar32 character, const FontDescription& description, ResolvedEmojiPolicy resolvedEmojiPolicy, IsForPlatformFont isForPlatformFont)
+RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacterCluster(const Font* font, StringView characterCluster, const FontDescription& description, ResolvedEmojiPolicy resolvedEmojiPolicy, IsForPlatformFont isForPlatformFont)
 {
     auto fontAddResult = m_characterFallbackMaps.add(font, CharacterFallbackMap());
 
-    if (!character) {
-        UChar codeUnit = 0;
-        return FontCache::forCurrentThread().systemFallbackForCharacters(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, &codeUnit, 1);
-    }
-
-    auto key = CharacterFallbackMapKey { description.computedLocale(), character, isForPlatformFont != IsForPlatformFont::No, resolvedEmojiPolicy };
+    auto key = CharacterFallbackMapKey { description.computedLocale(), characterCluster.toString(), isForPlatformFont != IsForPlatformFont::No, resolvedEmojiPolicy };
     return fontAddResult.iterator->value.ensure(WTFMove(key), [&] {
-        UChar codeUnits[3];
-        unsigned codeUnitsLength;
-        if (U_IS_BMP(character)) {
-            codeUnits[0] = FontCascade::normalizeSpaces(character);
-            codeUnitsLength = 1;
-        } else {
-            codeUnits[0] = U16_LEAD(character);
-            codeUnits[1] = U16_TRAIL(character);
-            codeUnitsLength = 2;
-        }
+        StringBuilder stringBuilder;
+        stringBuilder.append(FontCascade::normalizeSpaces(characterCluster));
 
         // FIXME: Is this the right place to add the variation selectors?
         // Should this be done in platform-specific code instead?
@@ -73,14 +60,14 @@ RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacter(const Font*
         case ResolvedEmojiPolicy::NoPreference:
             break;
         case ResolvedEmojiPolicy::RequireText:
-            codeUnits[codeUnitsLength++] = textVariationSelector;
+            stringBuilder.append(textVariationSelector);
             break;
         case ResolvedEmojiPolicy::RequireEmoji:
-            codeUnits[codeUnitsLength++] = emojiVariationSelector;
+            stringBuilder.append(emojiVariationSelector);
             break;
         }
 
-        auto fallbackFont = FontCache::forCurrentThread().systemFallbackForCharacters(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, codeUnits, codeUnitsLength).get();
+        auto fallbackFont = FontCache::forCurrentThread().systemFallbackForCharacterCluster(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, stringBuilder).get();
         if (fallbackFont)
             fallbackFont->setIsUsedInSystemFallbackFontCache();
         return fallbackFont;

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.h
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.h
@@ -43,7 +43,7 @@ enum class IsForPlatformFont : bool;
     
 struct CharacterFallbackMapKey {
     AtomString locale;
-    UChar32 character { 0 };
+    String string;
     bool isForPlatformFont { false };
     ResolvedEmojiPolicy resolvedEmojiPolicy { ResolvedEmojiPolicy::NoPreference };
 
@@ -52,13 +52,13 @@ struct CharacterFallbackMapKey {
 
 inline void add(Hasher& hasher, const CharacterFallbackMapKey& key)
 {
-    add(hasher, key.locale, key.character, key.isForPlatformFont, key.resolvedEmojiPolicy);
+    add(hasher, key.locale, key.string, key.isForPlatformFont, key.resolvedEmojiPolicy);
 }
 
 struct CharacterFallbackMapKeyHash {
     static unsigned hash(const CharacterFallbackMapKey& key) { return computeHash(key); }
     static bool equal(const CharacterFallbackMapKey& a, const CharacterFallbackMapKey& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
+    static const bool safeToCompareToEmptyOrDeleted = false;
 };
 
 class SystemFallbackFontCache {
@@ -69,13 +69,13 @@ public:
 
     SystemFallbackFontCache() = default;
 
-    RefPtr<Font> systemFallbackFontForCharacter(const Font*, UChar32 character, const FontDescription&, ResolvedEmojiPolicy, IsForPlatformFont);
+    RefPtr<Font> systemFallbackFontForCharacterCluster(const Font*, StringView, const FontDescription&, ResolvedEmojiPolicy, IsForPlatformFont);
     void remove(Font*);
 
 private:
     struct CharacterFallbackMapKeyHashTraits : SimpleClassHashTraits<CharacterFallbackMapKey> {
-        static void constructDeletedValue(CharacterFallbackMapKey& slot) { new (NotNull, &slot) CharacterFallbackMapKey { { }, U_SENTINEL, { } }; }
-        static bool isDeletedValue(const CharacterFallbackMapKey& key) { return key.character == U_SENTINEL; }
+        static void constructDeletedValue(CharacterFallbackMapKey& slot) { new (NotNull, &slot) CharacterFallbackMapKey { { }, WTF::HashTableDeletedValue, { } }; }
+        static bool isDeletedValue(const CharacterFallbackMapKey& key) { return key.string.isHashTableDeletedValue(); }
     };
 
     // Fonts are not ref'd to avoid cycles.

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -139,7 +139,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     }
 
     const auto& originalFont = fallbackRangesAt(0).fontForFirstRange();
-    if (auto systemFallback = FontCache::forCurrentThread().systemFallbackForCharacters(m_fontDescription, originalFont, IsForPlatformFont::No, preferColoredFont ? FontCache::PreferColoredFont::Yes : FontCache::PreferColoredFont::No, characters, length)) {
+    if (auto systemFallback = FontCache::forCurrentThread().systemFallbackForCharacterCluster(m_fontDescription, originalFont, IsForPlatformFont::No, preferColoredFont ? FontCache::PreferColoredFont::Yes : FontCache::PreferColoredFont::No, normalizedString.view)) {
         if (systemFallback->canRenderCombiningCharacterSequence(normalizedString.view) && (!preferColoredFont || systemFallback->platformData().isColorBitmapFont()))
             return systemFallback.get();
 

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -400,7 +400,6 @@ bool FontCascade::primaryFontIsSystemFont() const
     return isSystemFont(fontData.platformData().ctFont());
 }
 
-// FIXME: Use this on all ports.
 const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView) const
 {
     auto codePoints = stringView.codePoints();

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -124,9 +124,9 @@ static void getFontPropertiesFromPattern(FcPattern* pattern, const FontDescripti
     }
 }
 
-RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& description, const Font&, IsForPlatformFont, PreferColoredFont preferColoredFont, const UChar* characters, unsigned length)
+RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription& description, const Font&, IsForPlatformFont, PreferColoredFont preferColoredFont, StringView stringView)
 {
-    RefPtr<FcPattern> resultPattern = m_fontSetCache.bestForCharacters(description, preferColoredFont == PreferColoredFont::Yes, characters, length);
+    RefPtr<FcPattern> resultPattern = m_fontSetCache.bestForCharacters(description, preferColoredFont == PreferColoredFont::Yes, stringView);
     if (!resultPattern)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/freetype/FontSetCache.h
+++ b/Source/WebCore/platform/graphics/freetype/FontSetCache.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -75,7 +76,7 @@ class FontSetCache {
 public:
     FontSetCache() = default;
 
-    RefPtr<FcPattern> bestForCharacters(const FontDescription&, bool, const UChar*, unsigned);
+    RefPtr<FcPattern> bestForCharacters(const FontDescription&, bool, StringView);
     void clear();
 
 private:


### PR DESCRIPTION
#### 9df8edf812b7c4330d6f9c1578ef33e57f37457c
<pre>
[Fonts] systemFallbackForCharacters() only works on individual characters, not clusters
<a href="https://bugs.webkit.org/show_bug.cgi?id=260758">https://bugs.webkit.org/show_bug.cgi?id=260758</a>
rdar://114481597

Reviewed by Cameron McCormack.

When you pick a font, you have to pick a font for a whole cluster; different codepoints
in a cluster can&apos;t fall back to different fonts. If you&apos;ve exhausted the whole font-family
list and you fall off the end, you need to ask the system for a font that can render
the cluster. The Core Text platform facilities have support for this: they accept a
character pointer and a length. However, the only problem is that our own system fallback
code operated on an individual UChar32, rather than on a whole cluster.

This is a classic case of impedence mismatch: At the beginning of the procedure, you have
clusters, and at the end of the procedure (when we hit Core Text), we operate on clusters
too. This patch simply hooks up cluster support (via StringViews) throughout the interior
of the procedure.

Right now, this patch has no behavior change, because the only codepath that uses this
functionality is our fast text codepath, which currently only operates on a single
character at a time (another way to think of this: every cluster has exactly one code
point inside it). If we want to stop using the complex text codepath, this will be relaxed
in the future, to allow the fast text codepath to operate on whole clusters. When that day
comes, we&apos;ll need to be able to feed the clusters to systemFallbackForCharacters(), like
this patch allows for. (So, right now, this patch doesn&apos;t add any tests, because there is
no behavior change.)

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::systemFallbackFontForCharacter const):
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::glyphDataForSystemFallback):
* Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp:
(WebCore::SystemFallbackFontCache::systemFallbackFontForCharacter):
* Source/WebCore/platform/graphics/SystemFallbackFontCache.h:
(WebCore::add):
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKeyHashTraits::constructDeletedValue):
(WebCore::SystemFallbackFontCache::CharacterFallbackMapKeyHashTraits::isDeletedValue):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::lookupFallbackFont):
(WebCore::FontCache::systemFallbackForCharacters):
(WebCore::createFontForCharacters): Deleted.
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:

Canonical link: <a href="https://commits.webkit.org/267335@main">https://commits.webkit.org/267335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de49d96300bd64364b6b7af0ec8368f8c43f8fbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18858 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14786 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15188 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14754 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3903 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->