### PR TITLE
TransformationMatrix::Recompose() and Decompose() incorrectly transpose rotation.

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -114,9 +114,9 @@ Ref<TransformOperation> RotateTransformOperation::blend(const TransformOperation
     }
     
     // Convert that to Axis/Angle form
-    double x = -decomp.quaternionX;
-    double y = -decomp.quaternionY;
-    double z = -decomp.quaternionZ;
+    double x = decomp.quaternionX;
+    double y = decomp.quaternionY;
+    double z = decomp.quaternionZ;
     double length = std::hypot(x, y, z);
     double angle = 0;
     


### PR DESCRIPTION
#### a959acf1111c6f159ea4ada5c4dd6483170b6d0f
<pre>
TransformationMatrix::Recompose() and Decompose() incorrectly transpose rotation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=220856">https://bugs.webkit.org/show_bug.cgi?id=220856</a>
&lt;rdar://problem/73747851&gt;

Reviewed by Dean Jackson.

The computation of quaternions during matrix decomposition appeared
to be based off of the matrix transpose. Indexing in the quaternion
calculation is consistent with row-major ordering; however, the &quot;rows&quot;
variable is actually column major order (goes back to the original
implementation of unmatrix in Graphics Gems II).  The rotation matrix
constructed from the quaternions also appeared to be assuming row-major
ordering. These discrepancies were mostly corrected for by flipping the
direction of the quaternion when extracting from the matrix.

This is a (partial) cherry-pick from Blink:
  - <a href="https://chromium-review.googlesource.com/c/chromium/src/+/2489727">https://chromium-review.googlesource.com/c/chromium/src/+/2489727</a>

* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::blend):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::decompose4):
(WebCore::slerp):
(WebCore::accumulateQuaternion):
(WebCore::TransformationMatrix::recompose4):

Canonical link: <a href="https://commits.webkit.org/267424@main">https://commits.webkit.org/267424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a4b128d4302a19cdcaf7a2f5a3aba28d84da123

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17780 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19015 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21711 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15071 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19397 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14865 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3965 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->