### PR TITLE
[SVG][Optimization] Return more accurate values for SVGElement::selfHasRelativeLengths()

### DIFF
--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -51,6 +51,11 @@ Ref<SVGCircleElement> SVGCircleElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGCircleElement(tagName, document));
 }
 
+bool SVGCircleElement::selfHasRelativeLengths() const
+{
+    return cx().isRelative() || cy().isRelative() || r().isRelative();
+}
+
 void SVGCircleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -78,6 +83,7 @@ void SVGCircleElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
         setPresentationalHintStyleIsDirty();
+        updateRelativeLengthsInformation();
         return;
     }
 

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -48,7 +48,7 @@ private:
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -52,6 +52,11 @@ Ref<SVGEllipseElement> SVGEllipseElement::create(const QualifiedName& tagName, D
     return adoptRef(*new SVGEllipseElement(tagName, document));
 }
 
+bool SVGEllipseElement::selfHasRelativeLengths() const
+{
+    return cx().isRelative() || cy().isRelative() || rx().isRelative() || ry().isRelative();
+}
+
 void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -81,6 +86,7 @@ void SVGEllipseElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
         setPresentationalHintStyleIsDirty();
+        updateRelativeLengthsInformation();
         return;
     }
 

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -50,7 +50,7 @@ private:
     void svgAttributeChanged(const QualifiedName&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -63,6 +63,11 @@ Ref<SVGFilterElement> SVGFilterElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new SVGFilterElement(tagName, document));
 }
 
+bool SVGFilterElement::selfHasRelativeLengths() const
+{
+    return x().isRelative() || y().isRelative() || width().isRelative() || height().isRelative();
+}
+
 void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -109,7 +114,24 @@ void SVGFilterElement::svgAttributeChanged(const QualifiedName& attrName)
         return;
     }
 
-    if (PropertyRegistry::isKnownAttribute(attrName) || SVGURIReference::isKnownAttribute(attrName)) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::xAttr:
+    case AttributeNames::yAttr:
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+        updateRelativeLengthsInformation();
+        updateSVGRendererForElementChange();
+        return;
+    case AttributeNames::filterUnitsAttr:
+    case AttributeNames::primitiveUnitsAttr:
+        updateSVGRendererForElementChange();
+        return;
+    default:
+        ASSERT_WITH_MESSAGE(!PropertyRegistry::isKnownAttribute(attrName), "Should have been handled in this switch()");
+        break;
+    }
+
+    if (SVGURIReference::isKnownAttribute(attrName)) {
         updateSVGRendererForElementChange();
         return;
     }

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -62,7 +62,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool childShouldCreateRenderer(const Node&) const final;
 
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
 
     Ref<SVGAnimatedEnumeration> m_filterUnits { SVGAnimatedEnumeration::create(this, SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) };
     Ref<SVGAnimatedEnumeration> m_primitiveUnits { SVGAnimatedEnumeration::create(this, SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE) };

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -56,6 +56,11 @@ Ref<SVGForeignObjectElement> SVGForeignObjectElement::create(const QualifiedName
     return adoptRef(*new SVGForeignObjectElement(tagName, document));
 }
 
+bool SVGForeignObjectElement::selfHasRelativeLengths() const
+{
+    return x().isRelative() || y().isRelative() || width().isRelative() || height().isRelative();
+}
+
 void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -85,11 +90,11 @@ void SVGForeignObjectElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
+        updateRelativeLengthsInformation();
         if (attrName == SVGNames::widthAttr || attrName == SVGNames::heightAttr)
             setPresentationalHintStyleIsDirty();
         else {
             ASSERT(attrName == SVGNames::xAttr || attrName == SVGNames::yAttr);
-            updateRelativeLengthsInformation();
             updateSVGRendererForElementChange();
         }
         return;

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -53,7 +53,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
     bool isValid() const final { return SVGTests::isValid(); }
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
     Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height) };

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -87,6 +87,11 @@ bool SVGImageElement::renderingTaintsOrigin() const
     return cachedImage->isCORSCrossOrigin();
 }
 
+bool SVGImageElement::selfHasRelativeLengths() const
+{
+    return x().isRelative() || y().isRelative() || width().isRelative() || height().isRelative();
+}
+
 void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -135,9 +140,10 @@ void SVGImageElement::svgAttributeChanged(const QualifiedName& attrName)
                     return;
                 updateSVGRendererForElementChange();
             }
-        } else if (attrName == SVGNames::widthAttr || attrName == SVGNames::heightAttr)
+        } else if (attrName == SVGNames::widthAttr || attrName == SVGNames::heightAttr) {
+            updateRelativeLengthsInformation();
             setPresentationalHintStyleIsDirty();
-        else {
+        } else {
             ASSERT(attrName == SVGNames::preserveAspectRatioAttr);
             updateSVGRendererForElementChange();
         }

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -67,7 +67,7 @@ private:
     bool haveLoadedRequiredResources() final;
 
     bool isValid() const final { return SVGTests::isValid(); }
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width) };

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -65,6 +65,11 @@ Ref<SVGMaskElement> SVGMaskElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGMaskElement(tagName, document));
 }
 
+bool SVGMaskElement::selfHasRelativeLengths() const
+{
+    return x().isRelative() || y().isRelative() || width().isRelative() || height().isRelative();
+}
+
 void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -110,9 +115,21 @@ void SVGMaskElement::svgAttributeChanged(const QualifiedName& attrName)
         return;
     }
 
-    if (PropertyRegistry::isKnownAttribute(attrName)) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::xAttr:
+    case AttributeNames::yAttr:
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+        updateRelativeLengthsInformation();
         updateSVGRendererForElementChange();
         return;
+    case AttributeNames::maskUnitsAttr:
+    case AttributeNames::maskContentUnitsAttr:
+        updateSVGRendererForElementChange();
+        return;
+    default:
+        ASSERT_WITH_MESSAGE(!PropertyRegistry::isKnownAttribute(attrName), "Should have been handled in this switch()");
+        break;
     }
 
     SVGElement::svgAttributeChanged(attrName);

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -59,7 +59,7 @@ private:
 
     bool isValid() const final { return SVGTests::isValid(); }
     bool needsPendingResourceHandling() const final { return false; }
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width, "-10%"_s) };
     Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height, "-10%"_s) };

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -71,6 +71,11 @@ Ref<SVGPatternElement> SVGPatternElement::create(const QualifiedName& tagName, D
     return adoptRef(*new SVGPatternElement(tagName, document));
 }
 
+bool SVGPatternElement::selfHasRelativeLengths() const
+{
+    return x().isRelative() || y().isRelative() || width().isRelative() || height().isRelative();
+}
+
 void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     SVGParsingError parseError = NoError;
@@ -122,7 +127,25 @@ void SVGPatternElement::svgAttributeChanged(const QualifiedName& attrName)
         return;
     }
 
-    if (PropertyRegistry::isKnownAttribute(attrName) || SVGFitToViewBox::isKnownAttribute(attrName) || SVGURIReference::isKnownAttribute(attrName)) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::xAttr:
+    case AttributeNames::yAttr:
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+        updateRelativeLengthsInformation();
+        updateSVGRendererForElementChange();
+        return;
+    case AttributeNames::patternUnitsAttr:
+    case AttributeNames::patternContentUnitsAttr:
+    case AttributeNames::patternTransformAttr:
+        updateSVGRendererForElementChange();
+        return;
+    default:
+        ASSERT_WITH_MESSAGE(!PropertyRegistry::isKnownAttribute(attrName), "Should have been handled in this switch() above");
+        break;
+    }
+
+    if (SVGFitToViewBox::isKnownAttribute(attrName) || SVGURIReference::isKnownAttribute(attrName)) {
         updateSVGRendererForElementChange();
         return;
     }

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -70,7 +70,7 @@ private:
 
     bool isValid() const final { return SVGTests::isValid(); }
     bool needsPendingResourceHandling() const final { return false; }
-    bool selfHasRelativeLengths() const final { return true; }
+    bool selfHasRelativeLengths() const final;
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
     Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height) };


### PR DESCRIPTION
#### 1792ff21d54cc47cbdb48ca15ff306f2716cf6f5
<pre>
[SVG][Optimization] Return more accurate values for SVGElement::selfHasRelativeLengths()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260909">https://bugs.webkit.org/show_bug.cgi?id=260909</a>

Reviewed by NOBODY (OOPS!).

Return more accurate values for SVGElement::selfHasRelativeLengths(). Some
elements were returning true unconditionally, which would cause more
invalidation than needed when they don&apos;t have sizing attributes using relative
lengths.

* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::selfHasRelativeLengths const):
(WebCore::SVGCircleElement::svgAttributeChanged):
* Source/WebCore/svg/SVGCircleElement.h:
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::selfHasRelativeLengths const):
(WebCore::SVGEllipseElement::svgAttributeChanged):
* Source/WebCore/svg/SVGEllipseElement.h:
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::selfHasRelativeLengths const):
(WebCore::SVGFilterElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFilterElement.h:
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::selfHasRelativeLengths const):
(WebCore::SVGForeignObjectElement::svgAttributeChanged):
* Source/WebCore/svg/SVGForeignObjectElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::selfHasRelativeLengths const):
(WebCore::SVGImageElement::svgAttributeChanged):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::selfHasRelativeLengths const):
(WebCore::SVGMaskElement::svgAttributeChanged):
* Source/WebCore/svg/SVGMaskElement.h:
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::selfHasRelativeLengths const):
(WebCore::SVGPatternElement::svgAttributeChanged):
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::selfHasRelativeLengths const):
(WebCore::SVGRectElement::svgAttributeChanged):
* Source/WebCore/svg/SVGRectElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1792ff21d54cc47cbdb48ca15ff306f2716cf6f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17931 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19227 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21870 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13473 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->