### PR TITLE
Remove obsolete SVGPathElement members

### DIFF
--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -96,10 +96,6 @@ public:
     Ref<SVGPathSegList>& pathSegList() { return m_pathSegList->baseVal(); }
     RefPtr<SVGPathSegList>& animatedPathSegList() { return m_pathSegList->animVal(); }
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=15412 - Implement normalized path segment lists!
-    RefPtr<SVGPathSegList> normalizedPathSegList() { return nullptr; }
-    RefPtr<SVGPathSegList> animatedNormalizedPathSegList() { return nullptr; }
-
     const SVGPathByteStream& pathByteStream() const { return m_pathSegList->currentPathByteStream(); }
     Path path() const { return m_pathSegList->currentPath(); }
     size_t approximateMemoryCost() const final { return m_pathSegList->approximateMemoryCost(); }

--- a/Source/WebCore/svg/SVGPathElement.idl
+++ b/Source/WebCore/svg/SVGPathElement.idl
@@ -98,8 +98,7 @@
     SVGPathSegCurvetoQuadraticSmoothRel createSVGPathSegCurvetoQuadraticSmoothRel(optional unrestricted float x = NaN,
                                                                                   optional unrestricted float y = NaN);
 
+    // FIXME: these are removed from SVG2
     readonly attribute SVGPathSegList pathSegList;
-    readonly attribute SVGPathSegList normalizedPathSegList;
     readonly attribute SVGPathSegList animatedPathSegList;
-    readonly attribute SVGPathSegList animatedNormalizedPathSegList;
 };


### PR DESCRIPTION
#### 015533966bd738b8d2392a8ff5f6c92f63ba1085
<pre>
Remove obsolete SVGPathElement members
<a href="https://bugs.webkit.org/show_bug.cgi?id=200459">https://bugs.webkit.org/show_bug.cgi?id=200459</a>
rdar://114517026

Reviewed by Said Abou-Hallawa.

Both of these already return null so removing them should be fine. The
remaining two require more work.

* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGPathElement.idl:

Canonical link: <a href="https://commits.webkit.org/267446@main">https://commits.webkit.org/267446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b00b9cf365bfdb9e3769ccf28d8c76219ee2fda9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17809 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19037 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21732 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13329 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14899 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3976 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->