### PR TITLE
[32 bit] DFG graph generation: intrinsic getters are fallible

### DIFF
--- a/JSTests/stress/typed-array-intrinsic-getter-with-conflicting-value-profile.js
+++ b/JSTests/stress/typed-array-intrinsic-getter-with-conflicting-value-profile.js
@@ -1,0 +1,22 @@
+function foo(x) {
+    return x.byteLength
+}
+
+var arr = new Uint8Array(42);
+
+var badPrototype = {};
+var bad = Object.create(badPrototype);
+
+for (var i = 0; i < 1e6; i++) {
+    if (null != foo(bad)) {
+        throw new Error();
+    }
+}
+
+badPrototype.byteLength = 42;
+
+for (var i = 0; i < 1e6; i++) {
+    if (42 != foo(arr)) {
+        throw new Error();
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -5270,31 +5270,48 @@ void ByteCodeParser::handleGetById(
         return;
     }
 
+    ASSERT(type == AccessType::GetById || type == AccessType::GetByIdDirect || !variant.callLinkStatus());
+
+    auto const getGetter = [&] {
+        if (JSValue getterValue = m_graph.tryGetConstantGetter(loadedValue))
+            return weakJSConstant(getterValue);
+
+        return addToGraph(GetGetter, loadedValue);
+    };
+
+    if (variant.intrinsic() != NoIntrinsic) {
+        auto const addChecks = [&] {
+            Node* getter = getGetter();
+            addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(variant.intrinsicFunction())), getter);
+        };
+
+        if (handleIntrinsicGetter(destination, prediction, variant, base, addChecks)) {
+            if (UNLIKELY(m_graph.compilation()))
+                m_graph.compilation()->noticeInlinedGetById();
+            addToGraph(Phantom, base);
+            return;
+        }
+
+        // We couldn't handle this as an intrinsic and can't emit a direct call
+        // to the intrinsic function--bail and emit a regular GetById
+        if (!variant.callLinkStatus()) {
+            set(destination,
+                addToGraph(getById, OpInfo(identifier), OpInfo(prediction), base));
+            return;
+        }
+    }
+
     if (UNLIKELY(m_graph.compilation()))
         m_graph.compilation()->noticeInlinedGetById();
 
-    ASSERT(type == AccessType::GetById || type == AccessType::GetByIdDirect || !variant.callLinkStatus());
-    if (!variant.callLinkStatus() && variant.intrinsic() == NoIntrinsic) {
+    if (!variant.callLinkStatus()) {
         set(destination, loadedValue);
-        return;
-    }
-    
-    Node* getter = nullptr;
-    if (JSValue getterValue = m_graph.tryGetConstantGetter(loadedValue))
-        getter = weakJSConstant(getterValue);
-    else
-        getter = addToGraph(GetGetter, loadedValue);
-
-    if (handleIntrinsicGetter(destination, prediction, variant, base,
-            [&] () {
-                addToGraph(CheckIsConstant, OpInfo(m_graph.freeze(variant.intrinsicFunction())), getter);
-            })) {
-        addToGraph(Phantom, base);
         return;
     }
 
     // Make a call. We don't try to get fancy with using the smallest operand number because
     // the stack layout phase should compress the stack anyway.
+    Node* getter = getGetter();
     
     unsigned numberOfParameters = 0;
     numberOfParameters++; // The 'this' argument.


### PR DESCRIPTION
#### 7a9106c7a56f0cd97901a535361ba5418900e058
<pre>
[32 bit] DFG graph generation: intrinsic getters are fallible
<a href="https://bugs.webkit.org/show_bug.cgi?id=260908">https://bugs.webkit.org/show_bug.cgi?id=260908</a>

Reviewed by Yusuke Suzuki.

On 32-bit, unlike 64-bit, some of the DFG intrinsic getters (really, the
TypedArray ones) are _fallible_: if the SpeculatedType doesn&apos;t match our
expecations (a non-strict subset of SpecInt32Only), we refuse to generate code. [1]

However, DFG::ByteCodeParser::handleGetById doesn&apos;t appear to handle this case
gracefully--if `handleIntrinsicGetter` fails, we attempt to generate a call to
the getter, but in the case of TypedArray intrinsics, we won&apos;t have the
necessary CallLinkStatus and while attempting to do so, we crash.

To fix this, I&apos;ve added a bit of code that handles the failure from
handleIntrinsicGetter and emits an ordinary `GetById` node instead of trying to
inline anything for this op.

I&apos;ve added a test that demonstrates the current behavior (a segfault) on armv7
and passes with tihs patch.

[1] For what it&apos;s worth, maybe this shouldn&apos;t be the case: it does seem like we
should still be able to generate code in these cases anyhow, but it&apos;s simpler to
just cope with the failure.

* JSTests/stress/typed-array-intrinsic-getter-with-conflicting-value-profile.js: Added.
(foo):
(i.null.foo.Object.create):
(i.42.foo):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleGetById):

Canonical link: <a href="https://commits.webkit.org/267511@main">https://commits.webkit.org/267511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a568bad572cb1129b427af00f9577e31f85df8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17923 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19207 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21863 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14369 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19556 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13464 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18200 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15047 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4266 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4027 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19416 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19420 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15681 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4106 "Passed tests") | 
<!--EWS-Status-Bubble-End-->