### PR TITLE
Explicit tmp register for offlineasm instructions

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -2433,7 +2433,7 @@ instructionLabel(_i64_rotr)
 instructionLabel(_f32_abs)
     # f32.abs
     popFloat32FT0()
-    absf ft0, ft0
+    absf ft0, ft0, tmp0
     pushFloat32FT0()
 
     advancePC(1)
@@ -2442,7 +2442,7 @@ instructionLabel(_f32_abs)
 instructionLabel(_f32_neg)
     # f32.neg
     popFloat32FT0()
-    negf ft0, ft0
+    negf ft0, ft0, tmp0
     pushFloat32FT0()
 
     advancePC(1)
@@ -2624,7 +2624,7 @@ instructionLabel(_f32_copysign)
 instructionLabel(_f64_abs)
     # f64.abs
     popFloat64FT0()
-    absd ft0, ft0
+    absd ft0, ft0, tmp0
     pushFloat64FT0()
 
     advancePC(1)
@@ -2633,7 +2633,7 @@ instructionLabel(_f64_abs)
 instructionLabel(_f64_neg)
     # f64.neg
     popFloat64FT0()
-    negd ft0, ft0
+    negd ft0, ft0, tmp0
     pushFloat64FT0()
 
     advancePC(1)
@@ -2931,7 +2931,7 @@ instructionLabel(_i64_trunc_f32_u)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .ipint_i64_f32_u_outOfBoundsTrunc
 
-    truncatef2q ft0, t0
+    truncatef2q ft0, t0, tmp0
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
@@ -2965,7 +2965,7 @@ instructionLabel(_i64_trunc_f64_u)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .ipint_i64_f64_u_outOfBoundsTrunc
 
-    truncated2q ft0, t0
+    truncated2q ft0, t0, tmp0
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
@@ -2997,7 +2997,7 @@ instructionLabel(_f32_convert_i64_s)
 instructionLabel(_f32_convert_i64_u)
     popInt64(t0, t1)
     if X86_64
-        cq2f t0, t1, ft0
+        cq2f t0, t1, ft0, tmp0
     else
         cq2f t0, ft0
     end
@@ -3036,7 +3036,7 @@ instructionLabel(_f64_convert_i64_s)
 instructionLabel(_f64_convert_i64_u)
     popInt64(t0, t1)
     if X86_64
-        cq2d t0, t1, ft0
+        cq2d t0, t1, ft0, tmp0
     else
         cq2d t0, ft0
     end
@@ -3407,7 +3407,7 @@ instructionLabel(_i64_trunc_sat_f32_u)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .ipint_i64_trunc_sat_f32_u_outOfBoundsTruncSatMax
 
-    truncatef2q ft0, t0
+    truncatef2q ft0, t0, tmp0
     pushInt64(t0)
     advancePC(2)
     nextIPIntInstruction()
@@ -3469,7 +3469,7 @@ instructionLabel(_i64_trunc_sat_f64_u)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .ipint_i64_trunc_sat_f64_u_outOfBoundsTruncSatMax
 
-    truncated2q ft0, t0
+    truncated2q ft0, t0, tmp0
     pushInt64(t0)
     advancePC(2)
     nextIPIntInstruction()

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1481,7 +1481,7 @@ end)
 wasmI64ToFOp(f32_convert_u_i64, WasmF32ConvertUI64, macro (ctx)
     mloadq(ctx, m_operand, t0)
     if X86_64
-        cq2f t0, t1, ft0
+        cq2f t0, t1, ft0, tmp0
     else
         cq2f t0, ft0
     end
@@ -1491,7 +1491,7 @@ end)
 wasmI64ToFOp(f64_convert_u_i64, WasmF64ConvertUI64, macro (ctx)
     mloadq(ctx, m_operand, t0)
     if X86_64
-        cq2d t0, t1, ft0
+        cq2d t0, t1, ft0, tmp0
     else
         cq2d t0, ft0
     end
@@ -1808,13 +1808,13 @@ end)
 
 wasmOp(f32_abs, WasmF32Abs, macro(ctx)
     mloadf(ctx, m_operand, ft0)
-    absf ft0, ft1
+    absf ft0, ft1, tmp0
     returnf(ctx, ft1)
 end)
 
 wasmOp(f32_neg, WasmF32Neg, macro(ctx)
     mloadf(ctx, m_operand, ft0)
-    negf ft0, ft1
+    negf ft0, ft1, tmp0
     returnf(ctx, ft1)
 end)
 
@@ -1908,13 +1908,13 @@ end)
 
 wasmOp(f64_abs, WasmF64Abs, macro(ctx)
     mloadd(ctx, m_operand, ft0)
-    absd ft0, ft1
+    absd ft0, ft1, tmp0
     returnd(ctx, ft1)
 end)
 
 wasmOp(f64_neg, WasmF64Neg, macro(ctx)
     mloadd(ctx, m_operand, ft0)
-    negd ft0, ft1
+    negd ft0, ft1, tmp0
     returnd(ctx, ft1)
 end)
 

--- a/Source/JavaScriptCore/llint/WebAssembly64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly64.asm
@@ -657,7 +657,7 @@ wasmOp(i64_trunc_u_f32, WasmI64TruncUF32, macro (ctx)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .outOfBoundsTrunc
 
-    truncatef2q ft0, t0
+    truncatef2q ft0, t0, tmp0
     returnq(ctx, t0)
 
 .outOfBoundsTrunc:
@@ -693,7 +693,7 @@ wasmOp(i64_trunc_u_f64, WasmI64TruncUF64, macro (ctx)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .outOfBoundsTrunc
 
-    truncated2q ft0, t0
+    truncated2q ft0, t0, tmp0
     returnq(ctx, t0)
 
 .outOfBoundsTrunc:
@@ -790,7 +790,7 @@ wasmOp(i64_trunc_sat_f32_u, WasmI64TruncSatF32U, macro (ctx)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .outOfBoundsTruncSatMax
 
-    truncatef2q ft0, t0
+    truncatef2q ft0, t0, tmp0
     returnq(ctx, t0)
 
 .outOfBoundsTruncSatMin:
@@ -841,7 +841,7 @@ wasmOp(i64_trunc_sat_f64_u, WasmI64TruncSatF64U, macro (ctx)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .outOfBoundsTruncSatMax
 
-    truncated2q ft0, t0
+    truncated2q ft0, t0, tmp0
     returnq(ctx, t0)
 
 .outOfBoundsTruncSatMin:

--- a/Source/JavaScriptCore/offlineasm/registers.rb
+++ b/Source/JavaScriptCore/offlineasm/registers.rb
@@ -164,6 +164,7 @@ WASM_SCRATCHS =
      # archtecture specific registers:
      "ws2",
      "ws3",
+     "tmp0",
     ]
 
 REGISTERS = GPRS + FPRS + VECS + WASM_GPRS + WASM_FPRS + WASM_SCRATCHS


### PR DESCRIPTION
#### 4dad22299fc4feb7de71aee9e3bb6bddc16b2371
<pre>
Explicit tmp register for offlineasm instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260869">https://bugs.webkit.org/show_bug.cgi?id=260869</a>

Reviewed by NOBODY (OOPS!).

In offlineasm we reserve r11 as a scratch register on x86, for
truncatef2q, truncated2q, cq2f, cq2d, absf, absd, negf, negd.

We can change those instructions to take an additional GPR for use
as a scratch register, and return the power to choose when to use r11
to the programmer.

In arm this is usually a no-op for the tmp register, as there is a 1:1
mapping to an arm instruction. Mostly a change for x86_64.

Combined changes:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/llint/WebAssembly64.asm:
* Source/JavaScriptCore/offlineasm/registers.rb:
* Source/JavaScriptCore/offlineasm/x86.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dad22299fc4feb7de71aee9e3bb6bddc16b2371

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16604 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16927 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15572 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20157 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17068 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16802 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/20157 "Failed to compile WebKit") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19169 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/20157 "Failed to compile WebKit") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14337 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/20157 "Failed to compile WebKit") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15841 "Failed to compile JSC") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/15817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/17068 "Failed to compile WebKit") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18162 "Failed to compile JSC") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/18162 "Failed to compile JSC") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19382 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15642 "Failed to compile WebKit") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/4094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->