### PR TITLE
Optimize SVGPathByteStreamBuilder::append()

### DIFF
--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -96,7 +96,7 @@ public:
     DataIterator begin() const { return m_data.begin(); }
     DataIterator end() const { return m_data.end(); }
 
-    void append(unsigned char byte) { m_data.append(byte); }
+    void append(std::span<const unsigned char> bytes) { m_data.append(bytes); }
     void append(const SVGPathByteStream& other) { m_data.appendVector(other.m_data); }
     void clear() { m_data.clear(); }
     bool isEmpty() const { return m_data.isEmpty(); }

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.h
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.h
@@ -52,9 +52,7 @@ private:
     template<typename ByteType>
     void writeType(const ByteType& type)
     {
-        size_t typeSize = sizeof(ByteType);
-        for (size_t i = 0; i < typeSize; ++i)
-            m_byteStream.append(type.bytes[i]);
+        m_byteStream.append(std::span { type.bytes, sizeof(ByteType) });
     }
 
     void writeFlag(bool value)


### PR DESCRIPTION
#### bac6d7369d4bc1f8cba331c2c36c8d7b047f1cb5
<pre>
Optimize SVGPathByteStreamBuilder::append()
<a href="https://bugs.webkit.org/show_bug.cgi?id=260927">https://bugs.webkit.org/show_bug.cgi?id=260927</a>

Reviewed by Ryosuke Niwa.

Optimize SVGPathByteStreamBuilder::append() by appending several bytes at once
instead of appending bytes one by one to the Vector.

* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::append):
* Source/WebCore/svg/SVGPathByteStreamBuilder.h:

Canonical link: <a href="https://commits.webkit.org/267470@main">https://commits.webkit.org/267470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3799583d7974239cc280badb94ca381fc1ec8720

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19242 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15114 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19582 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15884 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15072 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3995 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->