### PR TITLE
SharedWorker referrer policy should default to its context referrer policy if none is provided in its script http response

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-referrer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-referrer-expected.txt
@@ -2,8 +2,8 @@
 PASS Same-origin top-level module script loading with "no-referrer" referrer policy
 PASS Same-origin top-level module script loading with "origin" referrer policy
 PASS Same-origin top-level module script loading with "same-origin" referrer policy
-FAIL Same-origin static import with "no-referrer" referrer policy. assert_equals: expected "" but got "http://localhost:8800/workers/modules/resources/static-import-same-origin-referrer-checker-worker.js"
-FAIL Same-origin static import with "origin" referrer policy. assert_equals: expected "http://localhost:8800/" but got "http://localhost:8800/workers/modules/resources/static-import-same-origin-referrer-checker-worker.js"
+PASS Same-origin static import with "no-referrer" referrer policy.
+PASS Same-origin static import with "origin" referrer policy.
 PASS Same-origin static import with "same-origin" referrer policy.
 FAIL Cross-origin static import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
 FAIL Cross-origin static import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -60,9 +60,14 @@ void SharedWorkerScriptLoader::didReceiveResponse(ResourceLoaderIdentifier ident
 
 void SharedWorkerScriptLoader::notifyFinished()
 {
-    if (auto* scriptExecutionContext = m_worker->scriptExecutionContext(); !m_loader->failed())
+    auto* scriptExecutionContext = m_worker->scriptExecutionContext();
+    if (scriptExecutionContext && !m_loader->failed())
         InspectorInstrumentation::scriptImported(*scriptExecutionContext, m_loader->identifier(), m_loader->script().toString());
-    m_completionHandler(m_loader->fetchResult(), WorkerInitializationData {
+
+    auto fetchResult = m_loader->fetchResult();
+    if (fetchResult.referrerPolicy.isNull() && scriptExecutionContext)
+        fetchResult.referrerPolicy = referrerPolicyToString(scriptExecutionContext->referrerPolicy());
+    m_completionHandler(WTFMove(fetchResult), WorkerInitializationData {
 #if ENABLE(SERVICE_WORKER)
         m_loader->takeServiceWorkerData(),
 #endif


### PR DESCRIPTION
#### d1c532b691d6db1eadb2cf717c22e25e943b0506
<pre>
SharedWorker referrer policy should default to its context referrer policy if none is provided in its script http response
<a href="https://bugs.webkit.org/show_bug.cgi?id=260858">https://bugs.webkit.org/show_bug.cgi?id=260858</a>
rdar://114625126

Reviewed by Chris Dumez.

As per <a href="https://github.com/w3c/webappsec-referrer-policy">https://github.com/w3c/webappsec-referrer-policy</a>, we should default to the context initiating the first load as of referrer policy.
Implement this for SharedWorker in SharedWorkerScriptLoader.

* LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-referrer-expected.txt:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::notifyFinished):

Canonical link: <a href="https://commits.webkit.org/267405@main">https://commits.webkit.org/267405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c50873ffc89f865428d82a9723509838937ec9bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16960 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19051 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14949 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21747 "2 flakes 137 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13340 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14910 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3950 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->