### PR TITLE
Propagate mouse events to site-isolated frames

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1478,6 +1478,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/FrameView.h
     page/GlobalFrameIdentifier.h
     page/GlobalWindowIdentifier.h
+    page/HandleMouseEventResult.h
     page/ImageAnalysisQueue.h
     page/InteractionRegion.h
     page/LayoutMilestone.h
@@ -1518,6 +1519,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/RemoteFrame.h
     page/RemoteFrameClient.h
     page/RemoteFrameView.h
+    page/RemoteMouseEventData.h
     page/RenderingUpdateScheduler.h
     page/ScreenOrientationLockType.h
     page/ScreenOrientationType.h

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -98,7 +98,7 @@ void AutoscrollController::stopAutoscrollTimer(bool rendererIsBeingDestroyed)
 
     auto* frame = scrollable->document().frame();
     if (autoscrollInProgress() && frame && frame->eventHandler().mouseDownWasInSubframe()) {
-        if (auto subframe = frame->eventHandler().subframeForTargetNode(frame->eventHandler().mousePressNode()))
+        if (auto subframe = dynamicDowncast<LocalFrame>(frame->eventHandler().subframeForTargetNode(frame->eventHandler().mousePressNode())))
             subframe->eventHandler().stopAutoscrollTimer(rendererIsBeingDestroyed);
         return;
     }

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -54,6 +54,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLTableElement.h"
+#include "HandleMouseEventResult.h"
 #include "HitTestResult.h"
 #include "ImageBuffer.h"
 #include "ImageOverlay.h"

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -72,6 +72,7 @@ class Event;
 class EventTarget;
 class FloatQuad;
 class HTMLFrameSetElement;
+class HandleMouseEventResult;
 class HitTestResult;
 class KeyboardEvent;
 class KeyboardScrollingAnimator;
@@ -193,8 +194,8 @@ public:
     IntPoint targetPositionInWindowForSelectionAutoscroll() const;
     bool shouldUpdateAutoscroll();
 
-    WEBCORE_EXPORT static RefPtr<LocalFrame> subframeForTargetNode(Node*);
-    static RefPtr<LocalFrame> subframeForHitTestResult(const MouseEventWithHitTestResults&);
+    WEBCORE_EXPORT static RefPtr<Frame> subframeForTargetNode(Node*);
+    static RefPtr<Frame> subframeForHitTestResult(const MouseEventWithHitTestResults&);
 
     WEBCORE_EXPORT bool scrollOverflow(ScrollDirection, ScrollGranularity, Node* startingNode = nullptr);
     WEBCORE_EXPORT bool scrollRecursively(ScrollDirection, ScrollGranularity, Node* startingNode = nullptr);
@@ -203,16 +204,16 @@ public:
     bool tabsToLinks(KeyboardEvent*) const;
     bool tabsToAllFormControls(KeyboardEvent*) const;
 
-    WEBCORE_EXPORT bool mouseMoved(const PlatformMouseEvent&);
+    WEBCORE_EXPORT HandleMouseEventResult mouseMoved(const PlatformMouseEvent&);
     WEBCORE_EXPORT bool passMouseMovedEventToScrollbars(const PlatformMouseEvent&);
 
     WEBCORE_EXPORT void lostMouseCapture();
 
-    WEBCORE_EXPORT bool handleMousePressEvent(const PlatformMouseEvent&);
+    WEBCORE_EXPORT HandleMouseEventResult handleMousePressEvent(const PlatformMouseEvent&);
     WEBCORE_EXPORT OptionSet<HitTestRequest::Type> getHitTypeForMouseMoveEvent(const PlatformMouseEvent&, bool onlyUpdateScrollbars = false);
     WEBCORE_EXPORT HitTestResult getHitTestResultForMouseEvent(const PlatformMouseEvent&);
-    bool handleMouseMoveEvent(const PlatformMouseEvent&, HitTestResult* = nullptr, bool onlyUpdateScrollbars = false);
-    WEBCORE_EXPORT bool handleMouseReleaseEvent(const PlatformMouseEvent&);
+    HandleMouseEventResult handleMouseMoveEvent(const PlatformMouseEvent&, HitTestResult* = nullptr, bool onlyUpdateScrollbars = false);
+    WEBCORE_EXPORT HandleMouseEventResult handleMouseReleaseEvent(const PlatformMouseEvent&);
     WEBCORE_EXPORT bool handleMouseForceEvent(const PlatformMouseEvent&);
 
     WEBCORE_EXPORT bool handleWheelEvent(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>);

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -29,6 +29,7 @@
 
 namespace WebCore {
 
+class Frame;
 enum class RenderAsTextFlag : uint16_t;
 
 class FrameView : public ScrollView {
@@ -36,6 +37,7 @@ public:
     enum class Type : bool { Local, Remote };
     virtual Type viewType() const = 0;
     virtual void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) = 0;
+    virtual Frame& frame() const = 0;
 };
 
 }

--- a/Source/WebCore/page/HandleMouseEventResult.h
+++ b/Source/WebCore/page/HandleMouseEventResult.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RemoteMouseEventData.h"
+
+namespace WebCore {
+
+class HandleMouseEventResult {
+public:
+    HandleMouseEventResult(bool handled)
+        : m_result(handled)
+    {
+    }
+
+    HandleMouseEventResult(RemoteMouseEventData remoteMouseEventData)
+        : m_result(makeUnexpected(remoteMouseEventData))
+    {
+    }
+
+    bool wasHandled() { return m_result ? *m_result : false; }
+    void setHandled(bool handled)
+    {
+        if (m_result.has_value())
+            m_result = handled;
+    }
+
+    std::optional<RemoteMouseEventData> remoteMouseEventData()
+    {
+        return m_result ? std::nullopt : std::optional<RemoteMouseEventData>(m_result.error());
+    }
+private:
+    Expected<bool, RemoteMouseEventData> m_result;
+};
+
+}

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -29,6 +29,7 @@
 #include "FrameView.h"
 #include "LayoutMilestone.h"
 #include "LayoutRect.h"
+#include "LocalFrame.h"
 #include "LocalFrameViewLayoutContext.h"
 #include "Pagination.h"
 #include "PaintPhase.h"
@@ -57,7 +58,6 @@ class FloatSize;
 class Frame;
 class GraphicsContext;
 class HTMLFrameOwnerElement;
-class LocalFrame;
 class Page;
 class RegionContext;
 class RenderBox;
@@ -109,7 +109,7 @@ public:
     Type viewType() const final { return Type::Local; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 
-    WEBCORE_EXPORT LocalFrame& frame() const;
+    WEBCORE_EXPORT LocalFrame& frame() const final;
 
     WEBCORE_EXPORT RenderView* renderView() const;
 

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "FrameView.h"
+#include "RemoteFrame.h"
 
 namespace WebCore {
 
@@ -37,8 +38,7 @@ public:
 
     Type viewType() const final { return Type::Remote; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
-    const RemoteFrame& frame() const { return m_frame.get(); }
-    RemoteFrame& frame() { return m_frame.get(); }
+    RemoteFrame& frame() const final { return m_frame; }
 
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);

--- a/Source/WebCore/page/RemoteMouseEventData.h
+++ b/Source/WebCore/page/RemoteMouseEventData.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FrameIdentifier.h"
+#include "IntPoint.h"
+
+namespace WebCore {
+
+struct RemoteMouseEventData {
+    FrameIdentifier targetFrameID;
+    IntPoint transformedPoint;
+};
+
+}

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -36,6 +36,7 @@
 #import "DragState.h"
 #import "EventNames.h"
 #import "FocusController.h"
+#import "HandleMouseEventResult.h"
 #import "KeyboardEvent.h"
 #import "LocalFrame.h"
 #import "LocalFrameView.h"
@@ -478,7 +479,7 @@ void EventHandler::mouseDown(WebEvent *event)
 
     CurrentEventScope scope(event);
 
-    event.wasHandled = handleMousePressEvent(currentPlatformMouseEvent());
+    event.wasHandled = handleMousePressEvent(currentPlatformMouseEvent()).wasHandled();
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -493,7 +494,7 @@ void EventHandler::mouseUp(WebEvent *event)
 
     CurrentEventScope scope(event);
 
-    event.wasHandled = handleMouseReleaseEvent(currentPlatformMouseEvent());
+    event.wasHandled = handleMouseReleaseEvent(currentPlatformMouseEvent()).wasHandled();
 
     m_mouseDownView = nil;
 
@@ -516,7 +517,7 @@ void EventHandler::mouseMoved(WebEvent *event)
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
         ContentChangeObserver::MouseMovedScope observingScope(document);
 #endif
-        event.wasHandled = mouseMoved(currentPlatformMouseEvent());
+        event.wasHandled = mouseMoved(currentPlatformMouseEvent()).wasHandled();
         // Run style recalc to be able to capture content changes as the result of the mouse move event.
         document.updateStyleIfNeeded();
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
@@ -730,7 +731,7 @@ bool EventHandler::tryToBeginDragAtPoint(const IntPoint& clientPosition, const I
     auto documentPoint = protectedFrame->view() ? protectedFrame->view()->windowToContents(syntheticMouseMoveEvent.position()) : syntheticMouseMoveEvent.position();
     auto hitTestedMouseEvent = document->prepareMouseEvent(hitType, documentPoint, syntheticMouseMoveEvent);
 
-    auto subframe = subframeForHitTestResult(hitTestedMouseEvent);
+    auto subframe = dynamicDowncast<LocalFrame>(subframeForHitTestResult(hitTestedMouseEvent));
     if (subframe && subframe->eventHandler().tryToBeginDragAtPoint(adjustedClientPosition, adjustedGlobalPosition))
         return true;
 

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -42,6 +42,7 @@
 #import "HTMLFrameSetElement.h"
 #import "HTMLHtmlElement.h"
 #import "HTMLIFrameElement.h"
+#import "HandleMouseEventResult.h"
 #import "KeyboardEvent.h"
 #import "LocalFrame.h"
 #import "LocalFrameView.h"

--- a/Source/WebCore/page/win/EventHandlerWin.cpp
+++ b/Source/WebCore/page/win/EventHandlerWin.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "EventHandler.h"
 
+#include "HandleMouseEventResult.h"
 #include "MouseEventWithHitTestResults.h"
 
 namespace WebCore {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5884,3 +5884,9 @@ using WebCore::FontSelectionValue::BackingType = int16_t;
     std::optional<WebCore::FontSelectionRange> width;
     std::optional<WebCore::FontSelectionRange> slope;
 };
+
+header: <WebCore/RemoteMouseEventData.h>
+struct WebCore::RemoteMouseEventData {
+    WebCore::FrameIdentifier targetFrameID;
+    WebCore::IntPoint transformedPoint;
+};

--- a/Source/WebKit/Shared/WebMouseEvent.h
+++ b/Source/WebKit/Shared/WebMouseEvent.h
@@ -74,6 +74,7 @@ public:
     WebMouseEventButton button() const { return static_cast<WebMouseEventButton>(m_button); }
     unsigned short buttons() const { return m_buttons; }
     const WebCore::IntPoint& position() const { return m_position; } // Relative to the view.
+    void setPosition(const WebCore::IntPoint& position) { m_position = position; }
     const WebCore::IntPoint& globalPosition() const { return m_globalPosition; }
     float deltaX() const { return m_deltaX; }
     float deltaY() const { return m_deltaY; }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -50,6 +50,7 @@ class ResourceRequest;
 
 namespace WebKit {
 
+class NativeWebMouseEvent;
 class RemotePageDrawingAreaProxy;
 class RemotePageVisitedLinkStoreRegistration;
 class UserData;
@@ -75,6 +76,8 @@ public:
     WebProcessProxy& process() { return m_process.get(); }
     WebCore::PageIdentifier pageID() const { return m_webPageID; }
     const WebCore::RegistrableDomain& domain() const { return m_domain; }
+
+    void sendMouseEvent(const WebCore::FrameIdentifier&, const NativeWebMouseEvent&, std::optional<Vector<SandboxExtensionHandle>>&&);
 
 private:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::RegistrableDomain&, WebPageProxyMessageReceiverRegistration*);

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -498,6 +498,11 @@ FrameTreeCreationParameters WebFrameProxy::frameTreeCreationParameters() const
     };
 }
 
+RefPtr<RemotePageProxy> WebFrameProxy::remotePageProxy()
+{
+    return m_remotePageProxy;
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -163,6 +163,7 @@ public:
     void setProcess(WebProcessProxy& process) { m_process = process; }
     ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
     std::unique_ptr<ProvisionalFrameProxy> takeProvisionalFrame();
+    RefPtr<RemotePageProxy> remotePageProxy();
 
 private:
     WebFrameProxy(WebPageProxy&, WebProcessProxy&, WebCore::FrameIdentifier);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -242,6 +242,7 @@ struct PlatformLayerIdentifierType;
 struct PlaybackTargetClientContextIdentifierType;
 struct PromisedAttachmentInfo;
 struct RecentSearch;
+struct RemoteMouseEventData;
 struct RunJavaScriptParameters;
 struct SerializedAttachmentData;
 struct ShareDataWithParsedURL;
@@ -1095,6 +1096,8 @@ public:
 
     bool isProcessingMouseEvents() const;
     void processNextQueuedMouseEvent();
+    void handleMouseEventReply(WebEventType, bool, const std::optional<WebCore::RemoteMouseEventData>&, std::optional<Vector<SandboxExtensionHandle>>&&);
+    void sendMouseEvent(const WebCore::FrameIdentifier&, const NativeWebMouseEvent&, std::optional<Vector<SandboxExtensionHandle>>&&);
     void handleMouseEvent(const NativeWebMouseEvent&);
     void dispatchMouseDidMoveOverElementAsynchronously(const NativeWebMouseEvent&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -76,6 +76,7 @@
 #include <WebCore/HTMLNames.h>
 #include <WebCore/HTMLSelectElement.h>
 #include <WebCore/HTMLTextAreaElement.h>
+#include <WebCore/HandleMouseEventResult.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/JSCSSStyleDeclaration.h>
 #include <WebCore/JSElement.h>
@@ -89,6 +90,7 @@
 #include <WebCore/RemoteDOMWindow.h>
 #include <WebCore/RemoteFrame.h>
 #include <WebCore/RemoteFrameView.h>
+#include <WebCore/RemoteMouseEventData.h>
 #include <WebCore/RenderLayerCompositor.h>
 #include <WebCore/RenderTreeAsText.h>
 #include <WebCore/RenderView.h>
@@ -1235,7 +1237,7 @@ bool WebFrame::handleContextMenuEvent(const PlatformMouseEvent& platformMouseEve
 }
 #endif
 
-bool WebFrame::handleMouseEvent(const WebMouseEvent& mouseEvent)
+WebCore::HandleMouseEventResult WebFrame::handleMouseEvent(const WebMouseEvent& mouseEvent)
 {
     auto* coreLocalFrame = dynamicDowncast<LocalFrame>(coreFrame());
     if (!coreLocalFrame)
@@ -1253,12 +1255,12 @@ bool WebFrame::handleMouseEvent(const WebMouseEvent& mouseEvent)
             page()->corePage()->contextMenuController().clearContextMenu();
 #endif
 
-        bool handled = coreLocalFrame->eventHandler().handleMousePressEvent(platformMouseEvent);
+        auto mousePressEventResult = coreLocalFrame->eventHandler().handleMousePressEvent(platformMouseEvent);
 #if ENABLE(CONTEXT_MENU_EVENT)
         if (isContextClick(platformMouseEvent))
-            handled = handleContextMenuEvent(platformMouseEvent);
+            mousePressEventResult.setHandled(handleContextMenuEvent(platformMouseEvent));
 #endif
-        return handled;
+        return mousePressEventResult;
     }
     case PlatformEvent::Type::MouseReleased:
         if (mouseEvent.gestureWasCancelled() == GestureWasCancelled::Yes)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -55,6 +55,7 @@ namespace WebCore {
 class CertificateInfo;
 class Frame;
 class HTMLFrameOwnerElement;
+class HandleMouseEventResult;
 class IntPoint;
 class IntRect;
 class LocalFrame;
@@ -229,7 +230,7 @@ public:
     OptionSet<WebCore::AdvancedPrivacyProtections> originatorAdvancedPrivacyProtections() const;
 
     bool handleContextMenuEvent(const WebCore::PlatformMouseEvent&);
-    bool handleMouseEvent(const WebMouseEvent&);
+    WebCore::HandleMouseEventResult handleMouseEvent(const WebMouseEvent&);
     bool handleKeyEvent(const WebKeyboardEvent&);
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -279,6 +279,7 @@ struct InteractionRegion;
 struct KeypressCommand;
 struct MediaUsageInfo;
 struct PromisedAttachmentInfo;
+struct RemoteMouseEventData;
 struct RequestStorageAccessResult;
 struct RunJavaScriptParameters;
 struct TextCheckingResult;
@@ -1791,7 +1792,7 @@ private:
 
     void setNeedsFontAttributes(bool);
 
-    void mouseEvent(WebCore::FrameIdentifier, const WebMouseEvent&, std::optional<Vector<SandboxExtension::Handle>>&& sandboxExtensions, CompletionHandler<void(WebEventType, bool)>&&);
+    void mouseEvent(WebCore::FrameIdentifier, const WebMouseEvent&, std::optional<Vector<SandboxExtension::Handle>>&& sandboxExtensions, CompletionHandler<void(WebEventType, bool, std::optional<WebCore::RemoteMouseEventData>)>&&);
     void keyEvent(WebCore::FrameIdentifier, const WebKeyboardEvent&, CompletionHandler<void(WebEventType, bool)>&&);
 
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -2364,7 +2365,7 @@ private:
     struct DeferredMouseEventCompletionHandler {
         WebEventType type { WebEventType::NoType };
         bool handled { false };
-        CompletionHandler<void(WebEventType, bool)> completionHandler;
+        CompletionHandler<void(WebEventType, bool, std::optional<WebCore::RemoteMouseEventData>)> completionHandler;
     };
     std::optional<DeferredMouseEventCompletionHandler> m_deferredMouseEventCompletionHandler;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -48,7 +48,7 @@ messages -> WebPage LegacyReceiver {
 
     ExecuteEditCommandWithCallback(String name, String argument) -> ()
     KeyEvent(WebCore::FrameIdentifier frameID, WebKit::WebKeyboardEvent event) -> (enum:int8_t WebKit::WebEventType eventType, bool handled)
-    MouseEvent(WebCore::FrameIdentifier frameID, WebKit::WebMouseEvent event, std::optional<Vector<WebKit::SandboxExtension::Handle>> sandboxExtensions) -> (enum:int8_t WebKit::WebEventType eventType, bool handled)
+    MouseEvent(WebCore::FrameIdentifier frameID, WebKit::WebMouseEvent event, std::optional<Vector<WebKit::SandboxExtension::Handle>> sandboxExtensions) -> (enum:int8_t WebKit::WebEventType eventType, bool handled, struct std::optional<WebCore::RemoteMouseEventData> remoteMouseEventData)
 
 #if ENABLE(NOTIFICATIONS)
     ClearNotificationPermissionState()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -109,6 +109,7 @@
 #import <WebCore/HTMLSummaryElement.h>
 #import <WebCore/HTMLTextAreaElement.h>
 #import <WebCore/HTMLVideoElement.h>
+#import <WebCore/HandleMouseEventResult.h>
 #import <WebCore/HistoryItem.h>
 #import <WebCore/HitTestResult.h>
 #import <WebCore/Image.h>
@@ -886,7 +887,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     // FIXME: Pass caps lock state.
     auto platformModifiers = platform(modifiers);
 
-    bool handledPress = localMainFrame->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId));
+    bool handledPress = localMainFrame->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId)).wasHandled();
     if (m_isClosed)
         return;
 
@@ -895,7 +896,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     else if (!handledPress)
         clearSelectionAfterTapIfNeeded();
 
-    bool handledRelease = localMainFrame->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId));
+    bool handledRelease = localMainFrame->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId)).wasHandled();
     if (m_isClosed)
         return;
 


### PR DESCRIPTION
#### 31eb0baafdee9f427762f3fe7fbd8049663c6882
<pre>
Propagate mouse events to site-isolated frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=260875">https://bugs.webkit.org/show_bug.cgi?id=260875</a>
rdar://114656583

Reviewed by Alex Christensen.

This patch makes changes to propagate mouse down, up, and move events to site-isolated frames.

When a hit test leads to a remote frame, the web process will send IPC to the UI process
containing the target frame ID and the transformed coordinates relative to the remote frame’s
parent. The UI process then sends the mouse event with the corrected coordinates to the specified
frame.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::subframeForHitTestResult):
(WebCore::EventHandler::subframeForTargetNode):

Change these functions to return a `Frame` so we can later check if the target subframe is a
remote frame.

(WebCore::documentPointForWindowPoint):

`documentPointForWindowPoint()` should take a Frame so we can use it to transform mouse coordinates
to be sent to a remote frame.

(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::mouseMoved):
(WebCore::EventHandler::passMouseMovedEventToScrollbars):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):

Update these functions to check when a remote frame is the target frame. If so, return
`RemoteMouseEventData`.

* Source/WebCore/page/HandleMouseEventResult.h: Added.
(WebCore::HandleMouseEventResult::HandleMouseEventResult):
(WebCore::HandleMouseEventResult::wasHandled):
(WebCore::HandleMouseEventResult::setHandled):
(WebCore::HandleMouseEventResult::remoteMouseEventData):

Add `HandleMouseEventResult` to replace to bool used as the return type for mouse events.

* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/RemoteFrameView.h:

Create a virtual `frame()` function on FrameView.

* Source/WebCore/page/RemoteMouseEventData.h: Added.

Add `RemoteMouseEventData` to store the target remote frame and the transformed coordinates that is
sent to the UI process.

* Source/WebKit/Shared/WebMouseEvent.h:
(WebKit::WebMouseEvent::setPosition):

Add a `setPosition()` function that is used to correct the position of the propagated mouse event.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::remotePageProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:

Add an accessor for a RemotePageProxy.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMouseEventReply):
(WebKit::WebPageProxy::sendMouseEvent):
(WebKit::WebPageProxy::processNextQueuedMouseEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:

Add functions to propagate the mouse event to the frame specified in the completion handler in
`RemoteMouseEventData`.

* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::stopAutoscrollTimer):
* Source/WebCore/page/ContextMenuController.cpp:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::mouseDown):
(WebCore::EventHandler::mouseUp):
(WebCore::EventHandler::mouseMoved):
(WebCore::EventHandler::tryToBeginDragAtPoint):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::handleMouseEvent):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
(WebKit::WebPage::mouseEvent):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::completeSyntheticClick):

Update these to use the new return type on the handle mouse event functions.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Add an API test to verify mouse up, down, and move events are sent to cross-origin frames when
site isolation is enabled. Also check that the mouse coordinates are correctly transformed.

Canonical link: <a href="https://commits.webkit.org/267964@main">https://commits.webkit.org/267964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ec3b57da3528f152e627ccdc49d7414b32c9652

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18668 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20903 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16582 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20973 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14684 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16412 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4336 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->