### PR TITLE
[JSC] Implement CanDeclareGlobalFunction abstract operation and friends

### DIFF
--- a/JSTests/stress/can-declare-global-function-invoked-before-any-binding-is-created-eval.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-any-binding-is-created-eval.js
@@ -1,0 +1,22 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.defineProperty(globalThis, "a", { writable: true, enumerable: false, configurable: false });
+
+let didThrow = false;
+try {
+    eval(`
+        var d;
+        function a() {}
+        function b() {}
+        var c;
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'a': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(["b", "c", "d"].every(k => !globalThis.hasOwnProperty(k)));

--- a/JSTests/stress/can-declare-global-function-invoked-before-any-binding-is-created-global.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-any-binding-is-created-global.js
@@ -1,0 +1,22 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.defineProperty(globalThis, "b", { writable: false, enumerable: true, configurable: false });
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        var d;
+        function a() {}
+        function b() {}
+        var c;
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'b': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(["a", "c", "d"].every(k => !globalThis.hasOwnProperty(k)));

--- a/JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-eval.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-eval.js
@@ -1,0 +1,25 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+let fooSetCalls = 0;
+Object.defineProperty(globalThis, "foo", { get() {}, set() { fooSetCalls++; }, enumerable: true, configurable: false });
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        function foo() {}
+
+        if (true) {
+            function bar() {}
+        }
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'foo': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(fooSetCalls === 0);
+assert(!globalThis.hasOwnProperty("bar"));

--- a/JSTests/stress/can-declare-global-function-invoked-before-can-declare-var-eval.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-can-declare-var-eval.js
@@ -1,0 +1,21 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.defineProperty(globalThis, "bar", { writable: false, enumerable: true, configurable: false });
+Object.preventExtensions(globalThis);
+
+let didThrow = false;
+try {
+    eval(`
+        var foo = 2;
+        function bar() {}
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'bar': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(!globalThis.hasOwnProperty("foo"));

--- a/JSTests/stress/can-declare-global-function-invoked-before-can-declare-var-global.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-can-declare-var-global.js
@@ -1,0 +1,21 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.defineProperty(globalThis, "foo", { get() {}, enumerable: true, configurable: false });
+Object.preventExtensions(globalThis);
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        var bar = 1;
+        function foo() {}
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'foo': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(!globalThis.hasOwnProperty("bar"));

--- a/JSTests/stress/can-declare-global-function-invoked-var-by-the-same-name-eval.js
+++ b/JSTests/stress/can-declare-global-function-invoked-var-by-the-same-name-eval.js
@@ -1,0 +1,20 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.defineProperty(globalThis, "foo", { value: 1, writable: false, enumerable: false, configurable: false });
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        var foo = 2;
+        function foo() {}
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'foo': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(foo === 1);

--- a/JSTests/stress/can-declare-global-function-invoked-var-by-the-same-name-global.js
+++ b/JSTests/stress/can-declare-global-function-invoked-var-by-the-same-name-global.js
@@ -1,0 +1,21 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+let fooSetCalls = 0;
+Object.defineProperty(globalThis, "foo", { set() { fooSetCalls++; }, enumerable: true, configurable: false });
+
+let didThrow = false;
+try {
+    eval(`
+        var foo = 2;
+        function foo() {}
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'foo': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(fooSetCalls === 0);

--- a/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-eval.js
+++ b/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-eval.js
@@ -1,0 +1,25 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+globalThis.a = 1;
+globalThis.b = 2;
+Object.preventExtensions(globalThis);
+
+let didThrow = false;
+try {
+    eval(`
+        var d = 4;
+        function a() {}
+        function b() {}
+        var c = 3;
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global variable 'c': global object must be extensible");
+}
+
+assert(didThrow);
+assert(a === 1);
+assert(b === 2);

--- a/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-global.js
+++ b/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-global.js
@@ -1,0 +1,25 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+globalThis.a = 1;
+globalThis.b = 2;
+Object.preventExtensions(globalThis);
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        var d = 4;
+        function a() {}
+        function b() {}
+        var c = 3;
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global variable 'c': global object must be extensible");
+}
+
+assert(didThrow);
+assert(a === 1);
+assert(b === 2);

--- a/JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-eval.js
+++ b/JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-eval.js
@@ -1,0 +1,24 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+globalThis.foo = 1;
+Object.preventExtensions(globalThis);
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        var bar;
+
+        if (true) {
+            function foo() {}
+        }
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global variable 'bar': global object must be extensible");
+}
+
+assert(didThrow);
+assert(foo === 1);

--- a/JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-eval.js
+++ b/JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-eval.js
@@ -1,0 +1,15 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+globalThis.bar = 1;
+Object.preventExtensions(globalThis);
+
+eval(`{
+    function foo() {}
+    function bar() {}
+}`);
+
+assert(typeof foo === "undefined");
+assert(typeof bar === "function");

--- a/JSTests/stress/can-declare-global-var-invoked-from-jsonp-fast-path.js
+++ b/JSTests/stress/can-declare-global-var-invoked-from-jsonp-fast-path.js
@@ -1,0 +1,19 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.preventExtensions(globalThis);
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        var foo = { "bar": 42 };
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global variable 'foo': global object must be extensible");
+}
+
+assert(didThrow);
+assert(!globalThis.hasOwnProperty("foo"));

--- a/JSTests/stress/create-global-function-binding-updates-descriptor-eval.js
+++ b/JSTests/stress/create-global-function-binding-updates-descriptor-eval.js
@@ -1,0 +1,47 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+function stringifyDescriptor(key) {
+    return JSON.stringify(Object.getOwnPropertyDescriptor(globalThis, key), (_, v) => typeof v === "function" ? "<function>" : v, 2);
+}
+
+Object.defineProperties(globalThis, {
+    conf1: { value: {}, writable: true, enumerable: true, configurable: true },
+    conf2: { value: {}, writable: true, enumerable: false, configurable: true },
+    conf3: { value: {}, writable: false, enumerable: false, configurable: true },
+    conf4: { get() {}, set: undefined, enumerable: true, configurable: true },
+    conf5: { get() {}, set() {}, enumerable: false, configurable: true },
+    nonConf: { value: {}, writable: true, enumerable: true, configurable: false },
+});
+
+eval(`
+    function conf1() {}
+    function conf2() {}
+    function conf3() {}
+    function conf4() {}
+    function conf5() {}
+    function nonConf() {}
+`);
+
+const expectedConfigurableDescriptor = `{
+  "value": "<function>",
+  "writable": true,
+  "enumerable": true,
+  "configurable": true
+}`;
+
+const expectedNonConfigurableDescriptor = `{
+  "value": "<function>",
+  "writable": true,
+  "enumerable": true,
+  "configurable": false
+}`;
+
+assert(stringifyDescriptor("conf1") === expectedConfigurableDescriptor);
+assert(stringifyDescriptor("conf2") === expectedConfigurableDescriptor);
+assert(stringifyDescriptor("conf3") === expectedConfigurableDescriptor);
+assert(stringifyDescriptor("conf4") === expectedConfigurableDescriptor);
+assert(stringifyDescriptor("conf5") === expectedConfigurableDescriptor);
+assert(stringifyDescriptor("nonConf") === expectedNonConfigurableDescriptor);

--- a/JSTests/stress/create-global-function-binding-updates-descriptor-global.js
+++ b/JSTests/stress/create-global-function-binding-updates-descriptor-global.js
@@ -1,0 +1,40 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+function stringifyDescriptor(key) {
+    return JSON.stringify(Object.getOwnPropertyDescriptor(globalThis, key), (_, v) => typeof v === "function" ? "<function>" : v, 2);
+}
+
+Object.defineProperties(globalThis, {
+    conf1: { value: {}, writable: true, enumerable: true, configurable: true },
+    conf2: { value: {}, writable: true, enumerable: false, configurable: true },
+    conf3: { value: {}, writable: false, enumerable: false, configurable: true },
+    conf4: { get() {}, set: undefined, enumerable: true, configurable: true },
+    conf5: { get() {}, set() {}, enumerable: false, configurable: true },
+    nonConf: { value: {}, writable: true, enumerable: true, configurable: false },
+});
+
+$262.evalScript(`
+    function conf1() {}
+    function conf2() {}
+    function conf3() {}
+    function conf4() {}
+    function conf5() {}
+    function nonConf() {}
+`);
+
+const expectedDescriptor = `{
+  "value": "<function>",
+  "writable": true,
+  "enumerable": true,
+  "configurable": false
+}`;
+
+assert(stringifyDescriptor("conf1") === expectedDescriptor);
+assert(stringifyDescriptor("conf2") === expectedDescriptor);
+assert(stringifyDescriptor("conf3") === expectedDescriptor);
+assert(stringifyDescriptor("conf4") === expectedDescriptor);
+assert(stringifyDescriptor("conf5") === expectedDescriptor);
+assert(stringifyDescriptor("nonConf") === expectedDescriptor);

--- a/JSTests/stress/eval-func-decl-block-does-not-invoke-setter.js
+++ b/JSTests/stress/eval-func-decl-block-does-not-invoke-setter.js
@@ -1,0 +1,28 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+Object.defineProperty(globalThis.__proto__, "foo", {
+    set(val) {
+        throw new Error("The setter shouldn't be invoked!");
+    }
+});
+
+var barSetterCalls = 0;
+var barSetterValue;
+Object.defineProperty(globalThis, "bar", {
+    set(val) {
+        barSetterCalls++;
+        barSetterValue = val;
+    }
+});
+
+eval(`if (true) {
+    function foo() {}
+    function bar() {}
+}`);
+
+assert(typeof foo === "function");
+assert(barSetterCalls === 1);
+assert(typeof barSetterValue === "function");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1898,31 +1898,6 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
-test/language/eval-code/direct/non-definable-function-with-function.js:
-  default: 'Test262Error: Expected SameValue(«[object Object]», «undefined») to be true'
-test/language/eval-code/direct/non-definable-function-with-variable.js:
-  default: 'Test262Error: Expected SameValue(«[object Object]», «undefined») to be true'
-test/language/eval-code/direct/non-definable-global-function.js:
-  default: 'Test262Error: Expected true but got false'
-test/language/eval-code/direct/non-definable-global-generator.js:
-  default: 'Test262Error: Expected true but got false'
-test/language/eval-code/direct/var-env-func-init-global-update-configurable.js:
-  default: 'Test262Error: Expected obj[f] to have enumerable:true.'
-test/language/eval-code/indirect/non-definable-function-with-function.js:
-  default: 'Test262Error: declaration preceding Expected SameValue(«[object Object]», «undefined») to be true'
-  strict mode: 'Test262Error: declaration preceding Expected SameValue(«[object Object]», «undefined») to be true'
-test/language/eval-code/indirect/non-definable-function-with-variable.js:
-  default: 'Test262Error: declaration preceding Expected SameValue(«[object Object]», «undefined») to be true'
-  strict mode: 'Test262Error: declaration preceding Expected SameValue(«[object Object]», «undefined») to be true'
-test/language/eval-code/indirect/non-definable-global-function.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/eval-code/indirect/non-definable-global-generator.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/eval-code/indirect/var-env-func-init-global-update-configurable.js:
-  default: 'Test262Error: Expected obj[f] to have enumerable:true.'
-  strict mode: 'Test262Error: Expected obj[f] to have enumerable:true.'
 test/language/expressions/arrow-function/scope-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/expressions/assignment/S11.13.1_A7_T3.js:
@@ -2154,15 +2129,6 @@ test/language/expressions/yield/star-rhs-iter-rtrn-res-done-no-value.js:
 test/language/expressions/yield/star-rhs-iter-thrw-res-done-no-value.js:
   default: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
   strict mode: 'Test262Error: access count (second iteration) Expected SameValue(«1», «0») to be true'
-test/language/global-code/script-decl-func-err-non-configurable.js:
-  default: 'Test262Error: writable, non-enumerable data property Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: writable, non-enumerable data property Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/global-code/script-decl-func-err-non-extensible.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/language/global-code/script-decl-var-err.js:
-  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/identifier-resolution/assign-to-global-undefined.js:
   strict mode: Expected uncaught exception with name 'ReferenceError' but none was thrown
 test/language/identifiers/start-unicode-10.0.0-class.js:

--- a/LayoutTests/js/dom/function-declarations-shadowing-expected.txt
+++ b/LayoutTests/js/dom/function-declarations-shadowing-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: TypeError: Can't declare global function 'document': property must be either configurable or both writable and enumerable
+CONSOLE MESSAGE: TypeError: Can't declare global function 'window': property must be either configurable or both writable and enumerable
+CONSOLE MESSAGE: TypeError: Can't declare global function 'location': property must be either configurable or both writable and enumerable
+CONSOLE MESSAGE: TypeError: Can't declare global function 'top': property must be either configurable or both writable and enumerable
+!! Per spec (https://tc39.es/ecma262/#sec-globaldeclarationinstantiation), only TypeError exceptions should be thrown for preceding scripts.
+
+This test ensures that non-configurable global properties aren't overwriten by function declarations.
+
+PASS: typeof globalThis["document"] is "object"
+PASS: typeof globalThis["window"] is "object"
+PASS: typeof globalThis["location"] is "object"
+PASS: typeof globalThis["top"] is "object"
+

--- a/LayoutTests/js/dom/function-declarations-shadowing.html
+++ b/LayoutTests/js/dom/function-declarations-shadowing.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+
+<script>function document() {}</script>
+<script>function window() {}</script>
+<script>function location() {}</script>
+<script>function top() {}</script>
+<p>!! Per spec (https://tc39.es/ecma262/#sec-globaldeclarationinstantiation), only TypeError exceptions should be thrown for preceding scripts.
+<p>This test ensures that non-configurable global properties aren't overwriten by function declarations.</p>
+
+<pre id="theConsole"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+for (const prop of ["document", "window", "location", "top"]) {
+    const actual = typeof globalThis[prop];
+    if (actual === "object")
+        theConsole.append(`PASS: typeof globalThis["${prop}"] is "object"\n`);
+    else
+        theConsole.append(`FAIL: typeof globalThis["${prop}"] should be "object", was: "${actual}"\n`);
+}
+</script>

--- a/LayoutTests/js/dom/var-declarations-shadowing-expected.txt
+++ b/LayoutTests/js/dom/var-declarations-shadowing-expected.txt
@@ -8,8 +8,8 @@ PASS: Element == undefined should be false and is.
 PASS: eval('Element == undefined') should be false and is.
 PASS: toString != undefined should be false and is.
 PASS: eval('toString != undefined') should be false and is.
-PASS: valueOf == undefined should be false and is.
-PASS: eval('valueOf == undefined') should be false and is.
+PASS: valueOf != undefined should be false and is.
+PASS: eval('valueOf != undefined') should be false and is.
 -----
 PASS: HTMLElement == marker should be true and is.
 PASS: eval('HTMLElement == marker') should be true and is.

--- a/LayoutTests/js/dom/var-declarations-shadowing.html
+++ b/LayoutTests/js/dom/var-declarations-shadowing.html
@@ -44,8 +44,8 @@ shouldBe(eval('Element == undefined'), "eval('Element == undefined')", false);
 shouldBe(toString != undefined, "toString != undefined", false);
 shouldBe(eval('toString != undefined'), "eval('toString != undefined')", false);
 
-shouldBe(valueOf == undefined, "valueOf == undefined", false);
-shouldBe(eval('valueOf == undefined'), "eval('valueOf == undefined')", false);
+shouldBe(valueOf != undefined, "valueOf != undefined", false);
+shouldBe(eval('valueOf != undefined'), "eval('valueOf != undefined')", false);
 
 log("-----");
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -941,7 +941,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, EvalNode* evalNode, UnlinkedEvalCod
         ASSERT(entry.key->isAtom() || entry.key->isSymbol());
         if (entry.value.isSloppyModeHoistingCandidate())
             hoistedFunctions.append(Identifier::fromUid(m_vm, entry.key.get()));
-        else
+        else if (!entry.value.isFunction())
             variables.append(Identifier::fromUid(m_vm, entry.key.get()));
     }
     codeBlock->adoptVariables(WTFMove(variables));

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -322,6 +322,16 @@ JSObject* createErrorForInvalidGlobalAssignment(JSGlobalObject* globalObject, co
     return createReferenceError(globalObject, makeString("Strict mode forbids implicit creation of global property '"_s, propertyName, '\''));
 }
 
+JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
+{
+    return createTypeError(globalObject, makeString("Can't declare global function '", ident.string(), "': property must be either configurable or both writable and enumerable"));
+}
+
+JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject* globalObject, const Identifier& ident)
+{
+    return createTypeError(globalObject, makeString("Can't declare global variable '", ident.string(), "': global object must be extensible"));
+}
+
 JSObject* createTDZError(JSGlobalObject* globalObject)
 {
     return createReferenceError(globalObject, "Cannot access uninitialized variable."_s);

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.h
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.h
@@ -53,6 +53,8 @@ JSObject* createNotAConstructorError(JSGlobalObject*, JSValue);
 JSObject* createNotAFunctionError(JSGlobalObject*, JSValue);
 JSObject* createInvalidPrototypeError(JSGlobalObject*, JSValue);
 JSObject* createErrorForInvalidGlobalAssignment(JSGlobalObject*, const String&);
+JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject*, const Identifier&);
+JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject*, const Identifier&);
 JSObject* createInvalidPrivateNameError(JSGlobalObject*);
 JSObject* createRedefinedPrivateNameError(JSGlobalObject*);
 String errorDescriptionForValue(JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -119,6 +119,8 @@ enum class ScriptExecutionStatus {
     Stopped,
 };
 
+enum class BindingCreationContext : bool { Global, Eval };
+
 constexpr bool typeExposedByDefault = true;
 
 #define DEFINE_STANDARD_BUILTIN(macro, upperName, lowerName) macro(upperName, lowerName, lowerName, JS ## upperName, upperName, object, typeExposedByDefault)
@@ -603,7 +605,7 @@ protected:
 
     JS_EXPORT_PRIVATE void finishCreation(VM&, JSObject*);
 
-    void addGlobalVar(const Identifier&);
+    void addSymbolTableEntry(const Identifier&);
 
 public:
     JS_EXPORT_PRIVATE ~JSGlobalObject();
@@ -615,8 +617,11 @@ public:
     JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
 
-    inline void addVar(JSGlobalObject*, const Identifier&);
-    void addFunction(JSGlobalObject*, const Identifier&);
+    bool canDeclareGlobalFunction(const Identifier&);
+    template<BindingCreationContext> void createGlobalFunctionBinding(const Identifier&);
+
+    inline bool canDeclareGlobalVar(const Identifier&);
+    template<BindingCreationContext> inline void createGlobalVarBinding(const Identifier&);
 
     inline JSScope* globalScope();
     JSGlobalLexicalEnvironment* globalLexicalEnvironment() { return m_globalLexicalEnvironment.get(); }

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -95,6 +95,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
     JSGlobalLexicalEnvironment* globalLexicalEnvironment = globalObject->globalLexicalEnvironment();
     const VariableEnvironment& variableDeclarations = unlinkedCodeBlock->variableDeclarations();
     const VariableEnvironment& lexicalDeclarations = unlinkedCodeBlock->lexicalDeclarations();
+    size_t numberOfFunctions = unlinkedCodeBlock->numberOfFunctionDecls();
     // The ES6 spec says that no vars/global properties/let/const can be duplicated in the global scope.
     // This carried out section 15.1.8 of the ES6 spec: http://www.ecma-international.org/ecma-262/6.0/index.html#sec-globaldeclarationinstantiation
     {
@@ -148,16 +149,39 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                     return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '"_s, StringView(entry.key.get()), '\''));
             }
         }
+
+        for (size_t i = 0; i < numberOfFunctions; ++i) {
+            UnlinkedFunctionExecutable* unlinkedFunctionExecutable = unlinkedCodeBlock->functionDecl(i);
+            ASSERT(!unlinkedFunctionExecutable->name().isEmpty());
+            bool canDeclare = globalObject->canDeclareGlobalFunction(unlinkedFunctionExecutable->name());
+            throwScope.assertNoExceptionExceptTermination();
+            if (!canDeclare)
+                return createErrorForInvalidGlobalFunctionDeclaration(globalObject, unlinkedFunctionExecutable->name());
+        }
+
+        if (!globalObject->isStructureExtensible()) {
+            for (auto& entry : variableDeclarations) {
+                if (entry.value.isFunction())
+                    continue;
+                ASSERT(entry.value.isVar());
+                const Identifier& ident = Identifier::fromUid(vm, entry.key.get());
+                bool canDeclare = globalObject->canDeclareGlobalVar(ident);
+                throwScope.assertNoExceptionExceptTermination();
+                if (!canDeclare)
+                    return createErrorForInvalidGlobalVarDeclaration(globalObject, ident);
+            }
+        }
     }
 
     m_unlinkedCodeBlock.set(vm, this, unlinkedCodeBlock);
 
     BatchedTransitionOptimizer optimizer(vm, globalObject);
 
-    for (size_t i = 0, numberOfFunctions = unlinkedCodeBlock->numberOfFunctionDecls(); i < numberOfFunctions; ++i) {
+    for (size_t i = 0; i < numberOfFunctions; ++i) {
         UnlinkedFunctionExecutable* unlinkedFunctionExecutable = unlinkedCodeBlock->functionDecl(i);
         ASSERT(!unlinkedFunctionExecutable->name().isEmpty());
-        globalObject->addFunction(globalObject, unlinkedFunctionExecutable->name());
+        globalObject->createGlobalFunctionBinding<BindingCreationContext::Global>(unlinkedFunctionExecutable->name());
+        throwScope.assertNoExceptionExceptTermination();
         if (vm.typeProfiler() || vm.controlFlowProfiler()) {
             vm.functionHasExecutedCache()->insertUnexecutedRange(sourceID(), 
                 unlinkedFunctionExecutable->unlinkedFunctionStart(),
@@ -166,9 +190,11 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
     }
 
     for (auto& entry : variableDeclarations) {
+        if (entry.value.isFunction())
+            continue;
         ASSERT(entry.value.isVar());
-        globalObject->addVar(globalObject, Identifier::fromUid(vm, entry.key.get()));
-        throwScope.assertNoException();
+        globalObject->createGlobalVarBinding<BindingCreationContext::Global>(Identifier::fromUid(vm, entry.key.get()));
+        throwScope.assertNoExceptionExceptTermination();
     }
 
     {


### PR DESCRIPTION
#### 14f1a47bd7264df4cf795d6ddb88f6e321e8701f
<pre>
[JSC] Implement CanDeclareGlobalFunction abstract operation and friends
<a href="https://bugs.webkit.org/show_bug.cgi?id=260487">https://bugs.webkit.org/show_bug.cgi?id=260487</a>
&lt;rdar://problem/114215396&gt;

Reviewed by Yusuke Suzuki.

For both global code and sloppy mode eval() in global scope, this change adds CanDeclareGlobalFunction [1]
that checks if a function can be declared while conforming to invariants of essential internal methods [2],
and also introduces CreateGlobalFunctionBinding [3] that creates a binding with best possible descriptor,
attempting to make the property both writable and enumerable.

For global code, the presence of these helpers is observable when attempting to shadow a non-configurable
global propeperty, and in browser environments with multiple &lt;script&gt; elements: if first script defines
non-configurable property X, the second one containing `function X() {}` should throw a TypeError.
In Bun, they can be observed via vm.runInThisContext() API.

Just like before the change, global code functions are defined on the symbol table unless there is a
non-configurable structure property, ensuring the best possible performance. CanDeclareGlobalFunction
and CreateGlobalFunctionBinding substitute the usage of non-idiomatic VM::DeletePropertyModeScope hack,
which used to ensure there is no property by the same name both on the structure and on the symbol table.
This change makes its removal one step closer.

Functions declared via sloppy mode eval() in global scope are unconditionally defined on the structure
because JSC relies on symbol table entries being immutable. This also preserves a bit weird global object
property enumeration order that is different from both V8 and SpiderMonkey.

For sloppy mode eval() in global scope, this change fixes a) binding creation for hoisted block-level
function declarations (Annex B) not to invoke [[Set]] on global object, and b) CanDeclareGlobalVar [3]
implementation to check only own properties, rather than performing [[Prototype]] lookup.

For global code, this change introduces CanDeclareGlobalVar checks that throw if the global object
is both non-extensible and doesn&apos;t have the given property, which is observable only in non-browser
environments where extension of global object can actually be prevented.

Performance analysis for declaration in global code:
  * `function` before: structure lookup, symbol table lookup [x2], add symbol table entry;
  * `function` after: structure lookup [x2], symbol table lookup [x2], add symbol table entry;
  * `var` before: structure lookup, symbol table lookup, symbol table lookup, add symbol table entry;
  * `var` after: structure lookup, symbol table lookup, add symbol table entry.

While this change adds extra structure lookup for `function`, it removes a few virtual calls, as well
as calling into JSLocalDOMWindow::getOwnPropertySlot().

As demonstrated by added tests, merging CanDeclareGlobalX with CreateGlobalXBinding is impossible since
no binding should be created, which is observable after catching an error, even if a single CanDeclareGlobalX
check fails. However, follow-up optimizations to reduce structure / symbol table lookups are possible.

All added / modified tests are were proven to align JSC with the spec, SpiderMonkey, and V8 (for the most part).

[1] <a href="https://tc39.es/ecma262/#sec-candeclareglobalfunction">https://tc39.es/ecma262/#sec-candeclareglobalfunction</a>
[2] <a href="https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods">https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods</a>
[3] <a href="https://tc39.es/ecma262/#sec-createglobalfunctionbinding">https://tc39.es/ecma262/#sec-createglobalfunctionbinding</a>
[4] <a href="https://tc39.es/ecma262/#sec-candeclareglobalvar">https://tc39.es/ecma262/#sec-candeclareglobalvar</a>

* JSTests/stress/can-declare-global-function-invoked-before-any-binding-is-created-eval.js: Added.
* JSTests/stress/can-declare-global-function-invoked-before-any-binding-is-created-global.js: Added.
* JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-eval.js: Added.
* JSTests/stress/can-declare-global-function-invoked-before-can-declare-var-eval.js: Added.
* JSTests/stress/can-declare-global-function-invoked-before-can-declare-var-global.js: Added.
* JSTests/stress/can-declare-global-function-invoked-var-by-the-same-name-eval.js: Added.
* JSTests/stress/can-declare-global-function-invoked-var-by-the-same-name-global.js: Added.
* JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-eval.js: Added.
* JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-global.js: Added.
* JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-eval.js: Added.
* JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-eval.js: Added.
* JSTests/stress/can-declare-global-var-invoked-from-jsonp-fast-path.js: Added.
* JSTests/stress/create-global-function-binding-updates-descriptor-eval.js: Added.
* JSTests/stress/create-global-function-binding-updates-descriptor-global.js: Added.
* JSTests/stress/eval-func-decl-block-does-not-invoke-setter.js: Added.
* JSTests/test262/expectations.yaml: Mark 21 tests as passing.
* LayoutTests/js/dom/var-declarations-shadowing-expected.txt:
* LayoutTests/js/dom/var-declarations-shadowing.html:
* LayoutTests/js/dom/function-declarations-shadowing-expected.txt: Added.
* LayoutTests/js/dom/function-declarations-shadowing.html: Added.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeEval):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::createErrorForInvalidGlobalFunctionDeclaration):
(JSC::createErrorForInvalidGlobalVarDeclaration):
* Source/JavaScriptCore/runtime/ExceptionHelpers.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::canDeclareGlobalFunction):
(JSC::JSGlobalObject::createGlobalFunctionBinding):
(JSC::JSGlobalObject::addSymbolTableEntry):
(JSC::JSGlobalObject::addGlobalVar): Deleted.
(JSC::JSGlobalObject::addFunction): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::canDeclareGlobalVar):
(JSC::JSGlobalObject::createGlobalVarBinding):
(JSC::JSGlobalObject::addVar): Deleted.
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):

Canonical link: <a href="https://commits.webkit.org/267655@main">https://commits.webkit.org/267655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6cfb13b7f7e1c67e508a19cfb3ce940ae5f9325

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16182 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17762 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19899 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15078 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14944 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16077 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20224 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16477 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18857 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15566 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4376 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19994 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/20083 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2113 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16312 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4231 "Found 1 jsc stress test failure: microbenchmarks/array-from-object-func.js.lockdown") | 
<!--EWS-Status-Bubble-End-->