### PR TITLE
m_has*EventListener does not have to be atomic

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -82,7 +82,7 @@ private:
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;
 
-    std::atomic<bool> m_hasChangeEventListener;
+    bool m_hasChangeEventListener { false };
     WeakPtr<CookieJar> m_cookieJar;
     String m_host;
 };

--- a/Source/WebCore/Modules/permissions/PermissionStatus.h
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.h
@@ -70,7 +70,7 @@ private:
     PermissionState m_state;
     PermissionDescriptor m_descriptor;
     MainThreadPermissionObserverIdentifier m_mainThreadPermissionObserverIdentifier;
-    std::atomic<bool> m_hasChangeEventListener;
+    bool m_hasChangeEventListener { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -255,7 +255,7 @@ private:
 
     std::optional<ExceptionCode> m_exceptionCode;
     RefPtr<UserGestureToken> m_userGestureToken;
-    std::atomic<bool> m_hasRelevantEventListener;
+    bool m_hasRelevantEventListener { false };
     TaskCancellationGroup m_abortErrorGroup;
     bool m_wasDidSendDataCalledForTotalBytes { false };
 };


### PR DESCRIPTION
#### 8b00141fa9f08379230c571f81cf57bb1b9617ad
<pre>
m_has*EventListener does not have to be atomic
<a href="https://bugs.webkit.org/show_bug.cgi?id=260804">https://bugs.webkit.org/show_bug.cgi?id=260804</a>
rdar://114572793

Reviewed by Ryosuke Niwa and Chris Dumez.

We were using atomic at these places because `virtualHasPendingActivity()` can be called on non-main thread and
`eventListenersDidChange()` is invoked on main thread. However, `virtualHasPendingActivity()` is called on non-main
thread only when main thread is paused, so there is no need to use atomic.

* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/Modules/permissions/PermissionStatus.h:
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/267387@main">https://commits.webkit.org/267387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad012ff0309b75760c18f43ffe97ee630ea02cf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17739 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18923 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14842 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21648 "5 flakes 127 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19322 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13249 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14808 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3943 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->