### PR TITLE
[WPE] Bump internal Cog commit

### DIFF
--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -30,7 +30,7 @@ if (ENABLE_COG)
         set(WPE_COG_REPO "https://github.com/Igalia/cog.git")
     endif ()
     if ("${WPE_COG_TAG}" STREQUAL "")
-        set(WPE_COG_TAG "49c2de4c82fe95571b95df48ec2a9319561d15b0")
+        set(WPE_COG_TAG "9e2dc0a086336d7cd025e50461d126992734672d")
     endif ()
     # TODO Use GIT_REMOTE_UPDATE_STRATEGY with 3.18 to allow switching between
     # conflicting branches without having to delete the repo


### PR DESCRIPTION
#### cfd564becff8fafc7101926efcb65c35b9360762
<pre>
[WPE] Bump internal Cog commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=260849">https://bugs.webkit.org/show_bug.cgi?id=260849</a>

Reviewed by Michael Catanzaro.

The list of changes since the previous version is:
9e2dc0a launcher: Add command-line option for controlling autoplay behavior
7a33249 drm: Fix logic error in indexing when using find_crtc_for_encoder
95d0aaf Update platform/drm/cog-platform-drm.c
689e7a6 Update platform/drm/cog-platform-drm.c
47dee03 drm: Fix crash on imx6 when no current encoder+crtc is bound
51e0951 gtk4: Prefix a scheme if none provided
7489ca5 Meson: check file sys/mman.h in order to define HAVE_MEMFD_CREATE
705e46d Fix maybe-uninitialized warning
5976f59 launcher: Handle GApplication::activate
da64b4a Add support for weston 13 protocols
7a60bda launcher: Add CLI flag to disable built-in key bindings
48fdd6e Fix compilation warning in i386
7b7c10b core: Move key binding handling into CogView
0606be4 launcher: Remove handling of plain WPE backends
7eb8ffb core: Add a fallback CogPlatform implementation
9001a8d core: Introduce a new CogView class
023fbb0 wl: fix blurry rendering in some compositors
f8ae0e6 core: Add missing underscore to environment variable names
0a9405c core: Move platform selection logic into the library
8e1acd3 webkit-utils: Check if the media engine will show the resource
c51d94e headless: Move frame tick source to platform object
a6d2321 launcher: Simplify by using global CogPlatform
9df4a77 drm: ignore key event if no xkb context is available
af5789c docs: Fix gi-docgen wrong type for GKeyFile warning

* Tools/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/267414@main">https://commits.webkit.org/267414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3006232f14220f38f5c426a28430409ae5d0c426

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17803 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19028 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19407 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14891 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->