### PR TITLE
[Gardening]: REGRESSION: [ Sonoma wk1 ] 3 compositing/repaint/iframes/compositing-iframe tests are a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint-expected.txt
@@ -1,0 +1,29 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2016.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2016.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 14.00 14.00)
+          (bounds 432.00 332.00)
+          (drawsContent 1)
+          (repaint rects
+            (rect 24.00 16.00 100.00 8.00)
+            (rect 16.00 16.00 400.00 300.00)
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 369.00)
+          (anchor 1.00 1.00)
+          (bounds 1.00 1.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/compositing-iframe-scroll-repaint-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/compositing-iframe-scroll-repaint-expected.txt
@@ -1,0 +1,61 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2016.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2016.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 14.00 14.00)
+          (bounds 432.00 332.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 16.00 16.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 400.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 0.00 -100.00)
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 400.00 1016.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 400.00 1016.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 8.00)
+                                  (bounds 100.00 100.00)
+                                  (contentsOpaque 1)
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 369.00)
+          (anchor 1.00 1.00)
+          (bounds 1.00 1.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint-expected.txt
@@ -1,0 +1,65 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2016.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2016.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 14.00 14.00)
+          (bounds 432.00 332.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 16.00 16.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 400.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 0.00 -100.00)
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 400.00 1016.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 400.00 1016.00)
+                              (drawsContent 1)
+                              (repaint rects
+                                (rect 8.00 8.00 100.00 100.00)
+                              )
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 108.00)
+                                  (bounds 100.00 100.00)
+                                  (contentsOpaque 1)
+                                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 369.00)
+          (anchor 1.00 1.00)
+          (bounds 1.00 1.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint-expected.txt
+++ b/LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint-expected.txt
@@ -1,0 +1,29 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2016.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2016.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 14.00 14.00)
+          (bounds 432.00 332.00)
+          (drawsContent 1)
+          (repaint rects
+            (rect 0.00 317.00 14.00 15.00)
+            (rect 24.00 16.00 100.00 8.00)
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 369.00)
+          (anchor 1.00 1.00)
+          (bounds 1.00 1.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/compositing-iframe-scroll-repaint-expected.txt
+++ b/LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/compositing-iframe-scroll-repaint-expected.txt
@@ -1,0 +1,64 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2016.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2016.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 14.00 14.00)
+          (bounds 432.00 332.00)
+          (drawsContent 1)
+          (repaint rects
+            (rect 0.00 317.00 14.00 15.00)
+          )
+          (children 1
+            (GraphicsLayer
+              (position 16.00 16.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 400.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 0.00 -100.00)
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 400.00 1016.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 400.00 1016.00)
+                              (drawsContent 1)
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 8.00)
+                                  (bounds 100.00 100.00)
+                                  (contentsOpaque 1)
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 369.00)
+          (anchor 1.00 1.00)
+          (bounds 1.00 1.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint-expected.txt
+++ b/LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint-expected.txt
@@ -1,0 +1,68 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2016.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2016.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 14.00 14.00)
+          (bounds 432.00 332.00)
+          (drawsContent 1)
+          (repaint rects
+            (rect 0.00 317.00 14.00 15.00)
+          )
+          (children 1
+            (GraphicsLayer
+              (position 16.00 16.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 400.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 0.00 -100.00)
+                      (anchor 0.00 0.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 400.00 1016.00)
+                          (children 1
+                            (GraphicsLayer
+                              (bounds 400.00 1016.00)
+                              (drawsContent 1)
+                              (repaint rects
+                                (rect 8.00 8.00 100.00 100.00)
+                              )
+                              (children 1
+                                (GraphicsLayer
+                                  (position 8.00 108.00)
+                                  (bounds 100.00 100.00)
+                                  (contentsOpaque 1)
+                                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 369.00)
+          (anchor 1.00 1.00)
+          (bounds 1.00 1.00)
+        )
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
#### 50ce03a7df999d9f9d273efc9ca8b34982da56d1
<pre>
[Gardening]: REGRESSION: [ Sonoma wk1 ] 3 compositing/repaint/iframes/compositing-iframe tests are a consistent failure
rdar://114098037

Unreviewed test gardening.

Adding rebaseline for Sonoma wk1
Moving expected for Ventura wk1

* LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint-expected.txt: Added.
* LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/compositing-iframe-scroll-repaint-expected.txt: Added.
* LayoutTests/platform/mac-ventura-wk1/compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint-expected.txt: Added.
* LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint-expected.txt: Added.
* LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/compositing-iframe-scroll-repaint-expected.txt: Added.
* LayoutTests/platform/mac/mac-wk1/compositing/repaint/iframes/compositing-iframe-with-fixed-background-doc-repaint-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/267386@main">https://commits.webkit.org/267386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adc44edcf781100da548262547374cd4b7956272

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17216 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/18235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16923 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/18235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16655 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19008 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/14915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/15672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/14873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2019 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/15498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->