### PR TITLE
[css-values] Rounding of <integer> type should round half towards positive infinity

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-z-index-fractions-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-z-index-fractions-001-expected.txt
@@ -1,4 +1,8 @@
 
+PASS testing z-index: calc(2.5 / 2)
 PASS testing z-index: calc(3 / 2)
-FAIL testing z-index: calc(-3 / 2) assert_equals: expected "-1" but got "-2"
+PASS testing z-index: calc(3.5 / 2)
+PASS testing z-index: calc(-2.5 / 2)
+PASS testing z-index: calc(-3 / 2)
+PASS testing z-index: calc(-3.5 / 2)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-z-index-fractions-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-z-index-fractions-001.html
@@ -46,11 +46,12 @@
     }
 
  /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value, description) */
-
+    verifyComputedStyle("z-index", "auto", "calc(2.5 / 2)", "1", "testing z-index: calc(2.5 / 2)");
     verifyComputedStyle("z-index", "auto", "calc(3 / 2)", "2", "testing z-index: calc(3 / 2)");
-
+    verifyComputedStyle("z-index", "auto", "calc(3.5 / 2)", "2", "testing z-index: calc(3.5 / 2)");
+    verifyComputedStyle("z-index", "auto", "calc(-2.5 / 2)", "-1", "testing z-index: calc(-2.5 / 2)");
     verifyComputedStyle("z-index", "auto", "calc(-3 / 2)", "-1", "testing z-index: calc(-3 / 2)");
-
+    verifyComputedStyle("z-index", "auto", "calc(-3.5 / 2)", "-2", "testing z-index: calc(-3.5 / 2)");
   }
 
   startTesting();

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -266,7 +266,9 @@ struct IntegerTypeRawKnownTokenTypeFunctionConsumer {
         auto rangeCopy = range;
         if (auto value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, { }, ValueRange::All)) {
             range = rangeCopy;
-            return clampTo<IntType>(std::round(std::max(value->doubleValue(), computeMinimumValue(integerRange))));
+            // https://drafts.csswg.org/css-values-4/#integers
+            // Rounding to the nearest integer requires rounding in the direction of +∞ when the fractional portion is exactly 0.5.
+            return clampTo<IntType>(std::floor(std::max(value->doubleValue(), computeMinimumValue(integerRange)) + 0.5));
         }
 
         return std::nullopt;


### PR DESCRIPTION
#### 98b6a2103ec09522e2ff5b3f5264355b8ee1dad8
<pre>
[css-values] Rounding of &lt;integer&gt; type should round half towards positive infinity
<a href="https://bugs.webkit.org/show_bug.cgi?id=260777">https://bugs.webkit.org/show_bug.cgi?id=260777</a>
rdar://114532926

Reviewed by Darin Adler.

<a href="https://drafts.csswg.org/css-values-4/#integers">https://drafts.csswg.org/css-values-4/#integers</a>
Rounding to the nearest integer requires rounding in the direction of +∞ when the fractional portion is exactly 0.5.

-1.5 should round to -1, not -2.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-z-index-fractions-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-z-index-fractions-001.html:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::IntegerTypeRawKnownTokenTypeFunctionConsumer::consume):

Canonical link: <a href="https://commits.webkit.org/267339@main">https://commits.webkit.org/267339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/849805b227664add13d80cc64daace844ae87059

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15325 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/16527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16793 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/16532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/16970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18873 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15552 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13206 "Failed to checkout and rebase branch from PR 17113") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14768 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/14644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19136 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2006 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->