### PR TITLE
Deploy more smart pointers in Source/WebKit/UIProcess/

### DIFF
--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -721,8 +721,8 @@ void GPUProcessProxy::updatePreferences(WebProcessProxy& webProcess)
     // In practice, all web pages' preferences should agree on these feature flag values.
     GPUProcessPreferences gpuPreferences;
     for (auto page : webProcess.pages()) {
-        auto& webPreferences = page->preferences();
-        if (!webPreferences.useGPUProcessForMediaEnabled())
+        Ref webPreferences = page->preferences();
+        if (!webPreferences->useGPUProcessForMediaEnabled())
             continue;
         gpuPreferences.copyEnabledWebPreferences(webPreferences);
     }

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -61,7 +61,7 @@ UIGamepadProvider::~UIGamepadProvider()
 
 void UIGamepadProvider::gamepadSyncTimerFired()
 {
-    auto webPageProxy = platformWebPageProxyForGamepadInput();
+    RefPtr webPageProxy = platformWebPageProxyForGamepadInput();
     if (!webPageProxy || !m_processPoolsUsingGamepads.contains(&webPageProxy->process().processPool()))
         return;
 
@@ -161,7 +161,7 @@ void UIGamepadProvider::viewBecameActive(WebPageProxy& page)
 
 void UIGamepadProvider::viewBecameInactive(WebPageProxy& page)
 {
-    auto pageForGamepadInput = platformWebPageProxyForGamepadInput();
+    RefPtr pageForGamepadInput = platformWebPageProxyForGamepadInput();
     if (pageForGamepadInput == &page)
         platformStopMonitoringInput();
 }

--- a/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp
@@ -43,13 +43,16 @@ HighPerformanceGraphicsUsageSampler::HighPerformanceGraphicsUsageSampler(WebProc
     m_timer.startRepeating(samplingInterval);
 }
 
+HighPerformanceGraphicsUsageSampler::~HighPerformanceGraphicsUsageSampler() = default;
+
 void HighPerformanceGraphicsUsageSampler::timerFired()
 {
     bool isUsingHighPerformanceWebGL = false;
     bool isUsingHighPerformanceWebGLInVisibleView = false;
 
     RefPtr<WebPageProxy> firstPage;
-    for (auto& webProcess : m_webProcessPool.processes()) {
+    Ref pool = m_webProcessPool.get();
+    for (auto& webProcess : pool->processes()) {
         for (auto& page : webProcess->pages()) {
             if (!page)
                 continue;

--- a/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h
+++ b/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h
@@ -35,11 +35,12 @@ class HighPerformanceGraphicsUsageSampler {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit HighPerformanceGraphicsUsageSampler(WebProcessPool&);
+    ~HighPerformanceGraphicsUsageSampler();
 
 private:
     void timerFired();
 
-    WebProcessPool& m_webProcessPool;
+    CheckedRef<WebProcessPool> m_webProcessPool;
     RunLoop::Timer m_timer;
 };
 


### PR DESCRIPTION
#### e2ae472c61f4b41fc3a9724afbf0336f3977f940
<pre>
Deploy more smart pointers in Source/WebKit/UIProcess/
<a href="https://bugs.webkit.org/show_bug.cgi?id=260847">https://bugs.webkit.org/show_bug.cgi?id=260847</a>

Reviewed by Chris Dumez.

Deployed more smart pointers.

* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::updatePreferences):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::gamepadSyncTimerFired):
(WebKit::UIGamepadProvider::viewBecameInactive):
* Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp:
(WebKit::HighPerformanceGraphicsUsageSampler::timerFired):
* Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h:

Canonical link: <a href="https://commits.webkit.org/267426@main">https://commits.webkit.org/267426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15a33e5f0f001daf260d74dc4222cf9e3f42507a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15443 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17795 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19021 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14329 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21715 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13316 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19253 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2037 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->