### PR TITLE
Deploy more smart pointers in Source/WebKit/UIProcess/Cocoa

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
@@ -83,7 +83,7 @@ void GroupActivitiesSessionNotifier::addWebPage(WebPageProxy& webPage)
     ASSERT(!m_webPages.contains(webPage));
     m_webPages.add(webPage);
 
-    auto frame = webPage.mainFrame();
+    RefPtr frame = webPage.mainFrame();
     if (!frame)
         return;
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -108,20 +108,22 @@ NavigationState::NavigationState(WKWebView *webView)
     , m_releaseNetworkActivityTimer(RunLoop::current(), this, &NavigationState::releaseNetworkActivityAfterLoadCompletion)
 #endif
 {
-    ASSERT(webView->_page);
-    ASSERT(!navigationStates().contains(*webView->_page));
+    RefPtr page = webView->_page;
+    ASSERT(page);
+    ASSERT(!navigationStates().contains(*page));
 
-    navigationStates().add(*webView->_page, *this);
-    webView->_page->pageLoadState().addObserver(*this);
+    navigationStates().add(*page, *this);
+    page->pageLoadState().addObserver(*this);
 }
 
 NavigationState::~NavigationState()
 {
     if (auto webView = this->webView()) {
-        ASSERT(navigationStates().get(*webView->_page).get() == this);
+        RefPtr page = webView->_page;
+        ASSERT(navigationStates().get(*page).get() == this);
 
-        navigationStates().remove(*webView->_page);
-        webView->_page->pageLoadState().removeObserver(*this);
+        navigationStates().remove(*page);
+        page->pageLoadState().removeObserver(*this);
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -55,7 +55,7 @@ void NavigationSOAuthorizationSession::shouldStartInternal()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("shouldStartInternal: m_page=%p", page());
 
-    auto* page = this->page();
+    RefPtr page = this->page();
     ASSERT(page);
     beforeStart();
     if (!page->isInWindow()) {
@@ -72,7 +72,7 @@ void NavigationSOAuthorizationSession::shouldStartInternal()
 void NavigationSOAuthorizationSession::webViewDidMoveToWindow()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("webViewDidMoveToWindow");
-    auto* page = this->page();
+    RefPtr page = this->page();
     if (state() != State::Waiting || !page || !page->isInWindow())
         return;
     if (pageActiveURLDidChangeDuringWaiting()) {
@@ -87,7 +87,7 @@ void NavigationSOAuthorizationSession::webViewDidMoveToWindow()
 bool NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting() const
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("pageActiveURLDidChangeDuringWaiting");
-    auto* page = this->page();
+    RefPtr page = this->page();
     return !page || page->pageLoadState().activeURL() != m_waitingPageActiveURL;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
@@ -64,9 +64,9 @@ void RedirectSOAuthorizationSession::completeInternal(const ResourceResponse& re
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: httpState=%d, navigationAction=%p", response.httpStatusCode(), navigationAction());
 
-    auto* navigationAction = this->navigationAction();
+    RefPtr navigationAction = this->navigationAction();
     ASSERT(navigationAction);
-    auto* page = this->page();
+    RefPtr page = this->page();
     // FIXME: Enable the useRedirectionForCurrentNavigation code path for all redirections.
     if ((response.httpStatusCode() != 302 && response.httpStatusCode() != 200 && !(response.httpStatusCode() == 307 && navigationAction->request().httpMethod() == "POST"_s)) || !page) {
         AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: httpState=%d page=%d, so falling back to web path.", response.httpStatusCode(), !!page);

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -74,7 +74,7 @@ void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navig
     }
 
     // SubFrameSOAuthorizationSession should only be allowed for Apple first parties.
-    auto* targetFrame = navigationAction->targetFrame();
+    RefPtr targetFrame = navigationAction->targetFrame();
     bool subframeNavigation = targetFrame && !targetFrame->isMainFrame();
     if (subframeNavigation && (!page.mainFrame() || ![AKAuthorizationController isURLFromAppleOwnedDomain:page.mainFrame()->url()])) {
         AUTHORIZATIONCOORDINATOR_RELEASE_LOG_ERROR("tryAuthorize: Attempting to perform subframe navigation for non-Apple authorization URL.");

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -103,7 +103,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
 void SubFrameSOAuthorizationSession::didFinishLoad()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("didFinishLoad");
-    auto* frame = WebFrameProxy::webFrame(m_frameID);
+    RefPtr frame = WebFrameProxy::webFrame(m_frameID);
     ASSERT(frame);
     if (m_requestsToLoad.isEmpty() || m_requestsToLoad.first().first != frame->url())
         return;
@@ -121,11 +121,11 @@ void SubFrameSOAuthorizationSession::appendRequestToLoad(URL&& url, Supplement&&
 void SubFrameSOAuthorizationSession::loadRequestToFrame()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("loadRequestToFrame");
-    auto* page = this->page();
+    RefPtr page = this->page();
     if (!page || m_requestsToLoad.isEmpty())
         return;
 
-    if (auto* frame = WebFrameProxy::webFrame(m_frameID)) {
+    if (RefPtr frame = WebFrameProxy::webFrame(m_frameID)) {
         page->setShouldSuppressSOAuthorizationInNextNavigationPolicyDecision();
         auto& url = m_requestsToLoad.first().first;
         WTF::switchOn(m_requestsToLoad.first().second, [&](const Vector<uint8_t>& data) {

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -1329,7 +1329,7 @@ void UIDelegate::UIClient::checkUserMediaPermissionForOrigin(WebPageProxy& page,
         return;
     }
 
-    const auto* mainFrame = frame.page()->mainFrame();
+    RefPtr mainFrame = frame.page()->mainFrame();
 
     if ([delegate respondsToSelector:@selector(_webView:includeSensitiveMediaDeviceDetails:)]) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:includeSensitiveMediaDeviceDetails:));

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -33,7 +33,7 @@ namespace WebKit {
 
 std::unique_ptr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
-    return m_page.process().throttler().backgroundActivity(name).moveToUniquePtr();
+    return protectedPage()->process().throttler().backgroundActivity(name).moveToUniquePtr();
 }
 
 UIRemoteObjectRegistry::UIRemoteObjectRegistry(_WKRemoteObjectRegistry *remoteObjectRegistry, WebPageProxy& page)
@@ -42,22 +42,29 @@ UIRemoteObjectRegistry::UIRemoteObjectRegistry(_WKRemoteObjectRegistry *remoteOb
 {
 }
 
+UIRemoteObjectRegistry::~UIRemoteObjectRegistry() = default;
+
+Ref<WebPageProxy> UIRemoteObjectRegistry::protectedPage()
+{
+    return m_page.get();
+}
+
 void UIRemoteObjectRegistry::sendInvocation(const RemoteObjectInvocation& invocation)
 {
     // For backward-compatibility, support invoking injected bundle methods before having done any load in the WebView.
-    m_page.launchInitialProcessIfNecessary();
+    protectedPage()->launchInitialProcessIfNecessary();
 
     RemoteObjectRegistry::sendInvocation(invocation);
 }
 
 IPC::MessageSender& UIRemoteObjectRegistry::messageSender()
 {
-    return m_page;
+    return m_page.get();
 }
 
 uint64_t UIRemoteObjectRegistry::messageDestinationID()
 {
-    return m_page.webPageID().toUInt64();
+    return protectedPage()->webPageID().toUInt64();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RemoteObjectRegistry.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebKit {
 
@@ -34,15 +35,17 @@ class WebPageProxy;
 class UIRemoteObjectRegistry final : public RemoteObjectRegistry {
 public:
     UIRemoteObjectRegistry(_WKRemoteObjectRegistry *, WebPageProxy&);
-    
+    ~UIRemoteObjectRegistry();
+
     void sendInvocation(const RemoteObjectInvocation&) final;
 
 private:
+    Ref<WebPageProxy> protectedPage();
     IPC::MessageSender& messageSender() final;
     uint64_t messageDestinationID() final;
     std::unique_ptr<ProcessThrottler::BackgroundActivity> backgroundActivity(ASCIILiteral) final;
 
-    WebPageProxy& m_page;
+    CheckedRef<WebPageProxy> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -424,7 +424,9 @@ void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstrai
 #endif
 
     ASSERT(!m_proxies.contains(id));
-    auto proxy = makeUnique<SourceProxy>(id, m_connectionProxy->connection(), ProcessIdentity { m_connectionProxy->resourceOwner() }, WTFMove(source), shouldUseGPUProcessRemoteFrames ? m_connectionProxy->remoteVideoFrameObjectHeap() : nullptr);
+    Ref connection = m_connectionProxy->connection();
+    RefPtr remoteVideoFrameObjectHeap = shouldUseGPUProcessRemoteFrames ? m_connectionProxy->remoteVideoFrameObjectHeap() : nullptr;
+    auto proxy = makeUnique<SourceProxy>(id, WTFMove(connection), ProcessIdentity { m_connectionProxy->resourceOwner() }, WTFMove(source), WTFMove(remoteVideoFrameObjectHeap));
 
     if (constraints && proxy->source().type() == RealtimeMediaSource::Type::Video) {
         if (auto result = proxy->applyConstraints(*constraints)) {
@@ -502,7 +504,9 @@ void UserMediaCaptureManagerProxy::clone(RealtimeMediaSourceIdentifier clonedID,
         if (sourceClone->deviceType() == WebCore::CaptureDevice::DeviceType::Camera)
             m_pageSources.ensure(pageIdentifier, [] { return PageSources { }; }).iterator->value.cameraSources.add(sourceClone.get());
 
-        auto cloneProxy = makeUnique<SourceProxy>(newSourceID, m_connectionProxy->connection(), ProcessIdentity { m_connectionProxy->resourceOwner() }, WTFMove(sourceClone), m_connectionProxy->remoteVideoFrameObjectHeap());
+        Ref connection = m_connectionProxy->connection();
+        RefPtr remoteVideoFrameObjectHeap = m_connectionProxy->remoteVideoFrameObjectHeap();
+        auto cloneProxy = makeUnique<SourceProxy>(newSourceID, WTFMove(connection), ProcessIdentity { m_connectionProxy->resourceOwner() }, WTFMove(sourceClone), WTFMove(remoteVideoFrameObjectHeap));
         cloneProxy->copySettings(*proxy);
         m_proxies.add(newSourceID, WTFMove(cloneProxy));
     }

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -616,7 +616,7 @@ void VideoFullscreenManagerProxy::forEachSession(Function<void(VideoFullscreenMo
 
 void VideoFullscreenManagerProxy::requestBitmapImageForCurrentTime(PlaybackSessionContextIdentifier identifier, CompletionHandler<void(ShareableBitmap::Handle&&)>&& completionHandler)
 {
-    auto* gpuProcess = GPUProcessProxy::singletonIfCreated();
+    RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated();
     if (!gpuProcess) {
         completionHandler({ });
         return;
@@ -646,7 +646,8 @@ void VideoFullscreenManagerProxy::addVideoInPictureInPictureDidChangeObserver(co
 void VideoFullscreenManagerProxy::hasVideoInPictureInPictureDidChange(bool value)
 {
     ALWAYS_LOG(LOGIDENTIFIER, value);
-    m_page->uiClient().hasVideoInPictureInPictureDidChange(m_page, value);
+    RefPtr page = m_page;
+    page->uiClient().hasVideoInPictureInPictureDidChange(page.get(), value);
     m_pipChangeObservers.forEach([value] (auto& observer) { observer(value); });
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
@@ -63,7 +63,7 @@
     if (!webView)
         return NO;
 
-    auto* webFrameProxy = WebKit::WebFrameProxy::webFrame(_frameHandle->_frameHandle->frameID());
+    RefPtr webFrameProxy = WebKit::WebFrameProxy::webFrame(_frameHandle->_frameHandle->frameID());
     if (!webFrameProxy)
         return NO;
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -101,14 +101,14 @@ std::optional<WebPasteboardProxy::PasteboardAccessType> WebPasteboardProxy::acce
 {
     MESSAGE_CHECK_WITH_RETURN_VALUE(!pasteboardName.isEmpty(), std::nullopt);
 
-    auto* process = webProcessProxyForConnection(connection);
+    RefPtr process = webProcessProxyForConnection(connection);
     MESSAGE_CHECK_WITH_RETURN_VALUE(process, std::nullopt);
 
     for (auto& page : process->pages()) {
         if (!page)
             continue;
-        auto& preferences = page->preferences();
-        if (!preferences.domPasteAllowed() || !preferences.javaScriptCanAccessClipboard())
+        Ref preferences = page->preferences();
+        if (!preferences->domPasteAllowed() || !preferences->javaScriptCanAccessClipboard())
             continue;
 
         // If a web page already allows JavaScript to programmatically read pasteboard data,

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -93,6 +93,8 @@ RefPtr<ObjCObjectGraph> WebProcessProxy::transformHandlesToObjects(ObjCObjectGra
         {
         }
 
+        Ref<WebProcessProxy> protectedWebProcessProxy() const { return const_cast<WebProcessProxy&>(m_webProcessProxy.get()); }
+
         bool shouldTransformObject(id object) const override
         {
             if (dynamic_objc_cast<WKBrowsingContextHandle>(object))
@@ -108,7 +110,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         RetainPtr<id> transformObject(id object) const override
         {
             if (auto* handle = dynamic_objc_cast<WKBrowsingContextHandle>(object)) {
-                if (auto webPageProxy = m_webProcessProxy.webPage(handle.pageProxyID)) {
+                if (auto webPageProxy = protectedWebProcessProxy()->webPage(handle.pageProxyID)) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                     return [WKBrowsingContextController _browsingContextControllerForPageRef:toAPI(webPageProxy.get())];
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -119,12 +121,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             if (auto* wrapper = dynamic_objc_cast<WKTypeRefWrapper>(object))
-                return adoptNS([[WKTypeRefWrapper alloc] initWithObject:toAPI(m_webProcessProxy.transformHandlesToObjects(toImpl(wrapper.object)).get())]);
+                return adoptNS([[WKTypeRefWrapper alloc] initWithObject:toAPI(protectedWebProcessProxy()->transformHandlesToObjects(toImpl(wrapper.object)).get())]);
 ALLOW_DEPRECATED_DECLARATIONS_END
             return object;
         }
 
-        WebProcessProxy& m_webProcessProxy;
+        CheckedRef<WebProcessProxy> m_webProcessProxy;
     };
 
     return ObjCObjectGraph::create(ObjCObjectGraph::transform(objectGraph.rootObject(), Transformer(*this)).get());


### PR DESCRIPTION
#### 232c6fa7a77f39bee55edb0757a800192663a912
<pre>
Deploy more smart pointers in Source/WebKit/UIProcess/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=260817">https://bugs.webkit.org/show_bug.cgi?id=260817</a>

Reviewed by Chris Dumez.

Deployed more smart pointers.

* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm:
(WebKit::GroupActivitiesSessionNotifier::addWebPage):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationState):
(WebKit::NavigationState::~NavigationState):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
(WebKit::NavigationSOAuthorizationSession::shouldStartInternal):
(WebKit::NavigationSOAuthorizationSession::webViewDidMoveToWindow):
(WebKit::NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting const):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm:
(WebKit::RedirectSOAuthorizationSession::completeInternal):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::tryAuthorize):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::didFinishLoad):
(WebKit::SubFrameSOAuthorizationSession::loadRequestToFrame):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::checkUserMediaPermissionForOrigin):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
(WebKit::UIRemoteObjectRegistry::protectedPage):
(WebKit::UIRemoteObjectRegistry::sendInvocation):
(WebKit::UIRemoteObjectRegistry::messageSender):
(WebKit::UIRemoteObjectRegistry::messageDestinationID):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
(WebKit::UserMediaCaptureManagerProxy::clone):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::requestBitmapImageForCurrentTime):
(WebKit::VideoFullscreenManagerProxy::hasVideoInPictureInPictureDidChange):
* Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm:
(-[WKReloadFrameErrorRecoveryAttempter attemptRecovery]):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::accessType const):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::transformHandlesToObjects):

Canonical link: <a href="https://commits.webkit.org/267388@main">https://commits.webkit.org/267388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0f2e7f10f96ec01367e6083968fd154a46aa0eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18942 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14271 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21666 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19342 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13268 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19193 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2020 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->