### PR TITLE
Update pendingAPIRequest navigationID if we create a new navigation

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2073,6 +2073,7 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListItem
     if (!m_backForwardList->currentItem()->itemIsInSameDocument(item))
         navigation = m_navigationState->createBackForwardNavigation(process().coreProcessIdentifier(), item, m_backForwardList->currentItem(), frameLoadType);
 
+
     auto transaction = internals().pageLoadState.transaction();
     internals().pageLoadState.setPendingAPIRequest(transaction, { navigation ? navigation->navigationID() : 0, item.url() });
 
@@ -6342,6 +6343,9 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         }
         if (!navigation)
             navigation = m_navigationState->createLoadRequestNavigation(process->coreProcessIdentifier(), ResourceRequest(request), m_backForwardList->currentItem());
+
+        if (fromAPI && !navigationID && !internals().pageLoadState.pendingAPIRequestURL().isNull())
+            internals().pageLoadState.setPendingAPIRequest(transaction, { navigation->navigationID(), internals().pageLoadState.pendingAPIRequestURL() });
     }
 
     navigationID = navigation->navigationID();


### PR DESCRIPTION
#### 7ba8d3e7f420e7d1e7f6783f3f97378c580ed97f
<pre>
Update pendingAPIRequest navigationID if we create a new navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=260636">https://bugs.webkit.org/show_bug.cgi?id=260636</a>
rdar://problem/114351057

Reviewed by NOBODY (OOPS!).

In some situations we may not have a valid navigationID when we initiate a load
request. This can happen if we restore from saved session state and the
restored state contained a back/forword list. In that case, we immediately load
the current item in that list, but we don&apos;t create an associated
API::Navigation. At that point, the current navigationID is 0. When this
happens, we eventually create a new API::Navigation in
WebPageProxy::decidePolicyForNavigationAction() but we don&apos;t update
PageLoadState::m_committedState.pendingAPIRequest if that was initalized, and
this creates an inconsistency between the new navigationID and the cached value
in PageLoadState::m_committedState.pendingAPIRequest.navigationID when we
compare them in later steps.

Similarly, a navigation request may become disconnected with its original
Navigation if the associated DocumentLoader is destroyed while the request is
being processed. In this case, we may reach
WebPageProxy::decidePolicyForNavigationAction without having a navigationID
while PageLoadState::m_committedState.pendingAPIRequest.navigationID may be
set. In this case, we should will create a new API::Navigation with a new
navigationID.

This change updates the navigationID if we didn&apos;t get a valid navigationID in
WebPageProxy::decidePolicyForNavigationAction and the request URL matches the
request received by API. This patch adds a new API test.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Tools/TestWebKitAPI/Tests/WebKit/RestoreSessionState.cpp:
(TestWebKitAPI::decidePolicyForNavigationActionIgnore):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ba8d3e7f420e7d1e7f6783f3f97378c580ed97f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18211 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15412 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16899 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18981 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14302 "Build is in progress. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 2 flakes 3 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14894 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21689 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15059 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19368 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; 3 api tests failed or timed out; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15651 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->