### PR TITLE
[JSC] Speculative fix for wrong MatchResult in StringReplaceCache

### DIFF
--- a/Source/JavaScriptCore/runtime/RegExpCachedResult.h
+++ b/Source/JavaScriptCore/runtime/RegExpCachedResult.h
@@ -68,6 +68,8 @@ public:
     static ptrdiff_t offsetOfResult() { return OBJECT_OFFSETOF(RegExpCachedResult, m_result); }
     static ptrdiff_t offsetOfReified() { return OBJECT_OFFSETOF(RegExpCachedResult, m_reified); }
 
+    MatchResult result() const { return m_result; }
+
 private:
     MatchResult m_result { 0, 0 };
     bool m_reified { false };

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.h
@@ -56,7 +56,8 @@ public:
 
     const Vector<int>& ovector() const { return m_ovector; }
 
-    void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, Vector<int>&&);
+    inline MatchResult matchResult() const;
+    void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, MatchResult, Vector<int>&&);
 
 private:
     RegExpCachedResult m_cachedResult;

--- a/Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h
@@ -90,11 +90,15 @@ ALWAYS_INLINE void RegExpGlobalData::recordMatch(VM& vm, JSGlobalObject* owner, 
     m_cachedResult.record(vm, owner, regExp, string, result);
 }
 
-inline void RegExpGlobalData::resetResultFromCache(JSGlobalObject* owner, RegExp* regExp, JSString* string, Vector<int>&& vector)
+inline MatchResult RegExpGlobalData::matchResult() const
 {
-    MatchResult result(vector[0], vector[1]);
+    return m_cachedResult.result();
+}
+
+inline void RegExpGlobalData::resetResultFromCache(JSGlobalObject* owner, RegExp* regExp, JSString* string, MatchResult matchResult, Vector<int>&& vector)
+{
     m_ovector = WTFMove(vector);
-    m_cachedResult.record(getVM(owner), owner, regExp, string, result);
+    m_cachedResult.record(getVM(owner), owner, regExp, string, matchResult);
 }
 
 }

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -468,11 +468,12 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearchWithCache(VM& vm, JSGloba
             return nullptr;
         }
 
-        vm.stringReplaceCache.set(source, regExp, result, globalObject->regExpGlobalData().ovector());
+        vm.stringReplaceCache.set(source, regExp, result, globalObject->regExpGlobalData().matchResult(), globalObject->regExpGlobalData().ovector());
     } else {
         result = entry->m_result;
         auto lastMatch = entry->m_lastMatch;
-        globalObject->regExpGlobalData().resetResultFromCache(globalObject, regExp, string, WTFMove(lastMatch));
+        auto matchResult = entry->m_matchResult;
+        globalObject->regExpGlobalData().resetResultFromCache(globalObject, regExp, string, matchResult, WTFMove(lastMatch));
     }
 
     // regExp->numSubpatterns() + 1 for pattern args, + 2 for match start and string

--- a/Source/JavaScriptCore/runtime/StringReplaceCache.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCache.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "MatchResult.h"
 #include <array>
 
 namespace JSC {
@@ -48,11 +49,12 @@ public:
         RefPtr<AtomStringImpl> m_subject { nullptr };
         RegExp* m_regExp { nullptr };
         JSImmutableButterfly* m_result { nullptr }; // We use JSImmutableButterfly since we would like to keep all entries alive while repeatedly calling a JS function.
+        MatchResult m_matchResult { };
         Vector<int> m_lastMatch { };
     };
 
     Entry* get(const String& subject, RegExp*);
-    void set(const String& subject, RegExp*, JSImmutableButterfly*, const Vector<int>&);
+    void set(const String& subject, RegExp*, JSImmutableButterfly*, MatchResult, const Vector<int>&);
 
     void clear()
     {

--- a/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
@@ -53,7 +53,7 @@ inline StringReplaceCache::Entry* StringReplaceCache::get(const String& subject,
     return nullptr;
 }
 
-inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImmutableButterfly* result, const Vector<int>& lastMatch)
+inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImmutableButterfly* result, MatchResult matchResult, const Vector<int>& lastMatch)
 {
     DisallowGC disallowGC;
     if (!subject.impl() || !subject.impl()->isAtom())
@@ -67,6 +67,7 @@ inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImm
             entry1.m_subject = subjectImpl;
             entry1.m_regExp = regExp;
             entry1.m_lastMatch = lastMatch;
+            entry1.m_matchResult = matchResult;
             entry1.m_result = result;
         } else {
             auto& entry2 = m_entries[(index + 1) & (cacheSize - 1)];
@@ -74,12 +75,14 @@ inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImm
                 entry2.m_subject = subjectImpl;
                 entry2.m_regExp = regExp;
                 entry2.m_lastMatch = lastMatch;
+                entry2.m_matchResult = matchResult;
                 entry2.m_result = result;
             } else {
                 entry2 = { };
                 entry1.m_subject = subjectImpl;
                 entry1.m_regExp = regExp;
                 entry1.m_lastMatch = lastMatch;
+                entry1.m_matchResult = matchResult;
                 entry1.m_result = result;
             }
         }


### PR DESCRIPTION
#### 8224c0710a837e80650855d39fb722bec8e5e0e8
<pre>
[JSC] Speculative fix for wrong MatchResult in StringReplaceCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=260839">https://bugs.webkit.org/show_bug.cgi?id=260839</a>
rdar://111910989

Reviewed by Mark Lam.

StringReplaceCache needs to setup RegExpCachedResult as if we do matching actually.
But it is wrongly setting MatchResult with the last failed matching. This is fine if
ovector is not updated in the last matching, but it is wrong if it gets updated even
in the failed RegExp matching. Failed to create such a test case, but anyway, there is no
guarantee not doing this. So, let&apos;s save and restore the actual RegExpCachedResult&apos;s MatchResult.

* Source/JavaScriptCore/runtime/RegExpCachedResult.h:
(JSC::RegExpCachedResult::result const):
* Source/JavaScriptCore/runtime/RegExpGlobalData.h:
* Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h:
(JSC::RegExpGlobalData::matchResult const):
(JSC::RegExpGlobalData::resetResultFromCache):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::replaceUsingRegExpSearchWithCache):
* Source/JavaScriptCore/runtime/StringReplaceCache.h:
* Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h:
(JSC::StringReplaceCache::set):

Canonical link: <a href="https://commits.webkit.org/267393@main">https://commits.webkit.org/267393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/970a387144782d026fb34e8f05b0de235f3fcd41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18242 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16662 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19017 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/14202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15702 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/15679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/18022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/18022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19241 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2024 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/15505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4066 "Passed tests") | 
<!--EWS-Status-Bubble-End-->