### PR TITLE
[css-typed-om] Add factory functions for all font relative units

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/factory-font-relative-length-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/factory-font-relative-length-expected.txt
@@ -1,0 +1,14 @@
+
+PASS CSS.cap() produces cap length
+PASS CSS.ch() produces ch length
+PASS CSS.em() produces em length
+PASS CSS.ex() produces ex length
+PASS CSS.ic() produces ic length
+PASS CSS.lh() produces lh length
+PASS CSS.rcap() produces rcap length
+PASS CSS.rch() produces rch length
+PASS CSS.rem() produces rem length
+PASS CSS.rex() produces rex length
+PASS CSS.ric() produces ric length
+PASS CSS.rlh() produces rlh length
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/factory-font-relative-length.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/factory-font-relative-length.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSSOM Test: Numeric Factory Functions for font relative length</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#numeric-factory">
+    <meta name="assert" content="CSS factory functions produce expected CSSUnitValue">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+        "use strict";
+
+        let units = [
+            "cap",
+            "ch",
+            "em",
+            "ex",
+            "ic",
+            "lh",
+            "rcap",
+            "rch",
+            "rem",
+            "rex",
+            "ric",
+            "rlh"
+        ];
+        let counter = 1;
+        for (let unit of units) {
+            test(function(){
+                let length = CSS[unit](counter);
+                assert_true(length instanceof CSSUnitValue);
+                assert_equals(length.value, counter);
+                assert_equals(length.unit, unit);
+                counter++;
+            }, `CSS.${unit}() produces ${unit} length`);
+        }
+    </script>
+</body>
+</html>

--- a/Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl
+++ b/Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl
@@ -33,12 +33,17 @@
     CSSUnitValue percent(double value);
 
     // <length>
+    CSSUnitValue cap(double value);
+    CSSUnitValue ch(double value);
     CSSUnitValue em(double value);
     CSSUnitValue ex(double value);
-    CSSUnitValue ch(double value);
     CSSUnitValue ic(double value);
-    CSSUnitValue rem(double value);
     CSSUnitValue lh(double value);
+    CSSUnitValue rcap(double value);
+    CSSUnitValue rch(double value);
+    CSSUnitValue rem(double value);
+    CSSUnitValue rex(double value);
+    CSSUnitValue ric(double value);
     CSSUnitValue rlh(double value);
     CSSUnitValue vw(double value);
     CSSUnitValue vh(double value);


### PR DESCRIPTION
#### 610cae50c66f3163e78598bc74bf27c267efbacb
<pre>
[css-typed-om] Add factory functions for all font relative units
<a href="https://bugs.webkit.org/show_bug.cgi?id=260760">https://bugs.webkit.org/show_bug.cgi?id=260760</a>
rdar://114482930

Reviewed by Darin Adler.

Add new font and root font relative lengths to CSSNumericFactory.

Houdini issue: <a href="https://github.com/w3c/css-houdini-drafts/issues/1106">https://github.com/w3c/css-houdini-drafts/issues/1106</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/factory-font-relative-length-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/factory-font-relative-length.html: Added.
* Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl:

Canonical link: <a href="https://commits.webkit.org/267437@main">https://commits.webkit.org/267437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a133899902e8d0421d7a3eac400ea9b271a19bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17022 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19122 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15008 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13389 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3969 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->