### PR TITLE
test-webkitpy should not use assertion functions removed in python 3.12

### DIFF
--- a/Source/WebKit/Scripts/webkit/parser_unittest.py
+++ b/Source/WebKit/Scripts/webkit/parser_unittest.py
@@ -348,9 +348,9 @@ class ParsingTest(unittest.TestCase):
 
 class UnsupportedPrecompilerDirectiveTest(unittest.TestCase):
     def test_error_at_else(self):
-        with self.assertRaisesRegexp(Exception, r"ERROR: '#else.*' is not supported in the \*\.in files"):
+        with self.assertRaisesRegex(Exception, r"ERROR: '#else.*' is not supported in the \*\.in files"):
             parser.parse(StringIO("asd\n#else bla\nfoo"))
 
     def test_error_at_elif(self):
-        with self.assertRaisesRegexp(Exception, r"ERROR: '#elif.*' is not supported in the \*\.in files"):
+        with self.assertRaisesRegex(Exception, r"ERROR: '#elif.*' is not supported in the \*\.in files"):
             parser.parse(StringIO("asd\n#elif bla\nfoo"))

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results_unittest.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_results_unittest.py
@@ -30,7 +30,7 @@ class BenchmarkResultsTest(unittest.TestCase):
         results = BenchmarkResults({'SomeTest': {'metrics': {'Time': {'current': [1, 2, 3]}}}})
         self.assertEqual(results._results, {'SomeTest': {'metrics': {'Time': {None: {'current': [1, 2, 3]}}}, 'tests': {}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" contains non-numeric value: \[1, 2, "a"\]'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" contains non-numeric value: \[1, 2, "a"\]'):
             BenchmarkResults({'SomeTest': {'metrics': {'Time': {'current': [1, 2, 'a']}}}})
 
     def test_format(self):
@@ -269,16 +269,16 @@ SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
                     'SubTest2': {'metrics': {'Time': {None: {'current': [9, 24]}}}, 'tests': {}}}}})
 
     def test_lint_results(self):
-        with self.assertRaisesRegexp(TypeError, r'"SomeTest" does not contain metrics or tests'):
+        with self.assertRaisesRegex(TypeError, r'"SomeTest" does not contain metrics or tests'):
             BenchmarkResults._lint_results({'SomeTest': {}})
 
-        with self.assertRaisesRegexp(TypeError, r'The metrics in "SomeTest" is not a dictionary'):
+        with self.assertRaisesRegex(TypeError, r'The metrics in "SomeTest" is not a dictionary'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': []}})
 
-        with self.assertRaisesRegexp(TypeError, r'The aggregator list is empty in "Time" metric of "SomeTest"'):
+        with self.assertRaisesRegex(TypeError, r'The aggregator list is empty in "Time" metric of "SomeTest"'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': []}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" is not wrapped by a configuration; e.g. "current"'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" is not wrapped by a configuration; e.g. "current"'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': [1, 2]}}})
 
         self.assertTrue(BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': {'current': [1, 2]}}}}))
@@ -286,39 +286,39 @@ SomeTest:Time:Arithmetic: 3.0ms stdev=33.3%
         self.assertTrue(BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': ['Total', 'Total']}, 'tests': {
             'SubTest1': {'metrics': {'Time': {'current': []}}}}}}))
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" was not an aggregator list or a dictionary of configurations: 1'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" was not an aggregator list or a dictionary of configurations: 1'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': 1}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" contains non-numeric value: \["Total"\]'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" contains non-numeric value: \["Total"\]'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': {'current': ['Total']}}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" contains non-numeric value: \["Total", "Geometric"\]'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" contains non-numeric value: \["Total", "Geometric"\]'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': {'current': [['Total', 'Geometric']]}}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"SomeTest" requires aggregation but it has no subtests'):
+        with self.assertRaisesRegex(TypeError, r'"SomeTest" requires aggregation but it has no subtests'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': ['Total']}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"OtherTest" requires aggregation but it has no subtests'):
+        with self.assertRaisesRegex(TypeError, r'"OtherTest" requires aggregation but it has no subtests'):
             BenchmarkResults._lint_results({'OtherTest': {'metrics': {'Time': ['Total']}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" uses unknown aggregator: KittenMean'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" uses unknown aggregator: KittenMean'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': ['KittenMean']}, 'tests': {
                 'SubTest1': {'metrics': {'Time': {'current': []}}}}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" had a mismatching subtest values'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" had a mismatching subtest values'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': ['Total']}, 'tests': {
                 'SubTest1': {'metrics': {'Time': {'current': [1, 2, 3]}}},
                 'SubTest2': {'metrics': {'Time': {'current': [4, 5, 6, 7]}}}}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" had a mismatching subtest values'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" had a mismatching subtest values'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': ['Total']}, 'tests': {
                 'SubTest1': {'metrics': {'Time': {'current': [[1, 2], [3]]}}},
                 'SubTest2': {'metrics': {'Time': {'current': [[4, 5], [6, 7]]}}}}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" had malformed values: \[1, \[2\], 3\]'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" had malformed values: \[1, \[2\], 3\]'):
             BenchmarkResults._lint_results({'SomeTest': {'metrics': {'Time': {'current': [1, [2], 3]}}}})
 
-        with self.assertRaisesRegexp(TypeError, r'"Time" metric of "SomeTest" has no value to aggregate as "Arithmetic" in a subtest "SubTest1"'):
+        with self.assertRaisesRegex(TypeError, r'"Time" metric of "SomeTest" has no value to aggregate as "Arithmetic" in a subtest "SubTest1"'):
             BenchmarkResults._lint_results({'SomeTest': {
                 'metrics': {'Time': ['Arithmetic']},
                 'tests': {

--- a/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
@@ -96,7 +96,7 @@ class XvfbDriverTest(unittest.TestCase):
         failing_print_screen_size_process = MockProcess(returncode=1)
         driver = self.make_driver(print_screen_size_process=failing_print_screen_size_process)
         with OutputCapture(level=logging.INFO) as captured:
-            self.assertRaisesRegexp(RuntimeError, 'Unable to start Xvfb display server', driver.start, False, [])
+            self.assertRaisesRegex(RuntimeError, 'Unable to start Xvfb display server', driver.start, False, [])
             captured_log = captured.root.log.getvalue()
             for retry in [1, 2, 3, 5, 6, 8, 9]:
                 self.assertTrue('Failed to check that the Xvfb display server is replying, retrying check [ {} of 9 ].'.format(retry) in captured_log)

--- a/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
@@ -365,8 +365,8 @@ CONTENT OF TEST
             converted = BeautifulSoup(converted)
 
         orig_path_pattern = re.compile('^/resources/testharness')
-        self.assertEquals(len(converted.findAll(src=orig_path_pattern)), num_src_paths, 'testharness src path should not have been converted')
-        self.assertEquals(len(converted.findAll(href=orig_path_pattern)), num_href_paths, 'testharness href path should not have been converted')
+        self.assertEqual(len(converted.findAll(src=orig_path_pattern)), num_src_paths, 'testharness src path should not have been converted')
+        self.assertEqual(len(converted.findAll(href=orig_path_pattern)), num_href_paths, 'testharness href path should not have been converted')
 
     def verify_prefixed_properties(self, converted, test_properties):
         self.assertEqual(len(set(converted[0])), len(set(test_properties)), 'Incorrect number of properties converted')


### PR DESCRIPTION
#### c8ea01b532084fd646a2e31bbafde5e283d2d712
<pre>
test-webkitpy should not use assertion functions removed in python 3.12
<a href="https://bugs.webkit.org/show_bug.cgi?id=260878">https://bugs.webkit.org/show_bug.cgi?id=260878</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Scripts/webkit/parser_unittest.py:
(UnsupportedPrecompilerDirectiveTest.test_error_at_else):
(UnsupportedPrecompilerDirectiveTest.test_error_at_elif):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_results_unittest.py:
(BenchmarkResultsTest.test_init):
* Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py:
(XvfbDriverTest.test_xvfb_not_replying):
* Tools/Scripts/webkitpy/w3c/test_converter_unittest.py:
(verify_test_harness_paths):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ea01b532084fd646a2e31bbafde5e283d2d712

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17848 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19098 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/16661 "Found 5 webkitpy python2 test failures: webkit.parser_unittest.UnsupportedPrecompilerDirectiveTest.test_error_at_elif, webkit.parser_unittest.UnsupportedPrecompilerDirectiveTest.test_error_at_else, webkitpy.benchmark_runner.benchmark_results_unittest.BenchmarkResultsTest.test_init, webkitpy.benchmark_runner.benchmark_results_unittest.BenchmarkResultsTest.test_lint_results, webkitpy.port.xvfbdriver_unittest.XvfbDriverTest.test_xvfb_not_replying") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21779 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19463 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15749 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13371 "1 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14949 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->