### PR TITLE
[WGSL] ParameterizedTypeName should accept more than 1 argument

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -418,7 +418,13 @@ void StringDumper::visit(NamedTypeName& type)
 void StringDumper::visit(ParameterizedTypeName& type)
 {
     m_out.print(type.base(), "<");
-    visit(type.elementType());
+    bool first = true;
+    for (auto& argument : type.arguments()) {
+        if (!first)
+            m_out.print(", ");
+        first = false;
+        visit(argument);
+    }
     m_out.print(">");
 }
 

--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -48,6 +48,7 @@ class TypeName : public Node {
 public:
     using Ref = std::reference_wrapper<TypeName>;
     using Ptr = TypeName*;
+    using List = ReferenceWrapperVector<TypeName>;
 
     const Type* resolvedType() const { return m_resolvedType; }
 
@@ -102,17 +103,17 @@ class ParameterizedTypeName : public TypeName {
 public:
     NodeKind kind() const override;
     Identifier& base() { return m_base; }
-    TypeName& elementType() { return m_elementType; }
+    TypeName::List& arguments() { return m_arguments; }
 
 private:
-    ParameterizedTypeName(SourceSpan span, Identifier&& base, TypeName::Ref&& elementType)
+    ParameterizedTypeName(SourceSpan span, Identifier&& base, TypeName::List&& arguments)
         : TypeName(span)
         , m_base(WTFMove(base))
-        , m_elementType(WTFMove(elementType))
+        , m_arguments(WTFMove(arguments))
     { }
 
     Identifier m_base;
-    TypeName::Ref m_elementType;
+    TypeName::List m_arguments;
 };
 
 class ReferenceTypeName final : public TypeName {

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -510,7 +510,8 @@ void Visitor::visit(AST::NamedTypeName&)
 
 void Visitor::visit(AST::ParameterizedTypeName& parameterizedTypeName)
 {
-    checkErrorAndVisit(parameterizedTypeName.elementType());
+    for (auto& argument : parameterizedTypeName.arguments())
+        checkErrorAndVisit(argument);
 }
 
 void Visitor::visit(AST::ReferenceTypeName& referenceTypeName)

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -573,9 +573,16 @@ Result<AST::TypeName::Ref> Parser<Lexer>::parseTypeNameAfterIdentifier(AST::Iden
 {
     if (current().type == TokenType::Lt) {
         CONSUME_TYPE(Lt);
-        PARSE(elementType, TypeName);
+        AST::TypeName::List arguments;
+        do {
+            PARSE(elementType, TypeName);
+            arguments.append(WTFMove(elementType));
+            if (current().type != TokenType::Comma)
+                break;
+            CONSUME_TYPE(Comma);
+        } while (current().type != TokenType::Gt);
         CONSUME_TYPE(Gt);
-        RETURN_ARENA_NODE(ParameterizedTypeName, WTFMove(name), WTFMove(elementType));
+        RETURN_ARENA_NODE(ParameterizedTypeName, WTFMove(name), WTFMove(arguments));
     }
     RETURN_ARENA_NODE(NamedTypeName, WTFMove(name));
 }

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -57,8 +57,9 @@ static void checkVecType(WGSL::AST::TypeName& type, ASCIILiteral vecType, ASCIIL
     EXPECT_TRUE(is<WGSL::AST::ParameterizedTypeName>(type));
     auto& parameterizedType = downcast<WGSL::AST::ParameterizedTypeName>(type);
     EXPECT_EQ(parameterizedType.base(), vecType);
-    EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(parameterizedType.elementType()));
-    EXPECT_EQ(downcast<WGSL::AST::NamedTypeName>(parameterizedType.elementType()).name(), paramTypeName);
+    EXPECT_EQ(parameterizedType.arguments().size(), 1u);
+    EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(parameterizedType.arguments()[0]));
+    EXPECT_EQ(downcast<WGSL::AST::NamedTypeName>(parameterizedType.arguments()[0]).name(), paramTypeName);
 }
 
 static void checkVec2F32Type(WGSL::AST::TypeName& type)
@@ -335,8 +336,9 @@ TEST(WGSLParserTests, TrivialGraphicsShader)
         EXPECT_TRUE(is<WGSL::AST::ParameterizedTypeName>(func.parameters()[0].typeName()));
         auto& paramType = downcast<WGSL::AST::ParameterizedTypeName>(func.parameters()[0].typeName());
         EXPECT_EQ(paramType.base(), "vec4"_s);
-        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(paramType.elementType()));
-        EXPECT_EQ(downcast<WGSL::AST::NamedTypeName>(paramType.elementType()).name(), "f32"_s);
+        EXPECT_EQ(paramType.arguments().size(), 1u);
+        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(paramType.arguments()[0]));
+        EXPECT_EQ(downcast<WGSL::AST::NamedTypeName>(paramType.arguments()[0]).name(), "f32"_s);
         EXPECT_EQ(func.returnAttributes().size(), 1u);
         checkBuiltin(func.returnAttributes()[0], "position"_s);
         EXPECT_TRUE(func.maybeReturnType());


### PR DESCRIPTION
#### 2c35d98f86379a837977f1fe99d5e0956c04dce2
<pre>
[WGSL] ParameterizedTypeName should accept more than 1 argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=260851">https://bugs.webkit.org/show_bug.cgi?id=260851</a>
rdar://114617257

Reviewed by Dan Glastonbury.

Currently we fail to parse types such as `texture_storage_2d&lt;f, a&gt;` because we assume
that all parameterized types will only have a single argument. This change is not sufficient
on its own to fix all the parsing issues, as the parameters aren&apos;t types, but values, but that
will be implemented in a subsequent patch.

* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTTypeName.h:
(WGSL::AST::ParameterizedTypeName::arguments):
(WGSL::AST::ParameterizedTypeName::ParameterizedTypeName):
(WGSL::AST::ParameterizedTypeName::elementType): Deleted.
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseTypeNameAfterIdentifier):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::allocateSimpleConstructor):

Canonical link: <a href="https://commits.webkit.org/267624@main">https://commits.webkit.org/267624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d7045ad9ead462c26120be58424558d66e5ff88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19765 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22278 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13868 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15502 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4110 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->