### PR TITLE
Explicit tmp register for offlineasm instructions

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -2433,7 +2433,11 @@ instructionLabel(_i64_rotr)
 instructionLabel(_f32_abs)
     # f32.abs
     popFloat32FT0()
-    absf ft0, ft0
+    if X86_64
+        absf ft0, ft0, ws2
+    else
+        absf ft0, ft0
+    end
     pushFloat32FT0()
 
     advancePC(1)
@@ -2442,7 +2446,11 @@ instructionLabel(_f32_abs)
 instructionLabel(_f32_neg)
     # f32.neg
     popFloat32FT0()
-    negf ft0, ft0
+    if X86_64
+        negf ft0, ft0, ws2
+    else
+        negf ft0, ft0
+    end
     pushFloat32FT0()
 
     advancePC(1)
@@ -2624,7 +2632,11 @@ instructionLabel(_f32_copysign)
 instructionLabel(_f64_abs)
     # f64.abs
     popFloat64FT0()
-    absd ft0, ft0
+    if X86_64
+        absd ft0, ft0, ws2
+    else
+        absd ft0, ft0
+    end
     pushFloat64FT0()
 
     advancePC(1)
@@ -2633,7 +2645,11 @@ instructionLabel(_f64_abs)
 instructionLabel(_f64_neg)
     # f64.neg
     popFloat64FT0()
-    negd ft0, ft0
+    if X86_64
+        negd ft0, ft0, ws2
+    else
+        negd ft0, ft0
+    end
     pushFloat64FT0()
 
     advancePC(1)
@@ -2931,7 +2947,11 @@ instructionLabel(_i64_trunc_f32_u)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .ipint_i64_f32_u_outOfBoundsTrunc
 
-    truncatef2q ft0, t0
+    if X86_64
+        truncatef2q ft0, t0, ws2
+    else
+        truncatef2q ft0, t0
+    end
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
@@ -2965,7 +2985,11 @@ instructionLabel(_i64_trunc_f64_u)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .ipint_i64_f64_u_outOfBoundsTrunc
 
-    truncated2q ft0, t0
+    if X86_64
+        truncated2q ft0, t0, ws2
+    else
+        truncated2q ft0, t0
+    end
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
@@ -2997,7 +3021,7 @@ instructionLabel(_f32_convert_i64_s)
 instructionLabel(_f32_convert_i64_u)
     popInt64(t0, t1)
     if X86_64
-        cq2f t0, t1, ft0
+        cq2f t0, t1, ft0, ws2
     else
         cq2f t0, ft0
     end
@@ -3036,7 +3060,7 @@ instructionLabel(_f64_convert_i64_s)
 instructionLabel(_f64_convert_i64_u)
     popInt64(t0, t1)
     if X86_64
-        cq2d t0, t1, ft0
+        cq2d t0, t1, ft0, ws2
     else
         cq2d t0, ft0
     end
@@ -3407,7 +3431,11 @@ instructionLabel(_i64_trunc_sat_f32_u)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .ipint_i64_trunc_sat_f32_u_outOfBoundsTruncSatMax
 
-    truncatef2q ft0, t0
+    if X86_64
+        truncatef2q ft0, t0, ws2
+    else
+        truncatef2q ft0, t0
+    end
     pushInt64(t0)
     advancePC(2)
     nextIPIntInstruction()
@@ -3469,7 +3497,11 @@ instructionLabel(_i64_trunc_sat_f64_u)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .ipint_i64_trunc_sat_f64_u_outOfBoundsTruncSatMax
 
-    truncated2q ft0, t0
+    if X86_64
+        truncated2q ft0, t0, ws2
+    else
+        truncated2q ft0, t0
+    end
     pushInt64(t0)
     advancePC(2)
     nextIPIntInstruction()

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1481,7 +1481,7 @@ end)
 wasmI64ToFOp(f32_convert_u_i64, WasmF32ConvertUI64, macro (ctx)
     mloadq(ctx, m_operand, t0)
     if X86_64
-        cq2f t0, t1, ft0
+        cq2f t0, t1, ft0, ws2
     else
         cq2f t0, ft0
     end
@@ -1491,7 +1491,7 @@ end)
 wasmI64ToFOp(f64_convert_u_i64, WasmF64ConvertUI64, macro (ctx)
     mloadq(ctx, m_operand, t0)
     if X86_64
-        cq2d t0, t1, ft0
+        cq2d t0, t1, ft0, ws2
     else
         cq2d t0, ft0
     end
@@ -1808,13 +1808,21 @@ end)
 
 wasmOp(f32_abs, WasmF32Abs, macro(ctx)
     mloadf(ctx, m_operand, ft0)
-    absf ft0, ft1
+    if X86_64
+        absf ft0, ft1, ws2
+    else
+        absf ft0, ft1
+    end
     returnf(ctx, ft1)
 end)
 
 wasmOp(f32_neg, WasmF32Neg, macro(ctx)
     mloadf(ctx, m_operand, ft0)
-    negf ft0, ft1
+    if X86_64
+        negf ft0, ft1, ws2
+    else
+        negf ft0, ft1
+    end
     returnf(ctx, ft1)
 end)
 
@@ -1908,13 +1916,21 @@ end)
 
 wasmOp(f64_abs, WasmF64Abs, macro(ctx)
     mloadd(ctx, m_operand, ft0)
-    absd ft0, ft1
+    if X86_64
+        absd ft0, ft1, ws2
+    else
+        absd ft0, ft1
+    end
     returnd(ctx, ft1)
 end)
 
 wasmOp(f64_neg, WasmF64Neg, macro(ctx)
     mloadd(ctx, m_operand, ft0)
-    negd ft0, ft1
+    if X86_64
+        negd ft0, ft1, ws2
+    else
+        negd ft0, ft1
+    end
     returnd(ctx, ft1)
 end)
 

--- a/Source/JavaScriptCore/llint/WebAssembly64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly64.asm
@@ -657,7 +657,11 @@ wasmOp(i64_trunc_u_f32, WasmI64TruncUF32, macro (ctx)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .outOfBoundsTrunc
 
-    truncatef2q ft0, t0
+    if X86_64
+        truncatef2q ft0, t0, ws2
+    else
+        truncatef2q ft0, t0
+    end
     returnq(ctx, t0)
 
 .outOfBoundsTrunc:
@@ -693,7 +697,11 @@ wasmOp(i64_trunc_u_f64, WasmI64TruncUF64, macro (ctx)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .outOfBoundsTrunc
 
-    truncated2q ft0, t0
+    if X86_64
+        truncated2q ft0, t0, ws2
+    else
+        truncated2q ft0, t0
+    end
     returnq(ctx, t0)
 
 .outOfBoundsTrunc:
@@ -790,7 +798,11 @@ wasmOp(i64_trunc_sat_f32_u, WasmI64TruncSatF32U, macro (ctx)
     fi2f t0, ft1
     bfgtequn ft0, ft1, .outOfBoundsTruncSatMax
 
-    truncatef2q ft0, t0
+    if X86_64
+        truncatef2q ft0, t0, ws2
+    else
+        truncatef2q ft0, t0
+    end
     returnq(ctx, t0)
 
 .outOfBoundsTruncSatMin:
@@ -841,7 +853,11 @@ wasmOp(i64_trunc_sat_f64_u, WasmI64TruncSatF64U, macro (ctx)
     fq2d t0, ft1
     bdgtequn ft0, ft1, .outOfBoundsTruncSatMax
 
-    truncated2q ft0, t0
+    if X86_64
+        truncated2q ft0, t0, ws2
+    else
+        truncated2q ft0, t0
+    end
     returnq(ctx, t0)
 
 .outOfBoundsTruncSatMin:

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -58,7 +58,7 @@ require "config"
 # r15 =>             csr4 (callee-save, tagMask)
 # rsp => sp
 # rbp => cfr
-# r11 =>                  (scratch)
+# r11 => ws2              (scratch)
 #
 # On x86-64 windows
 # Arguments need to be push/pop'd on the stack in addition to being stored in
@@ -79,7 +79,7 @@ require "config"
 # r15 =>             csr6 (callee-save, notCellMask)
 # rsp => sp
 # rbp => cfr
-# r11 =>                  (scratch)
+# r11 => ws2              (scratch)
 
 def isX64
     case $activeBackend
@@ -167,31 +167,6 @@ def getSizeString(kind)
     return size + " " + "ptr" + " ";
 end
 
-class SpecialRegister < NoChildren
-    def x86Operand(kind)
-        raise unless @name =~ /^r/
-        raise unless isX64
-        case kind
-        when :half
-            register(@name + "w")
-        when :int
-            register(@name + "d")
-        when :ptr
-            register(@name)
-        when :quad
-            register(@name)
-        else
-            raise codeOriginString
-        end
-    end
-    def x86CallOperand(kind)
-        # Call operands are not allowed to be partial registers.
-        "#{callPrefix}#{x86Operand(:quad)}"
-    end
-end
-
-X64_SCRATCH_REGISTER = SpecialRegister.new("r11")
-
 def x86GPRName(name, kind)
     case name
     when "eax", "ebx", "ecx", "edx"
@@ -204,7 +179,7 @@ def x86GPRName(name, kind)
         raise "bad GPR name #{name} in 32-bit X86" unless isX64
         name8 = name[1] + 'l'
         name16 = name[1..2]
-    when "r8", "r9", "r10", "r12", "r13", "r14", "r15"
+    when "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"
         raise "bad GPR name #{name} in 32-bit X86" unless isX64
         case kind
         when :half
@@ -275,6 +250,8 @@ class RegisterID
             when "t6", "ws1"
                 raise "cannot use register #{name} on X86-64 Windows" if isWin
                 "r10"
+            when "ws2"
+                "r11"
             when "csr0"
                 "ebx"
             when "csr1"
@@ -564,9 +541,11 @@ class Sequence
                             if usedScratch
                                 raise "Attempt to use scratch register twice at #{operand.codeOriginString}"
                             end
-                            newList << Instruction.new(operand.codeOrigin, "move", [operand, X64_SCRATCH_REGISTER])
+                            # This isn't ideal, because it's a hidden use of ws2 that the programmer can't easily see
+                            scratch = RegisterID.new(operand.codeOrigin, "ws2")
+                            newList << Instruction.new(operand.codeOrigin, "move", [operand, scratch])
                             usedScratch = true
-                            X64_SCRATCH_REGISTER
+                            scratch
                         else
                             operand
                         end
@@ -1073,7 +1052,7 @@ class Instruction
         dst = operands[1]
         slow = LocalLabel.unique("slow")
         done = LocalLabel.unique("done")
-        gprScratch = X64_SCRATCH_REGISTER
+        gprScratch = operands[2]
         fprScratch = FPRegisterID.forName(codeOrigin, "wfa7")
         int64SignBit = Immediate.new(codeOrigin, 0x8000000000000000)
         case kind
@@ -1116,7 +1095,7 @@ class Instruction
         dst = operands[2]
         slow = LocalLabel.unique("slow")
         done = LocalLabel.unique("done")
-        scratch2 = X64_SCRATCH_REGISTER
+        scratch2 = operands[3]
         one = Immediate.new(codeOrigin, 0x1)
 
         case kind
@@ -1918,20 +1897,20 @@ class Instruction
                 $asm.puts "lock; orl $0, (#{sp.x86Operand(:ptr)})"
             end
         when "absf"
-            $asm.puts "movl #{orderOperands("$0x80000000", X64_SCRATCH_REGISTER.x86Operand(:int))}"
-            $asm.puts "movd #{orderOperands(X64_SCRATCH_REGISTER.x86Operand(:int), operands[1].x86Operand(:float))}"
+            $asm.puts "movl #{orderOperands("$0x80000000", operands[2].x86Operand(:int))}"
+            $asm.puts "movd #{orderOperands(operands[2].x86Operand(:int), operands[1].x86Operand(:float))}"
             $asm.puts "andnps #{orderOperands(operands[0].x86Operand(:float), operands[1].x86Operand(:float))}"
         when "absd"
-            $asm.puts "movq #{orderOperands("$0x8000000000000000", X64_SCRATCH_REGISTER.x86Operand(:quad))}"
-            $asm.puts "movd #{orderOperands(X64_SCRATCH_REGISTER.x86Operand(:quad), operands[1].x86Operand(:double))}"
+            $asm.puts "movq #{orderOperands("$0x8000000000000000", operands[2].x86Operand(:quad))}"
+            $asm.puts "movd #{orderOperands(operands[2].x86Operand(:quad), operands[1].x86Operand(:double))}"
             $asm.puts "andnps #{orderOperands(operands[0].x86Operand(:double), operands[1].x86Operand(:double))}"
         when "negf"
-            $asm.puts "movl #{orderOperands("$0x80000000", X64_SCRATCH_REGISTER.x86Operand(:int))}"
-            $asm.puts "movd #{orderOperands(X64_SCRATCH_REGISTER.x86Operand(:int), operands[1].x86Operand(:float))}"
+            $asm.puts "movl #{orderOperands("$0x80000000", operands[2].x86Operand(:int))}"
+            $asm.puts "movd #{orderOperands(operands[2].x86Operand(:int), operands[1].x86Operand(:float))}"
             $asm.puts "xorps #{orderOperands(operands[0].x86Operand(:float), operands[1].x86Operand(:float))}"
         when "negd"
-            $asm.puts "movq #{orderOperands("$0x8000000000000000", X64_SCRATCH_REGISTER.x86Operand(:quad))}"
-            $asm.puts "movd #{orderOperands(X64_SCRATCH_REGISTER.x86Operand(:quad), operands[1].x86Operand(:double))}"
+            $asm.puts "movq #{orderOperands("$0x8000000000000000", operands[2].x86Operand(:quad))}"
+            $asm.puts "movd #{orderOperands(operands[2].x86Operand(:quad), operands[1].x86Operand(:double))}"
             $asm.puts "xorpd #{orderOperands(operands[0].x86Operand(:double), operands[1].x86Operand(:double))}"
         when "tls_loadp"
             raise "tls_loadp is only supported on x64" unless isX64


### PR DESCRIPTION
#### 47de51f033acbe144add3dcaec9ed2533dd3313c
<pre>
Explicit tmp register for offlineasm instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=260869">https://bugs.webkit.org/show_bug.cgi?id=260869</a>

Reviewed by NOBODY (OOPS!).

In offlineasm we reserve r11 as a scratch register on x86, for
truncatef2q, truncated2q, cq2f, cq2d, absf, absd, negf, negd.

We can change those instructions to take an additional GPR for use
as a scratch register, and return the power to choose when to use r11
to the programmer.

In arm this is usually a no-op for the tmp register, as there is a 1:1
mapping to an arm instruction. Mostly a change for x86_64.

Combined changes:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/llint/WebAssembly64.asm:
* Source/JavaScriptCore/offlineasm/registers.rb:
* Source/JavaScriptCore/offlineasm/x86.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7eeab038350f0522db70829917f9c686e9cf522d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19334 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21432 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23482 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16219 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21376 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18021 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15115 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22060 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16864 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5382 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21231 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23305 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17644 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5237 "Passed tests") | 
<!--EWS-Status-Bubble-End-->