### PR TITLE
Let the compiler generate more operator==() in WTF/

### DIFF
--- a/Source/WTF/wtf/Bag.h
+++ b/Source/WTF/wtf/Bag.h
@@ -124,10 +124,7 @@ public:
             return *this;
         }
         
-        bool operator==(const iterator& other) const
-        {
-            return m_node == other.m_node;
-        }
+        friend bool operator==(iterator, iterator) = default;
 
     private:
         template<typename, typename> friend class WTF::Bag;

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -55,6 +55,8 @@ public:
     // AlreadyTaggedValueTag will require a specialized template qualification.
     enum AlreadyTaggedValueTag { AlreadyTaggedValue };
 
+    friend bool operator==(CodePtrBase, CodePtrBase) = default;
+
 protected:
     WTF_EXPORT_PRIVATE static void dumpWithName(void* executableAddress, void* dataLocation, const char* name, PrintStream& out);
 };
@@ -189,7 +191,7 @@ public:
     }
     explicit operator bool() const { return !(!*this); }
     
-    bool operator==(const CodePtr& other) const { return m_value == other.m_value; }
+    friend bool operator==(CodePtr, CodePtr) = default;
 
     // Disallow any casting operations (except for booleans). Instead, the client
     // should be asking taggedPtr() explicitly.

--- a/Source/WTF/wtf/CompactPointerTuple.h
+++ b/Source/WTF/wtf/CompactPointerTuple.h
@@ -53,6 +53,8 @@ public:
 
     CompactPointerTuple() = default;
 
+    friend bool operator==(const CompactPointerTuple&, const CompactPointerTuple&) = default;
+
 #if CPU(ADDRESS64)
 public:
     static constexpr unsigned maxNumberOfBitsInPointer = 48;
@@ -96,11 +98,6 @@ public:
 
     uint64_t data() const { return m_data; }
 
-    bool operator==(const CompactPointerTuple& other) const
-    {
-        return m_data == other.m_data;
-    }
-
 private:
     static constexpr uint64_t encodeType(Type type)
     {
@@ -136,11 +133,6 @@ public:
     void setPointer(PointerType pointer) { m_pointer = pointer; }
     Type type() const { return m_type; }
     void setType(Type type) { m_type = type; }
-
-    bool operator==(const CompactPointerTuple& other) const
-    {
-        return m_type == other.m_type && m_pointer == other.m_pointer;
-    }
 
 private:
     PointerType m_pointer { nullptr };

--- a/Source/WTF/wtf/CountingLock.h
+++ b/Source/WTF/wtf/CountingLock.h
@@ -115,7 +115,7 @@ public:
     public:
         explicit operator bool() const { return !!m_value; }
         
-        bool operator==(const Count& other) const { return m_value == other.m_value; }
+        friend bool operator==(const Count&, const Count&) = default;
         
     private:
         friend class CountingLock;

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -67,10 +67,7 @@ struct LocalTimeOffset {
     {
     }
 
-    bool operator==(const LocalTimeOffset& other) const
-    {
-        return isDST == other.isDST && offset == other.offset;
-    }
+    friend bool operator==(const LocalTimeOffset&, const LocalTimeOffset&) = default;
 
     bool isDST { false };
     int offset { 0 };

--- a/Source/WTF/wtf/FixedBitVector.h
+++ b/Source/WTF/wtf/FixedBitVector.h
@@ -62,7 +62,7 @@ public:
 
     size_t findBit(size_t startIndex, bool value) const;
 
-    bool operator==(const FixedBitVector&) const;
+    friend bool operator==(const FixedBitVector&, const FixedBitVector&) = default;
 
     unsigned hash() const;
 
@@ -153,11 +153,6 @@ ALWAYS_INLINE bool FixedBitVector::test(size_t bitIndex)
 ALWAYS_INLINE size_t FixedBitVector::findBit(size_t startIndex, bool value) const
 {
     return m_bitVector.findBit(startIndex, value);
-}
-
-ALWAYS_INLINE bool FixedBitVector::operator==(const FixedBitVector& other) const
-{
-    return m_bitVector == other.m_bitVector;
 }
 
 ALWAYS_INLINE unsigned FixedBitVector::hash() const

--- a/Source/WTF/wtf/FunctionPtr.h
+++ b/Source/WTF/wtf/FunctionPtr.h
@@ -70,6 +70,8 @@ public:
     // We need to declare this in this non-template base. Otherwise, every use of
     // AlreadyTaggedValueTag will require a specialized template qualification.
     enum AlreadyTaggedValueTag { AlreadyTaggedValue };
+
+    friend bool operator==(FunctionPtrBase, FunctionPtrBase) = default;
 };
 
 template<PtrTag tag, typename Out, typename... In, FunctionAttributes attr>
@@ -127,7 +129,7 @@ public:
     explicit operator bool() const { return !!m_ptr; }
     bool operator!() const { return !m_ptr; }
 
-    bool operator==(const FunctionPtr& other) const { return m_ptr == other.m_ptr; }
+    friend bool operator==(FunctionPtr, FunctionPtr) = default;
 
     FunctionPtr& operator=(Ptr ptr)
     {

--- a/Source/WTF/wtf/GenericTimeMixin.h
+++ b/Source/WTF/wtf/GenericTimeMixin.h
@@ -84,10 +84,7 @@ public:
         return Seconds(m_value - other.m_value);
     }
 
-    constexpr bool operator==(const GenericTimeMixin& other) const
-    {
-        return m_value == other.m_value;
-    }
+    friend constexpr bool operator==(GenericTimeMixin, GenericTimeMixin) = default;
 
     constexpr bool operator<(const GenericTimeMixin& other) const
     {

--- a/Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h
+++ b/Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h
@@ -210,10 +210,7 @@ public:
                 [](const typename Set::iterator& it) -> IndexType { return *it; });
         }
 
-        bool operator==(const iterator& other) const
-        {
-            return m_underlying == other.m_underlying && m_shift == other.m_shift;
-        }
+        friend bool operator==(const iterator&, const iterator&) = default;
 
     private:
         std::variant<BitVector::iterator, typename Set::iterator> m_underlying;

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -232,7 +232,7 @@ public:
     // postfix -- intentionally omitted
 
     // Comparison.
-    bool operator==(const iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(const iterator&, const iterator&) = default;
 
     operator const_iterator() const { return m_iterator; }
 

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -117,7 +117,7 @@ public:
 
         Iterator& operator++(int) = delete;
 
-        bool operator==(const Iterator& other) const { return m_value == other.m_value; }
+        friend bool operator==(const Iterator&, const Iterator&) = default;
 
     private:
         Iterator(StorageType value) : m_value(value) { }
@@ -205,10 +205,7 @@ public:
         return hasExactlyOneBitSet() ? std::optional<E>(static_cast<E>(m_storage)) : std::nullopt;
     }
 
-    constexpr friend bool operator==(OptionSet lhs, OptionSet rhs)
-    {
-        return lhs.m_storage == rhs.m_storage;
-    }
+    friend constexpr bool operator==(const OptionSet&, const OptionSet&) = default;
 
     constexpr friend OptionSet operator|(OptionSet lhs, OptionSet rhs)
     {

--- a/Source/WTF/wtf/OrderMaker.h
+++ b/Source/WTF/wtf/OrderMaker.h
@@ -104,10 +104,7 @@ public:
             return *this;
         }
 
-        bool operator==(const iterator& other) const
-        {
-            return m_iter == other.m_iter;
-        }
+        friend bool operator==(const iterator&, const iterator&) = default;
 
     private:
         typename SentinelLinkedList<Node>::iterator m_iter;

--- a/Source/WTF/wtf/Range.h
+++ b/Source/WTF/wtf/Range.h
@@ -73,11 +73,7 @@ public:
         return Range(std::numeric_limits<Type>::min(), std::numeric_limits<Type>::max());
     }
 
-    bool operator==(const Range& other) const
-    {
-        return m_begin == other.m_begin
-            && m_end == other.m_end;
-    }
+    friend bool operator==(const Range&, const Range&) = default;
 
     explicit operator bool() const { return m_begin != m_end; }
 

--- a/Source/WTF/wtf/RefVector.h
+++ b/Source/WTF/wtf/RefVector.h
@@ -49,7 +49,7 @@ public:
     T& operator*() const { return m_iterator->get(); }
     T* operator->() const { return m_iterator->ptr(); }
 
-    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(const Iterator&, const Iterator&) = default;
 
     Iterator& operator++()
     {
@@ -85,7 +85,7 @@ public:
     const T& operator*() const { return m_iterator->get(); }
     const T* operator->() const { return m_iterator->ptr(); }
 
-    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(const Iterator&, const Iterator&) = default;
 
     Iterator& operator++()
     {

--- a/Source/WTF/wtf/ReferenceWrapperVector.h
+++ b/Source/WTF/wtf/ReferenceWrapperVector.h
@@ -48,7 +48,7 @@ public:
     T& operator*() const { return m_iterator->get(); }
     T* operator->() const { return m_iterator->ptr(); }
 
-    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(const Iterator&, const Iterator&) = default;
 
     Iterator& operator++()
     {
@@ -84,7 +84,7 @@ public:
     const T& operator*() const { return m_iterator->get(); }
     const T* operator->() const { return m_iterator->ptr(); }
 
-    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(const Iterator&, const Iterator&) = default;
 
     Iterator& operator++()
     {

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -188,10 +188,7 @@ public:
     WTF_EXPORT_PRIVATE ApproximateTime operator-(ApproximateTime) const;
     WTF_EXPORT_PRIVATE TimeWithDynamicClockType operator-(const TimeWithDynamicClockType&) const;
     
-    constexpr bool operator==(Seconds other) const
-    {
-        return m_value == other.m_value;
-    }
+    friend constexpr bool operator==(Seconds, Seconds) = default;
     
     constexpr bool operator<(Seconds other) const
     {

--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -107,10 +107,7 @@ public:
             return *this;
         }
         
-        bool operator==(const BaseIterator& other) const
-        {
-            return m_node == other.m_node;
-        }
+        friend bool operator==(BaseIterator, BaseIterator) = default;
 
     private:
         RawNodeType* m_node;

--- a/Source/WTF/wtf/SingleRootGraph.h
+++ b/Source/WTF/wtf/SingleRootGraph.h
@@ -54,11 +54,7 @@ public:
         return result;
     }
 
-    bool operator==(const SingleRootGraphNode& other) const
-    {
-        return m_node == other.m_node
-            && m_isRoot == other.m_isRoot;
-    }
+    friend bool operator==(const SingleRootGraphNode&, const SingleRootGraphNode&) = default;
 
     explicit operator bool() const { return *this != SingleRootGraphNode(); }
 

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -116,11 +116,7 @@ public:
     
     WTF_EXPORT_PRIVATE Seconds operator-(const TimeWithDynamicClockType&) const;
     
-    bool operator==(const TimeWithDynamicClockType& other) const
-    {
-        return m_value == other.m_value
-            && m_type == other.m_type;
-    }
+    friend bool operator==(const TimeWithDynamicClockType&, const TimeWithDynamicClockType&) = default;
     
     // To do relative comparisons, you must be using times with the same clock type.
     WTF_EXPORT_PRIVATE bool operator<(const TimeWithDynamicClockType&) const;

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -88,7 +88,7 @@ public:
         return std::span<const uint8_t, 16> { reinterpret_cast<const uint8_t*>(&m_data), 16 };
     }
 
-    bool operator==(const UUID& other) const { return m_data == other.m_data; }
+    friend bool operator==(const UUID&, const UUID&) = default;
 
     explicit constexpr UUID(HashTableDeletedValueType)
         : m_data(deletedValue)

--- a/Source/WTF/wtf/UniqueRefVector.h
+++ b/Source/WTF/wtf/UniqueRefVector.h
@@ -49,7 +49,7 @@ public:
     T& operator*() const { return m_iterator->get(); }
     T* operator->() const { return m_iterator->ptr(); }
 
-    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(Iterator, Iterator) = default;
 
     Iterator& operator++()
     {
@@ -85,7 +85,7 @@ public:
     const T& operator*() const { return m_iterator->get(); }
     const T* operator->() const { return m_iterator->ptr(); }
 
-    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    friend bool operator==(Iterator, Iterator) = default;
 
     Iterator& operator++()
     {

--- a/Source/WTF/wtf/text/CodePointIterator.h
+++ b/Source/WTF/wtf/text/CodePointIterator.h
@@ -51,11 +51,7 @@ public:
     ALWAYS_INLINE UChar32 operator*() const;
     ALWAYS_INLINE CodePointIterator& operator++();
 
-    ALWAYS_INLINE bool operator==(const CodePointIterator& other) const
-    {
-        return m_begin == other.m_begin
-            && m_end == other.m_end;
-    }
+    ALWAYS_INLINE friend bool operator==(const CodePointIterator&, const CodePointIterator&) = default;
 
     ALWAYS_INLINE bool atEnd() const
     {

--- a/Source/WTF/wtf/text/OrdinalNumber.h
+++ b/Source/WTF/wtf/text/OrdinalNumber.h
@@ -41,7 +41,7 @@ public:
     int zeroBasedInt() const { return m_zeroBasedValue; }
     int oneBasedInt() const { return m_zeroBasedValue + 1; }
 
-    bool operator==(OrdinalNumber other) const { return m_zeroBasedValue == other.m_zeroBasedValue; }
+    friend bool operator==(OrdinalNumber, OrdinalNumber) = default;
     bool operator>(OrdinalNumber other) const { return m_zeroBasedValue > other.m_zeroBasedValue; }
 
 private:

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -50,16 +50,16 @@ public:
     struct LineMode {
         using Behavior = TextBreakIteratorICU::LineMode::Behavior;
         Behavior behavior;
-        bool operator==(const LineMode&) const = default;
+        friend bool operator==(LineMode, LineMode) = default;
     };
     struct CaretMode {
-        bool operator==(const CaretMode&) const = default;
+        friend bool operator==(CaretMode, CaretMode) = default;
     };
     struct DeleteMode {
-        bool operator==(const DeleteMode&) const = default;
+        friend bool operator==(DeleteMode, DeleteMode) = default;
     };
     struct CharacterMode {
-        bool operator==(const CharacterMode&) const = default;
+        friend bool operator==(CharacterMode, CharacterMode) = default;
     };
     using Mode = std::variant<LineMode, CaretMode, DeleteMode, CharacterMode>;
 
@@ -286,7 +286,7 @@ public:
             return m_priorContext.data() + (m_priorContext.size() - length());
         }
 
-        bool operator==(const PriorContext& other) const = default;
+        friend bool operator==(const PriorContext&, const PriorContext&) = default;
 
     private:
         std::array<UChar, Length> m_priorContext;

--- a/Source/WTF/wtf/text/TextPosition.h
+++ b/Source/WTF/wtf/text/TextPosition.h
@@ -40,7 +40,7 @@ public:
     }
 
     TextPosition() { }
-    bool operator==(const TextPosition& other) const { return m_line == other.m_line && m_column == other.m_column; }
+    friend bool operator==(const TextPosition&, const TextPosition&) = default;
 
     // A value with line value less than a minimum; used as an impossible position.
     static TextPosition belowRangePosition() { return TextPosition(OrdinalNumber::beforeFirst(), OrdinalNumber::beforeFirst()); }


### PR DESCRIPTION
#### fc1741dbad51fcbfcc7b2a85387c97e29caaa03b
<pre>
Let the compiler generate more operator==() in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=260840">https://bugs.webkit.org/show_bug.cgi?id=260840</a>

Reviewed by Alan Baradlay and Darin Adler.

Let the compiler generate more operator==() in WTF/ now that we allow C++20.

* Source/WTF/wtf/Bag.h:
* Source/WTF/wtf/CodePtr.h:
(WTF::CodePtr::operator== const): Deleted.
* Source/WTF/wtf/CompactPointerTuple.h:
* Source/WTF/wtf/CountingLock.h:
* Source/WTF/wtf/DateMath.h:
(WTF::LocalTimeOffset::operator== const): Deleted.
* Source/WTF/wtf/FixedBitVector.h:
(WTF::FixedBitVector::operator== const): Deleted.
* Source/WTF/wtf/FunctionPtr.h:
* Source/WTF/wtf/GenericTimeMixin.h:
(WTF::GenericTimeMixin::operator== const): Deleted.
* Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h:
(WTF::LikelyDenseUnsignedIntegerSet::iterator::operator== const): Deleted.
* Source/WTF/wtf/ListHashSet.h:
(WTF::ListHashSetIterator::operator== const): Deleted.
* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::Iterator::operator== const): Deleted.
(WTF::OptionSet::operator==): Deleted.
* Source/WTF/wtf/OrderMaker.h:
(WTF::OrderMaker::iterator::operator== const): Deleted.
* Source/WTF/wtf/Range.h:
(WTF::Range::operator== const): Deleted.
* Source/WTF/wtf/RefVector.h:
(WTF::RefVectorIterator::operator== const): Deleted.
(WTF::RefVectorConstIterator::operator== const): Deleted.
* Source/WTF/wtf/ReferenceWrapperVector.h:
(WTF::ReferenceWrapperVectorIterator::operator== const): Deleted.
(WTF::ReferenceWrapperVectorConstIterator::operator== const): Deleted.
* Source/WTF/wtf/Seconds.h:
* Source/WTF/wtf/SentinelLinkedList.h:
(WTF::SentinelLinkedList::BaseIterator::operator== const): Deleted.
* Source/WTF/wtf/SingleRootGraph.h:
(WTF::SingleRootGraphNode::operator== const): Deleted.
* Source/WTF/wtf/TimeWithDynamicClockType.h:
* Source/WTF/wtf/UUID.h:
(WTF::UUID::operator== const): Deleted.
* Source/WTF/wtf/UniqueRefVector.h:
(WTF::UniqueRefVectorIterator::operator== const): Deleted.
(WTF::UniqueRefVectorConstIterator::operator== const): Deleted.
* Source/WTF/wtf/text/CodePointIterator.h:
(WTF::CodePointIterator::operator== const): Deleted.
* Source/WTF/wtf/text/OrdinalNumber.h:
(WTF::OrdinalNumber::operator== const): Deleted.
* Source/WTF/wtf/text/TextPosition.h:
(WTF::TextPosition::operator== const): Deleted.

Canonical link: <a href="https://commits.webkit.org/267427@main">https://commits.webkit.org/267427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e204fc2826e1ca42c60712a0d40374b8c48195

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18297 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15490 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17836 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19075 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21763 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14251 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19447 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15752 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13355 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18073 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14930 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/4251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3966 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19299 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19293 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15555 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4083 "Passed tests") | 
<!--EWS-Status-Bubble-End-->