### PR TITLE
(WIP Investigate fast path for Object.assign({}, nonEmptyObject)

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -92,6 +92,7 @@
 #include "WeakMapImplInlines.h"
 #include "WeakMapPrototype.h"
 #include "WeakSetPrototype.h"
+#include "wtf/DataLog.h"
 
 #if ENABLE(JIT)
 #if ENABLE(DFG_JIT)
@@ -349,6 +350,18 @@ JSC_DEFINE_JIT_OPERATION(operationObjectAssignObject, void, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool targetCanPerformFastPut = jsDynamicCast<JSFinalObject*>(target) && target->canPerformFastPutInlineExcludingProto() && target->isStructureExtensible();
 
+    Structure* structure = source->structure();
+    dataLogLn("<YIJIA> operationObjectAssignUntyped target->structure() ", *target->structure(), 
+        " target->canPerformFastPutInlineExcludingProto() ", target->canPerformFastPutInlineExcludingProto(), 
+        " target->isStructureExtensible() ", target->isStructureExtensible(),
+        " source->structure() ", *structure,
+        " source->hasNonReifiedStaticProperties() ", source->hasNonReifiedStaticProperties(),
+        " source->indexingType() ", IndexingTypeDump(source->indexingType()),
+        " source->structure()->hasAnyKindOfGetterSetterProperties() ", structure->hasAnyKindOfGetterSetterProperties(), 
+        " source->structure()->hasReadOnlyOrGetterSetterPropertiesExcludingProto() ", structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto(), 
+        " source->structure()->isUncacheableDictionary() ", structure->isUncacheableDictionary(), 
+        " source->structure()->hasUnderscoreProtoPropertyExcludingOriginalProto() ", structure->hasUnderscoreProtoPropertyExcludingOriginalProto());
+
     if (targetCanPerformFastPut) {
         Vector<RefPtr<UniquedStringImpl>, 8> properties;
         MarkedArgumentBuffer values;
@@ -368,11 +381,21 @@ JSC_DEFINE_JIT_OPERATION(operationObjectAssignObject, void, (JSGlobalObject* glo
         // https://bugs.webkit.org/show_bug.cgi?id=187837
 
         // Do not clear since Vector::clear shrinks the backing store.
-        if (objectAssignFast(vm, target, source, properties, values))
+        if (objectAssignFast(globalObject, target, source, properties, values))
             return;
     }
 
     scope.release();
+    dataLogLn("<YIJIA> operationObjectAssignUntyped objectAssignGeneric target->structure() ", *target->structure(), 
+        " target->canPerformFastPutInlineExcludingProto() ", target->canPerformFastPutInlineExcludingProto(), 
+        " target->isStructureExtensible() ", target->isStructureExtensible(),
+        " source->structure() ", *structure,
+        " source->hasNonReifiedStaticProperties() ", source->hasNonReifiedStaticProperties(),
+        " source->indexingType() ", IndexingTypeDump(source->indexingType()),
+        " source->structure()->hasAnyKindOfGetterSetterProperties() ", structure->hasAnyKindOfGetterSetterProperties(), 
+        " source->structure()->hasReadOnlyOrGetterSetterPropertiesExcludingProto() ", structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto(), 
+        " source->structure()->isUncacheableDictionary() ", structure->isUncacheableDictionary(), 
+        " source->structure()->hasUnderscoreProtoPropertyExcludingOriginalProto() ", structure->hasUnderscoreProtoPropertyExcludingOriginalProto());
     objectAssignGeneric(globalObject, vm, target, source);
 }
 
@@ -391,6 +414,18 @@ JSC_DEFINE_JIT_OPERATION(operationObjectAssignUntyped, void, (JSGlobalObject* gl
     JSObject* source = sourceValue.toObject(globalObject);
     RETURN_IF_EXCEPTION(scope, void());
 
+    Structure* structure = source->structure();
+    dataLogLn("<YIJIA> operationObjectAssignUntyped target->structure() ", *target->structure(), 
+        " target->canPerformFastPutInlineExcludingProto() ", target->canPerformFastPutInlineExcludingProto(), 
+        " target->isStructureExtensible() ", target->isStructureExtensible(),
+        " source->structure() ", *structure,
+        " source->hasNonReifiedStaticProperties() ", source->hasNonReifiedStaticProperties(),
+        " source->indexingType() ", IndexingTypeDump(source->indexingType()),
+        " source->structure()->hasAnyKindOfGetterSetterProperties() ", structure->hasAnyKindOfGetterSetterProperties(), 
+        " source->structure()->hasReadOnlyOrGetterSetterPropertiesExcludingProto() ", structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto(), 
+        " source->structure()->isUncacheableDictionary() ", structure->isUncacheableDictionary(), 
+        " source->structure()->hasUnderscoreProtoPropertyExcludingOriginalProto() ", structure->hasUnderscoreProtoPropertyExcludingOriginalProto());
+
     if (targetCanPerformFastPut) {
         if (!source->staticPropertiesReified()) {
             source->reifyAllStaticProperties(globalObject);
@@ -399,11 +434,21 @@ JSC_DEFINE_JIT_OPERATION(operationObjectAssignUntyped, void, (JSGlobalObject* gl
 
         Vector<RefPtr<UniquedStringImpl>, 8> properties;
         MarkedArgumentBuffer values;
-        if (objectAssignFast(vm, target, source, properties, values))
+        if (objectAssignFast(globalObject, target, source, properties, values))
             return;
     }
 
     scope.release();
+    dataLogLn("<YIJIA> operationObjectAssignUntyped objectAssignGeneric target->structure() ", *target->structure(), 
+        " target->canPerformFastPutInlineExcludingProto() ", target->canPerformFastPutInlineExcludingProto(), 
+        " target->isStructureExtensible() ", target->isStructureExtensible(),
+        " source->structure() ", *structure,
+        " source->hasNonReifiedStaticProperties() ", source->hasNonReifiedStaticProperties(),
+        " source->indexingType() ", IndexingTypeDump(source->indexingType()),
+        " source->structure()->hasAnyKindOfGetterSetterProperties() ", structure->hasAnyKindOfGetterSetterProperties(), 
+        " source->structure()->hasReadOnlyOrGetterSetterPropertiesExcludingProto() ", structure->hasReadOnlyOrGetterSetterPropertiesExcludingProto(), 
+        " source->structure()->isUncacheableDictionary() ", structure->isUncacheableDictionary(), 
+        " source->structure()->hasUnderscoreProtoPropertyExcludingOriginalProto() ", structure->hasUnderscoreProtoPropertyExcludingOriginalProto());
     objectAssignGeneric(globalObject, vm, target, source);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15396,6 +15396,7 @@ void SpeculativeJIT::compileObjectAssign(Node* node)
         JumpList doneCases;
         JumpList genericCases;
 
+        // Check empty JSObject
         genericCases.append(branchIfNotType(sourceGPR, FinalObjectType));
         genericCases.append(branchTest8(NonZero, Address(sourceGPR, JSObject::indexingTypeAndMiscOffset()), CCallHelpers::TrustedImm32(IndexingShapeMask)));
         emitLoadStructure(vm(), sourceGPR, scratch1GPR);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -481,7 +481,7 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
 //
 
 // We're disabling this for now because of a suspected linker issue.
-#define OFFLINE_ASM_USE_ALT_ENTRY 0
+#define OFFLINE_ASM_USE_ALT_ENTRY 1
 
 #if COMPILER(CLANG)
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -36,6 +36,7 @@
 #include "MegamorphicCache.h"
 #include "StructureInlines.h"
 #include "TypedArrayType.h"
+#include "wtf/DataLog.h"
 
 namespace JSC {
 
@@ -867,7 +868,7 @@ bool JSObject::fastForEachPropertyWithSideEffectFreeFunctor(VM& vm, const Functo
     Structure* structure = this->structure();
 
     if (!structure->canPerformFastPropertyEnumeration())
-        return false;
+        return false; // <-- here
 
     structure->forEachProperty(vm, functor);
     return true;

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -387,7 +387,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorAssign, (JSGlobalObject* globalObject,
                 RETURN_IF_EXCEPTION(scope, { });
             }
 
-            if (objectAssignFast(vm, target, source, properties, values))
+            if (objectAssignFast(globalObject, target, source, properties, values))
                 continue;
         }
 

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -832,11 +832,9 @@ ALWAYS_INLINE bool Structure::canPerformFastPropertyEnumeration() const
     // FIXME: Indexed properties can be handled.
     // https://bugs.webkit.org/show_bug.cgi?id=185358
 
-    if (hasIndexedProperties(indexingType()))
-        return false;
+    // if (hasIndexedProperties(indexingType())) // indexingType() == 10
+    //     return false; // <-- here
     if (hasAnyKindOfGetterSetterProperties())
-        return false;
-    if (hasReadOnlyOrGetterSetterPropertiesExcludingProto())
         return false;
     if (isUncacheableDictionary())
         return false;


### PR DESCRIPTION
#### fbc1302ad49dc3abc96aa94ea0ed3593f669cb1e
<pre>
(WIP Investigate fast path for Object.assign({}, nonEmptyObject)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256026">https://bugs.webkit.org/show_bug.cgi?id=256026</a>
rdar://108875645

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::fastForEachPropertyWithSideEffectFreeFunctor):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::canPerformFastPropertyEnumeration const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc1302ad49dc3abc96aa94ea0ed3593f669cb1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16643 "25 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/16966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17412 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18425 "Failed to compile WebKit") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20196 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17107 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/18425 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16841 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/20196 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/17412 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19208 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/20196 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/17412 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/19208 "Failed to compile WebKit") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/14370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/20196 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/17412 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/19208 "Failed to compile WebKit") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/15876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15855 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/17107 "Failed to compile WebKit") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18201 "Failed to compile JSC") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/17412 "Failed to compile WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/18201 "Failed to compile JSC") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19421 "Failed to compile JSC") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/15682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/19421 "Failed to compile JSC") | 
<!--EWS-Status-Bubble-End-->