### PR TITLE
Don’t open “details” when interacting with interactive “summary” descendants

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -749,7 +749,6 @@ imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-conten
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_navigate_ancestor-1.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/historical-search-event.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element.html [ Skip ]
 imported/w3c/web-platform-tests/service-workers/service-worker/same-site-cookies.https.html [ Skip ]
 imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/message-module-Error.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/css/css-position/position-absolute-crash-chrome-013.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element-expected.txt
@@ -1,13 +1,11 @@
 Anchor text is wrapped with <i> tag permalink
 This one uses <span>. permalink
-asdf
-
 
 <circle>
 
-Harness Error (TIMEOUT), message = null
-
-NOTRUN Clicking on anchor with embedded inline element should navigate instead of opening details
+PASS Clicking on anchor with embedded inline element should navigate instead of opening details
 PASS Expected <a> containing <i> to navigate
-NOTRUN Expected <a> containing <span> to navigate
+PASS Expected <a> containing <span> to navigate
+PASS Expected <a>, inside svg, containing <circle> to navigate
+PASS Expected <a>, inside svg, containing <text> to navigate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content-expected.txt
@@ -1,0 +1,45 @@
+OPEN FILE PANEL
+ anchor element
+SVG anchor element
+
+SVG foreignObject with HTML anchor element
+    button element
+label element
+
+This is clickable summary text
+
+PASS Clicking on non-interactive child of a <summary> opens its <details>
+PASS Clicking an <a> link doesn’t open <details>
+PASS Clicking an SVG <a> link doesn’t open <details>
+PASS Clicking an HTML <a> link in an SVG <foreignObject> doesn’t open <details>
+PASS Clicking an <audio> element doesn’t open <details>
+PASS Clicking a <button> doesn’t open <details>
+PASS Clicking the content of an <embed> doesn’t open <details>
+PASS Clicking in an <iframe> doesn’t open <details>
+PASS Clicking an <img> with a “usemap” attribute doesn’t open <details>
+PASS Clicking an <img> without a “usemap” attribute opens <details>
+PASS Clicking an <input type=button> doesn’t open <details>
+PASS Clicking an <input type=reset> doesn’t open <details>
+PASS Clicking an <input type=submit> doesn’t open <details>
+PASS Clicking an <input type=text> doesn’t open <details>
+PASS Clicking an <input type=search> doesn’t open <details>
+PASS Clicking an <input type=tel> doesn’t open <details>
+PASS Clicking an <input type=url> doesn’t open <details>
+PASS Clicking an <input type=email> doesn’t open <details>
+PASS Clicking an <input type=password> doesn’t open <details>
+PASS Clicking an <input type=date> doesn’t open <details>
+PASS Clicking an <input type=month> doesn’t open <details>
+PASS Clicking an <input type=week> doesn’t open <details>
+PASS Clicking an <input type=time> doesn’t open <details>
+PASS Clicking an <input type=datetime-local> doesn’t open <details>
+PASS Clicking an <input type=number> doesn’t open <details>
+PASS Clicking an <input type=range> doesn’t open <details>
+PASS Clicking an <input type=color> doesn’t open <details>
+PASS Clicking an <input type=checkbox> doesn’t open <details>
+PASS Clicking an <input type=radio> doesn’t open <details>
+PASS Clicking an <input type=file> doesn’t open <details>
+PASS Clicking an <input type=image> doesn’t open <details>
+PASS Clicking a <label> doesn’t open <details>
+PASS Clicking in a <textarea> doesn’t open <details>
+PASS Clicking a <video> doesn’t open <details>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>summary element: interactive content</title>
+<link rel="author" title="Michael[tm] Smith" href="mailto:mike@w3.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<details>
+  <summary id=summary>
+  <a id=a href="#">anchor element</a>
+  <svg style="width: 160px; height: 100px" viewBox="0 0 100 100">
+    <a href="#" id="svg_a"><text id="svg_text" x="50" y="90" text-anchor="middle">SVG anchor element</text></a>
+  </svg>
+  <svg style="width: 100px; height: 200px" viewBox="0 0 100 100">
+    <foreignObject x="0" y="60" width="100" height="200" text-anchor="middle">
+      <a xmlns="http://www.w3.org/1999/xhtml" href="#" id="svg_foreignObject_a">SVG foreignObject with HTML anchor element</a>
+    </foreignObject>
+  </svg>
+  <audio id="audio" controls src=/media/sound_5.mp3></audio>
+  <button id=button>button element</button>
+  <embed id=embed src="/images/blue.png" height="100" width="100">
+  <iframe id=iframe srcdoc="iframe element"></iframe>
+  <img id=img_usemap usemap src=/media/poster.png></img>
+  <img id=img src=/media/poster.png></img>
+  <input type="text" value="input@type=text" id="input_text">
+  <input type="search" value="input@type=search" id="input_search">
+  <input type="tel" value="input@type=tel" id="input_tel">
+  <input type="url" value="input@type=url" id="input_url">
+  <input type="email" value="input@type=email" id="input_email">
+  <input type="password" value="input@type=password" id="input_password">
+  <input type="button" value="input@type=button" id="input_button">
+  <input type="reset" id="input_reset">
+  <input type="submit" id="input_submit">
+  <input type="date" value="input@type=date" id="input_date">
+  <input type="month" value="input@type=month" id="input_month">
+  <input type="week" value="input@type=week" id="input_week">
+  <input type="time" id="input_time">
+  <input type="datetime-local" id="input_datetime-local">
+  <input type="color" id="input_color">
+  <input type="number" value="1337" id="input_number">
+  <input type="range" id="input_range">
+  <input type="checkbox" id="input_checkbox">
+  <input type="radio" id="input_radio" disabled>
+  <input type="file" id="input_file">
+  <input type="image" id="input_image" src=/media/poster.png>
+  <label id=label style="display: block">label element</label>
+  <textarea value="textarea" id="textarea">textarea element</textarea>
+  <video id="video" controls>
+    <source src="/media/test-1s.mp4" type="video/mp4">
+    <source src="/media/test-1s.webm" type="video/webm">
+  </video>
+  <div id="non-interactive">This is clickable summary text</div>
+  </summary>
+</details>
+
+<script>
+const details = document.querySelector("details");
+
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("non-interactive"));
+  assert_true(details.open)
+}, "Clicking on non-interactive child of a <summary> opens its <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("a"));
+  assert_false(details.open)
+}, "Clicking an <a> link doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("svg_a"));
+  assert_false(details.open)
+}, "Clicking an SVG <a> link doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("svg_foreignObject_a"));
+  assert_false(details.open)
+}, "Clicking an HTML <a> link in an SVG <foreignObject> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("audio"));
+  assert_false(details.open)
+}, "Clicking an <audio> element doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("button"));
+  assert_false(details.open)
+}, "Clicking a <button> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("embed"));
+  assert_false(details.open)
+}, "Clicking the content of an <embed> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("iframe"));
+  assert_false(details.open)
+}, "Clicking in an <iframe> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("img_usemap"));
+  assert_false(details.open)
+}, "Clicking an <img> with a “usemap” attribute doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("img"));
+  assert_true(details.open)
+}, "Clicking an <img> without a “usemap” attribute opens <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_button"));
+  assert_false(details.open)
+}, "Clicking an <input type=button> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_reset"));
+  assert_false(details.open)
+}, "Clicking an <input type=reset> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_submit"));
+  assert_false(details.open)
+}, "Clicking an <input type=submit> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_text"));
+  assert_false(details.open)
+}, "Clicking an <input type=text> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_search"));
+  assert_false(details.open)
+}, "Clicking an <input type=search> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_tel"));
+  assert_false(details.open)
+}, "Clicking an <input type=tel> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_url"));
+  assert_false(details.open)
+}, "Clicking an <input type=url> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_email"));
+  assert_false(details.open)
+}, "Clicking an <input type=email> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_password"));
+  assert_false(details.open)
+}, "Clicking an <input type=password> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_date"));
+  assert_false(details.open)
+}, "Clicking an <input type=date> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_month"));
+  assert_false(details.open)
+}, "Clicking an <input type=month> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_week"));
+  assert_false(details.open)
+}, "Clicking an <input type=week> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_time"));
+  assert_false(details.open)
+}, "Clicking an <input type=time> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_datetime-local"));
+  assert_false(details.open)
+}, "Clicking an <input type=datetime-local> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_number"));
+  assert_false(details.open)
+}, "Clicking an <input type=number> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_range"));
+  assert_false(details.open)
+}, "Clicking an <input type=range> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_color"));
+  assert_false(details.open)
+}, "Clicking an <input type=color> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_checkbox"));
+  assert_false(details.open)
+}, "Clicking an <input type=checkbox> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_radio"));
+  assert_false(details.open)
+}, "Clicking an <input type=radio> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_file"));
+  assert_false(details.open)
+}, "Clicking an <input type=file> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("input_image"));
+  assert_false(details.open)
+}, "Clicking an <input type=image> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("label"));
+  assert_false(details.open)
+}, "Clicking a <label> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("textarea"));
+  assert_false(details.open)
+}, "Clicking in a <textarea> doesn’t open <details>");
+promise_test(async () => {
+  details.open = false;
+  await test_driver.click(document.getElementById("video"));
+  assert_false(details.open)
+}, "Clicking a <video> doesn’t open <details>");
+</script>


### PR DESCRIPTION
#### aed2f1dba4a42f57914f579efc8f76b7c9fe8f3e
<pre>
Don’t open “details” when interacting with interactive “summary” descendants
<a href="https://bugs.webkit.org/show_bug.cgi?id=218758">https://bugs.webkit.org/show_bug.cgi?id=218758</a>

Reviewed by Tim Nguyen.

This change ensures that interacting with (clicking/pressing/etc.) any
interactive descendants of a “summary” element will trigger the
activation behavior of those descendants themselves — rather than
instead triggering the “summary” element’s “details” parent to open.

Otherwise, without this change, the activation behavior of interactive
content within a “summary” element will get triggered only if that
interactive content is a direct child of the “summary” element.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html: Added.
* Source/WebCore/html/HTMLSummaryElement.cpp:
(WebCore::isInSummaryInteractiveContent):
(WebCore::HTMLSummaryElement::defaultEventHandler):
(WebCore::isClickableControl): Deleted.

Canonical link: <a href="https://commits.webkit.org/267491@main">https://commits.webkit.org/267491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4e94017e6fced56d17e4e417651a06ceb904de3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16938 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17308 "2 new passes 2 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19310 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14552 "4 flakes 2 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21920 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15541 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15118 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15006 "Exiting early after 10 failures. 12 tests run. 1 flakes") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4011 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->