### PR TITLE
[webkitcorepy] Add string_utils.split

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
@@ -76,6 +76,19 @@ def join(list, conjunction='and'):
     return '{} {} {}'.format(', '.join(list[:-1]), conjunction, list[-1])
 
 
+def split(string, conjunctions=None):
+    conjunctions = ['and', 'or']
+    if not string:
+        return []
+
+    result = [string]
+    for conjunction in conjunctions:
+        conjunction = ' {} '.format(conjunction)
+        result = [clause.strip() for phrase in result for clause in phrase.split(conjunction) if clause.strip()]
+
+    return [word.strip() for clause in result for word in clause.split(',') if word.strip()]
+
+
 def out_of(number, base):
     number = str(number)
     base = str(base)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
@@ -67,6 +67,14 @@ class StringUtils(unittest.TestCase):
         self.assertEqual(string_utils.join([]), 'Nothing')
         self.assertEqual(string_utils.join(['integer', 'string'], conjunction='or'), 'integer or string')
 
+    def test_split(self):
+        self.assertEqual(string_utils.split('integer, string and float'), ['integer', 'string', 'float'])
+        self.assertEqual(string_utils.split('integer or string and float'), ['integer', 'string', 'float'])
+        self.assertEqual(string_utils.split('integer and string'), ['integer', 'string'])
+        self.assertEqual(string_utils.split('integer'), ['integer'])
+        self.assertEqual(string_utils.split(''), [])
+        self.assertEqual(string_utils.split('integer or string'), ['integer', 'string'])
+
     def test_outof(self):
         self.assertEqual(string_utils.out_of(1, 3), '[1/3]')
         self.assertEqual(string_utils.out_of(1, 10), '[ 1/10]')


### PR DESCRIPTION
#### 003b673b7350d7fad8105c3cccf29195155b52b6
<pre>
[webkitcorepy] Add string_utils.split
<a href="https://bugs.webkit.org/show_bug.cgi?id=261277">https://bugs.webkit.org/show_bug.cgi?id=261277</a>
redar://115116935

Reviewed by Elliott Williams.

string_utils.split is the reverse of string_utils.joins.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py:
(split):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py:
(StringUtils.test_split):

Canonical link: <a href="https://commits.webkit.org/268042@main">https://commits.webkit.org/268042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70b35c68cab4b7b0dc7b9f237b52ea2280b2a8fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18541 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20197 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17706 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22600 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20452 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14173 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/17419 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15854 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4395 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->