### PR TITLE
Programmatic form submission should also affect :user-invalid/valid state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html
@@ -2,6 +2,7 @@
 <title>Support for the :user-invalid pseudo-class</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="help" href="https://drafts.csswg.org/selectors/#user-pseudos">
+<link rel="help" href="https://html.spec.whatwg.org/#selector-user-invalid">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -79,7 +80,7 @@ promise_test(async () => {
   assert_false(requiredTextarea.matches(":user-valid"), "Initially does not match :user-valid");
   assert_false(requiredTextarea.matches(":user-invalid"), "Initially does not match :user-invalid");
 
-  await test_driver.click(submitButton);
+  submitButton.click();
 
   assert_true(requiredInput.matches(":user-invalid"), "Submitted the form, input is validated");
   assert_false(requiredInput.matches(":user-valid"), "Submitted the form, input is validated");
@@ -87,13 +88,22 @@ promise_test(async () => {
   assert_true(requiredTextarea.matches(":user-invalid"), "Submitted the form, textarea is validated");
   assert_false(requiredTextarea.matches(":user-valid"), "Submitted the form, textarea is validated");
 
-  await test_driver.click(resetButton);
+  resetButton.click();
 
   assert_false(requiredInput.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
   assert_false(requiredInput.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
 
   assert_false(requiredTextarea.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
   assert_false(requiredTextarea.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
+
+  // Test programmatic form submission with constraint validation.
+  form.requestSubmit();
+
+  assert_true(requiredInput.matches(":user-invalid"), "Called form.requestSubmit(), input is validated");
+  assert_false(requiredInput.matches(":user-valid"), "Called form.requestSubmit(), input is validated");
+
+  assert_true(requiredTextarea.matches(":user-invalid"), "Called form.requestSubmit(), textarea is validated");
+  assert_false(requiredTextarea.matches(":user-valid"), "Called form.requestSubmit(), textarea is validated");
 }, ":user-invalid selector properly interacts with submit & reset buttons");
 
 // historical: https://github.com/w3c/csswg-drafts/issues/1329

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html
@@ -2,6 +2,7 @@
 <title>Support for the :user-valid pseudo-class</title>
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="help" href="https://drafts.csswg.org/selectors/#user-pseudos">
+<link rel="help" href="https://html.spec.whatwg.org/#selector-user-valid">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -76,7 +77,7 @@ promise_test(async () => {
   assert_false(optionalTextarea.matches(":user-valid"), "Initially does not match :user-valid");
   assert_false(optionalTextarea.matches(":user-invalid"), "Initially does not match :user-invalid");
 
-  await test_driver.click(submitButton);
+  submitButton.click();
 
   assert_true(optionalInput.matches(":user-valid"), "Submitted the form, input is validated");
   assert_false(optionalInput.matches(":user-invalid"), "Submitted the form, input is validated");
@@ -84,12 +85,21 @@ promise_test(async () => {
   assert_true(optionalTextarea.matches(":user-valid"), "Submitted the form, textarea is validated");
   assert_false(optionalTextarea.matches(":user-invalid"), "Submitted the form, textarea is validated");
 
-  await test_driver.click(resetButton);
+  resetButton.click();
 
   assert_false(optionalInput.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
   assert_false(optionalInput.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
 
   assert_false(optionalTextarea.matches(":user-valid"), "Reset the form, user-interacted flag is reset");
   assert_false(optionalTextarea.matches(":user-invalid"), "Reset the form, user-interacted flag is reset");
+
+  // Test programmatic form submission with constraint validation.
+  form.requestSubmit();
+
+  assert_true(optionalInput.matches(":user-valid"), "Called form.requestSubmit(), input is validated");
+  assert_false(optionalInput.matches(":user-invalid"), "Called form.requestSubmit(), input is validated");
+
+  assert_true(optionalTextarea.matches(":user-valid"), "Called form.requestSubmit(), textarea is validated");
+  assert_false(optionalTextarea.matches(":user-invalid"), "Called form.requestSubmit(), textarea is validated");
 }, ":user-valid selector properly interacts with submit & reset buttons");
 </script>

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -260,11 +260,9 @@ void HTMLFormElement::submitIfPossible(Event* event, HTMLFormControlElement* sub
     m_isSubmittingOrPreparingForSubmission = true;
     m_shouldSubmit = false;
 
-    if (UserGestureIndicator::processingUserGesture()) {
-        for (auto& element : m_listedElements) {
-            if (auto* formControlElement = dynamicDowncast<HTMLFormControlElement>(*element))
-                formControlElement->setInteractedWithSinceLastFormSubmitEvent(true);
-        }
+    for (auto& element : m_listedElements) {
+        if (auto* formControlElement = dynamicDowncast<HTMLFormControlElement>(*element))
+            formControlElement->setInteractedWithSinceLastFormSubmitEvent(true);
     }
 
     bool shouldValidate = document().page() && document().page()->settings().interactiveFormValidationEnabled() && !noValidate();


### PR DESCRIPTION
#### f4bbd99f53b5b7f1f0bde29a1b874bd532bb5721
<pre>
Programmatic form submission should also affect :user-invalid/valid state
<a href="https://bugs.webkit.org/show_bug.cgi?id=260813">https://bugs.webkit.org/show_bug.cgi?id=260813</a>
rdar://114580382

Reviewed by Aditya Keerthi.

We should not check for an user gesture when setting the user-interacted flag on submission.
This also matches the HTML spec that landed.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitIfPossible):

Canonical link: <a href="https://commits.webkit.org/267384@main">https://commits.webkit.org/267384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8073683c97c322064a3b0ba7e816663619665765

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18227 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16915 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18999 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14909 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15665 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14749 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3941 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->