### PR TITLE
[iPadOS] Google search results page may be clipped in portrait mode with stage manager enabled

### DIFF
--- a/LayoutTests/fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode-expected.txt
+++ b/LayoutTests/fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode-expected.txt
@@ -1,0 +1,6 @@
+PASS contentWidth is 1280
+PASS contentWidth * scale is 820
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode.html
+++ b/LayoutTests/fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true enhancedWindowingEnabled=true ShouldIgnoreMetaViewport=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.horizontal-bar {
+    background: linear-gradient(to right, red 0%, green 50%, blue 100%);
+    width: 1280px;
+    height: 100px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+addEventListener("load", async () => {
+    scale = visualViewport.scale;
+    contentWidth = document.scrollingElement.scrollWidth;
+    // The expected value of 820 here matches the minimum shrink-to-fit width when preferring
+    // horizontal scrolling.
+    shouldBe("contentWidth", "1280");
+    shouldBe("contentWidth * scale", "820");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div class="horizontal-bar"></div>
+</body>
+</html>

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -55,6 +55,7 @@ static inline void adjustViewportArgumentsToAvoidExcessiveZooming(ViewportArgume
 }
 
 constexpr double defaultDesktopViewportWidth = 980;
+constexpr double minimumShrinkToFitWidthWhenPreferringHorizontalScrolling = 820;
 
 #if ASSERT_ENABLED
 static bool constraintsAreAllRelative(const ViewportConfiguration::Parameters& configuration)
@@ -305,7 +306,7 @@ double ViewportConfiguration::initialScaleFromSize(double width, double height, 
         else if (width > 0) {
             auto shrinkToFitWidth = m_viewLayoutSize.width();
             if (m_prefersHorizontalScrollingBelowDesktopViewportWidths)
-                shrinkToFitWidth = std::max<float>(shrinkToFitWidth, std::min(width, defaultDesktopViewportWidth));
+                shrinkToFitWidth = std::max<float>(shrinkToFitWidth, std::min(width, minimumShrinkToFitWidthWhenPreferringHorizontalScrolling));
             initialScale = shrinkToFitWidth / width;
         }
     }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1743,8 +1743,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (BOOL)_isWindowResizingEnabled
 {
-    UIWindowScene *scene = self.window.windowScene;
-    return [scene respondsToSelector:@selector(_enhancedWindowingEnabled)] && scene._enhancedWindowingEnabled;
+    return self.window.windowScene._enhancedWindowingEnabled;
 }
 
 #endif // HAVE(UIKIT_RESIZABLE_WINDOWS)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -610,6 +610,9 @@ private:
 #if ENABLE(IMAGE_ANALYSIS)
     std::unique_ptr<InstanceMethodSwizzler> m_imageAnalysisRequestSwizzler;
 #endif
+#if HAVE(UIKIT_RESIZABLE_WINDOWS)
+    std::unique_ptr<InstanceMethodSwizzler> m_enhancedWindowingEnabledSwizzler;
+#endif
     bool m_verbose { false };
     bool m_printSeparators { false };
     bool m_usingServerMode { false };

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -187,6 +187,7 @@ const TestFeatures& TestOptions::defaults()
             { "noUseRemoteLayerTree", false },
             { "useThreadedScrolling", false },
             { "suppressInputAccessoryView", false },
+            { "enhancedWindowingEnabled", false },
         };
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },
@@ -247,6 +248,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "useRemoteLayerTree", TestHeaderKeyType::BoolTestRunner },
         { "useThreadedScrolling", TestHeaderKeyType::BoolTestRunner },
         { "suppressInputAccessoryView", TestHeaderKeyType::BoolTestRunner },
+        { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
     
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "obscuredInset.top", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -78,6 +78,7 @@ public:
     bool noUseRemoteLayerTree() const { return boolTestRunnerFeatureValue("noUseRemoteLayerTree"); }
     bool useThreadedScrolling() const { return boolTestRunnerFeatureValue("useThreadedScrolling"); }
     bool suppressInputAccessoryView() const { return boolTestRunnerFeatureValue("suppressInputAccessoryView"); }
+    bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }
     double horizontalSystemMinimumLayoutMargin() const { return doubleTestRunnerFeatureValue("horizontalSystemMinimumLayoutMargin"); }


### PR DESCRIPTION
#### 85d3ed836d99c5f7e065ae5fe43ac1e44d73e2fc
<pre>
[iPadOS] Google search results page may be clipped in portrait mode with stage manager enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=260773">https://bugs.webkit.org/show_bug.cgi?id=260773</a>
rdar://109158566

Reviewed by Tim Horton.

When stage manager is enabled (i.e. `-[UIWindowScene _enhancedWindowingEnabled]` is `YES`) and we&apos;re
loading desktop-class websites with no meta viewport, our viewport configuration strategy is:

1.  If the web view is wider than 980 pt, shrink to fit the view.
2.  If the web view is narrower than 980 pt, shrink to fit 980 pt, and then let the rest of the page
    overflow horizontally. This was devised as a way to avoid extremely awkward viewport sizing
    behaviors when resizing windows on iPad to very narrow widths in stage manager, since the entire
    page would be scaled down so much, that it would be left with no legible text.

To achieve (2), 250431@main adjusted some logic when shrinking the viewport to fit, so that we&apos;d
shrink down to fit 980 pt instead of the actual view width when computing the initial scale, when
the stage manager window is smaller than 980 pt. However, this means that on some models of iPad
where portrait mode is as narrow as 820 pt, we get horizontal scrolling in portrait mode, even when
Safari is fullscreen. At the same time, shrinking down to 980 pt also breaks layout on Google search
results, due to (what appears to be) an issue with the site itself when determining which search
results layout to use.

To mitigate both the horizontal scrolling and the site issue on Google search results for now,
simply adjust the (arbitrarily chosen) desktop viewport width of 980 to 820, which is the width of
the narrowest iPad in portrait mode that currently supports Stage Manager, iPad Air (5th gen).

Test: fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode.html

* LayoutTests/fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode-expected.txt: Added.
* LayoutTests/fast/viewport/ios/wide-desktop-viewport-in-enhanced-windowing-mode.html: Added.

Add a layout test that enables stage manager and desktop-class website viewport behaviors, to verify
that we shrink a very wide webpage (1280pt) down to 820, and let the remainder overflow
horizontally. Note that this test runs and yields the same results on both iPhone and iPad, since
it doesn&apos;t matter what the actual viewport length is — as long as it&apos;s below 820pt. Running this on
iPhone effectively simulates changing the stage manager window width on iPad to the narrowest
possible setting, and verifying that it scrolls horizontally instead of scaling down to comically
small proportions.

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::initialScaleFromSize const):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _isWindowResizingEnabled]):

Drive-by fix: remove a runtime selector check that&apos;s no longer required.

* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::enhancedWindowingEnabled const):

Add a mechanism to simulate stage manager being enabled, by swizzling `-_enhancedWindowingEnabled`
and returning `YES`.

* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(overrideEnhancedWindowingEnabled):
(WTR::TestController::platformResetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/267365@main">https://commits.webkit.org/267365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa2366d34628cf0f7260270c8f689b3f0606ebda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18174 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16862 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18943 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14865 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3928 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->