### PR TITLE
[motion-path] Refactor various parts of path operation and RenderStyle

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5282,6 +5282,7 @@ webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-tra
 
 # CSS motion path ray test failing due to getting wrong size from containing block.
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-007.html [ ImageOnlyFailure ]
+webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-009.html [ ImageOnlyFailure ]
 
 # CSS motion path URL support.
 imported/w3c/web-platform-tests/css/motion/offset-path-url-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray paths</title>
+    <style>
+      #container1 {
+        width: 100px;
+        height: 100px;
+      }
+      #container2 {
+        width: 200px;
+        height: 200px;
+      }
+      #target1 {
+        position: relative;
+        width: 50px;
+        height: 50px;
+        background-color: lime;
+        transform-origin: 0px 0px;
+        transform: translateX(100px);
+      }
+      #target2 {
+        position: relative;
+        width: 50px;
+        height: 50px;
+        background-color: lime;
+        transform-origin: 0px 0px;
+        transform: translateX(200px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container1">
+      <div id="target1"></div>
+    </div>
+    <div id="container2">
+      <div id="target2"></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Motion Path: ray paths</title>
+    <link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
+    <link rel="match" href="offset-path-ray-007-ref.html">
+    <meta name="assert" content="Tests ray() when sharing style with different sized containing blocks.">
+    <style>
+      #container1 {
+        width: 100px;
+        height: 100px;
+      }
+      #container2 {
+        width: 200px;
+        height: 200px;
+      }
+      #target {
+        position: relative;
+        width: 50px;
+        height: 50px;
+        background-color: lime;
+        transform-origin: 0px 0px;
+        offset-path: ray(90deg sides);
+        offset-distance: 100%;
+        offset-position: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container1">
+      <div id="target"></div>
+    </div>
+    <div id="container2">
+      <div id="target"></div>
+    </div>
+    
+  </body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2270,6 +2270,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/LegacyLineLayout.h
     rendering/LegacyRootInlineBox.h
     rendering/MarkedText.h
+    rendering/MotionPath.h
     rendering/OrderIterator.h
     rendering/OverlapTestRequestClient.h
     rendering/Pagination.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2541,6 +2541,7 @@ rendering/LegacyLineLayout.cpp
 rendering/LegacyRootInlineBox.cpp
 rendering/LegacyInlineTextBox.cpp
 rendering/MarkedText.cpp
+rendering/MotionPath.cpp
 rendering/OrderIterator.cpp
 rendering/PathOperation.cpp
 rendering/PointerEventsHitRules.cpp

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -51,6 +51,7 @@
 #include "KeyframeEffectStack.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
+#include "MotionPath.h"
 #include "MutableStyleProperties.h"
 #include "PropertyAllowlist.h"
 #include "RenderBox.h"
@@ -2314,7 +2315,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
 bool KeyframeEffect::computeTransformedExtentViaMatrix(const FloatRect& rendererBox, const RenderStyle& style, LayoutRect& bounds) const
 {
     TransformationMatrix transform;
-    style.applyTransform(transform, rendererBox);
+    style.applyTransform(transform, TransformOperationData(rendererBox, renderer()));
     if (!transform.isAffine())
         return false;
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -59,6 +59,7 @@
 #include "FontCascade.h"
 #include "FontSelectionValueInlines.h"
 #include "GridPositionsResolver.h"
+#include "MotionPath.h"
 #include "NodeRenderStyle.h"
 #include "PerspectiveTransformOperation.h"
 #include "QuotesData.h"
@@ -846,7 +847,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
 
     if (renderer) {
         TransformationMatrix transform;
-        style.applyTransform(transform, renderer->transformReferenceBoxRect(style), { });
+        style.applyTransform(transform, TransformOperationData(renderer->transformReferenceBoxRect(style), renderer), { });
         return CSSTransformListValue::create(matrixTransformValue(transform, style));
     }
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -30,6 +30,7 @@
 
 #include "IntSize.h"
 #include "LengthFunctions.h"
+#include "MotionPath.h"
 #include "Path.h"
 #include "RenderStyleInlines.h"
 
@@ -165,7 +166,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         if (!offsetAnchor.x().isAuto())
             anchor = floatPointForLengthPoint(offsetAnchor, borderBoxRect.size()) + borderBoxRect.location();
 
-        auto path = offsetPath->getPath(borderBoxRect);
+        auto path = offsetPath->getPath(FloatRect(borderBoxRect));
         offsetDistance = { path ? path->length() : 0.0f, LengthType:: Fixed };
     }
 

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MotionPath.h"
+
+#include "GeometryUtilities.h"
+#include "PathOperation.h"
+#include "PathTraversalState.h"
+
+namespace WebCore {
+
+std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const RenderElement& renderer)
+{
+    MotionPathData data;
+    auto pathOperation = renderer.style().offsetPath();
+    if (!pathOperation || !is<RenderLayerModelObject>(renderer))
+        return std::nullopt;
+    if (is<BoxPathOperation>(pathOperation)) {
+        auto& boxPathOperation = downcast<BoxPathOperation>(*pathOperation);
+        data.containingBlockBoundingRect = snapRectToDevicePixelsIfNeeded(renderer.referenceBoxRect(boxPathOperation.referenceBox()), downcast<RenderLayerModelObject>(renderer));
+        return data;
+    }
+    if (is<RayPathOperation>(pathOperation)) {
+        if (auto* parentBlock = renderer.containingBlock()) {
+            auto pathReferenceBoxRect = snapRectToDevicePixelsIfNeeded(parentBlock->transformReferenceBoxRect(parentBlock->style()), downcast<RenderLayerModelObject>(renderer));
+            data.containingBlockBoundingRect = pathReferenceBoxRect;
+            auto left = renderer.style().left();
+            auto top = renderer.style().top();
+            data.offsetFromContainingBlock = FloatPoint(left.isPercent() ? left.value() / 100 * pathReferenceBoxRect.width() : left.value(), top.isPercent() ? top.value() / 100 * pathReferenceBoxRect.height() : top.value());
+            return data;
+        }
+    }
+    return std::nullopt;
+}
+
+static PathTraversalState traversalStateAtDistance(const Path& path, const Length& distance)
+{
+    auto pathLength = path.length();
+    auto distanceValue = floatValueForLength(distance, pathLength);
+
+    float resolvedLength = 0;
+    if (path.isClosed()) {
+        if (pathLength) {
+            resolvedLength = fmod(distanceValue, pathLength);
+            if (resolvedLength < 0)
+                resolvedLength += pathLength;
+        }
+    } else
+        resolvedLength = clampTo<float>(distanceValue, 0, pathLength);
+
+    ASSERT(resolvedLength >= 0);
+    return path.traversalStateAtLength(resolvedLength);
+}
+
+void MotionPath::applyMotionPathTransform(const RenderStyle& style, const TransformOperationData& transformData, TransformationMatrix& transform)
+{
+    if (!style.offsetPath())
+        return;
+
+    auto& boundingBox = transformData.boundingBox();
+    auto transformOrigin = style.computeTransformOrigin(boundingBox).xy();
+    auto anchor = transformOrigin;
+    if (!style.offsetAnchor().x().isAuto())
+        anchor = floatPointForLengthPoint(style.offsetAnchor(), boundingBox.size()) + boundingBox.location();
+
+    // Shift element to the point on path specified by offset-path and offset-distance.
+    auto path = style.offsetPath()->getPath(transformData);
+    if (!path)
+        return;
+    auto traversalState = traversalStateAtDistance(*path, style.offsetDistance());
+    transform.translate(traversalState.current().x(), traversalState.current().y());
+
+    // Shift element to the anchor specified by offset-anchor.
+    transform.translate(-anchor.x(), -anchor.y());
+
+    auto shiftToOrigin = anchor - transformOrigin;
+    transform.translate(shiftToOrigin.width(), shiftToOrigin.height());
+
+    // Apply rotation.
+    auto rotation = style.offsetRotate();
+    if (rotation.hasAuto())
+        transform.rotate(traversalState.normalAngle() + rotation.angle());
+    else
+        transform.rotate(rotation.angle());
+
+    transform.translate(-shiftToOrigin.width(), -shiftToOrigin.height());
+}
+
+bool MotionPath::needsUpdateAfterContainingBlockLayout(const PathOperation& pathOperation)
+{
+    return is<RayPathOperation>(pathOperation) || is<BoxPathOperation>(pathOperation);
+}
+
+double MotionPath::lengthForRayPath(const RayPathOperation& rayPathOperation, const MotionPathData& data)
+{
+    auto& boundingBox = data.containingBlockBoundingRect;
+    auto distances = distanceOfPointToSidesOfRect(boundingBox, data.offsetFromContainingBlock);
+
+    switch (rayPathOperation.size()) {
+    case RayPathOperation::Size::ClosestSide:
+        return std::min( { distances.top(), distances.bottom(), distances.left(), distances.right() } );
+    case RayPathOperation::Size::FarthestSide:
+        return std::max( { distances.top(), distances.bottom(), distances.left(), distances.right() } );
+    case RayPathOperation::Size::FarthestCorner:
+        return std::hypot(std::max(distances.left(), distances.right()), std::max(distances.top(), distances.bottom()));
+    case RayPathOperation::Size::ClosestCorner:
+        return std::hypot(std::min(distances.left(), distances.right()), std::min(distances.top(), distances.bottom()));
+    case RayPathOperation::Size::Sides:
+        return lengthOfRayIntersectionWithBoundingBox(boundingBox, std::make_pair(data.offsetFromContainingBlock, rayPathOperation.angle()));
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+double MotionPath::lengthForRayContainPath(const FloatRect& elementRect, double computedPathLength)
+{
+    return std::max(0.0, computedPathLength - (std::max(elementRect.width(), elementRect.height()) / 2));
+}
+
+std::optional<Path> MotionPath::computePathForRay(const RayPathOperation& rayPathOperation, const TransformOperationData& data)
+{
+    auto motionPathData = data.motionPathData();
+    auto elementBoundingBox = data.boundingBox();
+    if (!motionPathData || motionPathData->containingBlockBoundingRect.isZero())
+        return std::nullopt;
+
+    double length = lengthForRayPath(rayPathOperation, *motionPathData);
+    if (rayPathOperation.isContaining())
+        length = lengthForRayContainPath(elementBoundingBox, length);
+
+    auto radians = deg2rad(toPositiveAngle(rayPathOperation.angle()) - 90.0);
+    auto point = FloatPoint(std::cos(radians) * length, std::sin(radians) * length);
+
+    Path path;
+    path.addLineTo(point);
+    return path;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderLayerModelObject.h"
+
+namespace WebCore {
+
+class RenderElement;
+class PathOperation;
+class RayPathOperation;
+
+struct MotionPathData {
+    FloatRect containingBlockBoundingRect;
+    FloatPoint offsetFromContainingBlock;
+};
+
+class MotionPath {
+public:
+    static std::optional<MotionPathData> motionPathDataForRenderer(const RenderElement&);
+    static bool needsUpdateAfterContainingBlockLayout(const PathOperation&);
+    static void applyMotionPathTransform(const RenderStyle&, const TransformOperationData&, TransformationMatrix&);
+    static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&);
+    static double lengthForRayPath(const RayPathOperation&, const MotionPathData&);
+    static double lengthForRayContainPath(const FloatRect& elementRect, double computedPathLength);
+};
+
+class TransformOperationData {
+public:
+    TransformOperationData(FloatRect boundingBox)
+        : m_boundingBox(boundingBox)
+    {
+    }
+
+    TransformOperationData(FloatRect boundingBox, const RenderElement* renderer)
+        : m_boundingBox(boundingBox)
+    {
+        if (renderer)
+            m_motionPathData = MotionPath::motionPathDataForRenderer(*renderer);
+    }
+
+    TransformOperationData(FloatRect boundingBox, std::optional<MotionPathData> data)
+        : m_boundingBox(boundingBox)
+        , m_motionPathData(data)
+    {
+    }
+
+    const FloatRect& boundingBox() const { return m_boundingBox; }
+    const std::optional<MotionPathData> motionPathData() const { return m_motionPathData; }
+
+private :
+    FloatRect m_boundingBox;
+    std::optional<MotionPathData> m_motionPathData;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -27,7 +27,6 @@
 #include "PathOperation.h"
 
 #include "AnimationUtilities.h"
-#include "GeometryUtilities.h"
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGPathData.h"
@@ -75,16 +74,14 @@ const SVGElement* ReferencePathOperation::element() const
     return m_element.get();
 }
 
-Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining, FloatRect&& containingBlockBoundingRect, FloatPoint&& position)
+Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining)
 {
-    return adoptRef(*new RayPathOperation(angle, size, isContaining, WTFMove(containingBlockBoundingRect), WTFMove(position)));
+    return adoptRef(*new RayPathOperation(angle, size, isContaining));
 }
 
 Ref<PathOperation> RayPathOperation::clone() const
 {
-    auto containingBlockBoundingRect = m_containingBlockBoundingRect;
-    auto position = m_position;
-    return adoptRef(*new RayPathOperation(m_angle, m_size, m_isContaining, WTFMove(containingBlockBoundingRect), WTFMove(position)));
+    return adoptRef(*new RayPathOperation(m_angle, m_size, m_isContaining));
 }
 
 bool RayPathOperation::canBlend(const PathOperation& to) const
@@ -101,46 +98,9 @@ RefPtr<PathOperation> RayPathOperation::blend(const PathOperation* to, const Ble
     return RayPathOperation::create(WebCore::blend(m_angle, toRayPathOperation.angle(), context), m_size, m_isContaining);
 }
 
-double RayPathOperation::lengthForPath() const
+const std::optional<Path> RayPathOperation::getPath(const TransformOperationData& data) const
 {
-    auto boundingBox = m_containingBlockBoundingRect;
-    auto distances = distanceOfPointToSidesOfRect(boundingBox, m_position);
-    
-    switch (m_size) {
-    case Size::ClosestSide:
-        return std::min( { distances.top(), distances.bottom(), distances.left(), distances.right() } );
-    case Size::FarthestSide:
-        return std::max( { distances.top(), distances.bottom(), distances.left(), distances.right() } );
-    case Size::FarthestCorner:
-        return std::sqrt(std::pow(std::max(distances.left(), distances.right()), 2) + std::pow(std::max(distances.top(), distances.bottom()), 2));
-    case Size::ClosestCorner:
-        return std::sqrt(std::pow(std::min(distances.left(), distances.right()), 2) + std::pow(std::min(distances.top(), distances.bottom()), 2));
-    case Size::Sides:
-        return lengthOfRayIntersectionWithBoundingBox(boundingBox, std::make_pair(m_position, m_angle));
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-double RayPathOperation::lengthForContainPath(const FloatRect& elementRect, double computedPathLength) const
-{
-    return std::max(0.0, computedPathLength - (std::max(elementRect.width(), elementRect.height()) / 2));
-}
-
-const std::optional<Path> RayPathOperation::getPath(const FloatRect& referenceRect) const
-{
-    if (m_containingBlockBoundingRect.isZero())
-        return std::nullopt;
-
-    double length = lengthForPath();
-    if (m_isContaining)
-        length = lengthForContainPath(referenceRect, length);
-
-    auto radians = deg2rad(toPositiveAngle(m_angle) - 90.0);
-    auto point = FloatPoint(std::cos(radians) * length, std::sin(radians) * length);
-
-    Path path;
-    path.addLineTo(point);
-    return path;
+    return MotionPath::computePathForRay(*this, data);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4999,7 +4999,5 @@ LayoutUnit RenderBlockFlow::blockFormattingContextInFlowBlockLevelContentHeight(
     return logicalMarginBoxTopForChild(*lastChild) + logicalMarginBoxHeightForChild(*lastChild);
 }
 
-
-
 }
 // namespace WebCore

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -55,6 +55,7 @@
 #include "LayoutIntegrationLineLayout.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "MotionPath.h"
 #include "Page.h"
 #include "PaintInfo.h"
 #include "RenderBlockInlines.h"
@@ -637,7 +638,7 @@ void RenderBox::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
 
 void RenderBox::applyTransform(TransformationMatrix& t, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
 {
-    style.applyTransform(t, boundingBox, options);
+    style.applyTransform(t, TransformOperationData(boundingBox, this), options);
 }
 
 void RenderBox::constrainLogicalMinMaxSizesByAspectRatio(LayoutUnit& computedMinSize, LayoutUnit& computedMaxSize, LayoutUnit computedSize, MinimumSizeIsAutomaticContentBased minimumSizeType, ConstrainDimension dimension) const

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -87,6 +87,7 @@
 #include "LocalFrameLoaderClient.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
+#include "MotionPath.h"
 #include "OverflowEvent.h"
 #include "OverlapTestRequestClient.h"
 #include "Page.h"
@@ -1330,31 +1331,6 @@ void RenderLayer::updateTransformFromStyle(TransformationMatrix& transform, cons
     makeMatrixRenderable(transform, canRender3DTransforms());
 }
 
-void RenderLayer::setReferenceBoxForPathOperations()
-{
-    auto pathOperation = renderer().style().offsetPath();
-    if (!pathOperation)
-        return;
-    if (is<BoxPathOperation>(pathOperation)) {
-        auto& boxPathOperation = downcast<BoxPathOperation>(*pathOperation);
-        auto pathReferenceBoxRect = snapRectToDevicePixelsIfNeeded(renderer().referenceBoxRect(boxPathOperation.referenceBox()), renderer());
-        boxPathOperation.setPathForReferenceRect(FloatRoundedRect { pathReferenceBoxRect });
-    } else if (is<RayPathOperation>(pathOperation)) {
-        if (const auto* containingBlock = renderer().containingBlock()) {
-            auto& rayPathOperation = downcast<RayPathOperation>(*pathOperation);
-            auto pathReferenceBoxRect = snapRectToDevicePixelsIfNeeded(containingBlock->transformReferenceBoxRect(containingBlock->style()), renderer());
-            if (!pathReferenceBoxRect.width())
-                pathReferenceBoxRect.setWidth(pathReferenceBoxRect.height());
-            if (!pathReferenceBoxRect.height())
-                pathReferenceBoxRect.setHeight(pathReferenceBoxRect.width());
-            rayPathOperation.setContainingBlockReferenceRect(pathReferenceBoxRect);
-            auto left = renderer().style().left();
-            auto top = renderer().style().top();
-            rayPathOperation.setStartingPosition(FloatPoint(left.isPercent() ? left.value() / 100 * pathReferenceBoxRect.width() : left.value(), top.isPercent() ? top.value() / 100 * pathReferenceBoxRect.height() : top.value()));
-        }
-    }
-}
-
 void RenderLayer::updateTransform()
 {
     bool hasTransform = renderer().isTransformed();
@@ -1373,7 +1349,6 @@ void RenderLayer::updateTransform()
     
     if (hasTransform) {
         m_transform->makeIdentity();
-        setReferenceBoxForPathOperations();
         updateTransformFromStyle(*m_transform, renderer().style(), RenderStyle::allTransformOperations());
     }
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -512,7 +512,6 @@ public:
         return m_enclosingPaginationLayer.get();
     }
 
-    void setReferenceBoxForPathOperations();
     void updateTransform();
     
 #if ENABLE(CSS_COMPOSITING)

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -26,6 +26,7 @@
 #include "RenderLayerModelObject.h"
 
 #include "InspectorInstrumentation.h"
+#include "MotionPath.h"
 #include "RenderDescendantIterator.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
@@ -436,7 +437,7 @@ void RenderLayerModelObject::applySVGTransform(TransformationMatrix& transform, 
 
     // CSS transforms take precedence over SVG transforms.
     if (hasCSSTransform)
-        style.applyCSSTransform(transform, boundingBox, options);
+        style.applyCSSTransform(transform, TransformOperationData(boundingBox, this), options);
     else if (!svgTransform.isIdentity())
         transform.multiplyAffineTransform(svgTransform);
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -91,6 +91,7 @@ class TextSizeAdjustment;
 class TextUnderlineOffset;
 class TransformOperations;
 class TransformationMatrix;
+class TransformOperationData;
 class TranslateTransformOperation;
 class WillChangeData;
 
@@ -898,11 +899,10 @@ public:
     void unapplyTransformOrigin(TransformationMatrix&, const FloatPoint3D& originTranslate) const;
 
     // applyTransform calls applyTransformOrigin(), then applyCSSTransform(), followed by unapplyTransformOrigin().
-    void applyTransform(TransformationMatrix&, const FloatRect& boundingBox) const;
-    void applyTransform(TransformationMatrix&, const FloatRect& boundingBox, OptionSet<TransformOperationOption>) const;
-    void applyCSSTransform(TransformationMatrix&, const FloatRect& boundingBox) const;
-    void applyCSSTransform(TransformationMatrix&, const FloatRect& boundingBox, OptionSet<TransformOperationOption>) const;
-    void applyMotionPathTransform(TransformationMatrix&, const FloatRect& boundingBox) const;
+    void applyTransform(TransformationMatrix&, const TransformOperationData& boundingBox) const;
+    void applyTransform(TransformationMatrix&, const TransformOperationData& boundingBox, OptionSet<TransformOperationOption>) const;
+    void applyCSSTransform(TransformationMatrix&, const TransformOperationData& boundingBox) const;
+    void applyCSSTransform(TransformationMatrix&, const TransformOperationData& boundingBox, OptionSet<TransformOperationOption>) const;
     void setPageScaleTransform(float);
 
     inline bool hasPositionedMask() const;

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -32,6 +32,7 @@
 #include "LegacyRenderSVGShape.h"
 #include "LegacyRenderSVGTransformableContainer.h"
 #include "LegacyRenderSVGViewportContainer.h"
+#include "MotionPath.h"
 #include "NodeRenderStyle.h"
 #include "RenderChildIterator.h"
 #include "RenderElement.h"

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGGraphicsElement.h"
 
 #include "LegacyRenderSVGPath.h"
+#include "MotionPath.h"
 #include "RenderAncestorIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderLayer.h"
@@ -97,7 +98,7 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
         // Note: objectBoundingBox is an emptyRect for elements like pattern or clipPath.
         // See the "Object bounding box units" section of http://dev.w3.org/csswg/css3-transforms/
         TransformationMatrix transform;
-        style->applyTransform(transform, renderer()->transformReferenceBoxRect());
+        style->applyTransform(transform, TransformOperationData(renderer()->transformReferenceBoxRect(), renderer()));
 
         // Flatten any 3D transform.
         matrix = transform.toAffineTransform();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2679,6 +2679,17 @@ header: <WebCore/RenderStyleConstants.h>
     ViewBox
 };
 
+header: <WebCore/MotionPath.h>
+[CustomHeader] struct WebCore::MotionPathData {
+    WebCore::FloatRect containingBlockBoundingRect;
+    WebCore::FloatPoint offsetFromContainingBlock;
+};
+
+[CustomHeader] class WebCore::TransformOperationData {
+    WebCore::FloatRect boundingBox();
+    std::optional<WebCore::MotionPathData> motionPathData();
+}
+
 header: <WebCore/PathOperation.h>
 [RefCounted, CustomHeader] class WebCore::ReferencePathOperation {
     std::optional<WebCore::Path> path();
@@ -2706,8 +2717,6 @@ header: <WebCore/PathOperation.h>
     float angle();
     WebCore::RayPathOperation::Size size();
     bool isContaining();
-    WebCore::FloatRect containingBlockBoundingRect();
-    WebCore::FloatPoint position();
 }
 
 [RefCounted] class WebCore::PathOperation subclasses {


### PR DESCRIPTION
#### 3f5059d542cf81542755719fab60d75462d24768
<pre>
[motion-path] Refactor various parts of path operation and RenderStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=260818">https://bugs.webkit.org/show_bug.cgi?id=260818</a>
rdar://114584136

Reviewed by Simon Fraser.

This refactoring addresses a few issues with the current motion path design. First,
for paths that need additional data including its containing block rect or the element&apos;s
offset from its containing block, it is not correct to use the path operation to hold
these values, as the path operation is supposed to represent just the path specified by the
css. Instead, pass down these necessary values through a TransformOperationData struct.
Also added a test for this case to ensure that style sharing is not broken after this change.
Also, factor out some of the code related to computing the ray path into the new MotionPath
class, which now also includes applyMotionPathTransform.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-019.html: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeTransformedExtentViaMatrix const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computedTransform):
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::RayPathOperation::create):
(WebCore::RayPathOperation::clone const):
(WebCore::RayPathOperation::getPath const):
(WebCore::RayPathOperation::lengthForPath const): Deleted.
(WebCore::RayPathOperation::lengthForContainPath const): Deleted.
* Source/WebCore/rendering/PathOperation.h:
(WebCore::PathOperation::getPath): Deleted.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::applyTransform const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateTransform):
(WebCore::RenderLayer::setReferenceBoxForPathOperations): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::applySVGTransform const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::applyTransform const):
(WebCore::RenderStyle::applyCSSTransform const):
(WebCore::getTraversalStateAtDistance): Deleted.
(WebCore::RenderStyle::applyMotionPathTransform const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::animatedLocalTransform const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/267416@main">https://commits.webkit.org/267416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b8d65c212958bcf9ed4bc1b1ffbbb48d9435e69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16984 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19078 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14969 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19450 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14809 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3956 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->