### PR TITLE
SyntaxWarning when running 'git-webkit pr'

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/checkout.py
+++ b/Tools/Scripts/webkitpy/common/checkout/checkout.py
@@ -49,8 +49,8 @@ if sys.version_info > (3, 0):
 # FIXME: Move a bunch of ChangeLog-specific processing from SCM to this object.
 # NOTE: All paths returned from this class should be absolute.
 class Checkout(object):
-    COMMIT_SUBJECT_RE = re.compile(b'Subject: \[PATCH ?(\d+\/\d+)?] (.+)')
-    FILTER_BRANCH_PROGRAM = '''import re
+    COMMIT_SUBJECT_RE = re.compile(br'Subject: \[PATCH ?(\d+\/\d+)?] (.+)')
+    FILTER_BRANCH_PROGRAM = r'''import re
 import sys
 
 lines = [l for l in sys.stdin]


### PR DESCRIPTION
#### ade70bdb664e933e1244458b55965b877df48e51
<pre>
SyntaxWarning when running &apos;git-webkit pr&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=260729">https://bugs.webkit.org/show_bug.cgi?id=260729</a>

Reviewed by Jonathan Bedard.

The backslashes here are python string escapes, but they were intended
to be regex escapes. Each \ would need to be replaced with \\ for them
to function as regex escapes. We can use raw string notation to avoid
this problem.

* Tools/Scripts/webkitpy/common/checkout/checkout.py:
(Checkout):

Canonical link: <a href="https://commits.webkit.org/267558@main">https://commits.webkit.org/267558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/037f84148e6ae3e4a52170a7dc586a84553807ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19431 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/16978 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22018 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19757 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13611 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15220 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4062 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->