### PR TITLE
Reduce size of OptionsStorage in JSC::Config.

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -609,6 +609,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/AssemblerCommon.h
     assembler/AssemblyComments.h
     assembler/CPU.h
+    assembler/CPUInlines.h
     assembler/CodeLocation.h
     assembler/FastJITPermissions.h
     assembler/JITOperationList.h
@@ -625,6 +626,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/MacroAssemblerRISCV64.h
     assembler/MacroAssemblerX86Common.h
     assembler/MacroAssemblerX86_64.h
+    assembler/OSCheck.h
     assembler/Printer.h
     assembler/RISCV64Assembler.h
     assembler/RISCV64Registers.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2115,6 +2115,8 @@
 		FE336B5325DB497D0098F034 /* MarkingConstraintExecutorPair.h in Headers */ = {isa = PBXBuildFile; fileRef = FE336B5225DB497D0098F034 /* MarkingConstraintExecutorPair.h */; };
 		FE3422121D6B81C30032BE88 /* ThrowScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3422111D6B818C0032BE88 /* ThrowScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE34EE2124398AAE00AA2E7C /* EnsureStillAliveHere.h in Headers */ = {isa = PBXBuildFile; fileRef = FE34EE2024398A9A00AA2E7C /* EnsureStillAliveHere.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE37C5282A99A372003EE733 /* CPUInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE37C5272A99A371003EE733 /* CPUInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE37C52A2A9C3EA9003EE733 /* OSCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = FE37C5292A9C3EA9003EE733 /* OSCheck.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE3842332324D51B009DD445 /* OptionsList.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3842312324D51B009DD445 /* OptionsList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE384EE61ADDB7AD0055DE2C /* JSDollarVM.h in Headers */ = {isa = PBXBuildFile; fileRef = FE384EE21ADDB7AD0055DE2C /* JSDollarVM.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE3A06A61C10B72D00390FDD /* JITBitOrGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3A06A41C10B70800390FDD /* JITBitOrGenerator.h */; };
@@ -5874,6 +5876,8 @@
 		FE35C2FA21B1E6C7000F4CA8 /* Options.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = Options.rb; sourceTree = "<group>"; };
 		FE35C2FB21B1E6C7000F4CA8 /* OpcodeGroup.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = OpcodeGroup.rb; sourceTree = "<group>"; };
 		FE35C2FC21B1E6C7000F4CA8 /* Metadata.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = Metadata.rb; sourceTree = "<group>"; };
+		FE37C5272A99A371003EE733 /* CPUInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUInlines.h; sourceTree = "<group>"; };
+		FE37C5292A9C3EA9003EE733 /* OSCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSCheck.h; sourceTree = "<group>"; };
 		FE3842312324D51B009DD445 /* OptionsList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OptionsList.h; sourceTree = "<group>"; };
 		FE384EE11ADDB7AD0055DE2C /* JSDollarVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDollarVM.cpp; sourceTree = "<group>"; };
 		FE384EE21ADDB7AD0055DE2C /* JSDollarVM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDollarVM.h; sourceTree = "<group>"; };
@@ -9236,6 +9240,7 @@
 				86E116B00FE75AC800B512BC /* CodeLocation.h */,
 				52335628225EB8E900268BD2 /* CPU.cpp */,
 				0F30D7BF1D95D62F0053089D /* CPU.h */,
+				FE37C5272A99A371003EE733 /* CPUInlines.h */,
 				0F37308E1C0CD68500052BFA /* DisallowMacroScratchRegisterUsage.h */,
 				5267CF81249316AD0022BF6D /* FastJITPermissions.h */,
 				E3CA3A4B2527AB2E004802BF /* JITOperationList.cpp */,
@@ -9262,6 +9267,7 @@
 				65860177185A8F5E00030EEE /* MaxFrameExtentForSlowPathCall.h */,
 				86C568DF11A213EE0007F7F0 /* MIPSAssembler.h */,
 				86C568DF11A213EE0007F7FF /* MIPSRegisters.h */,
+				FE37C5292A9C3EA9003EE733 /* OSCheck.h */,
 				E38DAB522A95D23A0050B7A8 /* PerfLog.cpp */,
 				E38DAB512A95D23A0050B7A8 /* PerfLog.h */,
 				FE63DD551EA9BC5D00103A69 /* Printer.cpp */,
@@ -10437,6 +10443,7 @@
 				C4F4B6F41A05C944005CAB76 /* cpp_generator.py in Headers */,
 				C4F4B6F31A05C944005CAB76 /* cpp_generator_templates.py in Headers */,
 				0F30D7C01D95D6320053089D /* CPU.h in Headers */,
+				FE37C5282A99A372003EE733 /* CPUInlines.h in Headers */,
 				5DE6E5B30E1728EC00180407 /* create_hash_table in Headers */,
 				535C24611F78928E006EC40E /* create_regex_tables in Headers */,
 				9959E92B1BD17FA4001AA413 /* cssmin.py in Headers */,
@@ -11381,6 +11388,7 @@
 				BC18C4480E16F5CD00B34460 /* Operations.h in Headers */,
 				0FE228ED1436AB2700196C48 /* Options.h in Headers */,
 				FE3842332324D51B009DD445 /* OptionsList.h in Headers */,
+				FE37C52A2A9C3EA9003EE733 /* OSCheck.h in Headers */,
 				E356987222841187008CDCCB /* PackedCellPtr.h in Headers */,
 				E389D854291226BC0085C3DC /* PageCount.h in Headers */,
 				0F9DAA0A1FD1C3D30079C5B2 /* ParallelSourceAdapter.h in Headers */,

--- a/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,25 +25,9 @@
 
 #pragma once
 
+#include "OSCheck.h"
+
 namespace JSC {
-
-ALWAYS_INLINE constexpr bool isDarwin()
-{
-#if OS(DARWIN)
-    return true;
-#else
-    return false;
-#endif
-}
-
-ALWAYS_INLINE constexpr bool isIOS()
-{
-#if PLATFORM(IOS_FAMILY)
-    return true;
-#else
-    return false;
-#endif
-}
 
 template<size_t bits, typename Type>
 ALWAYS_INLINE constexpr bool isInt(Type t)

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "Options.h"
 #include <wtf/NumberOfCores.h>
 #include <wtf/StdIntExtras.h>
 
@@ -178,30 +177,11 @@ constexpr bool isRegister32Bit()
     return registerSize() == 4;
 }
 
-inline bool optimizeForARMv7IDIVSupported()
-{
-    return isARMv7IDIVSupported() && Options::useArchitectureSpecificOptimizations();
-}
-
-inline bool optimizeForARM64()
-{
-    return isARM64() && Options::useArchitectureSpecificOptimizations();
-}
-
-inline bool optimizeForX86()
-{
-    return isX86() && Options::useArchitectureSpecificOptimizations();
-}
-
-inline bool optimizeForX86_64()
-{
-    return isX86_64() && Options::useArchitectureSpecificOptimizations();
-}
-
-inline bool hasSensibleDoubleToInt()
-{
-    return optimizeForX86();
-}
+inline bool optimizeForARMv7IDIVSupported();
+inline bool optimizeForARM64();
+inline bool optimizeForX86();
+inline bool optimizeForX86_64();
+inline bool hasSensibleDoubleToInt();
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 bool isKernOpenSource();

--- a/Source/JavaScriptCore/assembler/CPUInlines.h
+++ b/Source/JavaScriptCore/assembler/CPUInlines.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CPU.h"
+#include "Options.h"
+
+namespace JSC {
+
+inline bool optimizeForARMv7IDIVSupported()
+{
+    return isARMv7IDIVSupported() && Options::useArchitectureSpecificOptimizations();
+}
+
+inline bool optimizeForARM64()
+{
+    return isARM64() && Options::useArchitectureSpecificOptimizations();
+}
+
+inline bool optimizeForX86()
+{
+    return isX86() && Options::useArchitectureSpecificOptimizations();
+}
+
+inline bool optimizeForX86_64()
+{
+    return isX86_64() && Options::useArchitectureSpecificOptimizations();
+}
+
+inline bool hasSensibleDoubleToInt()
+{
+    return optimizeForX86();
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/assembler/OSCheck.h
+++ b/Source/JavaScriptCore/assembler/OSCheck.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace JSC {
+
+ALWAYS_INLINE constexpr bool isDarwin()
+{
+#if OS(DARWIN)
+    return true;
+#else
+    return false;
+#endif
+}
+
+ALWAYS_INLINE constexpr bool isIOS()
+{
+#if PLATFORM(IOS_FAMILY)
+    return true;
+#else
+    return false;
+#endif
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "ArrayPrototype.h"
+#include "CPUInlines.h"
 #include "CacheableIdentifierInlines.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "BinarySwitch.h"
+#include "CPUInlines.h"
 #include "CodeBlockWithJITType.h"
 #include "DFGAbstractInterpreterInlines.h"
 #include "DFGArrayifySlowPathGenerator.h"

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -38,6 +38,7 @@
 #include "B3StackmapGenerationParams.h"
 #include "B3ValueInlines.h"
 #include "ButterflyInlines.h"
+#include "CPUInlines.h"
 #include "CallFrameShuffler.h"
 #include "ClonedArguments.h"
 #include "DFGAbstractInterpreterInlines.h"

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3649,8 +3649,7 @@ void CommandLine::parseArguments(int argc, char** argv)
     }
 
     int i = 1;
-    JSC::Options::DumpLevel dumpOptionsLevel = JSC::Options::DumpLevel::None;
-    bool needToExit = false;
+    bool optionsDumpRequested = false;
 
     bool hasBadJSCOptions = false;
     for (; i < argc; ++i) {
@@ -3726,12 +3725,12 @@ void CommandLine::parseArguments(int argc, char** argv)
             printUsageStatement(true);
 
         if (!strcmp(arg, "--options")) {
-            dumpOptionsLevel = JSC::Options::DumpLevel::Verbose;
-            needToExit = true;
+            JSC::Options::dumpOptions() = static_cast<unsigned>(JSC::Options::DumpLevel::Verbose);
+            optionsDumpRequested = true;
             continue;
         }
         if (!strcmp(arg, "--dumpOptions")) {
-            dumpOptionsLevel = JSC::Options::DumpLevel::Overridden;
+            JSC::Options::dumpOptions() = static_cast<unsigned>(JSC::Options::DumpLevel::Overridden);
             continue;
         }
         if (!strcmp(arg, "--sample")) {
@@ -3836,15 +3835,11 @@ void CommandLine::parseArguments(int argc, char** argv)
     for (; i < argc; ++i)
         m_arguments.append(String::fromLatin1(argv[i]));
 
-    if (dumpOptionsLevel != JSC::Options::DumpLevel::None) {
-        const char* optionsTitle = (dumpOptionsLevel == JSC::Options::DumpLevel::Overridden)
-            ? "Modified JSC runtime options:"
-            : "All JSC runtime options:";
-        JSC::Options::dumpAllOptions(dumpOptionsLevel, optionsTitle);
-    }
     JSC::Options::assertOptionsAreCoherent();
-    if (needToExit)
+    if (optionsDumpRequested) {
+        JSC::Options::executeDumpOptions();
         jscExit(EXIT_SUCCESS);
+    }
 }
 
 CommandLine::CommandLine(CommandLineForWorkersTag)

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Options.h"
 #include "SpeculatedType.h"
 #include <wtf/LockAlgorithm.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "CPU.h"
 #include "JITOperationValidation.h"
 #include <cmath>
+#include <optional>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -27,6 +27,7 @@
 
 #include "GCLogging.h"
 #include "JSExportMacros.h"
+#include "OSCheck.h"
 #include <wtf/MathExtras.h>
 
 #if OS(DARWIN)
@@ -142,9 +143,9 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpBBQDisassembly, false, Normal, "dumps disassembly of BBQ Wasm code upon compilation") \
     v(Bool, dumpOMGDisassembly, false, Normal, "dumps disassembly of OMG Wasm code upon compilation") \
     v(Bool, logJITCodeForPerf, false, Configurable, nullptr) \
-    v(OptionRange, bytecodeRangeToJITCompile, 0, Normal, "bytecode size range to allow compilation on, e.g. 1:100") \
-    v(OptionRange, bytecodeRangeToDFGCompile, 0, Normal, "bytecode size range to allow DFG compilation on, e.g. 1:100") \
-    v(OptionRange, bytecodeRangeToFTLCompile, 0, Normal, "bytecode size range to allow FTL compilation on, e.g. 1:100") \
+    v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100") \
+    v(OptionRange, bytecodeRangeToDFGCompile, nullptr, Normal, "bytecode size range to allow DFG compilation on, e.g. 1:100") \
+    v(OptionRange, bytecodeRangeToFTLCompile, nullptr, Normal, "bytecode size range to allow FTL compilation on, e.g. 1:100") \
     v(OptionString, jitAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow compilation on or, if no such file exists, the function signature to allow") \
     v(OptionString, dfgAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow DFG compilation on or, if no such file exists, the function signature to allow") \
     v(OptionString, ftlAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow FTL compilation on or, if no such file exists, the function signature to allow") \
@@ -518,7 +519,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWasmLLIntPrologueOSR, true, Normal, "allows prologue OSR from Wasm LLInt if true") \
     v(Bool, useWasmLLIntLoopOSR, true, Normal, "allows loop OSR from Wasm LLInt if true") \
     v(Bool, useWasmLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from Wasm LLInt if true") \
-    v(OptionRange, wasmFunctionIndexRangeToCompile, 0, Normal, "wasm function index range to allow compilation on, e.g. 1:100") \
+    v(OptionRange, wasmFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100") \
     v(Bool, wasmLLIntTiersUpToBBQ, true, Normal, nullptr) \
     v(Size, webAssemblyBBQAirModeThreshold, isIOS() ? (10 * MB) : 0, Normal, "If 0, we always use BBQ Air. If Wasm module code size hits this threshold, we compile Wasm module with B3 BBQ mode.") \
     v(Bool, useEagerWebAssemblyModuleHashing, false, Normal, "Unnamed WebAssembly modules are identified in backtraces through their hash, if available.") \
@@ -661,21 +662,11 @@ class OptionRange {
 private:
     enum RangeState { Uninitialized, InitError, Normal, Inverted };
 public:
-    OptionRange& operator=(int value)
-    {
-        // Only used for initialization to state Uninitialized.
-        // OptionsList specifies OptionRange options with default value 0.
-        RELEASE_ASSERT(!value);
-
-        m_state = Uninitialized;
-        m_rangeString = nullptr;
-        m_lowLimit = 0;
-        m_highLimit = 0;
-        return *this;
-    }
+    OptionRange() = default;
+    OptionRange(std::nullptr_t) { }
 
     bool init(const char*);
-    bool isInRange(unsigned);
+    bool isInRange(unsigned) const;
     const char* rangeString() const { return (m_state > InitError) ? m_rangeString : s_nullRangeStr; }
 
     void dump(PrintStream& out) const;
@@ -683,10 +674,10 @@ public:
 private:
     static const char* const s_nullRangeStr;
 
-    RangeState m_state;
-    const char* m_rangeString;
-    unsigned m_lowLimit;
-    unsigned m_highLimit;
+    RangeState m_state { Uninitialized };
+    const char* m_rangeString { nullptr };
+    unsigned m_lowLimit { 0 };
+    unsigned m_highLimit { 0 };
 };
 
 enum class OSLogType : uint8_t {
@@ -714,8 +705,7 @@ struct OptionsStorage {
     bool isFinalized;
 
 #define DECLARE_OPTION(type_, name_, defaultValue_, availability_, description_) \
-    type_ name_; \
-    type_ name_##Default;
+    type_ name_;
 FOR_EACH_JSC_OPTION(DECLARE_OPTION)
 #undef DECLARE_OPTION
 };


### PR DESCRIPTION
#### 242566c54a3ccfaa25fcfdbedbbe7be6c32b0b18
<pre>
Reduce size of OptionsStorage in JSC::Config.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260797">https://bugs.webkit.org/show_bug.cgi?id=260797</a>
rdar://114565432

Reviewed by Justin Michaud.

1. OptionsStorage was storing options default values.  This is unnecessary because default
   values are only used to provide more info when dumping options.  We&apos;ve move default values
   to a transient OptionsHelper::Metadata data structure that is heap allocated, and now freed
   in Options::finalize().

2. Consolidate calls to dump options.  Previously, we do it every time in
   Options::notifyOptionsChanged() and in the jsc shell.  Now, we only do it once in
   Options::finalize().  We also now only assertOptionsAreCoherent() in Options::finalize()
   instead of doing it repeatedly.

3. Renamed Options::dumpOptionsIfNeeded() into Options::executeDumpOptions().  This is now the
   entrypoint to dump options (with the exception of dumpAllOptionsInALine() which is used by
   tests).

4. Moved contents of the OptionReader class into the OptionsHelper namespace to consolidate all
   the helper tools.

5. Moved Options::s_constMetaData into the OptionsHelper namespace as g_constMetaData.  It is
   only needed for options initialization.

6. Added a g_optionWasOverridden BitSet to track whether an option has been modified
   (previously, we were comparing the options against their defaults).  We keep these as a
   global instead of in OptionsHelper::Metadata because it is small (56 bytes), and keeping it
   around makes options dumping more robust in case anyone wants to call the dumpers
   interactively in a debugging session.  g_optionWasOverridden is not protected in JSC::Config
   because after initialization, it is only used by the dumpers, and is not critical to
   security.

7. Convert some static functions used for computing default options values into members of
   Options.

On ARM64, OptionsStorage shrinks from 2632 bytes to 1424 bytes.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/AssemblerCommon.h:
(JSC::isDarwin): Deleted.
(JSC::isIOS): Deleted.
* Source/JavaScriptCore/assembler/CPU.h:
(JSC::optimizeForARMv7IDIVSupported): Deleted.
(JSC::optimizeForARM64): Deleted.
(JSC::optimizeForX86): Deleted.
(JSC::optimizeForX86_64): Deleted.
(JSC::hasSensibleDoubleToInt): Deleted.
* Source/JavaScriptCore/assembler/CPUInlines.h: Added.
(JSC::optimizeForARMv7IDIVSupported):
(JSC::optimizeForARM64):
(JSC::optimizeForX86):
(JSC::optimizeForX86_64):
(JSC::hasSensibleDoubleToInt):
* Source/JavaScriptCore/assembler/OSCheck.h: Added.
(JSC::isDarwin):
(JSC::isIOS):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/IndexingType.h:
* Source/JavaScriptCore/runtime/MathCommon.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::OptionsHelper::Option::name const):
(JSC::OptionsHelper::Option::description const):
(JSC::OptionsHelper::Option::type const):
(JSC::OptionsHelper::Option::availability const):
(JSC::OptionsHelper::Option::Option):
(JSC::OptionsHelper::initialize):
(JSC::OptionsHelper::releaseMetadata):
(JSC::OptionsHelper::defaultFor):
(JSC::OptionsHelper::addressOfOption):
(JSC::OptionsHelper::optionFor):
(JSC::OptionsHelper::hasMetadata):
(JSC::OptionsHelper::wasOverridden):
(JSC::OptionsHelper::setWasOverridden):
(JSC::Options::computeNumberOfWorkerThreads):
(JSC::Options::computePriorityDeltaOfWorkerThreads):
(JSC::Options::computeNumberOfGCMarkers):
(JSC::Options::defaultTCSMValue):
(JSC::OptionRange::isInRange const):
(JSC::Options::executeDumpOptions):
(JSC::Options::notifyOptionsChanged):
(JSC::Options::initialize):
(JSC::Options::finalize):
(JSC::Options::setOptionWithoutAlias):
(JSC::Options::dumpOption):
(JSC::OptionsHelper::Option::initValue):
(JSC::OptionsHelper::Option::dump const):
(JSC::OptionsHelper::Option::operator== const):
(JSC::computeNumberOfWorkerThreads): Deleted.
(JSC::computePriorityDeltaOfWorkerThreads): Deleted.
(JSC::jitEnabledByDefault): Deleted.
(JSC::computeNumberOfGCMarkers): Deleted.
(JSC::defaultTCSMValue): Deleted.
(JSC::OptionRange::isInRange): Deleted.
(JSC::Options::dumpOptionsIfNeeded): Deleted.
(JSC::Options::addressOfOption): Deleted.
(JSC::Options::addressOfOptionDefault): Deleted.
(JSC::OptionReader::Option::name const): Deleted.
(JSC::OptionReader::Option::description const): Deleted.
(JSC::OptionReader::Option::type const): Deleted.
(JSC::OptionReader::Option::availability const): Deleted.
(JSC::OptionReader::Option::isOverridden const): Deleted.
(JSC::OptionReader::Option::Option): Deleted.
(JSC::OptionReader::optionFor): Deleted.
(JSC::OptionReader::defaultFor): Deleted.
(JSC::OptionReader::Option::initValue): Deleted.
(JSC::OptionReader::Option::dump const): Deleted.
(JSC::OptionReader::Option::operator== const): Deleted.
* Source/JavaScriptCore/runtime/Options.h:
(JSC::Options::jitEnabledByDefault):
* Source/JavaScriptCore/runtime/OptionsList.h:
(JSC::OptionRange::OptionRange):
(JSC::OptionRange::operator=): Deleted.

Canonical link: <a href="https://commits.webkit.org/267371@main">https://commits.webkit.org/267371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/210014d9a062d80cec8dfa71af58265d09c8c77f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16384 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16848 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18929 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21659 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14127 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19334 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15622 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15600 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/17941 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14814 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/4142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19182 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19159 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2012 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15427 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4051 "Passed tests") | 
<!--EWS-Status-Bubble-End-->