### PR TITLE
Use BinaryType for RTCDataChannel

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt
@@ -1,9 +1,12 @@
 
+FAIL Default binaryType value assert_equals: dc.binaryType should be 'blob' expected "blob" but got "arraybuffer"
 PASS Setting binaryType to 'blob' should succeed
 PASS Setting binaryType to 'arraybuffer' should succeed
-PASS Setting invalid binaryType 'jellyfish' should throw SyntaxError
-PASS Setting invalid binaryType 'arraybuffer ' should throw SyntaxError
-PASS Setting invalid binaryType '' should throw SyntaxError
-PASS Setting invalid binaryType 'null' should throw SyntaxError
-PASS Setting invalid binaryType 'undefined' should throw SyntaxError
+PASS Setting binaryType to 'jellyfish' should be ignored
+PASS Setting binaryType to 'arraybuffer ' should be ignored
+PASS Setting binaryType to '' should be ignored
+PASS Setting binaryType to 'null' should be ignored
+PASS Setting binaryType to 'undefined' should be ignored
+PASS Setting binaryType to '234' should be ignored
+PASS Setting binaryType to '54' should be ignored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window.js
@@ -1,7 +1,15 @@
 'use strict';
 
 const validBinaryTypes = ['blob', 'arraybuffer'];
-const invalidBinaryTypes = ['jellyfish', 'arraybuffer ', '', null, undefined];
+const invalidBinaryTypes = ['jellyfish', 'arraybuffer ', '', null, undefined, 234, 54n];
+
+test((t) => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const dc = pc.createDataChannel('test-binary-type');
+
+  assert_equals(dc.binaryType, "blob", `dc.binaryType should be 'blob'`);
+}, `Default binaryType value`);
 
 for (const binaryType of validBinaryTypes) {
   test((t) => {
@@ -20,8 +28,8 @@ for (const binaryType of invalidBinaryTypes) {
     t.add_cleanup(() => pc.close());
     const dc = pc.createDataChannel('test-binary-type');
 
-    assert_throws_dom('SyntaxError', () => {
-      dc.binaryType = binaryType;
-    });
-  }, `Setting invalid binaryType '${binaryType}' should throw SyntaxError`);
+    dc.binaryType = "arraybuffer";
+    dc.binaryType = binaryType;
+    assert_equals(dc.binaryType, "arraybuffer");
+  }, `Setting binaryType to '${binaryType}' should be ignored`);
 }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -47,18 +47,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RTCDataChannel);
 
-static const AtomString& blobKeyword()
-{
-    static MainThreadNeverDestroyed<const AtomString> blob("blob"_s);
-    return blob;
-}
-
-static const AtomString& arraybufferKeyword()
-{
-    static MainThreadNeverDestroyed<const AtomString> arraybuffer("arraybuffer"_s);
-    return arraybuffer;
-}
-
 Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, std::unique_ptr<RTCDataChannelHandler>&& handler, String&& label, RTCDataChannelInit&& options, RTCDataChannelState state)
 {
     ASSERT(handler);
@@ -113,30 +101,9 @@ std::optional<unsigned short> RTCDataChannel::id() const
     return m_options.id;
 }
 
-const AtomString& RTCDataChannel::binaryType() const
+void RTCDataChannel::setBinaryType(BinaryType binaryType)
 {
-    switch (m_binaryType) {
-    case BinaryType::Blob:
-        return blobKeyword();
-    case BinaryType::ArrayBuffer:
-        return arraybufferKeyword();
-    }
-
-    ASSERT_NOT_REACHED();
-    return emptyAtom();
-}
-
-ExceptionOr<void> RTCDataChannel::setBinaryType(const AtomString& binaryType)
-{
-    if (binaryType == blobKeyword()) {
-        m_binaryType = BinaryType::Blob;
-        return { };
-    }
-    if (binaryType == arraybufferKeyword()) {
-        m_binaryType = BinaryType::ArrayBuffer;
-        return { };
-    }
-    return Exception { SyntaxError };
+    m_binaryType = binaryType;
 }
 
 ExceptionOr<void> RTCDataChannel::send(const String& data)
@@ -245,7 +212,7 @@ void RTCDataChannel::didReceiveRawData(const uint8_t* data, size_t dataLength)
     case BinaryType::Blob:
         scheduleDispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), Vector { data, dataLength }, emptyString()), { }));
         return;
-    case BinaryType::ArrayBuffer:
+    case BinaryType::Arraybuffer:
         scheduleDispatchEvent(MessageEvent::create(ArrayBuffer::create(data, dataLength)));
         return;
     }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -71,8 +71,9 @@ public:
     size_t bufferedAmountLowThreshold() const { return m_bufferedAmountLowThreshold; }
     void setBufferedAmountLowThreshold(size_t value) { m_bufferedAmountLowThreshold = value; }
 
-    const AtomString& binaryType() const;
-    ExceptionOr<void> setBinaryType(const AtomString&);
+    enum class BinaryType : bool { Blob, Arraybuffer };
+    BinaryType binaryType() const { return m_binaryType; }
+    void setBinaryType(BinaryType);
 
     ExceptionOr<void> send(const String&);
     ExceptionOr<void> send(JSC::ArrayBuffer&);
@@ -124,8 +125,7 @@ private:
     bool m_stopped { false };
     RTCDataChannelState m_readyState { RTCDataChannelState::Connecting };
 
-    enum class BinaryType { Blob, ArrayBuffer };
-    BinaryType m_binaryType { BinaryType::ArrayBuffer };
+    BinaryType m_binaryType { BinaryType::Arraybuffer };
 
     String m_label;
     RTCDataChannelInit m_options;

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.idl
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.idl
@@ -23,6 +23,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum BinaryType { "blob", "arraybuffer" };
+
 [
     ActiveDOMObject,
     Conditional=WEB_RTC,
@@ -43,7 +45,7 @@
     readonly attribute RTCPriorityType priority;
     attribute unsigned long bufferedAmountLowThreshold;
 
-    attribute [AtomString] DOMString binaryType;
+    attribute BinaryType binaryType;
 
     undefined send(ArrayBuffer data);
     undefined send(ArrayBufferView data);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -476,10 +476,9 @@ String WebSocket::extensions() const
     return m_extensions;
 }
 
-ExceptionOr<void> WebSocket::setBinaryType(BinaryType binaryType)
+void WebSocket::setBinaryType(BinaryType binaryType)
 {
     m_binaryType = binaryType;
-    return { };
 }
 
 EventTargetInterface WebSocket::eventTargetInterface() const

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -90,7 +90,7 @@ public:
 
     enum class BinaryType : bool { Blob, Arraybuffer };
     BinaryType binaryType() const { return m_binaryType; }
-    ExceptionOr<void> setBinaryType(BinaryType);
+    void setBinaryType(BinaryType);
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 


### PR DESCRIPTION
#### 6cabcd45af4dce6a46dc35330fa12a0aa078cab5
<pre>
Use BinaryType for RTCDataChannel
<a href="https://bugs.webkit.org/show_bug.cgi?id=260790">https://bugs.webkit.org/show_bug.cgi?id=260790</a>
rdar://114559008

Reviewed by Youenn Fablet.

Aligns RTCDataChannel with its specification (and WebSocket). Also
address some nits in our WebSocket setBinaryType() implementation.

This largely matches Gecko. (Chromium does not appear to implement
this.) Gecko and the specification still have a different default
value.

Updated tests are upstreamed via
<a href="https://github.com/web-platform-tests/wpt/pull/41663.">https://github.com/web-platform-tests/wpt/pull/41663.</a>

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window.js:
(test):
(const.binaryType.of.invalidBinaryTypes.test):
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::setBinaryType):
(WebCore::RTCDataChannel::didReceiveRawData):
(WebCore::blobKeyword): Deleted.
(WebCore::arraybufferKeyword): Deleted.
(WebCore::RTCDataChannel::binaryType const): Deleted.
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.idl:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::setBinaryType):
* Source/WebCore/Modules/websockets/WebSocket.h:

Canonical link: <a href="https://commits.webkit.org/267353@main">https://commits.webkit.org/267353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0596b279db4070dc148b232d8c2143253d2913c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16815 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18892 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14824 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19264 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13228 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14786 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3920 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->