### PR TITLE
Deploy more smart pointers in Source/WebKit/UIProcess/Inspector

### DIFF
--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -56,8 +56,8 @@ using namespace FileSystem;
 
 ContentRuleListStore& ContentRuleListStore::defaultStore()
 {
-    static ContentRuleListStore* defaultStore = adoptRef(new ContentRuleListStore()).leakRef();
-    return *defaultStore;
+    static NeverDestroyed<Ref<ContentRuleListStore>> defaultStore = adoptRef(*new ContentRuleListStore());
+    return defaultStore->get();
 }
 
 Ref<ContentRuleListStore> ContentRuleListStore::storeWithPath(const WTF::String& storePath)

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -107,19 +107,19 @@ ContentWorld::~ContentWorld()
         ASSERT_UNUSED(taken, taken == this);
     }
 
-    for (auto proxy : m_associatedContentControllerProxies)
-        proxy->contentWorldDestroyed(*this);
+    for (auto& proxy : m_associatedContentControllerProxies)
+        Ref { proxy }->contentWorldDestroyed(*this);
 }
 
 void ContentWorld::addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy& proxy)
 {
-    auto addResult = m_associatedContentControllerProxies.add(&proxy);
+    auto addResult = m_associatedContentControllerProxies.add(proxy);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
 
 void ContentWorld::userContentControllerProxyDestroyed(WebKit::WebUserContentControllerProxy& proxy)
 {
-    bool removed = m_associatedContentControllerProxies.remove(&proxy);
+    bool removed = m_associatedContentControllerProxies.remove(proxy);
     ASSERT_UNUSED(removed, removed);
 }
 

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -27,7 +27,7 @@
 
 #include "APIObject.h"
 #include "ContentWorldShared.h"
-#include <wtf/HashSet.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -58,7 +58,7 @@ private:
 
     WebKit::ContentWorldIdentifier m_identifier;
     WTF::String m_name;
-    HashSet<WebKit::WebUserContentControllerProxy*> m_associatedContentControllerProxies;
+    WeakHashSet<WebKit::WebUserContentControllerProxy> m_associatedContentControllerProxies;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -202,7 +202,7 @@ void PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebPr
 
 bool PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() const
 {
-    if (m_data.processPool && isInspectorProcessPool(*m_data.processPool)) {
+    if (RefPtr processPool = m_data.processPool; processPool && isInspectorProcessPool(*processPool)) {
         // Never delay process launch for inspector pages as inspector pages do not know how to transition from a terminated process.
         RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> false because of WebInspector pool", this);
         return false;

--- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
@@ -42,7 +42,7 @@ WKTypeID WKInspectorGetTypeID()
 
 WKPageRef WKInspectorGetPage(WKInspectorRef inspectorRef)
 {
-    return toAPI(toImpl(inspectorRef)->inspectedPage());
+    return toAPI(toImpl(inspectorRef)->inspectedPage().get());
 }
 
 bool WKInspectorIsConnected(WKInspectorRef inspectorRef)

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
@@ -52,7 +52,7 @@ InspectorBrowserAgent::~InspectorBrowserAgent() = default;
 
 bool InspectorBrowserAgent::enabled() const
 {
-    return m_inspectedPage.inspectorController().enabledBrowserAgent() == this;
+    return m_inspectedPage->inspectorController().enabledBrowserAgent() == this;
 }
 
 void InspectorBrowserAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*)
@@ -69,7 +69,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorBrowserAgent::enable()
     if (enabled())
         return makeUnexpected("Browser domain already enabled"_s);
 
-    m_inspectedPage.inspectorController().setEnabledBrowserAgent(this);
+    m_inspectedPage->inspectorController().setEnabledBrowserAgent(this);
 
     return { };
 }
@@ -79,7 +79,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorBrowserAgent::disable()
     if (!enabled())
         return makeUnexpected("Browser domain already disabled"_s);
 
-    m_inspectedPage.inspectorController().setEnabledBrowserAgent(nullptr);
+    m_inspectedPage->inspectorController().setEnabledBrowserAgent(nullptr);
 
     return { };
 }

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h
@@ -28,6 +28,7 @@
 #include "WebPageInspectorAgentBase.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 
 namespace WebKit {
@@ -56,7 +57,7 @@ public:
 private:
     std::unique_ptr<Inspector::BrowserFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::BrowserBackendDispatcher> m_backendDispatcher;
-    WebPageProxy& m_inspectedPage;
+    CheckedRef<WebPageProxy> m_inspectedPage;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -45,7 +45,8 @@ std::unique_ptr<InspectorTargetProxy> InspectorTargetProxy::create(WebPageProxy&
 
 std::unique_ptr<InspectorTargetProxy> InspectorTargetProxy::create(ProvisionalPageProxy& provisionalPage, const String& targetId, Inspector::InspectorTargetType type)
 {
-    auto target = InspectorTargetProxy::create(provisionalPage.page(), targetId, type);
+    Ref page = provisionalPage.page();
+    auto target = InspectorTargetProxy::create(page, targetId, type);
     target->m_provisionalPage = provisionalPage;
     return target;
 }

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -30,6 +30,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/InspectorFrontendClient.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
@@ -63,7 +64,7 @@ class WebView;
 class WebInspectorUIExtensionControllerProxy;
 #endif
 
-class RemoteWebInspectorUIProxyClient {
+class RemoteWebInspectorUIProxyClient : public CanMakeCheckedPtr {
 public:
     virtual ~RemoteWebInspectorUIProxyClient() { }
     virtual void sendMessageToBackend(const String& message) = 0;
@@ -124,6 +125,7 @@ public:
 
 private:
     RemoteWebInspectorUIProxy();
+    RefPtr<WebPageProxy> protectedInspectorPage();
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
@@ -164,8 +166,8 @@ private:
     void platformRevealFileExternally(const String& path);
     void platformShowCertificate(const WebCore::CertificateInfo&);
 
-    RemoteWebInspectorUIProxyClient* m_client { nullptr };
-    WebPageProxy* m_inspectorPage { nullptr };
+    CheckedPtr<RemoteWebInspectorUIProxyClient> m_client;
+    CheckedPtr<WebPageProxy> m_inspectorPage;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     RefPtr<WebInspectorUIExtensionControllerProxy> m_extensionController;

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -31,12 +31,14 @@
 #include "DebuggableInfoData.h"
 #include "MessageReceiver.h"
 #include "WebInspectorUtilities.h"
+#include "WebPageProxy.h"
 #include "WebPageProxyIdentifier.h"
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/InspectorClient.h>
 #include <WebCore/InspectorFrontendClient.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -73,7 +75,6 @@ namespace WebKit {
 
 class WebFrameProxy;
 class WebInspectorUIProxyClient;
-class WebPageProxy;
 class WebPreferences;
 #if ENABLE(INSPECTOR_EXTENSIONS)
 class WebInspectorUIExtensionControllerProxy;
@@ -108,8 +109,8 @@ public:
     void setInspectorClient(std::unique_ptr<API::InspectorClient>&&);
 
     // Public APIs
-    WebPageProxy* inspectedPage() const { return m_inspectedPage; }
-    WebPageProxy* inspectorPage() const { return m_inspectorPage; }
+    RefPtr<WebPageProxy> inspectedPage() const { return m_inspectedPage.get(); }
+    RefPtr<WebPageProxy> inspectorPage() const { return m_inspectorPage.get(); }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WebInspectorUIExtensionControllerProxy* extensionController() const { return m_extensionController.get(); }
@@ -301,8 +302,8 @@ private:
     void windowReceivedMessage(HWND, UINT, WPARAM, LPARAM) override;
 #endif
 
-    WebPageProxy* m_inspectedPage { nullptr };
-    WebPageProxy* m_inspectorPage { nullptr };
+    CheckedPtr<WebPageProxy> m_inspectedPage;
+    CheckedPtr<WebPageProxy> m_inspectorPage;
     std::unique_ptr<API::InspectorClient> m_inspectorClient;
     WebPageProxyIdentifier m_inspectedPageIdentifier;
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorAgentBase.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorAgentBase.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorAgentBase.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -41,7 +42,7 @@ class WebPageProxy;
 struct WebPageAgentContext {
     Inspector::FrontendRouter& frontendRouter;
     Inspector::BackendDispatcher& backendDispatcher;
-    WebPageProxy& inspectedPage;
+    CheckedRef<WebPageProxy> inspectedPage;
 };
 
 class InspectorAgentBase : public Inspector::InspectorAgentBase {

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -83,6 +83,7 @@ public:
     void browserExtensionsDisabled(HashSet<String>&&);
 
 private:
+    Ref<WebPageProxy> protectedInspectedPage();
     WebPageAgentContext webPageAgentContext();
     void createLazyAgents();
 
@@ -92,7 +93,7 @@ private:
     Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     Inspector::AgentRegistry m_agents;
 
-    WebPageProxy& m_inspectedPage;
+    CheckedRef<WebPageProxy> m_inspectedPage;
 
     Inspector::InspectorTargetAgent* m_targetAgent { nullptr };
     HashMap<String, std::unique_ptr<InspectorTargetProxy>> m_targets;

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -157,7 +157,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
     GRefPtr<GFile> file = adoptGRef(gtk_file_chooser_get_file(chooser));
     GUniquePtr<char> path(g_file_get_path(file.get()));
     g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
-        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, remoteFileReplaceContentsCallback, m_inspectorPage);
+        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, remoteFileReplaceContentsCallback, protectedInspectorPage().get());
 }
 
 void RemoteWebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -169,7 +169,7 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     preferences->setAcceleratedCompositingEnabled(inspectedPagePreferences.acceleratedCompositingEnabled());
     preferences->setForceCompositingMode(inspectedPagePreferences.forceCompositingMode());
     preferences->setThreadedScrollingEnabled(inspectedPagePreferences.threadedScrollingEnabled());
-    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage()));
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage().get()));
     auto websiteDataStore = inspectorWebsiteDataStore();
     auto& processPool = WebKit::defaultInspectorProcessPool(inspectionLevel());
 
@@ -540,7 +540,7 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
     GRefPtr<GFile> file = adoptGRef(gtk_file_chooser_get_file(chooser));
     GUniquePtr<char> path(g_file_get_path(file.get()));
     g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
-        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, m_inspectorPage);
+        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, inspectorPage().get());
 }
 
 void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -73,18 +73,18 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
 @end
 
 @implementation WKWebInspectorUIProxyObjCAdapter {
-    WebKit::WebInspectorUIProxy* _inspectorProxy;
+    WeakPtr<WebKit::WebInspectorUIProxy> _inspectorProxy;
 }
 
 - (WKInspectorRef)inspectorRef
 {
-    return toAPI(_inspectorProxy);
+    return toAPI(_inspectorProxy.get());
 }
 
 - (_WKInspector *)inspector
 {
-    if (_inspectorProxy)
-        return wrapper(*_inspectorProxy);
+    if (RefPtr proxy = _inspectorProxy.get())
+        return wrapper(*proxy);
     return nil;
 }
 
@@ -108,39 +108,39 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
 
 - (NSRect)window:(NSWindow *)window willPositionSheet:(NSWindow *)sheet usingRect:(NSRect)rect
 {
-    if (_inspectorProxy)
-        return NSMakeRect(0, _inspectorProxy->sheetRect().height(), _inspectorProxy->sheetRect().width(), 0);
+    if (RefPtr proxy = _inspectorProxy.get())
+        return NSMakeRect(0, proxy->sheetRect().height(), proxy->sheetRect().width(), 0);
     return rect;
 }
 
 - (void)windowDidMove:(NSNotification *)notification
 {
-    if (_inspectorProxy)
-        _inspectorProxy->windowFrameDidChange();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->windowFrameDidChange();
 }
 
 - (void)windowDidResize:(NSNotification *)notification
 {
-    if (_inspectorProxy)
-        _inspectorProxy->windowFrameDidChange();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->windowFrameDidChange();
 }
 
 - (void)windowWillClose:(NSNotification *)notification
 {
-    if (_inspectorProxy)
-        _inspectorProxy->close();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->close();
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification *)notification
 {
-    if (_inspectorProxy)
-        _inspectorProxy->windowFullScreenDidChange();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->windowFullScreenDidChange();
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification
 {
-    if (_inspectorProxy)
-        _inspectorProxy->windowFullScreenDidChange();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->windowFullScreenDidChange();
 }
 
 - (void)inspectedViewFrameDidChange:(NSNotification *)notification
@@ -151,8 +151,8 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
     // of the time the views will already have the correct frames because of autoresizing masks.
 
     dispatch_after(DISPATCH_TIME_NOW, dispatch_get_main_queue(), ^{
-        if (_inspectorProxy)
-            _inspectorProxy->inspectedViewFrameDidChange();
+        if (RefPtr proxy = _inspectorProxy.get())
+            proxy->inspectedViewFrameDidChange();
     });
 }
 
@@ -169,8 +169,8 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
         return;
 
     dispatch_after(DISPATCH_TIME_NOW, dispatch_get_main_queue(), ^{
-        if (_inspectorProxy)
-            _inspectorProxy->inspectedViewFrameDidChange();
+        if (RefPtr proxy = _inspectorProxy.get())
+            proxy->inspectedViewFrameDidChange();
     });
 }
 
@@ -178,14 +178,14 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
 
 - (void)inspectorViewControllerDidBecomeActive:(WKInspectorViewController *)inspectorViewController
 {
-    if (_inspectorProxy)
-        _inspectorProxy->didBecomeActive();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->didBecomeActive();
 }
 
 - (void)inspectorViewControllerInspectorDidCrash:(WKInspectorViewController *)inspectorViewController
 {
-    if (_inspectorProxy)
-        _inspectorProxy->closeForCrash();
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->closeForCrash();
 }
 
 - (BOOL)inspectorViewControllerInspectorIsUnderTest:(WKInspectorViewController *)inspectorViewController
@@ -195,20 +195,20 @@ static void* kWindowContentLayoutObserverContext = &kWindowContentLayoutObserver
 
 - (void)inspectorViewController:(WKInspectorViewController *)inspectorViewController willMoveToWindow:(NSWindow *)newWindow
 {
-    if (_inspectorProxy)
-        _inspectorProxy->attachmentWillMoveFromWindow(inspectorViewController.webView.window);
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->attachmentWillMoveFromWindow(inspectorViewController.webView.window);
 }
 
 - (void)inspectorViewControllerDidMoveToWindow:(WKInspectorViewController *)inspectorViewController
 {
-    if (_inspectorProxy)
-        _inspectorProxy->attachmentDidMoveToWindow(inspectorViewController.webView.window);
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->attachmentDidMoveToWindow(inspectorViewController.webView.window);
 }
 
 - (void)inspectorViewController:(WKInspectorViewController *)inspectorViewController openURLExternally:(NSURL *)url
 {
-    if (_inspectorProxy)
-        _inspectorProxy->openURLExternally(url.absoluteString);
+    if (RefPtr proxy = _inspectorProxy.get())
+        proxy->openURLExternally(url.absoluteString);
 }
 
 @end
@@ -457,7 +457,7 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:NSViewFrameDidChangeNotification object:inspectedView];
 
     auto configuration = inspectedPage()->uiClient().configurationForLocalInspector(*inspectedPage(),  *this);
-    m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration: WebKit::wrapper(configuration.get()) inspectedPage:inspectedPage()]);
+    m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration: WebKit::wrapper(configuration.get()) inspectedPage:inspectedPage().get()]);
     [m_inspectorViewController.get() setDelegate:m_objCAdapter.get()];
 
     WebPageProxy *inspectorPage = [m_inspectorViewController webView]->_page.get();
@@ -476,7 +476,7 @@ void WebInspectorUIProxy::platformCreateFrontendWindow()
         savedWindowFrame = NSRectFromString(savedWindowFrameString);
     }
 
-    m_inspectorWindow = WebInspectorUIProxy::createFrontendWindow(savedWindowFrame, InspectionTargetType::Local, inspectedPage());
+    m_inspectorWindow = WebInspectorUIProxy::createFrontendWindow(savedWindowFrame, InspectionTargetType::Local, inspectedPage().get());
     [m_inspectorWindow setDelegate:m_objCAdapter.get()];
 
     WKWebView *inspectorView = [m_inspectorViewController webView];

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -259,7 +259,7 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     preferences->setLogsPageMessagesToSystemConsoleEnabled(true);
 #endif
     preferences->setJavaScriptRuntimeFlags({ });
-    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage()));
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage().get()));
     auto pageConfiguration = API::PageConfiguration::create();
     pageConfiguration->setProcessPool(&WebKit::defaultInspectorProcessPool(inspectionLevel()));
     pageConfiguration->setPreferences(preferences.ptr());


### PR DESCRIPTION
#### 9dc842ed6c6bdb25124016c8614de1f2bbbe3a23
<pre>
Deploy more smart pointers in Source/WebKit/UIProcess/Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=260848">https://bugs.webkit.org/show_bug.cgi?id=260848</a>

Reviewed by Chris Dumez.

This PR addresses clang static analyzer warnings for smart pointers.

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::ContentRuleListStore::defaultStore):
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::ContentWorld::~ContentWorld):
(API::ContentWorld::addAssociatedUserContentControllerProxy):
(API::ContentWorld::userContentControllerProxyDestroyed):
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::delaysWebProcessLaunchUntilFirstLoad const):
* Source/WebKit/UIProcess/API/C/WKInspector.cpp:
(WKInspectorGetPage):
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp:
(WebKit::InspectorBrowserAgent::enabled const):
(WebKit::InspectorBrowserAgent::enable):
(WebKit::InspectorBrowserAgent::disable):
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.h:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
(WebKit::InspectorTargetProxy::create):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
(WebKit::RemoteWebInspectorUIProxy::protectedInspectorPage):
(WebKit::RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::RemoteWebInspectorUIProxy::initialize):
(WebKit::RemoteWebInspectorUIProxy::showConsole):
(WebKit::RemoteWebInspectorUIProxy::showResources):
(WebKit::RemoteWebInspectorUIProxy::sendMessageToFrontend):
(WebKit::RemoteWebInspectorUIProxy::frontendDidClose):
(WebKit::RemoteWebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled):
(WebKit::RemoteWebInspectorUIProxy::sendMessageToBackend):
(WebKit::RemoteWebInspectorUIProxy::createFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::closeFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
(): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::inspectionLevel const):
(WebKit::WebInspectorUIProxy::inspectorPagePreferences const):
(WebKit::WebInspectorUIProxy::createFrontendPage):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::sendMessageToBackend):
(WebKit::WebInspectorUIProxy::frontendLoaded):
(WebKit::WebInspectorUIProxy::attachAvailabilityChanged):
(WebKit::WebInspectorUIProxy::setDeveloperPreferenceOverride):
(WebKit::WebInspectorUIProxy::setEmulatedConditions):
(WebKit::WebInspectorUIProxy::evaluateInFrontendForTesting):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::inspectedPage const):
(WebKit::WebInspectorUIProxy::inspectorPage const):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorAgentBase.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::protectedInspectedPage):
(WebKit::WebPageInspectorController::init):
(WebKit::WebPageInspectorController::connectFrontend):
(WebKit::WebPageInspectorController::disconnectFrontend):
(WebKit::WebPageInspectorController::disconnectAllFrontends):
(WebKit::WebPageInspectorController::setIndicating):
(WebKit::WebPageInspectorController::createInspectorTarget):
(WebKit::WebPageInspectorController::setEnabledBrowserAgent):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):
(-[WKInspectorViewController webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[WKInspectorViewController inspectorWKWebViewReload:]):
(-[WKInspectorViewController inspectorWKWebViewReloadFromOrigin:]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(-[WKWebInspectorUIProxyObjCAdapter inspectorRef]):
(-[WKWebInspectorUIProxyObjCAdapter inspector]):
(-[WKWebInspectorUIProxyObjCAdapter window:willPositionSheet:usingRect:]):
(-[WKWebInspectorUIProxyObjCAdapter windowDidMove:]):
(-[WKWebInspectorUIProxyObjCAdapter windowDidResize:]):
(-[WKWebInspectorUIProxyObjCAdapter windowWillClose:]):
(-[WKWebInspectorUIProxyObjCAdapter windowDidEnterFullScreen:]):
(-[WKWebInspectorUIProxyObjCAdapter windowDidExitFullScreen:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectedViewFrameDidChange:]):
(-[WKWebInspectorUIProxyObjCAdapter observeValueForKeyPath:ofObject:change:context:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerDidBecomeActive:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerInspectorDidCrash:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewController:willMoveToWindow:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerDidMoveToWindow:]):
(-[WKWebInspectorUIProxyObjCAdapter inspectorViewController:openURLExternally:]):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):

Canonical link: <a href="https://commits.webkit.org/267576@main">https://commits.webkit.org/267576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d006567cbae0c2b0c17f2600eb126e52128fc56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15914 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18135 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19607 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14800 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15356 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19720 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2100 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->