### PR TITLE
Move off of UIKit SPI: -[UIContextMenuInteraction gestureRecognizerForFailureRelationships]

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1143,7 +1143,6 @@ typedef NS_ENUM(NSUInteger, UIMenuOptionsPrivate) {
 };
 
 @interface UIContextMenuInteraction ()
-@property (nonatomic, readonly) UIGestureRecognizer *gestureRecognizerForFailureRelationships;
 - (void)_presentMenuAtLocation:(CGPoint)location;
 @end
 


### PR DESCRIPTION
#### a183125d0e0a93e8117d4cc129c9dacae103fe07
<pre>
Move off of UIKit SPI: -[UIContextMenuInteraction gestureRecognizerForFailureRelationships]
<a href="https://bugs.webkit.org/show_bug.cgi?id=260887">https://bugs.webkit.org/show_bug.cgi?id=260887</a>
rdar://114330991

Reviewed by Tim Horton.

Use a combination of `-name` and `-view` to identify gestures used to add failure requirements for
context menu interactions on `WKContentView`.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove the now-unused declaration.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _isContextMenuGestureRecognizerForFailureRelationships:]):
(-[WKContentView gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]):
(-[WKContentView gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):

Canonical link: <a href="https://commits.webkit.org/267444@main">https://commits.webkit.org/267444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8da2a962fbc15c01e05ccb740f87e1ff35bf5e58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15536 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17030 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17166 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19130 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14410 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15779 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14977 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3973 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->