### PR TITLE
[GTK][WPE] Add Whisper.cpp as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Source/ThirdParty/whisper.cpp"]
+	path = Source/ThirdParty/whisper.cpp
+	url = https://github.com/ggerganov/whisper.cpp.git

--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -6,6 +6,7 @@ include(platform/GStreamer.cmake)
 include(platform/ImageDecoders.cmake)
 include(platform/Soup.cmake)
 include(platform/TextureMapper.cmake)
+include(platform/Whisper.cmake)
 
 list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
     "SourcesGTK.txt"

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -6,6 +6,7 @@ include(platform/GStreamer.cmake)
 include(platform/ImageDecoders.cmake)
 include(platform/Soup.cmake)
 include(platform/TextureMapper.cmake)
+include(platform/Whisper.cmake)
 
 if (USE_EXTERNAL_HOLEPUNCH)
     include(platform/HolePunch.cmake)

--- a/Source/WebCore/platform/Whisper.cmake
+++ b/Source/WebCore/platform/Whisper.cmake
@@ -1,0 +1,33 @@
+if (USE_WHISPER)
+    set(WHISPER_DIR
+        ${THIRDPARTY_DIR}/whisper.cpp
+    )
+    set(WHISPER_SOURCES
+        ${WHISPER_DIR}/ggml.c
+        ${WHISPER_DIR}/whisper.cpp
+    )
+
+    # FIXME: These flags are a temporary measure to suppress compilation issues
+    # until the next release contains the following fix.
+    # https://github.com/ggerganov/whisper.cpp/pull/1227
+    set(WHISPER_C_FLAGS "-Wno-undef -Wno-array-bounds")
+    # FIXME: the following options are intel CPU specific. They need to be tweaked
+    # for other CPU architectures since they substantially affect performance.
+    # Check ${THIRDPARTY_DIR}/whisper.cpp/Makefile
+    if (WTF_CPU_X86_64)
+        string(APPEND WHISPER_C_FLAGS " -mavx2 -mfma -mf16c -mavx -msse3")
+    endif ()
+
+    set_source_files_properties(
+        ${WHISPER_SOURCES}
+        PROPERTIES COMPILE_FLAGS "${WHISPER_C_FLAGS}"
+    )
+    add_library(whisper STATIC ${WHISPER_SOURCES})
+
+    list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
+        ${WHISPER_DIR}
+    )
+    list(APPEND WebCore_LIBRARIES
+        whisper
+    )
+endif ()

--- a/Source/cmake/GStreamerDefinitions.cmake
+++ b/Source/cmake/GStreamerDefinitions.cmake
@@ -10,5 +10,6 @@ WEBKIT_OPTION_DEFINE(USE_GSTREAMER_FULL "Whether to enable support for static GS
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_NATIVE_VIDEO "Toggle native video support in GStreamer media player" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_NATIVE_AUDIO "Toggle native audio support in GStreamer media player" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_TEXT_SINK "Toggle text sink support in GStreamer media player" PRIVATE ON)
+WEBKIT_OPTION_DEFINE(USE_WHISPER "Toggle whisper.cpp support for Speech Recognition." PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_TRANSCODER "Whether to enable support for GStreamer MediaRecorder backend" PUBLIC ON)
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_WEBRTC "Whether to enable support for WebRTC" PUBLIC ON)


### PR DESCRIPTION
#### 71222b6bddae86261025d4a31b83c42da3b6f18b
<pre>
[GTK][WPE] Add Whisper.cpp as a submodule
<a href="https://bugs.webkit.org/show_bug.cgi?id=260709">https://bugs.webkit.org/show_bug.cgi?id=260709</a>

Reviewed by NOBODY (OOPS!).

This change adds Whisper.cpp (v1.4.2) as a submodule to GTK and WPE builds.
Whisper.cpp [1] is a speech recognition library that would be the foundation of
Speech Recognition API support for GTK and WPE platforms. The full draft is here [2].

There is no system-wide package support for Whisper.cpp now, so we need to manually
download huge language model files (up to 2.9GB [3]) before use. Otherwise, we need to
ship the model files along with Whisper.cpp source files in the Flatpak SDK,
but that can cause another maintenance concern. Thus, we have Whisper.cpp as a submodule,
and this is a temporary measure until we have the system package. Later, we will
have a chance to reconsider how to deliver Whisper.cpp and its model files
when we release Speech Recognition APIs.

The initial implementation adopted some ideas from Philippe Normand&apos;s working branch [4]
and reflected his advice.

[1] <a href="https://github.com/ggerganov/whisper.cpp">https://github.com/ggerganov/whisper.cpp</a>
[2] <a href="https://github.com/shivamidow/WebKit/tree/eng/prototype-speech-to-text-with-whisper">https://github.com/shivamidow/WebKit/tree/eng/prototype-speech-to-text-with-whisper</a>
[3] <a href="https://github.com/ggerganov/whisper.cpp#memory-usage">https://github.com/ggerganov/whisper.cpp#memory-usage</a>
[4] <a href="https://github.com/WebKit/WebKit/compare/main...philn">https://github.com/WebKit/WebKit/compare/main...philn</a>:WebKit:wip/whisper

* .gitmodules: Added.
* Source/ThirdParty/whisper.cpp: Added.
* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/platform/Whisper.cmake: Added.
* Source/cmake/GStreamerDefinitions.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71222b6bddae86261025d4a31b83c42da3b6f18b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19637 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21942 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23831 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16645 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21784 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18508 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15442 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22562 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17352 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/5662 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (failure); Compiled JSC (cancelled)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21713 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23812 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18066 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5329 "Passed tests") | 
<!--EWS-Status-Bubble-End-->