### PR TITLE
[Fast text codepath] CharactersTreatedAsSpace is overly prescriptive

### DIFF
--- a/LayoutTests/platform/ios/tables/layering/paint-test-layering-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/layering/paint-test-layering-1-expected.txt
@@ -46,8 +46,8 @@ layer at (0,0) size 800x600
                 text run at (2,2) width 16: "    "
             RenderTableCell {TD} at (24,54) size 74x24 [bgcolor=#0000FF] [border: (1px inset #808080)] [r=1 c=1 rs=2 cs=2]
               RenderBlock {DIV} at (2,2) size 70x20 [color=#008000]
-                RenderText {#text} at (15,0) size 55x19
-                  text run at (15,0) width 55: "   FAIL  "
+                RenderText {#text} at (16,0) size 54x19
+                  text run at (16,0) width 54: "   FAIL  "
           RenderTableRow {TR} at (0,54) size 100x24
             RenderTableCell {TD} at (2,54) size 96x24 [bgcolor=#008000] [border: (1px inset #808080)] [r=2 c=0 rs=1 cs=3]
               RenderBlock {DIV} at (2,2) size 92x20

--- a/LayoutTests/platform/ios/tables/layering/paint-test-layering-2-expected.txt
+++ b/LayoutTests/platform/ios/tables/layering/paint-test-layering-2-expected.txt
@@ -61,5 +61,5 @@ layer at (0,0) size 800x600
           RenderTableRow {TR} at (0,80) size 186x24
             RenderTableCell {TD} at (2,80) size 182x24 [bgcolor=#008000] [border: (1px inset #808080)] [r=3 c=0 rs=1 cs=4]
               RenderBlock {DIV} at (2,2) size 178x20 [color=#008000]
-                RenderText {#text} at (139,0) size 39x19
-                  text run at (139,0) width 39: "FAIL "
+                RenderText {#text} at (140,0) size 38x19
+                  text run at (140,0) width 38: "FAIL "

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug4427-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug4427-expected.txt
@@ -90,11 +90,11 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,42) size 130x19
                 text run at (2,42) width 130: "4633 Ocean Avenue"
               RenderBR {BR} at (131,42) size 1x19
-              RenderText {#text} at (2,62) size 173x19
+              RenderText {#text} at (2,62) size 172x19
                 text run at (2,62) width 103: "San Francisco,  "
-                text run at (104,62) width 31: "CA  "
-                text run at (134,62) width 41: "94132"
-              RenderBR {BR} at (174,62) size 1x19
+                text run at (104,62) width 30: "CA  "
+                text run at (133,62) width 41: "94132"
+              RenderBR {BR} at (173,62) size 1x19
             RenderTableCell {TD} at (252,1) size 25x5 [border: (1px inset #808080)] [r=0 c=2 rs=1 cs=1]
               RenderImage {IMG} at (2,2) size 20x1
             RenderTableCell {TD} at (277,1) size 148x38 [border: (1px inset #808080)] [r=0 c=3 rs=1 cs=1]
@@ -122,10 +122,10 @@ layer at (0,0) size 800x600
               RenderText {#text} at (2,42) size 131x19
                 text run at (2,42) width 131: "Real Estate Services"
               RenderBR {BR} at (132,42) size 1x19
-              RenderText {#text} at (2,62) size 71x19
-                text run at (2,62) width 31: "CA  "
-                text run at (32,62) width 41: "00000"
-              RenderBR {BR} at (72,62) size 1x19
+              RenderText {#text} at (2,62) size 70x19
+                text run at (2,62) width 30: "CA  "
+                text run at (31,62) width 41: "00000"
+              RenderBR {BR} at (71,62) size 1x19
               RenderText {#text} at (2,82) size 100x19
                 text run at (2,82) width 100: "(000) 000-0000"
             RenderTableCell {TD} at (252,112) size 25x5 [border: (1px inset #808080)] [r=2 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -10,8 +10,8 @@ layer at (0,0) size 800x2685
         RenderTableSection {TBODY} at (1,1) size 473x106
           RenderTableRow {TR} at (0,2) size 473x24
             RenderTableCell {TH} at (2,2) size 69x24 [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (12,2) size 44x19
-                text run at (12,2) width 44: "Color "
+              RenderText {#text} at (13,2) size 43x19
+                text run at (13,2) width 43: "Color "
             RenderTableCell {TH} at (72,2) size 399x24 [border: (1px inset #808080)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (166,2) size 66x19
                 text run at (166,2) width 66: "Meaning "


### PR DESCRIPTION
#### 6566fb8f9216aae136892c5f32e6e50367de2969
<pre>
[Fast text codepath] CharactersTreatedAsSpace is overly prescriptive
<a href="https://bugs.webkit.org/show_bug.cgi?id=260843">https://bugs.webkit.org/show_bug.cgi?id=260843</a>
rdar://114607926

Reviewed by Cameron McCormack.

When we lay out web content, we make multiple passes over the text,
chopping it up multiple different ways. Because of this, we have an
invariant that the width of a space can&apos;t change depending on the
bounds of how we&apos;re chopping up the text. Kerning can affect the
width of a space, so we enforce the invariant by having a postprocess
that we perform after shaping to retroactively go back and adjust
the width of any glyphs associated with space characters, to reset
their widths. This is called &quot;CharactersTreatedAsSpace.&quot;

However, CharactersTreatedAsSpace actually does something else, too:
it also adjusts the width of the character directly before the space
to be whatever it was before shaping. However, this is kind of
bogus - it&apos;s totally valid for shaping to adjust the width of
whichever character happens to be before the space.

Now that we&apos;re trying to make the fast text codepath handle complex
character clusters, we&apos;re hitting the case more often where shaping
is adjusting the non-space glyphs to be correct, but then our
postprocess is coming along and messing them up. This patch removes
that logic, just for the glyphs before the space characters. The
logic about trying to reset the space characters&apos; width is still
there.

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::OriginalAdvancesForCharacterTreatedAsSpace::OriginalAdvancesForCharacterTreatedAsSpace):
(WebCore::WidthIterator::applyFontTransforms):
(WebCore::WidthIterator::advanceInternal):

Canonical link: <a href="https://commits.webkit.org/267541@main">https://commits.webkit.org/267541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/871afdb29f6c7f33cd2bccc6b7c555d9a9c481ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17346 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17442 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19475 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15307 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19790 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16084 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15251 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4049 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->