### PR TITLE
WebCodecs VideoEncoder configure should resolve its promise for unknown codecs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -12,8 +12,8 @@ PASS Test that VideoEncoder.configure() rejects invalid config: Height is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
@@ -21,16 +21,16 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd size
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
 FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
           codec.configure(entry.config);
-        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+        }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
           codec.configure(entry.config);
-        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+        }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -12,8 +12,8 @@ PASS Test that VideoEncoder.configure() rejects invalid config: Height is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
@@ -21,16 +21,16 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd size
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
 FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
           codec.configure(entry.config);
-        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+        }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
           codec.configure(entry.config);
-        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+        }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
@@ -2,11 +2,11 @@
 PASS Test VideoEncoder construction
 FAIL Test VideoEncoder.configure() assert_throws_dom: bogus function "() => {
       codec.configure(config);
-    }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+    }" did not throw
 PASS Test successful configure(), encode(), and flush()
 PASS encodeQueueSize test
 PASS Test successful reset() and re-confiugre()
-FAIL Test successful encode() after re-configure(). assert_throws_dom: function "() => encoder.configure(badConfig)" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL Test successful encode() after re-configure(). assert_throws_dom: function "() => encoder.configure(badConfig)" did not throw
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
 PASS Verify encoding closed frames throws.

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
@@ -2,11 +2,11 @@
 PASS Test VideoEncoder construction
 FAIL Test VideoEncoder.configure() assert_throws_dom: bogus function "() => {
       codec.configure(config);
-    }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+    }" did not throw
 PASS Test successful configure(), encode(), and flush()
 PASS encodeQueueSize test
 PASS Test successful reset() and re-confiugre()
-FAIL Test successful encode() after re-configure(). assert_throws_dom: function "() => encoder.configure(badConfig)" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL Test successful encode() after re-configure(). assert_throws_dom: function "() => encoder.configure(badConfig)" did not throw
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
 PASS Verify encoding closed frames throws.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -127,6 +127,11 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
 
     bool isSupportedCodec = isSupportedDecoderCodec(config.codec, context.settingsValues());
     queueControlMessageAndProcess([this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
+        if (!isSupportedCodec) {
+            closeDecoder(Exception { NotSupportedError, "Codec is not supported"_s });
+            return;
+        }
+
         m_isMessageQueueBlocked = true;
         VideoDecoder::PostTaskCallback postTaskCallback = [identifier, weakThis = WeakPtr { *this }](auto&& task) {
             ScriptExecutionContext::postTaskTo(identifier, [weakThis, task = WTFMove(task)](auto&) mutable {
@@ -138,18 +143,13 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
             });
         };
 
-        if (!isSupportedCodec) {
-            closeDecoder(Exception { NotSupportedError, "Codec is not supported"_s });
-            return;
-        }
-
         VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [this](auto&& result) {
+            m_isMessageQueueBlocked = false;
             if (!result.has_value()) {
                 closeDecoder(Exception { NotSupportedError, WTFMove(result.error()) });
                 return;
             }
             setInternalDecoder(WTFMove(result.value()));
-            m_isMessageQueueBlocked = false;
             processControlMessageQueue();
         }, [this](auto&& result) {
             if (m_state != WebCodecsCodecState::Configured)


### PR DESCRIPTION
#### 7e4ab69bd8f2b884468da81c4ed52a3b86fc2c34
<pre>
WebCodecs VideoEncoder configure should resolve its promise for unknown codecs
<a href="https://bugs.webkit.org/show_bug.cgi?id=260853">https://bugs.webkit.org/show_bug.cgi?id=260853</a>
rdar://problem/114622760

Reviewed by Jean-Yves Avenard.

Update implementation according latest spec to resolve the isConfigureSupported with supported equal to false.
Update implementation according latest spec to close the encoder in case of configuring with an unknown/invalid codec.

We more tightly align when we set m_isMessageQueueBlocked to true and false in the case when configure fails and we close the encoder/decoder.
Although this is not observable, this more closely aligns with the spec steps.

Covered by updated tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::isValidDecoderConfig):
(WebCore::WebCodecsVideoDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::isSupportedEncoderCodec):
(WebCore::isValidEncoderConfig):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::isConfigSupported):

Canonical link: <a href="https://commits.webkit.org/267668@main">https://commits.webkit.org/267668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42830836696c7888042d2114e2881d4b1ba0a867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19966 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15792 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20285 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15688 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4144 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->