### PR TITLE
Worker/SharedWorker should fire Event instead of ErrorEvent in case of parsing error

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and keep-origin redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to cross-https origin and swap-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and keep-origin redirection from https context.: securitypolicyviolation
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and no-redirect redirection from https context.: securitypolicyviolation
-FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object ErrorEvent]"
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context. promise_test: Unhandled rejection with value: object "[object Event]"
 PASS Content Security Policy: Expects allowed for sharedworker-import to same-https origin and swap-origin redirection from https context.: securitypolicyviolation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative-expected.txt
@@ -1,4 +1,5 @@
+CONSOLE MESSAGE: Error: assert_unreached: worker got an error Reached unreachable code
 CONSOLE MESSAGE: SyntaxError: Invalid character: '\0'
 
-FAIL Testing WebAssembly worker Script error.
+FAIL Testing WebAssembly worker Error: assert_unreached: worker got an error Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html
@@ -10,4 +10,7 @@ worker.onmessage = (msg) => {
   assert_equals(msg, 42);
   done();
 }
+worker.onerror = () => {
+  assert_unreached("worker got an error");
+}
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any-expected.txt
@@ -1,9 +1,7 @@
 CONSOLE MESSAGE: Importing a module script failed.
 
-Harness Error (FAIL), message = Script error.
-
 PASS Static import.
-FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "Importing a module script failed."
+FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "unknown error"
 PASS Static import (redirect).
 PASS Nested static import.
 PASS Static import and then dynamic import.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (FAIL), message = Error in remote: Importing a module script failed.
-
 PASS Static import.
-FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "Importing a module script failed."
+FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "unknown error"
 PASS Static import (redirect).
 PASS Nested static import.
 PASS Static import and then dynamic import.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-parse-error-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-parse-error-failure-expected.txt
@@ -1,14 +1,6 @@
 CONSOLE MESSAGE: SyntaxError: Unexpected token ';'
 CONSOLE MESSAGE: SyntaxError: Unexpected token ';'
 
-FAIL Module worker construction for script with syntax error should dispatch an event named error. assert_equals: expected function "function Event() {
-    [native code]
-}" but got function "function ErrorEvent() {
-    [native code]
-}"
-FAIL Static import on module worker for script with syntax error should dispatch an event named error. assert_equals: expected function "function Event() {
-    [native code]
-}" but got function "function ErrorEvent() {
-    [native code]
-}"
+PASS Module worker construction for script with syntax error should dispatch an event named error.
+PASS Static import on module worker for script with syntax error should dispatch an event named error.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-blob-url.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-blob-url.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Static import.
-FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "Importing a module script failed."
+FAIL Static import (cross-origin). promise_test: Unhandled rejection with value: "unknown error"
 PASS Static import (redirect).
 PASS Nested static import.
 PASS Static import and then dynamic import.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-parse-error-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-parse-error-failure-expected.txt
@@ -1,12 +1,4 @@
 
-FAIL Module shared worker construction for script with syntax error should dispatch an event named error. assert_equals: expected function "function Event() {
-    [native code]
-}" but got function "function ErrorEvent() {
-    [native code]
-}"
-FAIL Static import on module shared worker for script with syntax error should dispatch an event named error. assert_equals: expected function "function Event() {
-    [native code]
-}" but got function "function ErrorEvent() {
-    [native code]
-}"
+PASS Module shared worker construction for script with syntax error should dispatch an event named error.
+PASS Static import on module shared worker for script with syntax error should dispatch an event named error.
 

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -73,6 +73,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
 
     void dispatchEvent(Event&) final;
+    void reportError(const String&);
 
 #if ENABLE(WEB_RTC)
     void createRTCRtpScriptTransformer(RTCRtpScriptTransform&, MessageWithMessagePorts&&);

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -637,6 +637,11 @@ void WorkerGlobalScope::addImportedScriptSourceProvider(const URL& url, ScriptBu
     }).iterator->value.add(provider);
 }
 
+void WorkerGlobalScope::reportErrorToWorkerObject(const String& errorMessage)
+{
+    thread().workerReportingProxy().reportErrorToWorkerObject(errorMessage);
+}
+
 void WorkerGlobalScope::clearDecodedScriptData()
 {
     ASSERT(isContextThread());

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -170,6 +170,8 @@ public:
 
     WorkerClient* workerClient() { return m_workerClient.get(); }
 
+    void reportErrorToWorkerObject(const String&);
+
 protected:
     WorkerGlobalScope(WorkerThreadType, const WorkerParameters&, Ref<SecurityOrigin>&&, WorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -331,6 +331,17 @@ void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessag
     });
 }
 
+void WorkerMessagingProxy::reportErrorToWorkerObject(const String& errorMessage)
+{
+    if (!m_scriptExecutionContext)
+        return;
+
+    m_scriptExecutionContext->postTask([this,  errorMessage =  errorMessage.isolatedCopy()] (auto&) {
+        if (RefPtr workerObject = this->workerObject())
+            workerObject->reportError(errorMessage);
+    });
+}
+
 void WorkerMessagingProxy::postMessageToDebugger(const String& message)
 {
     RunLoop::main().dispatch([this, protectedThis = Ref { *this }, message = message.isolatedCopy()]() mutable {

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -62,6 +62,7 @@ private:
     void postMessageToWorkerObject(MessageWithMessagePorts&&) final;
     void postTaskToWorkerObject(Function<void(Worker&)>&&) final;
     void postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) final;
+    void reportErrorToWorkerObject(const String&) final;
     void workerGlobalScopeClosed() final;
     void workerGlobalScopeDestroyed() final;
 

--- a/Source/WebCore/workers/WorkerReportingProxy.h
+++ b/Source/WebCore/workers/WorkerReportingProxy.h
@@ -38,6 +38,8 @@ public:
 
     virtual void postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) = 0;
 
+    virtual void reportErrorToWorkerObject(const String&) = 0;
+
     // Invoked when close() is invoked on the worker context.
     virtual void workerGlobalScopeClosed() = 0;
 

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -160,12 +160,12 @@ void WorkerThread::evaluateScriptIfNecessary(String& exceptionMessage)
         sourceProvider = static_cast<ScriptBufferSourceProvider&>(sourceCode.provider());
         bool success = globalScope()->script()->loadModuleSynchronously(scriptFetcher.get(), sourceCode);
         if (success) {
-            if (std::optional<LoadableScript::Error> error = scriptFetcher->error()) {
+            if (auto error = scriptFetcher->error()) {
                 if (std::optional<LoadableScript::ConsoleMessage> message = error->consoleMessage)
                     exceptionMessage = message->message;
                 else
                     exceptionMessage = "Importing a module script failed."_s;
-                globalScope()->reportException(exceptionMessage, { }, { }, { }, { }, { });
+                globalScope()->reportErrorToWorkerObject(exceptionMessage);
             } else if (!scriptFetcher->wasCanceled()) {
                 globalScope()->script()->linkAndEvaluateModule(scriptFetcher.get(), sourceCode, &exceptionMessage);
                 finishedEvaluatingScript();

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -72,6 +72,7 @@ public:
 
 private:
     void postExceptionToWorkerObject(const String&, int, int, const String&) final { };
+    void reportErrorToWorkerObject(const String&) final { };
     void workerGlobalScopeDestroyed() final { };
     void postMessageToWorkerObject(MessageWithMessagePorts&&) final { };
 };

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
@@ -55,7 +55,7 @@ protected:
     // IPC messages.
     WEBCORE_EXPORT void fetchScriptInClient(URL&&, WebCore::SharedWorkerObjectIdentifier, WorkerOptions&&, CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
     WEBCORE_EXPORT void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const ResourceError&);
-    WEBCORE_EXPORT void postExceptionToWorkerObject(SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
+    WEBCORE_EXPORT void postErrorToWorkerObject(SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
 
     WEBCORE_EXPORT SharedWorkerObjectConnection();
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
@@ -49,7 +49,7 @@ public:
     public:
         virtual ~Connection() { }
         virtual void establishConnection(CompletionHandler<void()>&&) = 0;
-        virtual void postExceptionToWorkerObject(SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) = 0;
+        virtual void postErrorToWorkerObject(SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrrorEvent) = 0;
         virtual void sharedWorkerTerminated(SharedWorkerIdentifier) = 0;
         bool isClosed() const { return m_isClosed; }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -150,8 +150,20 @@ void SharedWorkerThreadProxy::postExceptionToWorkerObject(const String& errorMes
         return;
 
     callOnMainThread([sharedWorkerIdentifier = m_workerThread->identifier(), errorMessage = errorMessage.isolatedCopy(), lineNumber, columnNumber, sourceURL = sourceURL.isolatedCopy()] {
+        bool isErrorEvent = true;
         if (auto* connection = SharedWorkerContextManager::singleton().connection())
-            connection->postExceptionToWorkerObject(sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL);
+            connection->postErrorToWorkerObject(sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent);
+    });
+}
+
+void SharedWorkerThreadProxy::reportErrorToWorkerObject(const String& errorMessage)
+{
+    ASSERT(!isMainThread());
+
+    callOnMainThread([sharedWorkerIdentifier = m_workerThread->identifier(), errorMessage = errorMessage.isolatedCopy()] {
+        bool isErrorEvent = false;
+        if (auto* connection = SharedWorkerContextManager::singleton().connection())
+            connection->postErrorToWorkerObject(sharedWorkerIdentifier, errorMessage, 0, 0, { }, isErrorEvent);
     });
 }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -65,6 +65,7 @@ private:
 
     // WorkerObjectProxy.
     void postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) final;
+    void reportErrorToWorkerObject(const String&) final;
     void postMessageToWorkerObject(MessageWithMessagePorts&&) final { }
     void workerGlobalScopeDestroyed() final { }
     void workerGlobalScopeClosed() final;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -279,16 +279,16 @@ WebSharedWorkerServerToContextConnection* WebSharedWorkerServer::contextConnecti
     return m_contextConnections.get(domain);
 }
 
-void WebSharedWorkerServer::postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
+void WebSharedWorkerServer::postErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent)
 {
     auto* sharedWorker = WebSharedWorker::fromIdentifier(sharedWorkerIdentifier);
-    RELEASE_LOG_ERROR(SharedWorker, "WebSharedWorkerServer::postExceptionToWorkerObject: sharedWorkerIdentifier=%" PRIu64 ", sharedWorker=%p", sharedWorkerIdentifier.toUInt64(), sharedWorker);
+    RELEASE_LOG_ERROR(SharedWorker, "WebSharedWorkerServer::postErrorToWorkerObject: sharedWorkerIdentifier=%" PRIu64 ", sharedWorker=%p", sharedWorkerIdentifier.toUInt64(), sharedWorker);
     if (!sharedWorker)
         return;
 
     sharedWorker->forEachSharedWorkerObject([&](auto sharedWorkerObjectIdentifier, auto&) {
         if (auto* serverConnection = m_connections.get(sharedWorkerObjectIdentifier.processIdentifier()))
-            serverConnection->postExceptionToWorkerObject(sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL);
+            serverConnection->postErrorToWorkerObject(sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -66,7 +66,7 @@ public:
     void sharedWorkerObjectIsGoingAway(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
     void suspendForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
     void resumeForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
-    void postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
+    void postErrorToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
     void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier);
 
     void terminateContextConnectionWhenPossible(const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -129,10 +129,10 @@ void WebSharedWorkerServerConnection::notifyWorkerObjectOfLoadCompletion(WebCore
     send(Messages::WebSharedWorkerObjectConnection::NotifyWorkerObjectOfLoadCompletion { sharedWorkerObjectIdentifier, error });
 }
 
-void WebSharedWorkerServerConnection::postExceptionToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
+void WebSharedWorkerServerConnection::postErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent)
 {
-    CONNECTION_RELEASE_LOG_ERROR("postExceptionToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
-    send(Messages::WebSharedWorkerObjectConnection::PostExceptionToWorkerObject { sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL });
+    CONNECTION_RELEASE_LOG_ERROR("postErrorToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
+    send(Messages::WebSharedWorkerObjectConnection::PostErrorToWorkerObject { sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent });
 }
 
 #undef CONNECTION_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -66,7 +66,7 @@ public:
 
     void fetchScriptInClient(const WebSharedWorker&, WebCore::SharedWorkerObjectIdentifier, CompletionHandler<void(WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&)>&&);
     void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const WebCore::ResourceError&);
-    void postExceptionToWorkerObject(WebCore::SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
+    void postErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
 
 private:
     // IPC::MessageSender.

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -92,11 +92,11 @@ void WebSharedWorkerServerToContextConnection::connectionIsNoLongerNeeded()
     m_connection.sharedWorkerServerToContextConnectionIsNoLongerNeeded();
 }
 
-void WebSharedWorkerServerToContextConnection::postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
+void WebSharedWorkerServerToContextConnection::postErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent)
 {
-    CONTEXT_CONNECTION_RELEASE_LOG("postExceptionToWorkerObject: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
+    CONTEXT_CONNECTION_RELEASE_LOG("postErrorToWorkerObject: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
     if (m_server)
-        m_server->postExceptionToWorkerObject(sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL);
+        m_server->postErrorToWorkerObject(sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent);
 }
 
 void WebSharedWorkerServerToContextConnection::sharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -79,7 +79,7 @@ private:
     void connectionIsNoLongerNeeded();
 
     // IPC messages.
-    void postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL);
+    void postErrorToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
     void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier);
 
     // IPC::MessageSender.

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in
@@ -21,6 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> WebSharedWorkerServerToContextConnection NotRefCounted {
-    PostExceptionToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL)
+    PostErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL, bool isErrorEvent)
     SharedWorkerTerminated(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
 }

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -84,9 +84,9 @@ void WebSharedWorkerContextManagerConnection::establishConnection(CompletionHand
     m_connectionToNetworkProcess->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::EstablishSharedWorkerContextConnection { m_webPageProxyID, m_registrableDomain }, WTFMove(completionHandler), 0);
 }
 
-void WebSharedWorkerContextManagerConnection::postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
+void WebSharedWorkerContextManagerConnection::postErrorToWorkerObject(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent)
 {
-    m_connectionToNetworkProcess->send(Messages::WebSharedWorkerServerToContextConnection::PostExceptionToWorkerObject { sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL }, 0);
+    m_connectionToNetworkProcess->send(Messages::WebSharedWorkerServerToContextConnection::PostErrorToWorkerObject { sharedWorkerIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent }, 0);
 }
 
 void WebSharedWorkerContextManagerConnection::updatePreferencesStore(const WebPreferencesStore& store)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
@@ -53,7 +53,7 @@ public:
     ~WebSharedWorkerContextManagerConnection();
 
     void establishConnection(CompletionHandler<void()>&&) final;
-    void postExceptionToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) final;
+    void postErrorToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent) final;
     void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier) final;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
@@ -23,5 +23,5 @@
 messages -> WebSharedWorkerObjectConnection {
     FetchScriptInClient(URL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
     NotifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::ResourceError error)
-    PostExceptionToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL)
+    PostErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL, bool isErrorEvent)
 }


### PR DESCRIPTION
#### 276241243511562a30091c9cfb1170c9e87642d0
<pre>
Worker/SharedWorker should fire Event instead of ErrorEvent in case of parsing error
<a href="https://bugs.webkit.org/show_bug.cgi?id=260900">https://bugs.webkit.org/show_bug.cgi?id=260900</a>
rdar://problem/114694487

Reviewed by Chris Dumez.

In case of parsing error, there is no exception information, so we should not fire an ErrorEvent but an Error as per spec.
In WorkerThread, we are now separating the code path.
In DedicatedWorker, we are using a specific code path so as to continue adding a message log.
In SharedWorker case, we reuse the current code path and use a boolean to tell whether to use ErrorEvent or Error.

We update mported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html to not make it timeout and instead fail.
This aligns the behavior for this test with Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platfor* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/esm-integration/worker.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-blob-url.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-referrer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-parse-error-failure-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-blob-url.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-parse-error-failure-expected.txt:
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::reportError):
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::reportErrorToWorkerObject):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::reportErrorToWorkerObject):
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/WorkerReportingProxy.h:
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerThread::evaluateScriptIfNecessary):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp:
(WebCore::SharedWorkerObjectConnection::postErrorToWorkerObject):
(WebCore::SharedWorkerObjectConnection::postExceptionToWorkerObject): Deleted.
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.h:
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::postExceptionToWorkerObject):
(WebCore::SharedWorkerThreadProxy::reportErrorToWorkerObject):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::postErrorToWorkerObject):
(WebKit::WebSharedWorkerServer::postExceptionToWorkerObject): Deleted.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::postErrorToWorkerObject):
(WebKit::WebSharedWorkerServerConnection::postExceptionToWorkerObject): Deleted.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::postErrorToWorkerObject):
(WebKit::WebSharedWorkerServerToContextConnection::postExceptionToWorkerObject): Deleted.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::postErrorToWorkerObject):
(WebKit::WebSharedWorkerContextManagerConnection::postExceptionToWorkerObject): Deleted.
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/267546@main">https://commits.webkit.org/267546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6610b9c5521e567284fe88e0c38da62334dcf9fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17380 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19511 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15342 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19825 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16116 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->