### PR TITLE
Add more smart pointers to WKOpenPanelResultListener

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp
@@ -48,7 +48,7 @@ static Vector<String> filePathsFromFileURLs(const API::Array& fileURLs)
     filePaths.reserveInitialCapacity(size);
 
     for (size_t i = 0; i < size; ++i) {
-        API::URL* apiURL = fileURLs.at<API::URL>(i);
+        RefPtr apiURL = fileURLs.at<API::URL>(i);
         if (apiURL)
             filePaths.uncheckedAppend(URL { apiURL->string() }.fileSystemPath());
     }


### PR DESCRIPTION
#### 7c6597e7925ebf7ecaf706dec148bfb56d1f31b0
<pre>
Add more smart pointers to WKOpenPanelResultListener
<a href="https://bugs.webkit.org/show_bug.cgi?id=260759">https://bugs.webkit.org/show_bug.cgi?id=260759</a>
rdar://problem/114481901

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/API/C/WKOpenPanelResultListener.cpp:
(filePathsFromFileURLs):

Canonical link: <a href="https://commits.webkit.org/267328@main">https://commits.webkit.org/267328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1117cf2687561a7fe0aee32afae13464f83b587e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15263 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17647 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18816 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14158 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21554 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18182 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13129 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14710 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19076 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2000 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->