### PR TITLE
REGRESSION(267321@main): ASSERTION FAILED: style() in WebCore::CSSToLengthConversionData::fontCascadeForFontUnits()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6670,7 +6670,4 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/im
 # webkit.org/b/260546
 [ Debug ] imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html [ Pass Failure ]
 
-# webkit.org/b/260816 REGRESSION(267321@main): [ iOS Mac ] imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001.html is a constant crash 
-imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001.html [ Crash ]
-
 webkit.org/b/260823 http/tests/workers/service/self_registration.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt
@@ -26,11 +26,11 @@ PASS new DOMMatrix("scale(2, 2), translateX(5)  ,translateY(5)")
 PASS new DOMMatrix("translateX(5em)")
 PASS new DOMMatrix("translateX(5ex)")
 PASS new DOMMatrix("translateX(5ch)")
-FAIL new DOMMatrix("translateX(5rem)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrix("translateX(5vw)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrix("translateX(5vh)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrix("translateX(5vmin)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrix("translateX(5vmax)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
+PASS new DOMMatrix("translateX(5rem)")
+PASS new DOMMatrix("translateX(5vw)")
+PASS new DOMMatrix("translateX(5vh)")
+PASS new DOMMatrix("translateX(5vmin)")
+PASS new DOMMatrix("translateX(5vmax)")
 PASS new DOMMatrix("translateX(5%)")
 PASS new DOMMatrix("rotate(5)")
 PASS new DOMMatrix("rotate(5, 5, 5)")
@@ -81,11 +81,11 @@ PASS new DOMMatrixReadOnly("scale(2, 2), translateX(5)  ,translateY(5)")
 PASS new DOMMatrixReadOnly("translateX(5em)")
 PASS new DOMMatrixReadOnly("translateX(5ex)")
 PASS new DOMMatrixReadOnly("translateX(5ch)")
-FAIL new DOMMatrixReadOnly("translateX(5rem)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrixReadOnly("translateX(5vw)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrixReadOnly("translateX(5vh)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrixReadOnly("translateX(5vmin)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
-FAIL new DOMMatrixReadOnly("translateX(5vmax)") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
+PASS new DOMMatrixReadOnly("translateX(5rem)")
+PASS new DOMMatrixReadOnly("translateX(5vw)")
+PASS new DOMMatrixReadOnly("translateX(5vh)")
+PASS new DOMMatrixReadOnly("translateX(5vmin)")
+PASS new DOMMatrixReadOnly("translateX(5vmax)")
 PASS new DOMMatrixReadOnly("translateX(5%)")
 PASS new DOMMatrixReadOnly("rotate(5)")
 PASS new DOMMatrixReadOnly("rotate(5, 5, 5)")

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -151,7 +151,7 @@ public:
     template<typename T> T computeLength(const CSSToLengthConversionData&) const;
     template<int> Length convertToLength(const CSSToLengthConversionData&) const;
 
-    bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const;
+    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const;
 
     double doubleValue(CSSUnitType) const;
 

--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.h
@@ -61,7 +61,7 @@ public:
     virtual CSSUnitType primitiveType() const = 0;
 
     virtual void collectComputedStyleDependencies(ComputedStyleDependencies&) const = 0;
-    virtual bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const = 0;
+    virtual bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const = 0;
 
     CalculationCategory category() const { return m_category; }
 

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.h
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.h
@@ -57,7 +57,7 @@ private:
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }
 
     void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const final { m_child->collectComputedStyleDependencies(dependencies); }
-    bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final { return m_child->convertingToLengthRequiresNonNullStyle(lengthConversion); }
+    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const final { return m_child->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData); }
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.h
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.h
@@ -57,7 +57,7 @@ private:
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }
 
     void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const final { m_child->collectComputedStyleDependencies(dependencies); }
-    bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final { return m_child->convertingToLengthRequiresNonNullStyle(lengthConversion); }
+    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const final { return m_child->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData); }
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1065,10 +1065,10 @@ void CSSCalcOperationNode::collectComputedStyleDependencies(ComputedStyleDepende
         child->collectComputedStyleDependencies(dependencies);
 }
 
-bool CSSCalcOperationNode::convertingToLengthRequiresNonNullStyle(int lengthConversion) const
+bool CSSCalcOperationNode::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
 {
-    return WTF::anyOf(m_children, [lengthConversion] (auto& child) {
-        return child->convertingToLengthRequiresNonNullStyle(lengthConversion);
+    return WTF::anyOf(m_children, [lengthConversion, &conversionData] (auto& child) {
+        return child->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
     });
 }
 

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -128,7 +128,7 @@ private:
     double computeLengthPx(const CSSToLengthConversionData&) const final;
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
-    bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final;
+    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const final;
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -208,9 +208,9 @@ void CSSCalcPrimitiveValueNode::collectComputedStyleDependencies(ComputedStyleDe
     m_value->collectComputedStyleDependencies(dependencies);
 }
 
-bool CSSCalcPrimitiveValueNode::convertingToLengthRequiresNonNullStyle(int lengthConversion) const
+bool CSSCalcPrimitiveValueNode::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
 {
-    return m_value->convertingToLengthRequiresNonNullStyle(lengthConversion);
+    return m_value->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
 }
 
 bool CSSCalcPrimitiveValueNode::isZero() const

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -74,7 +74,7 @@ private:
 
     double computeLengthPx(const CSSToLengthConversionData&) const final;
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
-    bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const final;
+    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const final;
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -357,9 +357,9 @@ double CSSCalcValue::computeLengthPx(const CSSToLengthConversionData& conversion
     return clampToPermittedRange(m_expression->computeLengthPx(conversionData));
 }
 
-bool CSSCalcValue::convertingToLengthRequiresNonNullStyle(int lengthConversion) const
+bool CSSCalcValue::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
 {
-    return m_expression->convertingToLengthRequiresNonNullStyle(lengthConversion);
+    return m_expression->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
 }
 
 bool CSSCalcValue::isCalcFunction(CSSValueID functionId)

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -74,7 +74,7 @@ public:
 
     void dump(TextStream&) const;
 
-    bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const;
+    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const;
 
     const CSSCalcExpressionNode& expressionNode() const { return m_expression; }
 


### PR DESCRIPTION
#### 5b6ab99882daefbebdbf76ce7f3174d87aea48ff
<pre>
REGRESSION(267321@main): ASSERTION FAILED: style() in WebCore::CSSToLengthConversionData::fontCascadeForFontUnits()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260816">https://bugs.webkit.org/show_bug.cgi?id=260816</a>
rdar://114582938

Reviewed by Cameron McCormack.

Throw a SyntaxError when a DOMMatrix() is initialized with relative units per spec, don&apos;t let attempt to compute relative units with missing required dependencies.

<a href="https://drafts.fxtf.org/geometry/#dommatrix-parse">https://drafts.fxtf.org/geometry/#dommatrix-parse</a>

&gt; Parse transformList into parsedValue given the grammar for the CSS transform property. The result will be a &lt;transform-list&gt;, the keyword none, or failure. If parsedValue is failure, or any &lt;transform-function&gt; has &lt;length&gt; values without absolute length units, or any keyword other than none is used, then return failure. [CSS3-SYNTAX] [CSS3-TRANSFORMS]

* LayoutTests/TestExpectations
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::convertingToLengthHasRequiredConversionData const):
(WebCore::CSSPrimitiveValue::convertToLength const):
(WebCore::CSSPrimitiveValue::convertingToLengthRequiresNonNullStyle const): Deleted.
* Source/WebCore/css/calc/CSSCalcExpressionNode.h:
* Source/WebCore/css/calc/CSSCalcInvertNode.h:
* Source/WebCore/css/calc/CSSCalcNegateNode.h:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::convertingToLengthHasRequiredConversionData const):
(WebCore::CSSCalcOperationNode::convertingToLengthRequiresNonNullStyle const): Deleted.
* Source/WebCore/css/calc/CSSCalcOperationNode.h:
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
(WebCore::CSSCalcPrimitiveValueNode::convertingToLengthHasRequiredConversionData const):
(WebCore::CSSCalcPrimitiveValueNode::convertingToLengthRequiresNonNullStyle const): Deleted.
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::convertingToLengthHasRequiredConversionData const):
(WebCore::CSSCalcValue::convertingToLengthRequiresNonNullStyle const): Deleted.
* Source/WebCore/css/calc/CSSCalcValue.h:

Canonical link: <a href="https://commits.webkit.org/267378@main">https://commits.webkit.org/267378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e399a29158e5c6021a1cb7ffe78d97ca6f190aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18213 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16901 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18984 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14901 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19371 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15653 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3935 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->