### PR TITLE
[Yarr] Yarr JIT returns a nested capture when an outer paren matches a zero length string

### DIFF
--- a/JSTests/stress/regexp-lookaround-captures.js
+++ b/JSTests/stress/regexp-lookaround-captures.js
@@ -113,3 +113,9 @@ testRegExp(/abc(?=([iA-\u{103ff}]*)([A-\u{ffff}]+)([A-z]+))/u, "abcABCDEFGHIJK\u
 testRegExp(/(?<=([A-z]+)([A-\u{ffff}]+)([A-\u{103ff}]*))abc/u, "ABCDEFGHIJKabc", ["abc", "A", "B", "CDEFGHIJK"]);
 testRegExp(/(?<=([A-z]+)([A-\u{ffff}]+)([A-\u{103ff}]*))abc/u, "1\u{10420}X\u{273b}\u{10308}ABCDEFGHIJKabc", ["abc", "X", "\u{273b}", "\u{10308}ABCDEFGHIJK"]);
 testRegExp(/(?<=([A]+)([A-\u{103ff}]*))abc/u, "A\u{10420}X\u{273b}\u{10308}ABCDEFGHIJKabc", ["abc", "A", "BCDEFGHIJK"]);
+
+// Test 26
+testRegExp(/(?:(?=(abc)))a/, "abc", ["a", "abc"]);
+testRegExp(/(?:(?=(abc)))?a/, "abc", ["a", undefined]);
+testRegExp(/(?:(?=(abc)))??a/, "abc", ["a", undefined]);
+testRegExp(/(?:(?=(abc)))+a/, "abc", ["a", "abc"]);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -363,7 +363,7 @@ struct PatternTerm {
     {
         ASSERT(this->type == Type::ParenthesesSubpattern
             || this->type == Type::ParentheticalAssertion);
-        return parentheses.lastSubpatternId >= parentheses.subpatternId;
+        return parentheses.lastSubpatternId && parentheses.lastSubpatternId >= parentheses.subpatternId;
     }
 
     void quantify(unsigned count, QuantifierType type)


### PR DESCRIPTION
#### e5b0472ba9a22ebaedf4ddd9cfc3a20c931cc0b3
<pre>
[Yarr] Yarr JIT returns a nested capture when an outer paren matches a zero length string
<a href="https://bugs.webkit.org/show_bug.cgi?id=260928">https://bugs.webkit.org/show_bug.cgi?id=260928</a>
rdar://106376813

Reviewed by Yusuke Suzuki.

Corrected the behavior of the YARR JIT to match the ECMAScript spec and the YARR Interpreter when the matched contents
of a 0 based quantified group is the empty string.  In this case, any nested capture should be undefined.  This
case can happen if the nested contents contain an assertion that captured itself.

The fix is to clear any nested captures when we backtrack through the outer parenthesis group.

* JSTests/stress/regexp-lookaround-captures.js: Added new tests.
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::containsAnyCaptures):

Canonical link: <a href="https://commits.webkit.org/267486@main">https://commits.webkit.org/267486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/827e6d2c84fff74de402f56799494473bd922c33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17199 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19307 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15165 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14436 "Failed to checkout and rebase branch from PR 17254") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19632 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15966 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15938 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18295 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15116 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/4278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4005 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19480 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19517 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15768 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4125 "Passed tests") | 
<!--EWS-Status-Bubble-End-->