### PR TITLE
BackgroundProcessResponsivenessTimer should have CheckedRef of WebProcessProxy

### DIFF
--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -48,6 +48,11 @@ BackgroundProcessResponsivenessTimer::~BackgroundProcessResponsivenessTimer()
 {
 }
 
+Ref<WebProcessProxy> BackgroundProcessResponsivenessTimer::protectedWebProcessProxy() const
+{
+    return const_cast<WebProcessProxy&>(m_webProcessProxy.get());
+}
+
 void BackgroundProcessResponsivenessTimer::updateState()
 {
     if (!shouldBeActive()) {
@@ -93,7 +98,7 @@ void BackgroundProcessResponsivenessTimer::responsivenessCheckTimerFired()
     ASSERT(!m_timeoutTimer.isActive());
 
     m_timeoutTimer.startOneShot(responsivenessTimeout);
-    m_webProcessProxy.send(Messages::WebProcess::BackgroundResponsivenessPing(), 0);
+    protectedWebProcessProxy()->send(Messages::WebProcess::BackgroundResponsivenessPing(), 0);
 }
 
 void BackgroundProcessResponsivenessTimer::timeoutTimerFired()
@@ -104,7 +109,7 @@ void BackgroundProcessResponsivenessTimer::timeoutTimerFired()
 
     // This shouldn't happen but still check to be 100% sure we don't report
     // suspended processes as unresponsive.
-    if (m_webProcessProxy.throttler().isSuspended())
+    if (protectedWebProcessProxy()->throttler().isSuspended())
         return;
 
     if (!m_isResponsive)
@@ -128,10 +133,10 @@ void BackgroundProcessResponsivenessTimer::setResponsive(bool isResponsive)
     client().didChangeIsResponsive();
 
     if (m_isResponsive) {
-        RELEASE_LOG_ERROR(PerformanceLogging, "Notifying the client that background WebProcess with pid %d has become responsive again", m_webProcessProxy.processID());
+        RELEASE_LOG_ERROR(PerformanceLogging, "Notifying the client that background WebProcess with pid %d has become responsive again", m_webProcessProxy->processID());
         client().didBecomeResponsive();
     } else {
-        RELEASE_LOG_ERROR(PerformanceLogging, "Notifying the client that background WebProcess with pid %d has become unresponsive", m_webProcessProxy.processID());
+        RELEASE_LOG_ERROR(PerformanceLogging, "Notifying the client that background WebProcess with pid %d has become unresponsive", m_webProcessProxy->processID());
         client().didBecomeUnresponsive();
     }
 }
@@ -139,13 +144,14 @@ void BackgroundProcessResponsivenessTimer::setResponsive(bool isResponsive)
 bool BackgroundProcessResponsivenessTimer::shouldBeActive() const
 {
 #if !PLATFORM(IOS_FAMILY)
-    if (m_webProcessProxy.visiblePageCount())
+    auto webProcess = protectedWebProcessProxy();
+    if (webProcess->visiblePageCount())
         return false;
-    if (m_webProcessProxy.throttler().isSuspended())
+    if (webProcess->throttler().isSuspended())
         return false;
-    if (m_webProcessProxy.isStandaloneServiceWorkerProcess())
+    if (webProcess->isStandaloneServiceWorkerProcess())
         return true;
-    return m_webProcessProxy.pageCount();
+    return webProcess->pageCount();
 #else
     // Disable background process responsiveness checking when using RunningBoard since such processes usually get suspended.
     return false;
@@ -167,7 +173,7 @@ void BackgroundProcessResponsivenessTimer::scheduleNextResponsivenessCheck()
 
 ResponsivenessTimer::Client& BackgroundProcessResponsivenessTimer::client() const
 {
-    return m_webProcessProxy;
+    return const_cast<WebProcessProxy&>(m_webProcessProxy.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -45,6 +45,7 @@ public:
     void processTerminated();
 
 private:
+    Ref<WebProcessProxy> protectedWebProcessProxy() const;
     void responsivenessCheckTimerFired();
     void timeoutTimerFired();
     void setResponsive(bool);
@@ -54,7 +55,7 @@ private:
     void scheduleNextResponsivenessCheck();
     ResponsivenessTimer::Client& client() const;
 
-    WebProcessProxy& m_webProcessProxy;
+    CheckedRef<WebProcessProxy> m_webProcessProxy;
     Seconds m_checkingInterval;
     RunLoop::Timer m_responsivenessCheckTimer;
     RunLoop::Timer m_timeoutTimer;


### PR DESCRIPTION
#### 907c98fd7174fa186998e53c6c759451de9450e0
<pre>
BackgroundProcessResponsivenessTimer should have CheckedRef of WebProcessProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=260783">https://bugs.webkit.org/show_bug.cgi?id=260783</a>

Reviewed by Chris Dumez.

Use CheckedRef of WebProcessProxy in place of a raw reference.

* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::protectedWebProcessProxy const):
(WebKit::BackgroundProcessResponsivenessTimer::responsivenessCheckTimerFired):
(WebKit::BackgroundProcessResponsivenessTimer::timeoutTimerFired):
(WebKit::BackgroundProcessResponsivenessTimer::setResponsive):
(WebKit::BackgroundProcessResponsivenessTimer::shouldBeActive const):
(WebKit::BackgroundProcessResponsivenessTimer::client const):
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:

Canonical link: <a href="https://commits.webkit.org/267356@main">https://commits.webkit.org/267356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55521a56a588c185c95f3e9b96790a1b7cbe9ded

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17697 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18871 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14213 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21601 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19093 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13203 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19134 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2008 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->