### PR TITLE
[CSS] Allow nesting style rule with relaxed syntax

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6563,9 +6563,6 @@ imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-padding.htm
 imported/w3c/web-platform-tests/css/css-overflow/webkit-line-clamp-029.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/webkit-line-clamp-block-in-inline-001.html [ Skip ]
 
-# CSS nesting relaxed syntax
-imported/w3c/web-platform-tests/css/css-nesting/nesting-type-selector.html [ ImageOnlyFailure ]
-
 # These tests have been flaky since their import.
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-top-navigation-child-special-cases.tentative.sub.window.html [ DumpJSConsoleLogInStdErr Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/sandbox-top-navigation-child.tentative.sub.window.html [ DumpJSConsoleLogInStdErr Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -13,7 +13,7 @@ PASS Simple CSSOM manipulation of subrules 5
 PASS Simple CSSOM manipulation of subrules 6
 PASS Simple CSSOM manipulation of subrules 7
 PASS Simple CSSOM manipulation of subrules 8
-FAIL Simple CSSOM manipulation of subrules 9 The string did not match the expected pattern.
+FAIL Simple CSSOM manipulation of subrules 9 assert_equals: selectorText and insertRule expected ".a {\n  color: red;\n  div & { }\n  div.b .c & { color: green; }\n  .c div.b &, div & { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  div & { }\n  div.b .c & { color: green; }\n  .c div.b &, div & { color: blue; }\n}"
 PASS Simple CSSOM manipulation of subrules 10
 PASS Mutating the selectorText of outer rule invalidates inner rules
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -14,7 +14,7 @@ PASS .foo { :is(.bar, .baz) { color: green; }}
 PASS .foo { &:is(.bar, .baz) { color: green; }}
 PASS .foo { :is(.bar, &.baz) { color: green; }}
 PASS .foo { &:is(.bar, &.baz) { color: green; }}
-FAIL .foo { div& { color: green; }} assert_equals: Inner rule should exist. expected 1 but got 0
+PASS .foo { div& { color: green; }}
 PASS INVALID: .foo { &div { color: green; }}
 PASS .foo { .class& { color: green; }}
 PASS .foo { &.class { color: green; }}

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -163,10 +163,10 @@ private:
     enum class ParsingStyleDeclarationsInRuleList : bool { No, Yes };
 
     // FIXME: We should return value for all those functions instead of using class member attributes.
-    void consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange, StyleRuleType, OnlyDeclarations, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
+    void consumeBlockContent(CSSParserTokenRange, StyleRuleType, OnlyDeclarations, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
     void consumeDeclarationList(CSSParserTokenRange, StyleRuleType);
     void consumeStyleBlock(CSSParserTokenRange, StyleRuleType, ParsingStyleDeclarationsInRuleList = ParsingStyleDeclarationsInRuleList::No);
-    void consumeDeclaration(CSSParserTokenRange, StyleRuleType);
+    bool consumeDeclaration(CSSParserTokenRange, StyleRuleType);
     void consumeDeclarationValue(CSSParserTokenRange, CSSPropertyID, bool important, StyleRuleType);
     void consumeCustomPropertyValue(CSSParserTokenRange, const AtomString& propertyName, bool important);
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -135,11 +135,6 @@ CSSSelectorList CSSSelectorParser::consumeRelativeSelectorList(CSSParserTokenRan
 
 CSSSelectorList CSSSelectorParser::consumeNestedSelectorList(CSSParserTokenRange& range)
 {
-    // We explicitely avoid starting a nested selector list with ident-like token
-    // This is already handled by parsing algorithm, but the CSSOM can bypass it.
-    if (range.peek().type() == IdentToken || range.peek().type() == FunctionToken)
-        return { };
-
     return consumeSelectorList(range, [&] (CSSParserTokenRange& range) {
         return consumeNestedComplexSelector(range);
     });


### PR DESCRIPTION
#### 2cfe184f6dbee766aefa51db1de3e613c185b0fb
<pre>
[CSS] Allow nesting style rule with relaxed syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=260812">https://bugs.webkit.org/show_bug.cgi?id=260812</a>
rdar://113475843

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-nesting/#nesting">https://drafts.csswg.org/css-nesting/#nesting</a>

The CSS nesting spec now allows having identifier as the first token
in the nested style rule selector.
This implementation follows the spec algorithm of first trying to parse
a declaration, then a nested style rule, otherwise it goes to error recovery (until next semicolon).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeStyleRule):
(WebCore::CSSParserImpl::consumeBlockContent):
(WebCore::CSSParserImpl::consumeDeclarationListInNewNestingContext):
(WebCore::CSSParserImpl::consumeDeclarationList):
(WebCore::CSSParserImpl::consumeStyleBlock):
(WebCore::CSSParserImpl::consumeDeclaration):
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeNestedSelectorList):

Canonical link: <a href="https://commits.webkit.org/267549@main">https://commits.webkit.org/267549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa294dedf3abc1b188ddcaf52560f21e380dfe5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15847 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17389 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19521 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22073 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19834 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13662 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15288 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->