### PR TITLE
updateRendering() gets stuck at the wrong framerate when thermal throttling changes

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -50,6 +50,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+#import <QuartzCore/CADisplay.h>
 #import <QuartzCore/CADisplayLinkPrivate.h>
 #endif
 
@@ -65,8 +66,12 @@
 typedef struct _CARenderContext CARenderContext;
 
 #if PLATFORM(IOS_FAMILY)
+@interface CADisplay : NSObject
+@end
+
 @interface CADisplayLink ()
 @property (readonly, nonatomic) CFTimeInterval maximumRefreshRate;
+@property (readonly, nonatomic) CADisplay *display;
 @end
 #endif
 


### PR DESCRIPTION
#### a33d2c717ecb2870f364d3952bd340b4f54728a7
<pre>
updateRendering() gets stuck at the wrong framerate when thermal throttling changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=260846">https://bugs.webkit.org/show_bug.cgi?id=260846</a>
rdar://112799115

Reviewed by Wenson Hsieh and Simon Fraser.

It turns out that `maximumRefreshRate` is actually &quot;the maximum frame rate you can
achieve given current throttling behaviors&quot;, not &quot;the frame rate of the display&quot;.
That means that, when throttling states change, maximumRefreshRate can change too.

We currently do not respond to changes in maximumRefreshRate. This means that we
can get stuck with an incorrect `maximumRefreshRate` (and `preferredFramesPerSecond`,
which is downstream of it).

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):
(-[WKDisplayLinkHandler invalidate]):
(-[WKDisplayLinkHandler observeValueForKeyPath:ofObject:change:context:]):
(-[WKDisplayLinkHandler didChangeNominalFramesPerSecond]):
When the CADisplayLink&apos;s CADisplay&apos;s `refreshRate` changes, reconfigure the display, which
results in communicating the new maximum frame rate back to WebCore and also (indirectly)
updating the CADisplayLink&apos;s `preferredFramesPerSecond`.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
Add CADisplay SPI.

Canonical link: <a href="https://commits.webkit.org/267440@main">https://commits.webkit.org/267440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f662c57ddb97be8b2400af17abc762be22e57d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17028 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19128 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15012 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15395 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19486 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14975 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3971 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->