### PR TITLE
Disallow URL::setProtocol on a non-parsable URL

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -419,15 +419,12 @@ StringView URL::path() const LIFETIME_BOUND
 
 bool URL::setProtocol(StringView newProtocol)
 {
+    ASSERT(m_isValid);
+
     auto newProtocolPrefix = newProtocol.left(newProtocol.find(':'));
     auto newProtocolCanonicalized = URLParser::maybeCanonicalizeScheme(newProtocolPrefix);
     if (!newProtocolCanonicalized)
         return false;
-
-    if (!m_isValid) {
-        parse(makeString(*newProtocolCanonicalized, ':', m_string));
-        return true;
-    }
 
     if (URLParser::isSpecialScheme(this->protocol()) != URLParser::isSpecialScheme(*newProtocolCanonicalized))
         return true;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -700,13 +700,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     setEventTargetFlag(EventTargetFlag::IsConnected);
     addToDocumentsMap();
 
-    // We depend on the url getting immediately set in subframes, but we
-    // also depend on the url NOT getting immediately set in opened windows.
-    // See fast/dom/early-frame-url.html
-    // and fast/dom/location-new-window-no-crash.html, respectively.
-    // FIXME: Can/should we unify this behavior?
-    if ((frame && frame->ownerElement()) || !url.isEmpty())
-        setURL(URL { url });
+    setURL(URL { url });
 
     if (!frame)
         setUsesNullCustomElementRegistry();
@@ -4677,7 +4671,7 @@ const URL& Document::urlForBindings()
     if (shouldAdjustURL)
         return m_adjustedURL;
 
-    return m_url.url().isEmpty() ? aboutBlankURL() : m_url.url();
+    return m_url.url();
 }
 
 URL Document::adjustedURL() const

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -48,6 +48,8 @@ String URLDecomposition::protocol() const
 void URLDecomposition::setProtocol(StringView value)
 {
     URL copy = fullURL();
+    if (!copy.isValid())
+        return;
     copy.setProtocol(value);
     setFullURL(copy);
 }

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -78,11 +78,7 @@ const URL& Location::url() const
         return nullURL.get();
     }
 
-    const URL& url = localWindow->document()->urlForBindings();
-    if (!url.isValid())
-        return aboutBlankURL(); // Use "about:blank" while the page is still loading (before we have a frame).
-
-    return url;
+    return localWindow->document()->urlForBindings();
 }
 
 String Location::href() const

--- a/Source/WebCore/platform/StringEntropyHelpers.cpp
+++ b/Source/WebCore/platform/StringEntropyHelpers.cpp
@@ -179,11 +179,8 @@ URL removeHighEntropyComponents(const URL& url)
     if (url.protocolIs("mailto"_s) || url.protocolIs("tel"_s))
         return url;
 
-    if (url.protocolIsData() || url.protocolIsBlob() || url.protocolIsJavaScript()) {
-        URL urlPreservingProtocolOnly;
-        urlPreservingProtocolOnly.setProtocol(url.protocol());
-        return urlPreservingProtocolOnly;
-    }
+    if (url.protocolIsData() || url.protocolIsBlob() || url.protocolIsJavaScript())
+        return URL { makeString(url.protocol(), ':') };
 
     auto newURL = url;
 

--- a/Source/WebCore/platform/network/curl/CurlProxySettings.cpp
+++ b/Source/WebCore/platform/network/curl/CurlProxySettings.cpp
@@ -46,8 +46,8 @@ CurlProxySettings::CurlProxySettings(URL&& proxyUrl, String&& ignoreHosts)
     , m_url(WTF::move(proxyUrl))
     , m_ignoreHosts(WTF::move(ignoreHosts))
 {
-    if (m_url.protocol().isEmpty())
-        m_url.setProtocol("http"_s);
+    if (!m_url.isValid())
+        m_url = URL { makeString("http:"_s, m_url.string()) };
 
     rebuildUrl();
 }

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -662,8 +662,8 @@ void WebsiteDataStore::initializeAppBoundDomains(ForceReinitialization forceRein
                 }
 
                 URL url { data };
-                if (url.protocol().isEmpty())
-                    url.setProtocol("https"_s);
+                if (!url.isValid())
+                    url = URL { makeString("https:"_s, String(data)) };
                 if (!url.isValid())
                     continue;
                 WebCore::RegistrableDomain appBoundDomain { url };
@@ -855,8 +855,8 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
                     break;
 
                 URL url { data };
-                if (url.protocol().isEmpty())
-                    url.setProtocol("https"_s);
+                if (!url.isValid())
+                    url = URL { makeString("https:"_s, String(data)) };
                 if (!url.isValid())
                     continue;
                 WebCore::RegistrableDomain managedDomain { url };


### PR DESCRIPTION
#### 90dece740ba08fe4c048d2b3c3e08a0df181d1c7
<pre>
Disallow URL::setProtocol on a non-parsable URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=260855">https://bugs.webkit.org/show_bug.cgi?id=260855</a>
<a href="https://rdar.apple.com/114624674">rdar://114624674</a>

Reviewed by NOBODY (OOPS!).

This should be good after <a href="https://commits.webkit.org/267265@main">267265@main</a>.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90dece740ba08fe4c048d2b3c3e08a0df181d1c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109685 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28979 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120659 "Found 3 new test failures: fast/dom/location-new-window-no-crash.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84997 "1 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22847 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139976 "Found 5 new API test failures: TestWebKitAPI._WKDownload.DownloadRequestOriginalURLDirectDownload, TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.EnhancedSecurityPolicies.HttpsOnlyExplicitlyBypassedWithHttpRedirect, TestWebKitAPI._WKDownload.DownloadRequestOriginalURLDirectDownloadWithLoadedContent, TestWebKitAPI.WKNavigation.HTTPSOnlyWithSameSiteBypass (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101348 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21932 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20074 "Found 5 new API test failures: TestWebKitAPI._WKDownload.DownloadRequestOriginalURLDirectDownload, TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI.EnhancedSecurityPolicies.HttpsOnlyExplicitlyBypassedWithHttpRedirect, TestWebKitAPI._WKDownload.DownloadRequestOriginalURLDirectDownloadWithLoadedContent, TestWebKitAPI.WKNavigation.HTTPSOnlyWithSameSiteBypass (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12463 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147919 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131601 "Found 4 new API test failures: TestWebKitAPI.WKNavigation.HTTPSOnlyWithHTTPRedirect, TestWebKitAPI._WKDownload.DownloadRequestOriginalURLDirectDownload, TestWebKitAPI._WKDownload.DownloadRequestOriginalURLDirectDownloadWithLoadedContent, TestWebKitAPI.WKNavigation.HTTPSOnlyWithSameSiteBypass (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167113 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16701 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11287 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19419 "Found 3 new test failures: fast/dom/location-new-window-no-crash.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128779 "Found 3 new test failures: fast/dom/location-new-window-no-crash.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28673 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24108 "Found 3 new test failures: fast/dom/location-new-window-no-crash.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86457 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23732 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16400 "Found 3 new test failures: fast/dom/location-new-window-no-crash.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html imported/w3c/web-platform-tests/html/infrastructure/urls/base-url/initial-about-blank-baseURI.window.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187754 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92394 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->