### PR TITLE
editing/inserting/insert-paragraph-separator-with-html-elements-crash.html is a consistent failure.

### DIFF
--- a/LayoutTests/editing/inserting/insert-paragraph-separator-with-html-elements-crash.html
+++ b/LayoutTests/editing/inserting/insert-paragraph-separator-with-html-elements-crash.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <script type="text/javascript">
-  if (window.testRunner)
+  if (window.testRunner) {
       testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+  }
   console.log('The test PASS if it does not crash.')
   requestAnimationFrame(function() {
       document.documentElement.addEventListener("DOMNodeRemoved", function() {
@@ -42,5 +44,8 @@
           document.execCommand('InsertParagraph');
       }, {once: true});
       oElement.outerHTML = "";
+
+      if (window.testRunner)
+          testRunner.notifyDone();
   })
 </script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2864,9 +2864,6 @@ webkit.org/b/130490 media/video-remote-control-playpause.html [ Pass Timeout Cra
 
 webkit.org/b/260529 [ Ventura+ x86_64 ] animations/suspend-resume-animation-events.html [ Pass Failure ]
 
-# rdar://114291916 (REGRESSION (266884@main): [ Sonoma wk2 ] editing/inserting/insert-paragraph-separator-with-html-elements-crash.html is a consistent failure)
-[ Sonoma+ ] editing/inserting/insert-paragraph-separator-with-html-elements-crash.html [ Failure ]
-
 webkit.org/b/260870 [ Ventura+ ] imported/w3c/web-platform-tests/svg/import/metadata-example-01-t-manual.svg [ Failure ]
 
 webkit.org/b/260912 [ Monterey+ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html [ Timeout ]


### PR DESCRIPTION
#### 099337e9bba70c533e69212e94fb6190e11d0f61
<pre>
editing/inserting/insert-paragraph-separator-with-html-elements-crash.html is a consistent failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260555">https://bugs.webkit.org/show_bug.cgi?id=260555</a>&gt;:
&lt;rdar://114287454&gt;

Reviewed by Ryosuke Niwa.

The test sets a requestAnimationFrame handler, and we need to wait for that to run.

* LayoutTests/editing/inserting/insert-paragraph-separator-with-html-elements-crash.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/267478@main">https://commits.webkit.org/267478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/224aaf1574c0ea88bee481f53f58571faa0a18fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17158 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19264 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15129 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15295 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15899 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3998 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->