### PR TITLE
[Cocoa] font-family:system-ui results in totally garbled text when the user has a user-installed system font

### DIFF
--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -48,12 +48,11 @@ FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool
 #endif
 }
 
-static RetainPtr<CTFontDescriptorRef> findFontDescriptor(CFStringRef referenceURL, CFStringRef postScriptName)
+static RetainPtr<CTFontDescriptorRef> findFontDescriptor(CFURLRef url, CFStringRef postScriptName)
 {
-    auto url = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, referenceURL, nullptr));
     if (!url)
         return nullptr;
-    auto fontDescriptors = adoptCF(CTFontManagerCreateFontDescriptorsFromURL(url.get()));
+    auto fontDescriptors = adoptCF(CTFontManagerCreateFontDescriptorsFromURL(url));
     if (!fontDescriptors || !CFArrayGetCount(fontDescriptors.get()))
         return nullptr;
     if (CFArrayGetCount(fontDescriptors.get()) == 1)
@@ -70,18 +69,23 @@ static RetainPtr<CTFontDescriptorRef> findFontDescriptor(CFStringRef referenceUR
 
 RetainPtr<CTFontRef> createCTFont(CFDictionaryRef attributes, float size, CTFontDescriptorOptions options, CFStringRef referenceURL, CFStringRef desiredPostScriptName)
 {
-    auto fontDescriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes));
+    auto desiredReferenceURL = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, referenceURL, nullptr));
+
+    auto fontDescriptor = adoptCF(CTFontDescriptorCreateWithAttributesAndOptions(attributes, options));
     if (fontDescriptor) {
-        auto font = adoptCF(CTFontCreateWithFontDescriptorAndOptions(fontDescriptor.get(), size, nullptr, options));
+        auto font = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
         auto actualPostScriptName = adoptCF(CTFontCopyPostScriptName(font.get()));
-        if (CFEqual(actualPostScriptName.get(), desiredPostScriptName))
+        auto actualReferenceURL = adoptCF(CTFontCopyAttribute(font.get(), kCTFontReferenceURLAttribute));
+        if (safeCFEqual(actualPostScriptName.get(), desiredPostScriptName) && safeCFEqual(desiredReferenceURL.get(), actualReferenceURL.get()))
             return font;
     }
 
     // CoreText couldn't round-trip the font.
     // We can fall back to doing our best to find it ourself.
-    fontDescriptor = findFontDescriptor(referenceURL, desiredPostScriptName);
-    if (!fontDescriptor)
+    fontDescriptor = findFontDescriptor(desiredReferenceURL.get(), desiredPostScriptName);
+    if (fontDescriptor)
+        fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(fontDescriptor.get(), attributes));
+    else
         fontDescriptor = adoptCF(CTFontDescriptorCreateLastResort());
     ASSERT(fontDescriptor);
     return adoptCF(CTFontCreateWithFontDescriptorAndOptions(fontDescriptor.get(), size, nullptr, options));


### PR DESCRIPTION
#### 9de3b434f4b0c6b0f0f166df0a180963080ba045
<pre>
[Cocoa] font-family:system-ui results in totally garbled text when the user has a user-installed system font
<a href="https://bugs.webkit.org/show_bug.cgi?id=260886">https://bugs.webkit.org/show_bug.cgi?id=260886</a>
rdar://113706205

Reviewed by Cameron McCormack.

When we serialize fonts across IPC, we aren&apos;t precise enough in our description of the system font.
This was causing the web process to use the real system font, while the GPU process uses the user-
installed system font.

This patch does 2 things to mitigate this:
1. Refuses to use a font if its location on disk (&quot;reference URL&quot;) is different than the desired
       location on disk
2. If we end up in this situation where we refuse to use a font, fall back to trying to create it
       from the file on-disk rather than the higher-level font descriptor

This patch is untestable, as it requires a system-wide installation of a user-installed system font
that shadows the real system font.

* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::findFontDescriptor):
(WebCore::createCTFont):

Canonical link: <a href="https://commits.webkit.org/267463@main">https://commits.webkit.org/267463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdf11e0f28257ea19e3687e07fa779d8aaba19ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19193 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15075 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19543 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13452 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15035 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3991 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->