### PR TITLE
Add SelectionMode enum for setRangeText() in HTMLInputElement and HTMLTextAreaElement

### DIFF
--- a/LayoutTests/fast/forms/resources/common-setrangetext.js
+++ b/LayoutTests/fast/forms/resources/common-setrangetext.js
@@ -83,10 +83,10 @@ function runTestsShouldPass(tagName, attributes)
 
     evalAndLog("element.value = '0123456789'");
     evalAndLog("element.setSelectionRange(6, 9)");
-    evalAndLog("element.setRangeText('AB', 1, 1, 'invalid')"); // Invalid selectMode values default to preserve.
-    shouldBeEqualToString("element.value", "0AB123456789");
-    shouldBe("element.selectionStart", "8");
-    shouldBe("element.selectionEnd", "11");
+    shouldThrow("element.setRangeText('AB', 1, 1, 'invalid')"); // Invalid selectMode should throw TypeError
+    shouldBeEqualToString("element.value", "0123456789");
+    shouldBe("element.selectionStart", "6");
+    shouldBe("element.selectionEnd", "9");
 
     evalAndLog("element.value = '0123456789'");
     evalAndLog("element.setSelectionRange(6, 9)");

--- a/LayoutTests/fast/forms/textarea/textarea-setrangetext-expected.txt
+++ b/LayoutTests/fast/forms/textarea/textarea-setrangetext-expected.txt
@@ -78,9 +78,9 @@ PASS element.selectionEnd is 9
 element.value = '0123456789'
 element.setSelectionRange(6, 9)
 element.setRangeText('AB', 1, 1, 'invalid')
-PASS element.value is "0AB123456789"
-PASS element.selectionStart is 8
-PASS element.selectionEnd is 11
+PASS element.value is "0123456789"
+PASS element.selectionStart is 6
+PASS element.selectionEnd is 9
 element.value = '0123456789'
 element.setSelectionRange(6, 9)
 element.setRangeText('A', 1, 3, 'preserve')

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -2,6 +2,7 @@
  * Copyright (C) 2006, 2010 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -82,7 +83,7 @@
     [ImplementedAs=selectionDirectionForBindings] attribute DOMString? selectionDirection;
 
     undefined setRangeText(DOMString replacement);
-    undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional DOMString selectionMode);
+    undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional DOMString selectionMode = "preserve");
 
     [ImplementedAs=setSelectionRangeForBindings] undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 

--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -2,6 +2,7 @@
  * Copyright (C) 2006, 2010 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  * Copyright (C) 2011 Motorola Mobility, Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -55,7 +56,7 @@
     attribute DOMString selectionDirection;
 
     undefined setRangeText(DOMString replacement);
-    undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional DOMString selectionMode);
+    undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional DOMString selectionMode = "preserve");
 
     undefined setSelectionRange(optional unsigned long start = 0, optional unsigned long end = 0, optional DOMString direction);
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -4,7 +4,7 @@
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
- * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -241,7 +241,7 @@ void HTMLTextFormControlElement::dispatchFormControlChangeEvent()
 
 ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacement)
 {
-    return setRangeText(replacement, selectionStart(), selectionEnd(), String());
+    return setRangeText(replacement, selectionStart(), selectionEnd(), "preserve"_s);
 }
 
 ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode)
@@ -265,15 +265,16 @@ ExceptionOr<void> HTMLTextFormControlElement::setRangeText(StringView replacemen
 
     setValue(text, TextFieldEventBehavior::DispatchNoEvent, TextControlSetValueSelection::DoNotSet);
 
-    if (equalLettersIgnoringASCIICase(selectionMode, "select"_s)) {
+    if (selectionMode == "select"_s) {
         newSelectionStart = start;
         newSelectionEnd = start + replacementLength;
-    } else if (equalLettersIgnoringASCIICase(selectionMode, "start"_s))
+    } else if (selectionMode == "start"_s)
         newSelectionStart = newSelectionEnd = start;
-    else if (equalLettersIgnoringASCIICase(selectionMode, "end"_s))
+    else if (selectionMode == "end"_s)
         newSelectionStart = newSelectionEnd = start + replacementLength;
     else {
         // Default is "preserve".
+        ASSERT(selectionMode == "preserve"_s);
         long delta = replacementLength - (end - start);
 
         if (newSelectionStart > end)


### PR DESCRIPTION
<pre>
Add SelectionMode enum for setRangeText() in HTMLInputElement and HTMLTextAreaElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=248901">https://bugs.webkit.org/show_bug.cgi?id=248901</a>
rdar://problem/103369726

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=199316">https://src.chromium.org/viewvc/blink?view=revision&revision=199316</a>

This PR also aligns WebKit to the specification [1] & [2] for 'setRangeText'.

[1] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement</a>
[2] <a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a>

* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/html/HTMLTextAreaElement.idl:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(HTMLTextFormControlElement::setRangeText): Both functions
* LayoutTests/fast/forms/resources/common-setrangetext.js: Updated
* LayoutTests/fast/forms/textarea/textarea-setrangetext-expected.txt: Rebaselined
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3695ff69219d728c5fad5def7b664de37203dc8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17956 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16910 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17286 "2 new passes 4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19312 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14530 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15143 "7 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21921 "3 flakes 101 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15519 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15309 "5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15913 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13503 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->