### PR TITLE
[GTK][WPE] Test `/webkit/WebKitWebExtension/user-messages` is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp
@@ -568,7 +568,7 @@ static void pageCreatedCallback(WebKitWebProcessExtension* extension, WebKitWebP
 static gboolean extensionMessageReceivedCallback(WebKitWebProcessExtension* extension, WebKitUserMessage* message)
 {
     const char* messageName = webkit_user_message_get_name(message);
-    if (g_strcmp0(messageName, "RequestPing")) {
+    if (!g_strcmp0(messageName, "Test.RequestPing")) {
 #if ENABLE(2022_GLIB_API)
         webkit_web_process_extension_send_message_to_context(extension, webkit_user_message_new("Ping", nullptr), nullptr,
 #else

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -80,12 +80,6 @@
         "subtests": {
             "/webkit/WebKitWebProcessExtension/form-submission-steps": {
                 "expected": {"all": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205333"}}
-            },
-            "/webkit/WebKitWebProcessExtension/user-messages": {
-                "expected": {
-                    "all": {"slow": true},
-                    "gtk": {"status": ["FAIL", "TIMEOUT", "PASS"], "bug": "webkit.org/b/211336"}
-                }
             }
         }
     },


### PR DESCRIPTION
#### fce44888e8cccc1dc2b35163195d27aaf62e7494
<pre>
[GTK][WPE] Test `/webkit/WebKitWebExtension/user-messages` is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=211336">https://bugs.webkit.org/show_bug.cgi?id=211336</a>

Reviewed by Carlos Garcia Campos.

The last part of this test verifies that we get back message replies
from web process extensions.

At this point of the test, we have two web processes running, one per
web view. Thus we expect to get two replies.

Currently, we run the main loop and wait for the first reply. When we
get it we stop the main loop and then start it again and wait for the
second reply.

The problem is that the second reply might be sent exactly at the moment
when the main loop is stopped. Thus the message will not be handled and
the test will fail.

The solution to this problem is to wait until we get both messages and
only then stop the main loop to process them.

This patch also fixes the wrong message name comparison in
`extensionMessageReceivedCallback()`.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp:
(UserMessageTest::contextUserMessageReceived):
(UserMessageTest::waitUntilContextMessagesReceived):
(UserMessageTest::waitUntilContextMessageReceived):
(testWebProcessExtensionUserMessages):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp:
(extensionMessageReceivedCallback):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/267462@main">https://commits.webkit.org/267462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f7ffb546d9f41ea359efc2ebb99dd9fe81a4bdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19173 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21835 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19525 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15821 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13435 "10 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15017 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3990 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15646 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->