### PR TITLE
[Cocoa] Cancel pending getDisplayMedia prompt when page is reloaded

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h
@@ -104,6 +104,7 @@ public:
     void cancelPendingSessionForDevice(const CaptureDevice&);
 
     WEBCORE_EXPORT void promptForGetDisplayMedia(DisplayCapturePromptType, CompletionHandler<void(std::optional<CaptureDevice>)>&&);
+    WEBCORE_EXPORT void cancelGetDisplayMediaPrompt();
 
 private:
     void cleanupAllSessions();
@@ -119,7 +120,6 @@ private:
     WeakPtr<ScreenCaptureSessionSource> findActiveSource(SCContentSharingSession*);
 
     Vector<WeakPtr<ScreenCaptureSessionSource>> m_activeSources;
-    Vector<std::tuple<RetainPtr<SCContentFilter>, RetainPtr<SCContentSharingSession>>> m_pendingSessions;
 
     RetainPtr<SCContentSharingSession> m_pendingSession;
     RetainPtr<SCContentFilter> m_pendingContentFilter;

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -231,6 +231,12 @@ ScreenCaptureKitSharingSessionManager::~ScreenCaptureKitSharingSessionManager()
     }
 }
 
+void ScreenCaptureKitSharingSessionManager::cancelGetDisplayMediaPrompt()
+{
+    if (promptingInProgress())
+        cancelPicking();
+}
+
 void ScreenCaptureKitSharingSessionManager::cancelPicking()
 {
     ASSERT(isMainThread());

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -507,6 +507,12 @@ void GPUProcess::promptForGetDisplayMedia(WebCore::DisplayCapturePromptType type
 {
     WebCore::ScreenCaptureKitSharingSessionManager::singleton().promptForGetDisplayMedia(type, WTFMove(completionHandler));
 }
+
+void GPUProcess::cancelGetDisplayMediaPrompt()
+{
+    WebCore::ScreenCaptureKitSharingSessionManager::singleton().cancelGetDisplayMediaPrompt();
+}
+
 #endif // HAVE(SCREEN_CAPTURE_KIT)
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -170,6 +170,7 @@ private:
 #endif
 #if HAVE(SCREEN_CAPTURE_KIT)
     void promptForGetDisplayMedia(WebCore::DisplayCapturePromptType, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
+    void cancelGetDisplayMediaPrompt();
 #endif
 #if PLATFORM(MAC)
     void displayConfigurationChanged(CGDirectDisplayID, CGDisplayChangeSummaryFlags);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -60,6 +60,7 @@ messages -> GPUProcess LegacyReceiver {
 
 #if HAVE(SCREEN_CAPTURE_KIT)
     PromptForGetDisplayMedia(enum:uint8_t WebCore::DisplayCapturePromptType type) -> (std::optional<WebCore::CaptureDevice> device)
+    CancelGetDisplayMediaPrompt()
 #endif
 
 #if ENABLE(VIDEO)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -460,6 +460,11 @@ void GPUProcessProxy::promptForGetDisplayMedia(WebCore::DisplayCapturePromptType
 {
     sendWithAsyncReply(Messages::GPUProcess::PromptForGetDisplayMedia { type }, WTFMove(completionHandler));
 }
+
+void GPUProcessProxy::cancelGetDisplayMediaPrompt()
+{
+    send(Messages::GPUProcess::CancelGetDisplayMediaPrompt { }, 0);
+}
 #endif
 
 void GPUProcessProxy::getLaunchOptions(ProcessLauncher::LaunchOptions& launchOptions)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -99,6 +99,7 @@ public:
 
 #if HAVE(SCREEN_CAPTURE_KIT)
     void promptForGetDisplayMedia(WebCore::DisplayCapturePromptType, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
+    void cancelGetDisplayMediaPrompt();
 #endif
 
     void removeSession(PAL::SessionID);

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -331,6 +331,11 @@ void UserMediaPermissionRequestManagerProxy::resetAccess(std::optional<FrameIden
 {
     ALWAYS_LOG(LOGIDENTIFIER, frameID ? frameID->object().toUInt64() : 0);
 
+    if (m_currentUserMediaRequest && (!frameID || m_currentUserMediaRequest->frameID() == *frameID)) {
+        m_currentUserMediaRequest->invalidate();
+        m_currentUserMediaRequest = nullptr;
+    }
+
     if (frameID) {
         m_grantedRequests.removeAllMatching([frameID](const auto& grantedRequest) {
             return grantedRequest->mainFrameID() == frameID;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -55,7 +55,7 @@ public:
     enum class UserMediaAccessDenialReason { NoConstraints, UserMediaDisabled, NoCaptureDevices, InvalidConstraint, HardwareError, PermissionDenied, OtherFailure };
     void deny(UserMediaAccessDenialReason = UserMediaAccessDenialReason::UserMediaDisabled);
 
-    void invalidate();
+    virtual void invalidate();
     bool isPending() const { return m_manager; }
 
     bool requiresAudioCapture() const { return m_eligibleAudioDevices.size(); }

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
@@ -48,6 +48,7 @@ public:
     ~DisplayCaptureSessionManager();
 
     void promptForGetDisplayMedia(UserMediaPermissionRequestProxy::UserMediaDisplayCapturePromptType, WebPageProxy&, const WebCore::SecurityOriginData&, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
+    void cancelGetDisplayMediaPrompt(WebPageProxy&);
     bool canRequestDisplayCapturePermission();
     void setIndexOfDeviceSelectedForTesting(std::optional<unsigned> index) { m_indexOfDeviceSelectedForTesting = index; }
 

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -250,6 +250,27 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
 #endif
 }
 
+void DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt(WebPageProxy& page)
+{
+#if HAVE(SCREEN_CAPTURE_KIT)
+    ASSERT(isAvailable());
+
+    if (!isAvailable() || !WebCore::ScreenCaptureKitSharingSessionManager::isAvailable())
+        return;
+
+    if (!page.preferences().useGPUProcessForDisplayCapture()) {
+        WebCore::ScreenCaptureKitSharingSessionManager::singleton().cancelGetDisplayMediaPrompt();
+        return;
+    }
+
+    auto gpuProcess = page.process().processPool().gpuProcess();
+    if (!gpuProcess)
+        return;
+
+    gpuProcess->cancelGetDisplayMediaPrompt();
+#endif
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h
@@ -36,8 +36,14 @@ public:
 
     UserMediaPermissionRequestProxyMac(UserMediaPermissionRequestManagerProxy&, WebCore::UserMediaRequestIdentifier, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& userMediaDocumentOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, Vector<WebCore::CaptureDevice>&& audioDevices, Vector<WebCore::CaptureDevice>&& videoDevices, WebCore::MediaStreamRequest&&, CompletionHandler<void(bool)>&&);
 
+private:
     void promptForGetDisplayMedia(UserMediaDisplayCapturePromptType) final;
     bool canRequestDisplayCapturePermission() final;
+    void invalidate() final;
+
+#if ENABLE(MEDIA_STREAM)
+    bool m_hasPendingGetDispayMediaPrompt { false };
+#endif
 };
 
 


### PR DESCRIPTION
#### 80f25d4770c9630760067facda8dd3a670784e5b
<pre>
[Cocoa] Cancel pending getDisplayMedia prompt when page is reloaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=260795">https://bugs.webkit.org/show_bug.cgi?id=260795</a>
<a href="https://rdar.apple.com/114563662">rdar://114563662</a>

Reviewed by Youenn Fablet.

If the page is reloaded while the system prompt window/screen picker is active, cancel
the picker instead waiting for the ScreenCaptureKitSharingSessionManager watchdog timer
to go off and cancel it.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(WebCore::ScreenCaptureKitSharingSessionManager::cancelGetDisplayMediaPrompt):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::cancelGetDisplayMediaPrompt):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::cancelGetDisplayMediaPrompt):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::resetAccess):
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt):
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.h:
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm:
(WebKit::UserMediaPermissionRequestProxyMac::invalidate):
(WebKit::UserMediaPermissionRequestProxyMac::promptForGetDisplayMedia):

Canonical link: <a href="https://commits.webkit.org/274439@main">https://commits.webkit.org/274439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07881eb0fc402915373bdc334fc818afe65cba9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16854 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17752 "14 flakes 165 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14176 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15024 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21660 "2 flakes 103 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19335 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14819 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->