### PR TITLE
Implement the `i18n.getMessage()` API which returns the localized string for a specified message.

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2159,11 +2159,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module _WKWebExtensionLocalization {
-      header "_WKWebExtensionLocalization.h"
-      export *
-  }
-
   explicit module _WKWebExtensionMatchPattern {
     header "_WKWebExtensionMatchPattern.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3061,11 +3061,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module _WKWebExtensionLocalization {
-      header "_WKWebExtensionLocalization.h"
-      export *
-  }
-
   explicit module _WKWebExtensionMatchPattern {
     header "_WKWebExtensionMatchPattern.h"
     export *

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -38,11 +38,10 @@ struct WebExtensionContextParameters {
 
     URL baseURL;
     String uniqueIdentifier;
+    Ref<API::Data> localizationJSON;
     Ref<API::Data> manifestJSON;
     double manifestVersion;
     bool testingMode;
-
-    // FIXME: <https://webkit.org/b/246488> Add localized dictionary.
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -27,6 +27,7 @@ struct WebKit::WebExtensionContextParameters {
 
     URL baseURL;
     String uniqueIdentifier;
+    Ref<API::Data> localizationJSON;
     Ref<API::Data> manifestJSON;
     double manifestVersion;
     bool testingMode;

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h
@@ -25,22 +25,22 @@
 
 #import <WebKit/WKFoundation.h>
 
+namespace WebKit {
+class WebExtension;
+}
+
 NS_ASSUME_NONNULL_BEGIN
 
-WK_EXTERN NSString * const _WKLocalizationDictionaryMessageKey;
-WK_EXTERN NSString * const _WKLocalizationDictionaryDescriptionKey;
-WK_EXTERN NSString * const _WKLocalizationDictionaryPlaceholdersKey;
-
-WK_EXTERN
 @interface _WKWebExtensionLocalization : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
 @property (nonatomic, nullable, copy) NSString *uniqueIdentifier;
+@property (nonatomic, nullable, copy) NSDictionary *localizationDictionary;
 
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL defaultLocale:(NSString *)defaultLocaleString uniqueIdentifier:(nullable NSString *)uniqueIdentifier;
-- (instancetype)initWithRegionalLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)regionalLocalization languageLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)languageLocalization defaultLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)defaultLocalization withBestLocale:(nullable NSString *)localeString uniqueIdentifier:(NSString *)uniqueIdentifier NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithWebExtension:(WebKit::WebExtension&)webExtension;
+- (instancetype)initWithRegionalLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)regionalLocalization languageLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)languageLocalization defaultLocalization:(nullable NSDictionary<NSString *, NSDictionary *> *)defaultLocalization withBestLocale:(nullable NSString *)localeString uniqueIdentifier:(nullable NSString *)uniqueIdentifier NS_DESIGNATED_INITIALIZER;
 
 - (NSDictionary<NSString *, id> *)localizedDictionaryForDictionary:(NSDictionary<NSString *, id> *)dictionary;
 - (nullable NSString *)localizedStringForKey:(NSString *)key withPlaceholders:(nullable NSArray<NSString *> *)placeholders;

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -149,6 +149,8 @@ public:
     double manifestVersion();
     bool supportsManifestVersion(double version) { return manifestVersion() >= version; }
 
+    Ref<API::Data> serializeLocalization();
+
 #if PLATFORM(MAC)
     SecStaticCodeRef bundleStaticCode();
     bool validateResourceData(NSURL *, NSData *, NSError **);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -57,12 +57,11 @@ WebExtensionContext::WebExtensionContext()
 
 WebExtensionContextParameters WebExtensionContext::parameters() const
 {
-    // FIXME: <https://webkit.org/b/246488> Send over localized dictionary to the WebProcess.
-
     return WebExtensionContextParameters {
         identifier(),
         baseURL(),
         uniqueIdentifier(),
+        extension().serializeLocalization(),
         extension().serializeManifest(),
         extension().manifestVersion(),
         inTestingMode()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1791,7 +1791,7 @@
 		B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		B68437B329A3E2F500472D1B /* _WKWebExtensionLocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B68437B329A3E2F500472D1B /* _WKWebExtensionLocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */; };
 		B6CCAAB929A445E90092E846 /* JSWebExtensionAPILocalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6CCAAB729A445E90092E846 /* JSWebExtensionAPILocalization.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */; };
 		B6E5F2A7299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -34,6 +34,7 @@
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "WebExtensionContextMessages.h"
+#import "WebExtensionContextProxy.h"
 #import "WebProcess.h"
 #import "_WKWebExtensionLocalization.h"
 #import <JavaScriptCore/APICast.h>
@@ -51,8 +52,8 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 
-    // FIXME: <https://webkit.org/b/246488> Retrieve localized dictionary from the WebExtensionContextProxy.
-    _WKWebExtensionLocalization *localizedDictionary;
+    _WKWebExtensionLocalization *localization = extensionContext().localization();
+
     NSArray<NSString *> *substitutionsArray;
     if ([substitutions isKindOfClass:NSString.class])
         substitutionsArray = @[ substitutions ];
@@ -62,14 +63,12 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
         });
     }
 
-    return [localizedDictionary localizedStringForKey:messageName withPlaceholders:substitutionsArray];
+    return [localization localizedStringForKey:messageName withPlaceholders:substitutionsArray];
 }
 
 NSString *WebExtensionAPILocalization::getUILanguage()
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
-
-    RELEASE_LOG_INFO(Extensions, "i18n.getUILanguage()");
 
     return localeStringInWebExtensionFormat(NSLocale.currentLocale);
 }
@@ -77,8 +76,6 @@ NSString *WebExtensionAPILocalization::getUILanguage()
 void WebExtensionAPILocalization::getAcceptLanguages(Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getAcceptLanguages
-
-    RELEASE_LOG_INFO(Extensions, "i18n.getAcceptedLanguages()");
 
     NSArray<NSString *> *preferredLocaleIdentifiers = NSLocale.preferredLanguages;
     NSMutableOrderedSet<NSString *> *acceptLanguages = [NSMutableOrderedSet orderedSetWithCapacity:preferredLocaleIdentifiers.count];

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -50,8 +50,6 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/getAll
 
-    RELEASE_LOG(Extensions, "permissions.getAll()");
-
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::PermissionsGetAll(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<String> permissions, Vector<String> origins) {
         callback->call(@{
             permissionsKey: createNSArray(permissions).get(),
@@ -63,8 +61,6 @@ void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callb
 void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/contains
-
-    RELEASE_LOG(Extensions, "permissions.contains()");
 
     HashSet<String> permissions, origins;
     WebExtension::MatchPatternSet matchPatterns;
@@ -81,8 +77,6 @@ void WebExtensionAPIPermissions::contains(NSDictionary *details, Ref<WebExtensio
 void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request
-
-    RELEASE_LOG(Extensions, "permissions.request()");
 
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);
@@ -117,8 +111,6 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
 void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/remove
-
-    RELEASE_LOG(Extensions, "permissions.remove()");
 
     HashSet<String> permissions, origins;
     parseDetailsDictionary(details, permissions, origins);

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -37,6 +37,7 @@
 #include "WebExtensionAPINamespace.h"
 #include "WebExtensionAPIPermissions.h"
 #include "WebExtensionAPIWebNavigation.h"
+#include "_WKWebExtensionLocalization.h"
 #include <WebCore/ProcessQualified.h>
 #include <wtf/ObjectIdentifier.h>
 
@@ -44,9 +45,19 @@ namespace WebKit {
 
 using namespace WebCore;
 
-RetainPtr<NSDictionary> WebExtensionContextProxy::parseManifest(API::Data& json)
+RetainPtr<NSDictionary> WebExtensionContextProxy::parseJSON(API::Data& json)
 {
     return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:wrapper(json) options:0 error:nullptr]);
+}
+
+RetainPtr<_WKWebExtensionLocalization> WebExtensionContextProxy::parseLocalization(API::Data& json)
+{
+    NSDictionary *localizedDictionary = parseJSON(json).get();
+    if (!localizedDictionary)
+        return nil;
+
+    _WKWebExtensionLocalization *localization = [[_WKWebExtensionLocalization alloc] initWithRegionalLocalization:localizedDictionary languageLocalization:nil defaultLocalization:nil withBestLocale:localizedDictionary[@"@@ui_locale"][@"message"] uniqueIdentifier:nil];
+    return localization;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -57,7 +57,8 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
     auto updateProperties = [&](WebExtensionContextProxy& context) {
         context.m_baseURL = parameters.baseURL;
         context.m_uniqueIdentifier = parameters.uniqueIdentifier;
-        context.m_manifest = parseManifest(parameters.manifestJSON.get());
+        context.m_localization = parseLocalization(parameters.localizationJSON.get());
+        context.m_manifest = parseJSON(parameters.manifestJSON.get());
         context.m_manifestVersion = parameters.manifestVersion;
         context.m_testingMode = parameters.testingMode;
     };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -38,6 +38,7 @@
 #include <wtf/WeakHashSet.h>
 
 OBJC_CLASS NSDictionary;
+OBJC_CLASS _WKWebExtensionLocalization;
 
 namespace WebKit {
 
@@ -67,10 +68,14 @@ public:
     const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
 
     NSDictionary *manifest() { return m_manifest.get(); }
-    static RetainPtr<NSDictionary> parseManifest(API::Data&);
 
     double manifestVersion() { return m_manifestVersion; }
     bool supportsManifestVersion(double version) { return manifestVersion() >= version; }
+
+    _WKWebExtensionLocalization *localization() { return m_localization.get(); }
+
+    static RetainPtr<_WKWebExtensionLocalization> parseLocalization(API::Data&);
+    static RetainPtr<NSDictionary> parseJSON(API::Data&);
 
     bool inTestingMode() { return m_testingMode; }
 
@@ -103,6 +108,7 @@ private:
     WebExtensionContextIdentifier m_identifier;
     URL m_baseURL;
     String m_uniqueIdentifier;
+    RetainPtr<_WKWebExtensionLocalization> m_localization;
     RetainPtr<NSDictionary> m_manifest;
     double m_manifestVersion { 0 };
     bool m_testingMode { false };

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -941,6 +941,7 @@
 		AD7C434D1DD2A54E0026888B /* Expected.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD7C434C1DD2A5470026888B /* Expected.cpp */; };
 		B55AD1D5179F3B3000AC1494 /* PreventImageLoadWithAutoResizing_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B55AD1D3179F3ABF00AC1494 /* PreventImageLoadWithAutoResizing_Bundle.cpp */; };
 		B55F11B71517D03300915916 /* attributedStringCustomFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = B55F11B01517A2C400915916 /* attributedStringCustomFont.html */; };
+		B68735A32AA78E620006FB3A /* WKWebExtensionAPILocalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6D1708E2A9F9C9F004C72E6 /* WKWebExtensionAPILocalization.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		BC22D31914DC68B900FFB1DD /* UserMessage_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC22D31714DC68B800FFB1DD /* UserMessage_Bundle.cpp */; };
 		BC246D9C132F1FF000B56D7C /* CanHandleRequest_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC246D97132F1FE100B56D7C /* CanHandleRequest_Bundle.cpp */; };
 		BC2D006412AA04CE00E732A3 /* file-with-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC2D004A12A9FEB300E732A3 /* file-with-anchor.html */; };
@@ -3115,6 +3116,7 @@
 		B61EB1642994734A0048DFC0 /* WKWebExtensionAPIPermissions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIPermissions.mm; sourceTree = "<group>"; };
 		B63EF53E2995797F00A190A3 /* TestWebExtensionsDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestWebExtensionsDelegate.h; path = cocoa/TestWebExtensionsDelegate.h; sourceTree = "<group>"; };
 		B63EF5462995797F00A190A3 /* TestWebExtensionsDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = TestWebExtensionsDelegate.mm; path = cocoa/TestWebExtensionsDelegate.mm; sourceTree = "<group>"; };
+		B6D1708E2A9F9C9F004C72E6 /* WKWebExtensionAPILocalization.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPILocalization.mm; sourceTree = "<group>"; };
 		B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIEvent.mm; sourceTree = "<group>"; };
 		BC029B161486AD6400817DA9 /* RetainPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RetainPtr.cpp; sourceTree = "<group>"; };
 		BC029B1B1486B25900817DA9 /* RetainPtr.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RetainPtr.mm; path = ns/RetainPtr.mm; sourceTree = "<group>"; };
@@ -4206,6 +4208,7 @@
 				1C2B4D4C2A81F42800C528A1 /* WKWebExtensionAPIAlarms.mm */,
 				B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */,
 				1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */,
+				B6D1708E2A9F9C9F004C72E6 /* WKWebExtensionAPILocalization.mm */,
 				330E135E2943C92000367438 /* WKWebExtensionAPINamespace.mm */,
 				B61EB1642994734A0048DFC0 /* WKWebExtensionAPIPermissions.mm */,
 				1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */,
@@ -6753,6 +6756,7 @@
 				7CCE7F221A411AE600447C4C /* WKString.cpp in Sources */,
 				7CCE7F1E1A411AE600447C4C /* WKStringJSString.cpp in Sources */,
 				2D4CF8BD1D8360CC0001CE8D /* WKThumbnailView.mm in Sources */,
+				B68735A32AA78E620006FB3A /* WKWebExtensionAPILocalization.mm in Sources */,
 				514958BE1F7427AC00E87BAD /* WKWebViewAutofillTests.mm in Sources */,
 				F425831624F07CA5006B985D /* WKWebViewCoders.mm in Sources */,
 				F4FA91811E61849B007B8C1D /* WKWebViewMacEditingTests.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WebExtensionUtilities.h"
+
+static NSString * const messageKey = @"message";
+static NSString * const placeholdersKey = @"placeholders";
+static NSString * const placeholderDictionaryContentKey = @"content";
+
+static NSLocale *currentLocale = NSLocale.currentLocale;
+static NSWritingDirection writingDirection = [NSParagraphStyle defaultWritingDirectionForLanguage:currentLocale.languageCode];
+static NSString *textDirection = writingDirection == NSWritingDirectionLeftToRight ? @"ltr" : @"rtl";
+static NSString *reversedTextDirection = writingDirection == NSWritingDirectionLeftToRight ? @"rtl" : @"ltr";
+static NSString *startEdge = writingDirection == NSWritingDirectionLeftToRight ? @"left" : @"right";
+static NSString *endEdge = writingDirection == NSWritingDirectionLeftToRight ? @"right" : @"left";
+
+namespace TestWebKitAPI {
+
+static auto *manifest = @{
+    @"manifest_version": @3,
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+    @"default_locale": @"en"
+};
+
+static auto *messages = @{
+    @"extension_name": @{
+        @"message": @"Web Extension Test Extension",
+        @"description": @"The display name for the extension."
+    },
+    @"extension_description": @{
+        @"message": @"This is a Web Extension. Tell us what your extension does here",
+        @"description": @"Description of what the extension does."
+    }
+};
+
+static NSString *localeStringInWebExtensionFormat(NSLocale *locale)
+{
+    if (!locale.languageCode)
+        return @"";
+
+    if (locale.countryCode.length)
+        return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];
+    return locale.languageCode;
+}
+
+static NSString *currentLocaleString = localeStringInWebExtensionFormat(currentLocale);
+
+static auto *baseURLString = @"test-extension://76C788B8-3374-400D-8259-40E5B9DF79D3";
+
+TEST(WKWebExtensionAPILocalization, Errors)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(() => browser.i18n.getMessage(''), /'message' argument should not be an empty string./)",
+        @"browser.test.assertRejects(() => browser.i18n.getMessage(), /'message' argument is invalid because a string is expected./)",
+        @"browser.test.assertRejects(() => browser.i18n.getMessage(123), /'message' argument is invalid because a string is expected./)",
+        @"browser.test.assertRejects(() => browser.i18n.getMessage(null), /'message' argument is invalid because a string is expected./)",
+        @"browser.test.assertRejects(() => browser.i18n.getMessage(undefined), /'message' argument is invalid because a string is expected./)",
+
+        // Finish
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript, @"_locales/en/messages.json": messages }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    // Set a base URL so it is a known value and not the default random one.
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, i18n)
+{
+    NSArray<NSString *> *preferredLocaleIdentifiers = NSLocale.preferredLanguages;
+    NSMutableOrderedSet<NSString *> *acceptedLanguages = [NSMutableOrderedSet orderedSetWithArray:preferredLocaleIdentifiers];
+    for (NSString *localeIdentifier in preferredLocaleIdentifiers)
+        [acceptedLanguages addObject:[NSLocale localeWithLocaleIdentifier:localeIdentifier].languageCode];
+
+    auto *acceptedLanguagesString = Util::constructJSArrayOfStrings(acceptedLanguages.array);
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Variable setup
+        [NSString stringWithFormat:@"const acceptedLanguages = %@", acceptedLanguagesString],
+        [NSString stringWithFormat:@"const currentUILanguage = '%@'", currentLocaleString],
+        [NSString stringWithFormat:@"const textDirection = '%@'", textDirection],
+        [NSString stringWithFormat:@"const reversedTextDirection = '%@'", reversedTextDirection],
+        [NSString stringWithFormat:@"const startEdge = '%@'", startEdge],
+        [NSString stringWithFormat:@"const endEdge = '%@'", endEdge],
+
+        // Test predefined localization
+        @"browser.test.assertEq(browser.i18n.getMessage('extension_name'), 'Web Extension Test Extension')",
+        @"browser.test.assertEq(browser.i18n.getMessage('@@ui_locale'), 'en')",
+        @"browser.test.assertEq(browser.i18n.getMessage('@@bidi_dir'), textDirection)",
+        @"browser.test.assertEq(browser.i18n.getMessage('@@bidi_reversed_dir'), reversedTextDirection)",
+        @"browser.test.assertEq(browser.i18n.getMessage('@@bidi_start_edge'), startEdge)",
+        @"browser.test.assertEq(browser.i18n.getMessage('@@bidi_end_edge'), endEdge)",
+        @"browser.test.assertEq(browser.i18n.getMessage('unknown_message'), '')",
+
+        // FIXME: <https://webkit.org/b/261047> Test getting message with name '@@extension_id'.
+
+        @"browser.test.assertEq(await browser.i18n.getUILanguage(), currentUILanguage)",
+        @"browser.test.assertDeepEq(await browser.i18n.getAcceptLanguages(), acceptedLanguages)",
+
+        // Test return types
+        @"browser.test.assertEq(typeof browser.i18n.getMessage('extension_name'), 'string')",
+        @"browser.test.assertEq(typeof browser.i18n.getUILanguage(), 'string')",
+        @"browser.test.assertEq(typeof browser.i18n.getAcceptLanguages(), 'object')",
+
+        // Finish
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript, @"_locales/en/messages.json": messages }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    // Set a base URL so it is a known value and not the default random one.
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPILocalization, Placeholders)
+{
+    NSDictionary *localizationDictionary = @{
+        @"key1": @{
+            messageKey: @"$placeholder$",
+            placeholdersKey: @{
+                @"placeholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+            },
+        },
+        @"key2": @{
+            messageKey: @"$Placeholder$ + $PlAcEhOlDeR$",
+            placeholdersKey: @{
+                @"placeholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+            },
+        },
+        @"key3": @{
+            messageKey: @"$placeholder$ and $place_holder$",
+            placeholdersKey: @{
+                @"placeholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+                @"pLaCe_hoLder": @{
+                    placeholderDictionaryContentKey: @"different value",
+                },
+            },
+        },
+        @"key4": @{
+            messageKey: @"$placeholder$ with $$5",
+            placeholdersKey: @{
+                @"unusedplaceholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+            },
+        },
+        @"key5": @{
+            messageKey: @"$placeholder$ and $positional$",
+            placeholdersKey: @{
+                @"unusedplaceholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+                @"positional": @{
+                    placeholderDictionaryContentKey: @"$2",
+                },
+            },
+        },
+        @"key6": @{
+            messageKey: @"$1 and $2 but not $3 or $0",
+            placeholdersKey: @{
+                @"unusedplaceholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+            },
+        },
+        @"key7": @{
+            messageKey: @"$dontreplaceme or me$ or th$is or $$th$$at$",
+            placeholdersKey: @{
+                @"unusedplaceholder": @{
+                    placeholderDictionaryContentKey: @"replacement value",
+                },
+            },
+        },
+        @"key8": @{
+            messageKey: @"$total$명, 총 $found$명",
+            placeholdersKey: @{
+                @"total": @{
+                    placeholderDictionaryContentKey: @"1234",
+                },
+                @"found": @{
+                    placeholderDictionaryContentKey: @"42",
+                },
+            },
+        },
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Variable setup
+        [NSString stringWithFormat:@"var placeholders = %@", Util::constructJSArrayOfStrings(@[ @"irrelevant", @"unused" ])],
+
+        // Test predefined localization
+        @"browser.test.assertEq(browser.i18n.getMessage('key1', placeholders), 'replacement value')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key2', placeholders), 'replacement value + replacement value')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key3', placeholders), 'replacement value and different value')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key4', placeholders), ' with $5')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key7', placeholders), '$dontreplaceme or me$ or th$is or $th$at$')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key8', placeholders), '1234명, 총 42명')",
+
+        [NSString stringWithFormat:@"placeholders = %@", Util::constructJSArrayOfStrings(@[ @"irrelevant", @"argument value" ])],
+        @"browser.test.assertEq(browser.i18n.getMessage('key5', placeholders), ' and argument value')",
+
+        [NSString stringWithFormat:@"placeholders = %@", Util::constructJSArrayOfStrings(@[ @"value1", @"value2" ])],
+        @"browser.test.assertEq(browser.i18n.getMessage('key6', placeholders), 'value1 and value2 but not  or ')",
+
+        // Finish
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript, @"_locales/en/messages.json": localizationDictionary }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    // Set a base URL so it is a known value and not the default random one.
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -89,6 +89,7 @@ namespace TestWebKitAPI::Util {
 #ifdef __OBJC__
 
 inline NSString *constructScript(NSArray *lines) { return [lines componentsJoinedByString:@"\n"]; }
+inline NSString *constructJSArrayOfStrings(NSArray *elements) { return [NSString stringWithFormat:@"['%@']", [elements componentsJoinedByString:@"', '"]]; }
 
 #endif
 


### PR DESCRIPTION
#### 272d269ad268b83873c56b0a591e33c4471cebbb
<pre>
Implement the `i18n.getMessage()` API which returns the localized string for a specified message.
<a href="https://webkit.org/b/246488">https://webkit.org/b/246488</a>
rdar://102720462 (Web Extensions in WebKit: Add support for i18n(Localization) in WebKit)

Reviewed by Timothy Hatcher.

This patch adds support for i18n.getMessage(). This was done by storing the _WKWebExtensionLocalization
object for the extension onto the WebExtensionContextProxy, so that it could be used in the WebProcess
to return the localized string for the specified message name.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm:
(-[_WKWebExtensionLocalization initWithWebExtension:]):
We should use the resource methods on the WebExtension object to create the localized dictionary
instead of the using the bundleURL to find the resources on disk.

(-[_WKWebExtensionLocalization
initWithRegionalLocalization:languageLocalization:defaultLocalization:withBestLocale:uniqueIdentifier:]):
Removed nil check that  caused the uniqueIdentifier to never be set.
Fixed a bug where the regional dictionary was never being used/merged to the localizedDictionary.

(-[_WKWebExtensionLocalization localizedStringForKey:withPlaceholders:]):
(-[_WKWebExtensionLocalization _localizationDictionaryForWebExtension:withLocale:]):
(-[_WKWebExtensionLocalization _predefinedMessagesForLocale:]):
(localizationDictionaryAtURL): Deleted.
(-[_WKWebExtensionLocalization initWithBundleURL:defaultLocale:uniqueIdentifier:]): Deleted.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::manifest):
(WebKit::WebExtension::serializeLocalization):
(WebKit::WebExtension::resourceDataForPath):
Add support for NSDictionary.

* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
Add localization dictionary to the parameters struct.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Remove _WKWebExtensionLocalization from the Private header.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getMessage):
(WebKit::WebExtensionAPILocalization::getUILanguage):
(WebKit::WebExtensionAPILocalization::getAcceptLanguages):

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::getAll):
(WebKit::WebExtensionAPIPermissions::contains):
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):

* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::parseJSON):
(WebKit::WebExtensionContextProxy::parseLocalization):
(WebKit::WebExtensionContextProxy::parseManifest): Deleted.

* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::getOrCreate):

* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPILocalization.mm: Added.
(TestWebKitAPI::localeStringInWebExtensionFormat):
(TestWebKitAPI::TEST):

* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
(TestWebKitAPI::Util::constructJSArrayOfStrings):
A &quot;stringify&quot; helper method that turns a NSArray of elements into a string.

Canonical link: <a href="https://commits.webkit.org/267674@main">https://commits.webkit.org/267674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9186cbbb6343acb8d58512402c9af8cc8fc4b94f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17371 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17909 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19975 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22465 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20292 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20067 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2119 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->