### PR TITLE
Fine-grained invalidation for :host pseudo-class in non-subject position

### DIFF
--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -68,26 +68,34 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
     if (shouldInvalidateCurrent)
         m_element.invalidateStyle();
 
-    auto& ruleSets = m_element.styleResolver().ruleSets();
+    auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
+        auto* invalidationRuleSets = ruleSets.attributeInvalidationRuleSets(attributeNameForLookups);
+        if (!invalidationRuleSets)
+            return;
 
-    auto* invalidationRuleSets = ruleSets.attributeInvalidationRuleSets(attributeNameForLookups);
-    if (!invalidationRuleSets)
-        return;
-
-    for (auto& invalidationRuleSet : *invalidationRuleSets) {
-        for (auto* selector : invalidationRuleSet.invalidationSelectors) {
-            if (!selector->isAttributeSelector()) {
-                ASSERT_NOT_REACHED();
+        for (auto& invalidationRuleSet : *invalidationRuleSets) {
+            if (onlyMatchElement && invalidationRuleSet.matchElement != onlyMatchElement)
                 continue;
-            }
-            bool oldMatches = !oldValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, oldValue, *selector);
-            bool newMatches = !newValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, newValue, *selector);
-            if (oldMatches != newMatches) {
-                Invalidator::addToMatchElementRuleSets(m_matchElementRuleSets, invalidationRuleSet);
-                break;
+
+            for (auto* selector : invalidationRuleSet.invalidationSelectors) {
+                if (!selector->isAttributeSelector()) {
+                    ASSERT_NOT_REACHED();
+                    continue;
+                }
+                bool oldMatches = !oldValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, oldValue, *selector);
+                bool newMatches = !newValue.isNull() && SelectorChecker::attributeSelectorMatches(m_element, attributeName, newValue, *selector);
+                if (oldMatches != newMatches) {
+                    Invalidator::addToMatchElementRuleSets(m_matchElementRuleSets, invalidationRuleSet);
+                    break;
+                }
             }
         }
-    }
+    };
+
+    collect(m_element.styleResolver().ruleSets());
+
+    if (auto* shadowRoot = m_element.shadowRoot())
+        collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 }
 
 void AttributeChangeInvalidation::invalidateStyleWithRuleSets()

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -224,7 +224,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             idsInRules.add(selector->value());
             if (matchElement == MatchElement::Parent || matchElement == MatchElement::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
-            else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling || matchElement == MatchElement::HostChild)
+            else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling || matchElement == MatchElement::Host || matchElement == MatchElement::HostChild)
                 selectorFeatures.ids.append({ selector, matchElement, isNegation });
         } else if (selector->match() == CSSSelector::Match::Class)
             selectorFeatures.classes.append({ selector, matchElement, isNegation });

--- a/Source/WebCore/style/StyleInvalidationFunctions.h
+++ b/Source/WebCore/style/StyleInvalidationFunctions.h
@@ -41,15 +41,13 @@ inline void traverseRuleFeaturesInShadowTree(Element& element, TraverseFunction&
         return;
 
     auto& shadowRuleSets = element.shadowRoot()->styleScope().resolver().ruleSets();
-    bool hasHostPseudoClassRulesMatchingInShadowTree = false;
     bool hasHostPseudoClassRule = shadowRuleSets.hasMatchingUserOrAuthorStyle([&] (auto& style) {
-        hasHostPseudoClassRulesMatchingInShadowTree = style.hasHostPseudoClassRulesMatchingInShadowTree();
-        return !style.hostPseudoClassRules().isEmpty();
+        return !style.hostPseudoClassRules().isEmpty() || style.hasHostPseudoClassRulesMatchingInShadowTree();
     });
-    if (!hasHostPseudoClassRule && !hasHostPseudoClassRulesMatchingInShadowTree)
+    if (!hasHostPseudoClassRule)
         return;
 
-    function(shadowRuleSets.features(), hasHostPseudoClassRulesMatchingInShadowTree);
+    function(shadowRuleSets.features(), false);
 }
 
 template <typename TraverseFunction>

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -121,6 +121,8 @@ Invalidator::RuleInformation Invalidator::collectRuleInformation()
             information.hasSlottedPseudoElementRules = true;
         if (!ruleSet->hostPseudoClassRules().isEmpty())
             information.hasHostPseudoClassRules = true;
+        if (ruleSet->hasHostPseudoClassRulesMatchingInShadowTree())
+            information.hasHostPseudoClassRulesMatchingInShadowTree = true;
         if (ruleSet->hasShadowPseudoElementRules())
             information.hasShadowPseudoElementRules = true;
 #if ENABLE(VIDEO)
@@ -410,6 +412,13 @@ void Invalidator::invalidateInShadowTreeIfNeeded(Element& element)
 
     if (m_ruleInformation.hasShadowPseudoElementRules)
         invalidateShadowPseudoElements(*shadowRoot);
+
+    if (m_ruleInformation.hasHostPseudoClassRulesMatchingInShadowTree) {
+        for (auto& child : childrenOfType<Element>(*shadowRoot)) {
+            SelectorMatchingState selectorMatchingState;
+            invalidateStyleForTree(child, &selectorMatchingState);
+        }
+    }
 
 #if ENABLE(VIDEO)
     if (m_ruleInformation.hasCuePseudoElementRules && element.isMediaElement())

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -81,6 +81,7 @@ private:
     struct RuleInformation {
         bool hasSlottedPseudoElementRules { false };
         bool hasHostPseudoClassRules { false };
+        bool hasHostPseudoClassRulesMatchingInShadowTree { false };
         bool hasShadowPseudoElementRules { false };
         bool hasCuePseudoElementRules { false };
         bool hasPartPseudoElementRules { false };


### PR DESCRIPTION
#### 321396c31ca55d74570f52eea689216142d98af1
<pre>
Fine-grained invalidation for :host pseudo-class in non-subject position
<a href="https://bugs.webkit.org/show_bug.cgi?id=260791">https://bugs.webkit.org/show_bug.cgi?id=260791</a>
rdar://problem/114560066

Reviewed by Alan Baradlay.

Handle invalidation of cases like

:host(.foo) bar

efficiently.

* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):

Collect any host rules from the shadow tree. This pattern repeats for attribute/id/class/pseudo-class cases.

* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/IdChangeInvalidation.cpp:
(WebCore::Style::IdChangeInvalidation::invalidateStyle):
* Source/WebCore/style/PseudoClassChangeInvalidation.cpp:
(WebCore::Style::PseudoClassChangeInvalidation::collectRuleSets):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeNextMatchElement):
(WebCore::Style::computeHasPseudoClassMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
* Source/WebCore/style/StyleInvalidationFunctions.h:
(WebCore::Style::traverseRuleFeaturesInShadowTree):

Don&apos;t force full shadow tree style recalc by returning mayAffectShadowTree bit in these cases.

* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::collectRuleInformation):

Collect host rules for id invalidation.

(WebCore::Style::Invalidator::invalidateInShadowTreeIfNeeded):

Traverse the shadow tree if needed.

* Source/WebCore/style/StyleInvalidator.h:

Canonical link: <a href="https://commits.webkit.org/267355@main">https://commits.webkit.org/267355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0712fc9b1ac50d5edebf5ef84b38aba7034b9e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17718 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18893 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21623 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13229 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14787 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3921 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->