### PR TITLE
[git-webkit] Handle existing symlink hooks

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.7',
+    version='6.6.8',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 7)
+version = Version(6, 6, 8)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -182,10 +182,16 @@ class InstallHooks(Command):
         trailers_to_strip = ['Identifier'] + ([identifier_template.split(':', 1)[0]] if identifier_template else [])
         source_remotes = repository.source_remotes() or ['origin']
 
+        installed_hooks = 0
         for hook in hook_names:
             source_path = os.path.join(hooks, hook)
             if not os.path.isfile(source_path):
                 continue
+            target = os.path.join(repository.common_directory, 'hooks', hook)
+            if os.path.islink(target):
+                sys.stderr.write("'{}' is a symlink, refusing to overwrite it\n".format(hook))
+                continue
+
             log.info("Configuring and copying hook '{}' for this repository".format(hook))
             with open(source_path, 'r') as f:
                 from jinja2 import Template
@@ -201,13 +207,15 @@ class InstallHooks(Command):
                     source_remotes=source_remotes,
                 )
 
-            target = os.path.join(repository.common_directory, 'hooks', hook)
             if not os.path.exists(os.path.dirname(target)):
                 os.makedirs(os.path.dirname(target))
             with open(target, 'w') as f:
                 f.write(contents)
                 f.write('\n')
             os.chmod(target, 0o775)
+            installed_hooks += 1
 
-        print('Successfully installed {} repository hooks'.format(len(hook_names)))
+        print('Successfully installed {} of {} repository hooks'.format(installed_hooks, len(hook_names)))
+        if installed_hooks != len(hook_names):
+            print('    {} repository hooks skipped because of existing symlinks'.format(len(hook_names) - installed_hooks))
         return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py
@@ -105,7 +105,7 @@ class TestInstallHooks(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            'Successfully installed 1 repository hooks\n',
+            'Successfully installed 1 of 1 repository hooks\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(
@@ -141,7 +141,7 @@ class TestInstallHooks(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            'Successfully installed 1 repository hooks\n',
+            'Successfully installed 1 of 1 repository hooks\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(
@@ -182,7 +182,7 @@ print('Hello, world!\\n')
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            'Successfully installed 1 repository hooks\n',
+            'Successfully installed 1 of 1 repository hooks\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(


### PR DESCRIPTION
#### 981a048eebf49b247a5fa7149ca5dc2658f891e5
<pre>
[git-webkit] Handle existing symlink hooks
<a href="https://bugs.webkit.org/show_bug.cgi?id=260799">https://bugs.webkit.org/show_bug.cgi?id=260799</a>
rdar://114566642

Reviewed by Dewei Zhu.

Some repositories use symlinks to configure hooks. Overwriting
these is usually wrong.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main): Warn user when hooks contain symlinks and do not overwrite them.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/install_hooks_unittest.py:
(TestInstallHooks.test_install_hook):
(TestInstallHooks.test_security_level_in_hook):

Canonical link: <a href="https://commits.webkit.org/267372@main">https://commits.webkit.org/267372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f3a8601ddd107cc77ba4a4054fadb6a44233c66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/16429 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/16750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/17185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/18205 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/16620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/19981 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/16893 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/18205 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/16625 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/19981 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/17185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/18974 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/16554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/19981 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/17185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/18974 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/19981 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/17185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/18974 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/15645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/16893 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/16312 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/17185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2013 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/15470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->