### PR TITLE
REGRESSION (262629@main): [ Sonoma WK2 ] printing/print-with-media-query-destory.html is a constant failure

### DIFF
--- a/LayoutTests/platform/mac-monterey/printing/print-with-media-query-destory-expected.txt
+++ b/LayoutTests/platform/mac-monterey/printing/print-with-media-query-destory-expected.txt
@@ -1,2 +1,1 @@
 Pass if no crash or assert
-

--- a/LayoutTests/platform/mac-ventura/printing/print-with-media-query-destory-expected.txt
+++ b/LayoutTests/platform/mac-ventura/printing/print-with-media-query-destory-expected.txt
@@ -1,2 +1,1 @@
 Pass if no crash or assert
-

--- a/LayoutTests/platform/mac-wk1/printing/print-with-media-query-destory-expected.txt
+++ b/LayoutTests/platform/mac-wk1/printing/print-with-media-query-destory-expected.txt
@@ -1,2 +1,1 @@
 Pass if no crash or assert
-

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2087,7 +2087,4 @@ webkit.org/b/260867 [ Monterey+ ] fast/canvas/webgl/texImage2D-mse-flipY-false.h
 
 webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html [ Pass Failure ]
 
-# rdar://114674858 (REGRESSION (262629@main): [ Sonoma wk2 ] printing/print-with-media-query-destory.html is a constant failure)
-[ Sonoma+ ] printing/print-with-media-query-destory.html [ Failure ]
-
 webkit.org/b/260917 [ Ventura ] fast/forms/border-color-relayout.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 8ff17190ccf99106d39d5fc0f12d242d872ce300
<pre>
REGRESSION (262629@main): [ Sonoma WK2 ] printing/print-with-media-query-destory.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=260923">https://bugs.webkit.org/show_bug.cgi?id=260923</a>
rdar://114674858

Unreviewed. Rebaselined the test.

* LayoutTests/platform/mac-monterey/printing/print-with-media-query-destory-expected.txt: Copied from LayoutTests/printing/print-with-media-query-destory-expected.txt.
* LayoutTests/platform/mac-ventura/printing/print-with-media-query-destory-expected.txt: Copied from LayoutTests/printing/print-with-media-query-destory-expected.txt.
* LayoutTests/platform/mac-wk1/printing/print-with-media-query-destory-expected.txt: Copied from LayoutTests/printing/print-with-media-query-destory-expected.txt.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/printing/print-with-media-query-destory-expected.txt:

Canonical link: <a href="https://commits.webkit.org/267475@main">https://commits.webkit.org/267475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e7d32259beb8e733870de95aa3715749861938c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16701 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/17025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17473 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/18483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/20257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/17164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/18483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16900 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/20257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/19268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/20257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/19268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/20257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/19268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/15903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/17164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2061 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/15734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->