### PR TITLE
[git-webkit] Recognize self in Bitbucket PRs

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.10',
+    version='6.6.11',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 10)
+version = Version(6, 6, 11)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py
@@ -130,13 +130,20 @@ class Contributor(object):
 
             return result
 
-        def create(self, name=None, *emails):
+        def create(self, name=None, *emails, **kwargs):
             emails = [email for email in emails or []]
             if not name and not emails:
                 return None
 
+            github = kwargs.pop('github', None)
+            bitbucket = kwargs.pop('bitbucket', None)
+            for key in kwargs.keys():
+                raise ValueError("'{}' is not a valid argument to Contributor.create".format(key))
+
             contributor = None
-            for argument in [name] + (emails or []):
+            for argument in [name, github, bitbucket] + (emails or []):
+                if not argument:
+                    continue
                 contributor = self[argument]
                 if contributor:
                     break
@@ -147,8 +154,12 @@ class Contributor(object):
                         contributor.emails.append(email)
                 if contributor.name in contributor.emails and name:
                     contributor.name = name
+                if github:
+                    contributor.github = github
+                if bitbucket:
+                    contributor.bitbucket = bitbucket
             else:
-                contributor = Contributor(name or emails[0], emails=emails)
+                contributor = Contributor(name or emails[0], emails=emails, github=github, bitbucket=bitbucket)
 
             self[contributor.name] = contributor
             for email in contributor.emails or []:
@@ -156,6 +167,10 @@ class Contributor(object):
                     continue
                 self[email] = contributor
                 self[email.lower()] = contributor
+            if contributor.github:
+                self[contributor.github] = contributor
+            if contributor.bitbucket:
+                self[contributor.bitbucket] = contributor
             return contributor
 
         def __iter__(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/contributor_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/contributor_unittest.py
@@ -200,21 +200,18 @@ class TestContributor(unittest.TestCase):
 
     def test_github(self):
         mapping = Contributor.Mapping()
-        mapping.add(Contributor(
-            'Jonathan Bedard',
-            emails=['jbedard@apple.com'],
+        mapping.create(
+            'Jonathan Bedard', 'jbedard@apple.com',
             github='JonWBedard',
-        ))
-        mapping.add(Contributor(
-            'Jonathan Bedard',
-            emails=['jbedard@apple.com'],
+        )
+        mapping.create(
+            'Jonathan Bedard', 'jbedard@apple.com',
             github='JonWBedard',
-        ))
-        mapping.add(Contributor(
-            'Kocsen Chung',
-            emails=['kocsen_chung@apple.com'],
+        )
+        mapping.create(
+            'Kocsen Chung', 'kocsen_chung@apple.com',
             github='kocsenc',
-        ))
+        )
 
         self.assertEqual(mapping['JonWBedard'], mapping['jbedard@apple.com'])
         self.assertEqual(mapping['kocsenc'], mapping['kocsen_chung@apple.com'])
@@ -223,16 +220,14 @@ class TestContributor(unittest.TestCase):
 
     def test_bitbucket(self):
         mapping = Contributor.Mapping()
-        mapping.add(Contributor(
-            'Jonathan Bedard',
-            emails=['jbedard@apple.com'],
+        mapping.create(
+            'Jonathan Bedard', 'jbedard@apple.com',
             bitbucket='jonathan_bedard',
-        ))
-        mapping.add(Contributor(
-            'Kocsen Chung',
-            emails=['kocsen_chung@apple.com'],
+        )
+        mapping.create(
+            'Kocsen Chung', 'kocsen_chung@apple.com',
             bitbucket='kocsen_chung',
-        ))
+        )
 
         self.assertEqual(mapping['jonathan_bedard'], mapping['jbedard@apple.com'])
         self.assertEqual(mapping['kocsen_chung'], mapping['kocsen_chung@apple.com'])


### PR DESCRIPTION
#### 767f671b38739465c9bd477d1c1d73a596ab6948
<pre>
[git-webkit] Recognize self in Bitbucket PRs
<a href="https://bugs.webkit.org/show_bug.cgi?id=260802">https://bugs.webkit.org/show_bug.cgi?id=260802</a>
rdar://114570779

Reviewed by Dewei Zhu.

We should include the Bitbucket username in contributor objects returned
from Bitbucket APIs, so that `git-webkit pr` can recognize PRs uploaded
by the current user.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/contributor.py:
(Contributor.Mapping.create): Allow github and bitbucket usernames to be specified.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.PRGenerator.PullRequest): Include Bitbucket username in contributor object.
(BitBucket.PRGenerator.update): Ditto.
(BitBucket.PRGenerator.comments): Ditto.
(BitBucket.commit): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/contributor_unittest.py:
(TestContributor.test_github):
(TestContributor.test_bitbucket):

Canonical link: <a href="https://commits.webkit.org/267702@main">https://commits.webkit.org/267702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db53b416ac35d302aadd1953d1ed104415a3e634

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/17452 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/17777 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/18291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/19241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/17649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/21054 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/17920 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/19241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/17658 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/21054 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/18291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/17593 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/21054 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/18291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/20061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/21054 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/18291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20061 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/16631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/17920 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/17311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/18291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2135 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/16468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->