### PR TITLE
REGRESSION(263118@main): [CoordinatedGraphics] Incomplete rendering after 10s inactivity without hardware acceleration

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -75,16 +75,61 @@ void DrawingAreaProxyCoordinatedGraphics::paint(BackingStore::PlatformGraphicsCo
     if (isInAcceleratedCompositingMode())
         return;
 
-    if (!m_backingStore) {
-        if (!m_isWaitingForDidUpdateGeometry)
-            m_webPageProxy.send(Messages::DrawingArea::ForceUpdate(), m_identifier);
+    if (!m_backingStore && !forceUpdateIfNeeded())
         return;
-    }
 
     m_backingStore->paint(context, rect);
     unpaintedRegion.subtract(IntRect(IntPoint(), m_backingStore->size()));
 
     discardBackingStoreSoon();
+}
+
+bool DrawingAreaProxyCoordinatedGraphics::forceUpdateIfNeeded()
+{
+    ASSERT(!isInAcceleratedCompositingMode());
+
+    if (!m_webPageProxy.hasRunningProcess())
+        return false;
+
+    if (m_webPageProxy.process().state() == WebProcessProxy::State::Launching)
+        return false;
+
+    if (m_isWaitingForDidUpdateGeometry)
+        return false;
+
+    if (!m_webPageProxy.isViewVisible())
+        return false;
+
+    SetForScope inForceUpdate(m_inForceUpdate, true);
+    m_webPageProxy.send(Messages::DrawingArea::ForceUpdate(), m_identifier);
+    m_webPageProxy.process().connection()->waitForAndDispatchImmediately<Messages::DrawingAreaProxy::Update>(m_identifier, Seconds::fromMilliseconds(500));
+    return !!m_backingStore;
+}
+
+void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(UpdateInfo&& updateInfo)
+{
+    ASSERT(!isInAcceleratedCompositingMode());
+
+    if (updateInfo.updateRectBounds.isEmpty())
+        return;
+
+    if (!m_backingStore || m_backingStore->size() != updateInfo.viewSize || m_backingStore->deviceScaleFactor() != updateInfo.deviceScaleFactor)
+        m_backingStore = makeUnique<BackingStore>(updateInfo.viewSize, updateInfo.deviceScaleFactor, m_webPageProxy);
+
+    if (m_inForceUpdate) {
+        m_backingStore->incorporateUpdate(WTFMove(updateInfo));
+        return;
+    }
+
+    Region damageRegion;
+    if (updateInfo.scrollRect.isEmpty()) {
+        for (const auto& rect : updateInfo.updateRects)
+            damageRegion.unite(rect);
+    } else
+        damageRegion = IntRect(IntPoint(), m_webPageProxy.viewSize());
+
+    m_backingStore->incorporateUpdate(WTFMove(updateInfo));
+    m_webPageProxy.setViewNeedsDisplay(damageRegion);
 }
 #endif
 
@@ -170,30 +215,6 @@ void DrawingAreaProxyCoordinatedGraphics::targetRefreshRateDidChange(unsigned ra
     m_webPageProxy.send(Messages::DrawingArea::TargetRefreshRateDidChange(rate), m_identifier);
 }
 
-#if !PLATFORM(WPE)
-void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(UpdateInfo&& updateInfo)
-{
-    ASSERT(!isInAcceleratedCompositingMode());
-
-    if (updateInfo.updateRectBounds.isEmpty())
-        return;
-
-    if (!m_backingStore || m_backingStore->size() != updateInfo.viewSize || m_backingStore->deviceScaleFactor() != updateInfo.deviceScaleFactor)
-        m_backingStore = makeUnique<BackingStore>(updateInfo.viewSize, updateInfo.deviceScaleFactor, m_webPageProxy);
-
-    Region damageRegion;
-    if (updateInfo.scrollRect.isEmpty()) {
-        for (const auto& rect : updateInfo.updateRects)
-            damageRegion.unite(rect);
-    } else
-        damageRegion = IntRect(IntPoint(), m_webPageProxy.viewSize());
-
-    m_backingStore->incorporateUpdate(WTFMove(updateInfo));
-
-    m_webPageProxy.setViewNeedsDisplay(damageRegion);
-}
-#endif
-
 bool DrawingAreaProxyCoordinatedGraphics::alwaysUseCompositing() const
 {
     return m_webPageProxy.preferences().acceleratedCompositingEnabled() && m_webPageProxy.preferences().forceCompositingMode();
@@ -203,7 +224,7 @@ void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(const 
 {
     ASSERT(!isInAcceleratedCompositingMode());
 #if !PLATFORM(WPE)
-    discardBackingStore();
+    m_backingStore = nullptr;
 #endif
     m_layerTreeContext = layerTreeContext;
     m_webPageProxy.enterAcceleratedCompositingMode(layerTreeContext);
@@ -265,7 +286,11 @@ void DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon()
 
 void DrawingAreaProxyCoordinatedGraphics::discardBackingStore()
 {
+    if (!m_backingStore)
+        return;
+
     m_backingStore = nullptr;
+    m_webPageProxy.send(Messages::DrawingArea::DidDiscardBackingStore(), m_identifier);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -72,10 +72,6 @@ private:
 
     bool shouldSendWheelEventsToEventDispatcher() const override { return true; }
 
-#if !PLATFORM(WPE)
-    void incorporateUpdate(UpdateInfo&&);
-#endif
-
     bool alwaysUseCompositing() const;
     void enterAcceleratedCompositingMode(const LayerTreeContext&);
     void exitAcceleratedCompositingMode();
@@ -85,6 +81,8 @@ private:
     void didUpdateGeometry();
 
 #if !PLATFORM(WPE)
+    bool forceUpdateIfNeeded();
+    void incorporateUpdate(UpdateInfo&&);
     void discardBackingStoreSoon();
     void discardBackingStore();
 #endif
@@ -123,6 +121,7 @@ private:
 
 #if !PLATFORM(WPE)
     bool m_isBackingStoreDiscardable { true };
+    bool m_inForceUpdate { false };
     std::unique_ptr<BackingStore> m_backingStore;
     RunLoop::Timer m_discardBackingStoreTimer;
 #endif

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
@@ -27,7 +27,7 @@ messages -> DrawingAreaProxy NotRefCounted {
     DispatchPresentationCallbacksAfterFlushingLayers(Vector<IPC::AsyncReplyID> callbackIDs);
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    Update(uint64_t stateID, struct WebKit::UpdateInfo updateInfo)
+    Update(uint64_t stateID, struct WebKit::UpdateInfo updateInfo) CanDispatchOutOfOrder
     ExitAcceleratedCompositingMode(uint64_t backingStoreStateID, struct WebKit::UpdateInfo updateInfo)
 #endif
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -88,6 +88,7 @@ private:
     void displayDidRefresh() override;
     void setDeviceScaleFactor(float) override;
     void forceUpdate() override;
+    void didDiscardBackingStore() override;
 
 #if PLATFORM(GTK)
     void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -213,6 +213,7 @@ private:
     virtual void targetRefreshRateDidChange(unsigned /*rate*/) { }
     virtual void setDeviceScaleFactor(float) { }
     virtual void forceUpdate() { }
+    virtual void didDiscardBackingStore() { }
 #endif
     virtual void displayDidRefresh() { }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -26,6 +26,7 @@ messages -> DrawingArea NotRefCounted {
     TargetRefreshRateDidChange(unsigned rate)
     SetDeviceScaleFactor(float deviceScaleFactor)
     ForceUpdate()
+    DidDiscardBackingStore()
 #endif
 
     DisplayDidRefresh()


### PR DESCRIPTION
#### 3e47e6d0c366be710c81c8b594d0aa33d1096400
<pre>
REGRESSION(263118@main): [CoordinatedGraphics] Incomplete rendering after 10s inactivity without hardware acceleration
<a href="https://bugs.webkit.org/show_bug.cgi?id=260505">https://bugs.webkit.org/show_bug.cgi?id=260505</a>

Reviewed by Michael Catanzaro.

When the backing store is discarded in the UI process we need to notify
the web process to reset the dirty region to the entire web view and
ensure next update is not partial. This avoids flickering and ensures a
full update of the view when a new backing store is created. We should
also avoid flickering when forcing an update, by waiting for the Update
message synchronously.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::paint):
(WebKit::DrawingAreaProxyCoordinatedGraphics::forceUpdateIfNeeded):
(WebKit::DrawingAreaProxyCoordinatedGraphics::incorporateUpdate):
(WebKit::DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode):
(WebKit::DrawingAreaProxyCoordinatedGraphics::discardBackingStore):
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updateGeometry):
(WebKit::DrawingAreaCoordinatedGraphics::didDiscardBackingStore):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::didDiscardBackingStore):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:

Canonical link: <a href="https://commits.webkit.org/267399@main">https://commits.webkit.org/267399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5028a951a2adff4b5b3630b76a41998f16ca90ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15333 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18881 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14222 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21611 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19213 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13216 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19144 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2025 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->