### PR TITLE
Remove inconsistent plural from CSSUnitType enum values

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -57,7 +57,7 @@ static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_NUMBER:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_DEG:
@@ -68,8 +68,8 @@ static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
     case CSSUnitType::CSS_DVMAX:
     case CSSUnitType::CSS_DVMIN:
     case CSSUnitType::CSS_DVW:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_GRAD:
     case CSSUnitType::CSS_HZ:
@@ -84,17 +84,17 @@ static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
     case CSSUnitType::CSS_PT:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
+    case CSSUnitType::CSS_LH:
     case CSSUnitType::CSS_LVB:
     case CSSUnitType::CSS_LVH:
     case CSSUnitType::CSS_LVI:
     case CSSUnitType::CSS_LVMAX:
     case CSSUnitType::CSS_LVMIN:
     case CSSUnitType::CSS_LVW:
-    case CSSUnitType::CSS_RLHS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_RLH:
+    case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RAD:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
     case CSSUnitType::CSS_SVH:
@@ -156,7 +156,7 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_NUMBER:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_DEG:
@@ -171,8 +171,8 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_DVMIN:
     case CSSUnitType::CSS_DVW:
     case CSSUnitType::CSS_X:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_GRAD:
     case CSSUnitType::CSS_HZ:
@@ -195,11 +195,11 @@ static inline bool isStringType(CSSUnitType type)
     case CSSUnitType::CSS_PT:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
+    case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RAD:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_RGBCOLOR:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
@@ -376,12 +376,12 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PERCENTAGE:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
-    case CSSUnitType::CSS_EXS:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
@@ -427,8 +427,8 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_DPCM:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_PROPERTY_ID:
@@ -685,14 +685,14 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         return value;
 
     switch (primitiveType) {
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
-    case CSSUnitType::CSS_REMS: {
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_REM: {
         ASSERT(fontCascadeForUnit);
         auto& fontDescription = fontCascadeForUnit->fontDescription();
         return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription.specifiedSize() : fontDescription.computedSize()) * value;
     }
-    case CSSUnitType::CSS_EXS: {
+    case CSSUnitType::CSS_EX: {
         ASSERT(fontCascadeForUnit);
         auto& fontMetrics = fontCascadeForUnit->metricsOfPrimaryFont();
         if (fontMetrics.hasXHeight())
@@ -707,7 +707,7 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
             return fontMetrics.floatCapHeight() * value;
         return fontMetrics.ascent() * value;
     }
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
         ASSERT(fontCascadeForUnit);
         return fontCascadeForUnit->metricsOfPrimaryFont().zeroWidth().value_or(fontCascadeForUnit->fontDescription().computedSize() / 2) * value;
     case CSSUnitType::CSS_IC:
@@ -721,8 +721,8 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         return cssPixelsPerInch / mmPerInch * value;
     case CSSUnitType::CSS_Q:
         return cssPixelsPerInch / QPerInch * value;
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
         ASSERT_NOT_REACHED();
         return -1.0;
     case CSSUnitType::CSS_IN:
@@ -819,11 +819,11 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
     };
 
     switch (primitiveType) {
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
         // FIXME: We have a bug right now where the zoom will be applied twice to EX units.
         // We really need to compute EX using fontMetrics for the original specifiedSize and not use
@@ -831,7 +831,7 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
         value = computeUnzoomedNonCalcLengthDouble(primitiveType, value, conversionData.propertyToCompute(), &conversionData.fontCascadeForFontUnits());
         break;
 
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_REM:
         value = computeUnzoomedNonCalcLengthDouble(primitiveType, value, conversionData.propertyToCompute(), conversionData.rootStyle() ? &conversionData.rootStyle()->fontCascade() : nullptr);
         break;
 
@@ -919,7 +919,7 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
     case CSSUnitType::CSS_DVI:
         return value * lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, conversionData.dynamicViewportFactor(), conversionData.style());
 
-    case CSSUnitType::CSS_LHS:
+    case CSSUnitType::CSS_LH:
         if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
             // Try to get the parent's computed line-height, or fall back to the initial line-height of this element's font spacing.
             value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().lineSpacing();
@@ -957,7 +957,7 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
     case CSSUnitType::CSS_CQMIN:
         return std::min(computeNonCalcLengthDouble(conversionData, CSSUnitType::CSS_CQB, value), computeNonCalcLengthDouble(conversionData, CSSUnitType::CSS_CQI, value));
 
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_RLH:
         if (conversionData.rootStyle()) {
             if (conversionData.computingLineHeight() || conversionData.computingFontSize())
                 value *= conversionData.rootStyle()->computeLineHeight(conversionData.rootStyle()->specifiedLineHeight());
@@ -1216,7 +1216,7 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
 {
     switch (unitType) {
     case CSSUnitType::CSS_CAP: return "cap"_s;
-    case CSSUnitType::CSS_CHS: return "ch"_s;
+    case CSSUnitType::CSS_CH: return "ch"_s;
     case CSSUnitType::CSS_CM: return "cm"_s;
     case CSSUnitType::CSS_CQB: return "cqb"_s;
     case CSSUnitType::CSS_CQH: return "cqh"_s;
@@ -1234,15 +1234,15 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_DVMAX: return "dvmax"_s;
     case CSSUnitType::CSS_DVMIN: return "dvmin"_s;
     case CSSUnitType::CSS_DVW: return "dvw"_s;
-    case CSSUnitType::CSS_EMS: return "em"_s;
-    case CSSUnitType::CSS_EXS: return "ex"_s;
+    case CSSUnitType::CSS_EM: return "em"_s;
+    case CSSUnitType::CSS_EX: return "ex"_s;
     case CSSUnitType::CSS_FR: return "fr"_s;
     case CSSUnitType::CSS_GRAD: return "grad"_s;
     case CSSUnitType::CSS_HZ: return "hz"_s;
     case CSSUnitType::CSS_IC: return "ic"_s;
     case CSSUnitType::CSS_IN: return "in"_s;
     case CSSUnitType::CSS_KHZ: return "khz"_s;
-    case CSSUnitType::CSS_LHS: return "lh"_s;
+    case CSSUnitType::CSS_LH: return "lh"_s;
     case CSSUnitType::CSS_LVB: return "lvb"_s;
     case CSSUnitType::CSS_LVH: return "lvh"_s;
     case CSSUnitType::CSS_LVI: return "lvi"_s;
@@ -1257,8 +1257,8 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_PX: return "px"_s;
     case CSSUnitType::CSS_Q: return "q"_s;
     case CSSUnitType::CSS_RAD: return "rad"_s;
-    case CSSUnitType::CSS_REMS: return "rem"_s;
-    case CSSUnitType::CSS_RLHS: return "rlh"_s;
+    case CSSUnitType::CSS_REM: return "rem"_s;
+    case CSSUnitType::CSS_RLH: return "rlh"_s;
     case CSSUnitType::CSS_S: return "s"_s;
     case CSSUnitType::CSS_SVB: return "svb"_s;
     case CSSUnitType::CSS_SVH: return "svh"_s;
@@ -1286,7 +1286,7 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_PROPERTY_ID:
-    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RGBCOLOR:
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
@@ -1305,7 +1305,7 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     auto type = primitiveUnitType();
     switch (type) {
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_CQB:
     case CSSUnitType::CSS_CQH:
@@ -1323,15 +1323,15 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     case CSSUnitType::CSS_DVMAX:
     case CSSUnitType::CSS_DVMIN:
     case CSSUnitType::CSS_DVW:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_GRAD:
     case CSSUnitType::CSS_HZ:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_IN:
     case CSSUnitType::CSS_KHZ:
-    case CSSUnitType::CSS_LHS:
+    case CSSUnitType::CSS_LH:
     case CSSUnitType::CSS_LVB:
     case CSSUnitType::CSS_LVH:
     case CSSUnitType::CSS_LVI:
@@ -1347,8 +1347,8 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_Q:
     case CSSUnitType::CSS_RAD:
-    case CSSUnitType::CSS_REMS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_S:
     case CSSUnitType::CSS_SVB:
     case CSSUnitType::CSS_SVH:
@@ -1379,7 +1379,7 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
         return serializeFontFamily(m_value.string);
     case CSSUnitType::CSS_INTEGER:
         return formatIntegerValue(""_s);
-    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_QUIRKY_EM:
         return formatNumberValue("em"_s);
     case CSSUnitType::CSS_RGBCOLOR:
         return serializationForCSS(color());
@@ -1439,12 +1439,12 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PERCENTAGE:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
-    case CSSUnitType::CSS_EXS:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
@@ -1490,8 +1490,8 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CSS_DVI:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_DIMENSION:
     case CSSUnitType::CSS_CQW:
     case CSSUnitType::CSS_CQH:
@@ -1537,12 +1537,12 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PERCENTAGE:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
-    case CSSUnitType::CSS_EXS:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
@@ -1588,8 +1588,8 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
     case CSSUnitType::CSS_DVI:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_DIMENSION:
     case CSSUnitType::CSS_CQW:
     case CSSUnitType::CSS_CQH:
@@ -1635,22 +1635,22 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
 void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const
 {
     switch (primitiveUnitType()) {
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_REM:
         dependencies.rootProperties.appendIfNotContains(CSSPropertyFontSize);
         break;
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_RLH:
         dependencies.rootProperties.appendIfNotContains(CSSPropertyFontSize);
         dependencies.rootProperties.appendIfNotContains(CSSPropertyLineHeight);
         break;
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_QUIRKY_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_QUIRKY_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
         dependencies.properties.appendIfNotContains(CSSPropertyFontSize);
         break;
-    case CSSUnitType::CSS_LHS:
+    case CSSUnitType::CSS_LH:
         dependencies.properties.appendIfNotContains(CSSPropertyFontSize);
         dependencies.properties.appendIfNotContains(CSSPropertyLineHeight);
         break;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -77,7 +77,7 @@ public:
     bool isFontRelativeLength() const { return isFontRelativeLength(primitiveUnitType()); }
     bool isParentFontRelativeLength() const { return isPercentage() || (isFontRelativeLength() && !isRootFontRelativeLength()); }
     bool isRootFontRelativeLength() const { return isRootFontRelativeLength(primitiveUnitType()); }
-    bool isQuirkyEms() const { return primitiveType() == CSSUnitType::CSS_QUIRKY_EMS; }
+    bool isQuirkyEms() const { return primitiveType() == CSSUnitType::CSS_QUIRKY_EM; }
     bool isLength() const { return isLength(static_cast<CSSUnitType>(primitiveType())); }
     bool isNumber() const { return primitiveType() == CSSUnitType::CSS_NUMBER; }
     bool isInteger() const { return primitiveType() == CSSUnitType::CSS_INTEGER; }
@@ -255,40 +255,40 @@ constexpr bool CSSPrimitiveValue::isFontIndependentLength(CSSUnitType type)
 
 constexpr bool CSSPrimitiveValue::isRootFontRelativeLength(CSSUnitType type)
 {
-    return type == CSSUnitType::CSS_RLHS
-        || type == CSSUnitType::CSS_REMS;
+    return type == CSSUnitType::CSS_RLH
+        || type == CSSUnitType::CSS_REM;
 }
 
 constexpr bool CSSPrimitiveValue::isFontRelativeLength(CSSUnitType type)
 {
-    return type == CSSUnitType::CSS_EMS
-        || type == CSSUnitType::CSS_EXS
-        || type == CSSUnitType::CSS_LHS
-        || type == CSSUnitType::CSS_RLHS
-        || type == CSSUnitType::CSS_REMS
+    return type == CSSUnitType::CSS_EM
+        || type == CSSUnitType::CSS_EX
+        || type == CSSUnitType::CSS_LH
+        || type == CSSUnitType::CSS_RLH
+        || type == CSSUnitType::CSS_REM
         || type == CSSUnitType::CSS_CAP
-        || type == CSSUnitType::CSS_CHS
+        || type == CSSUnitType::CSS_CH
         || type == CSSUnitType::CSS_IC
-        || type == CSSUnitType::CSS_QUIRKY_EMS;
+        || type == CSSUnitType::CSS_QUIRKY_EM;
 }
 
 constexpr bool CSSPrimitiveValue::isLength(CSSUnitType type)
 {
-    return type == CSSUnitType::CSS_EMS
-        || type == CSSUnitType::CSS_EXS
+    return type == CSSUnitType::CSS_EM
+        || type == CSSUnitType::CSS_EX
         || type == CSSUnitType::CSS_PX
         || type == CSSUnitType::CSS_CM
         || type == CSSUnitType::CSS_MM
         || type == CSSUnitType::CSS_IN
         || type == CSSUnitType::CSS_PT
         || type == CSSUnitType::CSS_PC
-        || type == CSSUnitType::CSS_REMS
+        || type == CSSUnitType::CSS_REM
         || type == CSSUnitType::CSS_CAP
-        || type == CSSUnitType::CSS_CHS
+        || type == CSSUnitType::CSS_CH
         || type == CSSUnitType::CSS_IC
         || type == CSSUnitType::CSS_Q
-        || type == CSSUnitType::CSS_LHS
-        || type == CSSUnitType::CSS_RLHS
+        || type == CSSUnitType::CSS_LH
+        || type == CSSUnitType::CSS_RLH
         || type == CSSUnitType::CSS_CQW
         || type == CSSUnitType::CSS_CQH
         || type == CSSUnitType::CSS_CQI
@@ -296,12 +296,12 @@ constexpr bool CSSPrimitiveValue::isLength(CSSUnitType type)
         || type == CSSUnitType::CSS_CQMIN
         || type == CSSUnitType::CSS_CQMAX
         || isViewportPercentageLength(type)
-        || type == CSSUnitType::CSS_QUIRKY_EMS;
+        || type == CSSUnitType::CSS_QUIRKY_EM;
 }
 
 constexpr bool CSSPrimitiveValue::isViewportPercentageLength(CSSUnitType type)
 {
-    return type >= CSSUnitType::FirstViewportCSSUnitType && type <= CSSUnitType::LastViewporCSSUnitType;
+    return type >= CSSUnitType::FirstViewportCSSUnitType && type <= CSSUnitType::LastViewportCSSUnitType;
 }
 
 template<typename T, CSSPrimitiveValue::TimeUnit timeUnit> inline T CSSPrimitiveValue::computeTime() const

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1961,12 +1961,12 @@ inline bool CSSPrimitiveValue::convertingToLengthRequiresNonNullStyle(int length
     // CSSPrimitiveValue::computeNonCalcLengthDouble (which has the style assertion)
     // return std::optional<double> instead of having this check here.
     switch (primitiveUnitType()) {
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
-    case CSSUnitType::CSS_LHS:
+    case CSSUnitType::CSS_LH:
         return lengthConversion & (FixedIntegerConversion | FixedFloatConversion);
     case CSSUnitType::CSS_CALC:
         return m_value.calc->convertingToLengthRequiresNonNullStyle(lengthConversion);

--- a/Source/WebCore/css/CSSUnits.cpp
+++ b/Source/WebCore/css/CSSUnits.cpp
@@ -43,14 +43,14 @@ CSSUnitCategory unitCategory(CSSUnitType type)
     case CSSUnitType::CSS_Q:
         return CSSUnitCategory::AbsoluteLength;
     // https://drafts.csswg.org/css-values-4/#font-relative-lengths
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_REMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
         return CSSUnitCategory::FontRelativeLength;
     // https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
     case CSSUnitType::CSS_VW:
@@ -115,7 +115,7 @@ CSSUnitCategory unitCategory(CSSUnitType type)
     case CSSUnitType::CSS_FONT_FAMILY:
     case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_PROPERTY_ID:
-    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_RGBCOLOR:
     case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
@@ -187,8 +187,8 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_NUMBER: ts << "number"; break;
     case CSSUnitType::CSS_INTEGER: ts << "integer"; break;
     case CSSUnitType::CSS_PERCENTAGE: ts << "percentage"; break;
-    case CSSUnitType::CSS_EMS: ts << "ems"; break;
-    case CSSUnitType::CSS_EXS: ts << "exs"; break;
+    case CSSUnitType::CSS_EM: ts << "em"; break;
+    case CSSUnitType::CSS_EX: ts << "ex"; break;
     case CSSUnitType::CSS_PX: ts << "px"; break;
     case CSSUnitType::CSS_CM: ts << "cm"; break;
     case CSSUnitType::CSS_MM: ts << "mm"; break;
@@ -239,8 +239,8 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_DPCM: ts << "dpcm"; break;
     case CSSUnitType::CSS_FR: ts << "fr"; break;
     case CSSUnitType::CSS_Q: ts << "q"; break;
-    case CSSUnitType::CSS_LHS: ts << "lh"; break;
-    case CSSUnitType::CSS_RLHS: ts << "rlh"; break;
+    case CSSUnitType::CSS_LH: ts << "lh"; break;
+    case CSSUnitType::CSS_RLH: ts << "rlh"; break;
     case CSSUnitType::CSS_CQW: ts << "cqw"; break;
     case CSSUnitType::CSS_CQH: ts << "cqh"; break;
     case CSSUnitType::CSS_CQI: ts << "cqi"; break;
@@ -248,9 +248,9 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_CQMAX: ts << "cqmax"; break;
     case CSSUnitType::CSS_CQMIN: ts << "cqmin"; break;
     case CSSUnitType::CSS_TURN: ts << "turn"; break;
-    case CSSUnitType::CSS_REMS: ts << "rem"; break;
+    case CSSUnitType::CSS_REM: ts << "rem"; break;
     case CSSUnitType::CSS_CAP: ts << "cap"; break;
-    case CSSUnitType::CSS_CHS: ts << "ch"; break;
+    case CSSUnitType::CSS_CH: ts << "ch"; break;
     case CSSUnitType::CSS_IC: ts << "ic"; break;
     case CSSUnitType::CSS_COUNTER_NAME: ts << "counter_name"; break;
     case CSSUnitType::CSS_CALC: ts << "calc"; break;
@@ -260,7 +260,7 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_FONT_FAMILY: ts << "font_family"; break;
     case CSSUnitType::CSS_PROPERTY_ID: ts << "property_id"; break;
     case CSSUnitType::CSS_VALUE_ID: ts << "value_id"; break;
-    case CSSUnitType::CSS_QUIRKY_EMS: ts << "quirky_ems"; break;
+    case CSSUnitType::CSS_QUIRKY_EM: ts << "quirky_em"; break;
     }
     return ts;
 }

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -33,8 +33,8 @@ enum class CSSUnitType : uint8_t {
     CSS_NUMBER,
     CSS_INTEGER,
     CSS_PERCENTAGE,
-    CSS_EMS,
-    CSS_EXS,
+    CSS_EM,
+    CSS_EX,
     CSS_PX,
     CSS_CM,
     CSS_MM,
@@ -80,7 +80,7 @@ enum class CSSUnitType : uint8_t {
     CSS_DVB,
     CSS_DVI,
     FirstViewportCSSUnitType = CSS_VW,
-    LastViewporCSSUnitType = CSS_DVI,
+    LastViewportCSSUnitType = CSS_DVI,
 
     CSS_CQW,
     CSS_CQH,
@@ -95,15 +95,15 @@ enum class CSSUnitType : uint8_t {
     CSS_DPCM,
     CSS_FR,
     CSS_Q,
-    CSS_LHS,
-    CSS_RLHS,
+    CSS_LH,
+    CSS_RLH,
 
     CustomIdent,
 
     CSS_TURN,
-    CSS_REMS,
+    CSS_REM,
     CSS_CAP,
-    CSS_CHS,
+    CSS_CH,
     CSS_IC,
 
     CSS_COUNTER_NAME,
@@ -123,7 +123,7 @@ enum class CSSUnitType : uint8_t {
     // The basic idea is that a stylesheet can use the value __qem (for quirky em) instead of em.
     // When the quirky value is used, if you're in quirks mode, the margin will collapse away
     // inside a table cell. This quirk is specified in the HTML spec but our impl is different.
-    CSS_QUIRKY_EMS
+    CSS_QUIRKY_EM
 
     // Note that CSSValue allocates 7 bits for m_primitiveUnitType, so there can be no value here > 127.
 };

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -50,8 +50,8 @@ unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
     case CSSUnitType::CSS_CM:                           return CSS_CM;
     case CSSUnitType::CSS_DEG:                          return CSS_DEG;
     case CSSUnitType::CSS_DIMENSION:                    return CSS_DIMENSION;
-    case CSSUnitType::CSS_EMS:                          return CSS_EMS;
-    case CSSUnitType::CSS_EXS:                          return CSS_EXS;
+    case CSSUnitType::CSS_EM:                           return CSS_EMS;
+    case CSSUnitType::CSS_EX:                           return CSS_EXS;
     case CSSUnitType::CSS_FONT_FAMILY:                  return CSS_STRING;
     case CSSUnitType::CSS_GRAD:                         return CSS_GRAD;
     case CSSUnitType::CSS_HZ:                           return CSS_HZ;
@@ -87,8 +87,8 @@ ExceptionOr<float> DeprecatedCSSOMPrimitiveValue::getFloatValue(unsigned short u
         case CSS_CM:            return CSSUnitType::CSS_CM;
         case CSS_DEG:           return CSSUnitType::CSS_DEG;
         case CSS_DIMENSION:     return CSSUnitType::CSS_DIMENSION;
-        case CSS_EMS:           return CSSUnitType::CSS_EMS;
-        case CSS_EXS:           return CSSUnitType::CSS_EXS;
+        case CSS_EMS:           return CSSUnitType::CSS_EM;
+        case CSS_EXS:           return CSSUnitType::CSS_EX;
         case CSS_GRAD:          return CSSUnitType::CSS_GRAD;
         case CSS_HZ:            return CSSUnitType::CSS_HZ;
         case CSS_IN:            return CSSUnitType::CSS_IN;

--- a/Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp
+++ b/Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp
@@ -37,8 +37,8 @@ CalculationCategory calcUnitCategory(CSSUnitType type)
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_INTEGER:
         return CalculationCategory::Number;
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_MM:
@@ -46,11 +46,11 @@ CalculationCategory calcUnitCategory(CSSUnitType type)
     case CSSUnitType::CSS_PT:
     case CSSUnitType::CSS_PC:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_VH:
@@ -138,13 +138,13 @@ CalculationCategory calculationCategoryForCombination(CSSUnitType type)
     case CSSUnitType::CSS_DPCM:
     case CSSUnitType::CSS_X:
         return CalculationCategory::Resolution;
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_REMS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_REM:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_VH:
@@ -206,12 +206,12 @@ bool hasDoubleValue(CSSUnitType type)
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PERCENTAGE:
-    case CSSUnitType::CSS_EMS:
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EM:
+    case CSSUnitType::CSS_EX:
     case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CHS:
+    case CSSUnitType::CSS_CH:
     case CSSUnitType::CSS_IC:
-    case CSSUnitType::CSS_REMS:
+    case CSSUnitType::CSS_REM:
     case CSSUnitType::CSS_PX:
     case CSSUnitType::CSS_CM:
     case CSSUnitType::CSS_MM:
@@ -257,8 +257,8 @@ bool hasDoubleValue(CSSUnitType type)
     case CSSUnitType::CSS_DPCM:
     case CSSUnitType::CSS_FR:
     case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LHS:
-    case CSSUnitType::CSS_RLHS:
+    case CSSUnitType::CSS_LH:
+    case CSSUnitType::CSS_RLH:
     case CSSUnitType::CSS_CQW:
     case CSSUnitType::CSS_CQH:
     case CSSUnitType::CSS_CQI:
@@ -275,7 +275,7 @@ bool hasDoubleValue(CSSUnitType type)
     case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_RGBCOLOR:
     case CSSUnitType::CSS_COUNTER_NAME:
-    case CSSUnitType::CSS_QUIRKY_EMS:
+    case CSSUnitType::CSS_QUIRKY_EM:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_NUMBER:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -61,7 +61,7 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
         case 'c':
             switch (toASCIILower(data[1])) {
             case 'h':
-                return CSSUnitType::CSS_CHS;
+                return CSSUnitType::CSS_CH;
             case 'm':
                 return CSSUnitType::CSS_CM;
             }
@@ -69,9 +69,9 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
         case 'e':
             switch (toASCIILower(data[1])) {
             case 'm':
-                return CSSUnitType::CSS_EMS;
+                return CSSUnitType::CSS_EM;
             case 'x':
-                return CSSUnitType::CSS_EXS;
+                return CSSUnitType::CSS_EX;
             }
             break;
         case 'f':
@@ -92,7 +92,7 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
             break;
         case 'l':
             if (toASCIILower(data[1]) == 'h' && DeprecatedGlobalSettings::lineHeightUnitsEnabled())
-                return CSSUnitType::CSS_LHS;
+                return CSSUnitType::CSS_LH;
             break;
         case 'm':
             switch (toASCIILower(data[1])) {
@@ -196,11 +196,11 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
                 break;
             case 'e':
                 if (toASCIILower(data[2]) == 'm')
-                    return CSSUnitType::CSS_REMS;
+                    return CSSUnitType::CSS_REM;
                 break;
             case 'l':
                 if (toASCIILower(data[2]) == 'h' && DeprecatedGlobalSettings::lineHeightUnitsEnabled())
-                    return CSSUnitType::CSS_RLHS;
+                    return CSSUnitType::CSS_RLH;
                 break;
             }
             break;
@@ -268,7 +268,7 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
         switch (toASCIILower(data[0])) {
         case '_':
             if (toASCIILower(data[1]) == '_' && toASCIILower(data[2]) == 'q' && toASCIILower(data[3]) == 'e' && toASCIILower(data[4]) == 'm')
-                return CSSUnitType::CSS_QUIRKY_EMS;
+                return CSSUnitType::CSS_QUIRKY_EM;
             break;
         case 'c':
             if (toASCIILower(data[1]) == 'q' && toASCIILower(data[2]) == 'm') {

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -539,18 +539,18 @@ struct LengthRawKnownTokenTypeDimensionConsumer {
 
         auto unitType = token.unitType();
         switch (unitType) {
-        case CSSUnitType::CSS_QUIRKY_EMS:
+        case CSSUnitType::CSS_QUIRKY_EM:
             if (parserMode != UASheetMode)
                 return std::nullopt;
             FALLTHROUGH;
-        case CSSUnitType::CSS_EMS:
-        case CSSUnitType::CSS_REMS:
-        case CSSUnitType::CSS_LHS:
-        case CSSUnitType::CSS_RLHS:
+        case CSSUnitType::CSS_EM:
+        case CSSUnitType::CSS_REM:
+        case CSSUnitType::CSS_LH:
+        case CSSUnitType::CSS_RLH:
         case CSSUnitType::CSS_CAP:
-        case CSSUnitType::CSS_CHS:
+        case CSSUnitType::CSS_CH:
         case CSSUnitType::CSS_IC:
-        case CSSUnitType::CSS_EXS:
+        case CSSUnitType::CSS_EX:
         case CSSUnitType::CSS_PX:
         case CSSUnitType::CSS_CM:
         case CSSUnitType::CSS_MM:

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -56,7 +56,7 @@ float SizesAttributeParser::computeLength(double value, CSSUnitType type, const 
     // the pointer to it for the duration of the unit evaluation. This is acceptible because the style always comes from the
     // RenderView, which has its font information hardcoded in resolveForDocument() to be -webkit-standard, whose operations
     // don't require a font selector.
-    if (type == CSSUnitType::CSS_EXS || type == CSSUnitType::CSS_CAP || type == CSSUnitType::CSS_CHS || type == CSSUnitType::CSS_IC) {
+    if (type == CSSUnitType::CSS_EX || type == CSSUnitType::CSS_CAP || type == CSSUnitType::CSS_CH || type == CSSUnitType::CSS_IC) {
         RefPtr<FontSelector> fontSelector = style.fontCascade().fontSelector();
         style.fontCascade().update(nullptr);
         float result = CSSPrimitiveValue::computeNonCalcLengthDouble(conversionData, type, value);

--- a/Source/WebCore/css/typedom/CSSNumericFactory.h
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.h
@@ -48,14 +48,14 @@ public:
 
 
     // <length>
-    static Ref<CSSUnitValue> em(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EMS); }
-    static Ref<CSSUnitValue> ex(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EXS); }
+    static Ref<CSSUnitValue> em(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EM); }
+    static Ref<CSSUnitValue> ex(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_EX); }
     static Ref<CSSUnitValue> cap(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CAP); }
-    static Ref<CSSUnitValue> ch(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CHS); }
+    static Ref<CSSUnitValue> ch(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CH); }
     static Ref<CSSUnitValue> ic(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_IC); }
-    static Ref<CSSUnitValue> rem(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_REMS); }
-    static Ref<CSSUnitValue> lh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LHS); }
-    static Ref<CSSUnitValue> rlh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_RLHS); }
+    static Ref<CSSUnitValue> rem(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_REM); }
+    static Ref<CSSUnitValue> lh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LH); }
+    static Ref<CSSUnitValue> rlh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_RLH); }
     static Ref<CSSUnitValue> vw(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_VW); }
     static Ref<CSSUnitValue> vh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_VH); }
     static Ref<CSSUnitValue> vi(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_VI); }

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -192,21 +192,21 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
             return Ref<CSSStyleValue> { CSSNumericFactory::number(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_PERCENTAGE:
             return Ref<CSSStyleValue> { CSSNumericFactory::percent(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_EMS:
+        case CSSUnitType::CSS_EM:
             return Ref<CSSStyleValue> { CSSNumericFactory::em(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_EXS:
+        case CSSUnitType::CSS_EX:
             return Ref<CSSStyleValue> { CSSNumericFactory::ex(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_CAP:
             return Ref<CSSStyleValue> { CSSNumericFactory::cap(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_CHS:
+        case CSSUnitType::CSS_CH:
             return Ref<CSSStyleValue> { CSSNumericFactory::ch(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_IC:
             return Ref<CSSStyleValue> { CSSNumericFactory::ic(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_REMS:
+        case CSSUnitType::CSS_REM:
             return Ref<CSSStyleValue> { CSSNumericFactory::rem(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_LHS:
+        case CSSUnitType::CSS_LH:
             return Ref<CSSStyleValue> { CSSNumericFactory::lh(primitiveValue->doubleValue()) };
-        case CSSUnitType::CSS_RLHS:
+        case CSSUnitType::CSS_RLH:
             return Ref<CSSStyleValue> { CSSNumericFactory::rlh(primitiveValue->doubleValue()) };
         case CSSUnitType::CSS_VW:
             return Ref<CSSStyleValue> { CSSNumericFactory::vw(primitiveValue->doubleValue()) };

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -132,7 +132,7 @@ std::optional<Style::ResolvedStyle> TextControlInnerElement::resolveCustomStyle(
         // Set "flex-basis: 1em". Note that CSSPrimitiveValue::computeLength<int>() only needs the element's
         // style to calculate em lengths. Since the element might not be in a document, just pass nullptr
         // for the root element style, the parent element style, and the render view.
-        auto emSize = CSSPrimitiveValue::create(1, CSSUnitType::CSS_EMS);
+        auto emSize = CSSPrimitiveValue::create(1, CSSUnitType::CSS_EM);
         int pixels = emSize->computeLength<int>(CSSToLengthConversionData { *newStyle, nullptr, nullptr, nullptr });
         newStyle->setFlexBasis(Length { pixels, LengthType::Fixed });
     }

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -697,7 +697,7 @@ LengthBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& style, cons
 {
     float padding = MenuListButtonPaddingAfter;
     if (settings.iOSFormControlRefreshEnabled()) {
-        auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EMS);
+        auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EM);
         padding = emSize->computeLength<float>({ style, nullptr, nullptr, nullptr });
     }
 
@@ -746,7 +746,7 @@ void RenderThemeIOS::adjustRoundBorderRadius(RenderStyle& style, RenderBox& box)
 static void applyCommonButtonPaddingToStyle(RenderStyle& style, const Element& element)
 {
     Document& document = element.document();
-    auto emSize = CSSPrimitiveValue::create(0.5, CSSUnitType::CSS_EMS);
+    auto emSize = CSSPrimitiveValue::create(0.5, CSSUnitType::CSS_EM);
     // We don't need this element's parent style to calculate `em` units, so it's okay to pass nullptr for it here.
     int pixels = emSize->computeLength<int>({ style, document.renderStyle(), nullptr, document.renderView() });
     style.setPaddingBox(LengthBox(0, pixels, 0, pixels));
@@ -1280,7 +1280,7 @@ void RenderThemeIOS::adjustButtonStyle(RenderStyle& style, const Element* elemen
     // CSSPrimitiveValue::computeLengthInt only needs the element's style to calculate em lengths.
     // Since the element might not be in a document, just pass nullptr for the root element style,
     // the parent element style, and the render view.
-    auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EMS);
+    auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EM);
     int pixels = emSize->computeLength<int>({ style, nullptr, nullptr, nullptr });
     style.setPaddingBox(LengthBox(0, pixels, 0, pixels));
 
@@ -2467,7 +2467,7 @@ void RenderThemeIOS::paintMenuListButtonDecorationsWithFormControlRefresh(const 
         glyphPath.addBezierCurveTo({ 29.4179f, 71.8f }, { 30.541f, 72.3867f }, { 31.8593f, 72.3867 });
     }
 
-    auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EMS);
+    auto emSize = CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_EM);
     auto emPixels = emSize->computeLength<float>({ style, nullptr, nullptr, nullptr });
     auto glyphScale = 0.65f * emPixels / glyphSize.width();
     glyphSize = glyphScale * glyphSize;
@@ -2498,7 +2498,7 @@ void RenderThemeIOS::adjustSearchFieldDecorationPartStyle(RenderStyle& style, co
 
     CSSToLengthConversionData conversionData(style, nullptr, nullptr, nullptr);
 
-    auto emSize = CSSPrimitiveValue::create(searchFieldDecorationEmSize, CSSUnitType::CSS_EMS);
+    auto emSize = CSSPrimitiveValue::create(searchFieldDecorationEmSize, CSSUnitType::CSS_EM);
     auto size = emSize->computeLength<float>(conversionData);
 
     style.setWidth({ size, LengthType::Fixed });

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -240,7 +240,7 @@ inline Length BuilderConverter::convertLength(const BuilderState& builderState, 
 
     if (primitiveValue.isLength()) {
         Length length = primitiveValue.computeLength<Length>(conversionData);
-        length.setHasQuirk(primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EMS);
+        length.setHasQuirk(primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EM);
         return length;
     }
 
@@ -966,7 +966,7 @@ inline float BuilderConverter::convertTextStrokeWidth(BuilderState& builderState
             result *= 3;
         else if (primitiveValue.valueID() == CSSValueThick)
             result *= 5;
-        auto emsValue = CSSPrimitiveValue::create(result, CSSUnitType::CSS_EMS);
+        auto emsValue = CSSPrimitiveValue::create(result, CSSUnitType::CSS_EM);
         width = convertComputedLength<float>(builderState, emsValue);
         break;
     }

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -106,9 +106,9 @@ static inline SVGLengthType primitiveTypeToLengthType(CSSUnitType primitiveType)
         return SVGLengthType::Number;
     case CSSUnitType::CSS_PERCENTAGE:
         return SVGLengthType::Percentage;
-    case CSSUnitType::CSS_EMS:
+    case CSSUnitType::CSS_EM:
         return SVGLengthType::Ems;
-    case CSSUnitType::CSS_EXS:
+    case CSSUnitType::CSS_EX:
         return SVGLengthType::Exs;
     case CSSUnitType::CSS_PX:
         return SVGLengthType::Pixels;
@@ -139,9 +139,9 @@ static inline CSSUnitType lengthTypeToPrimitiveType(SVGLengthType lengthType)
     case SVGLengthType::Percentage:
         return CSSUnitType::CSS_PERCENTAGE;
     case SVGLengthType::Ems:
-        return CSSUnitType::CSS_EMS;
+        return CSSUnitType::CSS_EM;
     case SVGLengthType::Exs:
-        return CSSUnitType::CSS_EXS;
+        return CSSUnitType::CSS_EX;
     case SVGLengthType::Pixels:
         return CSSUnitType::CSS_PX;
     case SVGLengthType::Centimeters:


### PR DESCRIPTION
#### dacd77c6b3ba16c556b3dd63a004af539a1b8004
<pre>
Remove inconsistent plural from CSSUnitType enum values
<a href="https://bugs.webkit.org/show_bug.cgi?id=260761">https://bugs.webkit.org/show_bug.cgi?id=260761</a>
rdar://114483138

Reviewed by Alexey Shvayka.

None of the other length units use a plural, and it&apos;s inconsistent between font relative units as well.

Let&apos;s fix this up, a more thorough rename can be done in bug 229622 to fix the case and remove the CSS_ prefix.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::isValidCSSUnitTypeForDoubleConversion):
(WebCore::isStringType):
(WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
(WebCore::CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble):
(WebCore::CSSPrimitiveValue::computeNonCalcLengthDouble):
(WebCore::CSSPrimitiveValue::unitTypeString):
(WebCore::CSSPrimitiveValue::serializeInternal const):
(WebCore::CSSPrimitiveValue::equals const):
(WebCore::CSSPrimitiveValue::addDerivedHash const):
(WebCore::CSSPrimitiveValue::collectComputedStyleDependencies const):
* Source/WebCore/css/CSSPrimitiveValue.h:
(WebCore::CSSPrimitiveValue::isRootFontRelativeLength):
(WebCore::CSSPrimitiveValue::isFontRelativeLength):
(WebCore::CSSPrimitiveValue::isLength):
(WebCore::CSSPrimitiveValue::isViewportPercentageLength):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::convertingToLengthRequiresNonNullStyle const):
* Source/WebCore/css/CSSUnits.cpp:
(WebCore::unitCategory):
(WebCore::operator&lt;&lt;):
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
(WebCore::DeprecatedCSSOMPrimitiveValue::primitiveType const):
(WebCore::DeprecatedCSSOMPrimitiveValue::getFloatValue const):
* Source/WebCore/css/calc/CSSCalcCategoryMapping.cpp:
(WebCore::calcUnitCategory):
(WebCore::calculationCategoryForCombination):
(WebCore::hasDoubleValue):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::cssPrimitiveValueUnitFromTrie):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::LengthRawKnownTokenTypeDimensionConsumer::consume):
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::computeLength):
* Source/WebCore/css/typedom/CSSNumericFactory.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerElement::resolveCustomStyle):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::popupInternalPaddingBox const):
(WebCore::applyCommonButtonPaddingToStyle):
(WebCore::RenderThemeIOS::adjustButtonStyle const):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorationsWithFormControlRefresh):
(WebCore::RenderThemeIOS::adjustSearchFieldDecorationPartStyle const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLength):
(WebCore::Style::BuilderConverter::convertTextStrokeWidth):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::primitiveTypeToLengthType):
(WebCore::lengthTypeToPrimitiveType):

Canonical link: <a href="https://commits.webkit.org/267319@main">https://commits.webkit.org/267319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffee0b1f739747f913c2a3dad1e87ff991dead62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16281 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16712 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18815 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15495 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14715 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/3891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19080 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1998 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->