### PR TITLE
[CMake] Store the custom compile_commands.json file in a sub-directory

### DIFF
--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -240,12 +240,12 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     if (CMAKE_EXPORT_COMPILE_COMMANDS AND ENABLE_UNIFIED_BUILDS)
         add_custom_target(RewriteCompileCommands
             ALL
-            BYPRODUCTS webkit_compile_commands.json
+            BYPRODUCTS DeveloperTools/compile_commands.json
             DEPENDS "${CMAKE_BINARY_DIR}/compile_commands.json"
             COMMAND "${PYTHON_EXECUTABLE}"
                     "${CMAKE_SOURCE_DIR}/Tools/Scripts/rewrite-compile-commands"
                     "${CMAKE_BINARY_DIR}/compile_commands.json"
-                    "${CMAKE_BINARY_DIR}/webkit_compile_commands.json"
+                    "${CMAKE_BINARY_DIR}/DeveloperTools/compile_commands.json"
                     "${CMAKE_SOURCE_DIR}"
                     "${CMAKE_BINARY_DIR}"
         )

--- a/Tools/Scripts/rewrite-compile-commands
+++ b/Tools/Scripts/rewrite-compile-commands
@@ -88,5 +88,9 @@ for entry in compile_commands:
             else:
                 print('Failed to find', include_path)
 
+output_directory = os.path.dirname(args.output_file)
+if not os.path.isdir(output_directory):
+    os.makedirs(output_directory)
+
 with open(args.output_file, 'w') as f:
     json.dump(generated_compile_commands, f, indent=2)


### PR DESCRIPTION
#### 8d3c77d0963679f435fb7f45f9406b51dfb51134
<pre>
[CMake] Store the custom compile_commands.json file in a sub-directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=260769">https://bugs.webkit.org/show_bug.cgi?id=260769</a>

Reviewed by Michael Catanzaro.

clangd and similar tools should be configured to look for the compile_commands.json file in the
DeveloperTools directory, so for GTK for instance, WebKitBuild/GTK/Release/DeveloperTools/.

* Source/cmake/WebKitCommon.cmake:
* Tools/Scripts/rewrite-compile-commands:

Canonical link: <a href="https://commits.webkit.org/267324@main">https://commits.webkit.org/267324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe1ab40d017b024e832fadc79e9792cf01f22b03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18833 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21567 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14039 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18286 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15533 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15512 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16500 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14730 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4109 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19096 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17668 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15339 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3902 "Passed tests") | 
<!--EWS-Status-Bubble-End-->