### PR TITLE
[CSS Container Queries] Container for ::part pseudo-element should be selected from originating element tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-for-shadow-dom-expected.txt
@@ -10,5 +10,5 @@ PASS Match container for ::before in ::part selector's originating element tree
 PASS Match container for ::part selector's originating element tree for exportparts
 PASS Match container for slot light tree child fallback
 PASS Should not match container inside shadow tree for ::part()
-FAIL A :host::part rule should match containers in the originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS A :host::part rule should match containers in the originating element tree
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -127,8 +127,12 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> axes
 
     auto findOriginatingElement = [&]() -> const Element* {
         // ::part() selectors can query its originating host, but not internal query containers inside the shadow tree.
-        if (scopeOrdinal <= ScopeOrdinal::ContainingHost)
-            return hostForScopeOrdinal(element, scopeOrdinal);
+        if (selectionMode == SelectionMode::PartPseudoElement) {
+            if (scopeOrdinal <= ScopeOrdinal::ContainingHost)
+                return hostForScopeOrdinal(element, scopeOrdinal);
+            ASSERT(scopeOrdinal == ScopeOrdinal::Element);
+            return element.shadowHost();
+        }
         // ::slotted() selectors can query containers inside the shadow tree, including the slot itself.
         if (scopeOrdinal >= ScopeOrdinal::FirstSlot && scopeOrdinal <= ScopeOrdinal::SlotLimit)
             return assignedSlotForScopeOrdinal(element, scopeOrdinal);

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -38,7 +38,7 @@ namespace Style {
 
 class ContainerQueryEvaluator : public MQ::GenericMediaQueryEvaluator<ContainerQueryEvaluator> {
 public:
-    enum class SelectionMode : bool { Element, PseudoElement };
+    enum class SelectionMode : uint8_t { Element, PseudoElement, PartPseudoElement };
     ContainerQueryEvaluator(const Element&, SelectionMode, ScopeOrdinal, SelectorMatchingState*);
 
     bool evaluate(const CQ::ContainerQuery&) const;

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -33,8 +33,8 @@
 
 namespace WebCore::Style {
 
-class MatchRequest;
 class ScopeRuleSets;
+struct MatchRequest;
 struct SelectorMatchingState;
 enum class CascadeLevel : uint8_t;
 


### PR DESCRIPTION
#### 48fb05f652fabe37e6b455c8c06d6b680f808b98
<pre>
[CSS Container Queries] Container for ::part pseudo-element should be selected from originating element tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=260861">https://bugs.webkit.org/show_bug.cgi?id=260861</a>
rdar://114626579

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-for-shadow-dom-expected.txt:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):

Add separate selection mode for ::part pseudo-element where we never look for container in the current tree.

* Source/WebCore/style/ContainerQueryEvaluator.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRulesForScope):

Pass a bit via MatchRequest to indicate we are matching ::part pseudo-elements.

(WebCore::Style::ElementRuleCollector::containerQueriesMatch):
* Source/WebCore/style/ElementRuleCollector.h:

Canonical link: <a href="https://commits.webkit.org/267421@main">https://commits.webkit.org/267421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfc550ccf2ad8c884e76095043c075510f9e0576

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17825 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19054 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21752 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19436 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13344 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14913 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->