### PR TITLE
[Cocoa] VideoFullscreenInterfaceContext::m_manager should be a WeakPtr

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -76,8 +76,6 @@ public:
     }
     virtual ~VideoFullscreenInterfaceContext();
 
-    void invalidate() { m_manager = nullptr; }
-
     LayerHostingContext* layerHostingContext() { return m_layerHostingContext.get(); }
     void setLayerHostingContext(std::unique_ptr<LayerHostingContext>&&);
 
@@ -108,7 +106,7 @@ private:
 
     VideoFullscreenInterfaceContext(VideoFullscreenManager&, PlaybackSessionContextIdentifier);
 
-    VideoFullscreenManager* m_manager;
+    WeakPtr<VideoFullscreenManager> m_manager;
     PlaybackSessionContextIdentifier m_contextId;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     AnimationType m_animationType { AnimationType::None };
@@ -119,8 +117,15 @@ private:
     RetainPtr<CALayer> m_rootLayer;
 };
 
-class VideoFullscreenManager : public RefCounted<VideoFullscreenManager>, private IPC::MessageReceiver {
+class VideoFullscreenManager
+    : public RefCounted<VideoFullscreenManager>
+    , public CanMakeWeakPtr<VideoFullscreenManager>
+    , private IPC::MessageReceiver {
 public:
+    using CanMakeWeakPtr<VideoFullscreenManager>::WeakPtrImplType;
+    using CanMakeWeakPtr<VideoFullscreenManager>::WeakValueType;
+    using CanMakeWeakPtr<VideoFullscreenManager>::weakPtrFactory;
+
     static Ref<VideoFullscreenManager> create(WebPage&, PlaybackSessionManager&);
     virtual ~VideoFullscreenManager();
 

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -87,7 +87,7 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
 #pragma mark - VideoFullscreenInterfaceContext
 
 VideoFullscreenInterfaceContext::VideoFullscreenInterfaceContext(VideoFullscreenManager& manager, PlaybackSessionContextIdentifier contextId)
-    : m_manager(&manager)
+    : m_manager(manager)
     , m_contextId(contextId)
 {
 }
@@ -147,8 +147,6 @@ VideoFullscreenManager::~VideoFullscreenManager()
     for (auto& [model, interface] : m_contextMap.values()) {
         model->setVideoElement(nullptr);
         model->removeClient(*interface);
-
-        interface->invalidate();
     }
 
     m_contextMap.clear();
@@ -215,7 +213,6 @@ void VideoFullscreenManager::removeContext(PlaybackSessionContextIdentifier cont
         return;
 
     model->removeClient(*interface);
-    interface->invalidate();
     m_contextMap.remove(contextId);
 
     RefPtr videoElement = model->videoElement();


### PR DESCRIPTION
#### 4165157020d8e4b60062b5d144279c06b8c6c0ab
<pre>
[Cocoa] VideoFullscreenInterfaceContext::m_manager should be a WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=260873">https://bugs.webkit.org/show_bug.cgi?id=260873</a>
rdar://114654278

Reviewed by Jer Noble.

Changed VideoFullscreenInterfaceContext::m_manager from a VideoFullscreenManager* to a
WeakPtr&lt;VideoFullscreenManager&gt;.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
(WebKit::VideoFullscreenInterfaceContext::invalidate): Deleted.
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenInterfaceContext::VideoFullscreenInterfaceContext):
(WebKit::VideoFullscreenManager::~VideoFullscreenManager):
(WebKit::VideoFullscreenManager::removeContext):

Canonical link: <a href="https://commits.webkit.org/267505@main">https://commits.webkit.org/267505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4397b8908c66ffe26b5cd5fbeca0d07533a73eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15529 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17861 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19123 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14403 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21794 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19482 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13395 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14970 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4023 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->