### PR TITLE
[WPE][GTK] `WebKitWebsiteData/cache` is crashing in debug builds

### DIFF
--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -42,12 +42,9 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
     launchOptions.extraInitializationData.set("enable-sandbox"_s, m_processPool->sandboxEnabled() ? "true"_s : "false"_s);
 
     if (m_processPool->sandboxEnabled()) {
-        WebsiteDataStore* dataStore = websiteDataStore();
-        if (!dataStore) {
-            // Prewarmed processes don't have a WebsiteDataStore yet, so use the primary WebsiteDataStore from the WebProcessPool.
-            // The process won't be used if current WebsiteDataStore is different than the WebProcessPool primary one.
-            dataStore = WebsiteDataStore::defaultDataStore().ptr();
-        }
+        // Prewarmed processes don't have a WebsiteDataStore yet, so use the primary WebsiteDataStore from the WebProcessPool.
+        // The process won't be used if current WebsiteDataStore is different than the WebProcessPool primary one.
+        WebsiteDataStore* dataStore = isPrewarmed() ? WebsiteDataStore::defaultDataStore().ptr() : websiteDataStore();
 
         ASSERT(dataStore);
         dataStore->resolveDirectoriesIfNecessary();

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -86,13 +86,6 @@
             }
         }
     },
-    "TestWebsiteData": {
-        "subtests": {
-            "/webkit/WebKitWebsiteData/cache": {
-                "expected": {"wpe": {"status": ["CRASH", "PASS"], "bug": "webkit.org/b/260524"}}
-            }
-        }
-    },
     "TestWebKitWebView": {
         "subtests": {
             "/webkit/WebKitWebView/is-web-process-responsive": {


### PR DESCRIPTION
#### 1d0cf34fdae6143b31c0ce57cee0272c7a55f0d7
<pre>
[WPE][GTK] `WebKitWebsiteData/cache` is crashing in debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=260524">https://bugs.webkit.org/show_bug.cgi?id=260524</a>

Reviewed by Michael Catanzaro.

In `WebProcessProxy::platformGetLaunchOptions()` we evaluate if
`websiteDataStore()` is `NULL`, which is true for prewarmed processes.

But there is an assert in it, so this call will crash in debug builds.

* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformGetLaunchOptions):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/267395@main">https://commits.webkit.org/267395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4566c9cb9265e19739740430e85759993c65a15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17725 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18905 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21632 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19285 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13234 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14794 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->