### PR TITLE
[Tools][GTK][WPE] Add missing 'mesa-common-dev' dependency

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -484,7 +484,11 @@ class BundleCreator(object):
     def _get_mesa_libraries(self):
         mesa_library_names = ['libglapi', 'libEGL', 'libGL', 'libGLESv2', 'libGLX', 'libdrm', 'libgbm', 'libMesaOpenCL']
         mesa_libraries = []
-        lib_dir_dri = self._get_pkg_config_var('dri', 'libdir')
+        try:
+            lib_dir_dri = self._get_pkg_config_var('dri', 'libdir')
+        except RuntimeError:
+            lib_dir_dri = os.path.dirname(self._get_pkg_config_var('dri', 'dridriverdir'))
+
         # Some versions of the flatpak SDK ship the Mesa libraries into a non-standard path.
         candidate_lib_dirs = [ lib_dir_dri, os.path.join(lib_dir_dri, 'GL/default/lib') ]
         for lib_dir in candidate_lib_dirs:

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -70,6 +70,7 @@ PACKAGES=(
     $(aptIfExists libwpebackend-fdo-1.0-dev)
     libxml2-utils
     libxslt1-dev
+    mesa-common-dev
     ninja-build
     patch
     ruby


### PR DESCRIPTION
#### 8124fd9a748e43f40956b338fc58f132d145bfab
<pre>
[Tools][GTK][WPE] Add missing &apos;mesa-common-dev&apos; dependency
<a href="https://bugs.webkit.org/show_bug.cgi?id=260496">https://bugs.webkit.org/show_bug.cgi?id=260496</a>

Reviewed by Carlos Alberto Lopez Perez.

267186@main requires dri.pkg but this file is only available if
&apos;mesa-common-dev&apos; is installed.

Besides, Debian 12 reported a runtime error because the file
&apos;dri.pkg&apos; no longer defines the variable &apos;libdir&apos;. In case &apos;libdir&apos; doesn&apos;t
exist, set &apos;libdir&apos; to the parent dir of &apos;dridriverdir&apos; fixes the issue.

* Tools/Scripts/generate-bundle:
* Tools/glib/dependencies/apt:

Canonical link: <a href="https://commits.webkit.org/267404@main">https://commits.webkit.org/267404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bfd8527b4a54d880672cee62f5861dade769c87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17769 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18969 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21680 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19358 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13282 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14843 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3949 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->