### PR TITLE
Interpolate rotate3D using Quaternions.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-composition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-composition-expected.txt
@@ -28,19 +28,19 @@ PASS Compositing: property <rotate> underlying [1 2 3 270deg] from add [1 2 3 90
 PASS Compositing: property <rotate> underlying [1 2 3 270deg] from add [1 2 3 90deg] to replace [0 1 0 100deg] at (0.25) should be [y 25deg]
 PASS Compositing: property <rotate> underlying [1 2 3 270deg] from add [1 2 3 90deg] to replace [0 1 0 100deg] at (0.75) should be [y 75deg]
 PASS Compositing: property <rotate> underlying [1 2 3 270deg] from add [1 2 3 90deg] to replace [0 1 0 100deg] at (1) should be [y 100deg]
-FAIL Compositing: property <rotate> underlying [1 2 3 270deg] from add [1 2 3 90deg] to replace [0 1 0 100deg] at (2) should be [y 200deg] assert_equals: expected "0 1 0 200deg" but got "0 -1 0 160deg"
+PASS Compositing: property <rotate> underlying [1 2 3 270deg] from add [1 2 3 90deg] to replace [0 1 0 100deg] at (2) should be [y 200deg]
 FAIL Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (-1) should be [0 -1 0 100deg] assert_equals: expected "0 1 0 100deg" but got "0 -1 0 100deg"
 PASS Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (0) should be [0deg]
 PASS Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (0.25) should be [y 25deg]
 PASS Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (0.75) should be [y 75deg]
 PASS Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (1) should be [y 100deg]
-FAIL Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (2) should be [y 200deg] assert_equals: expected "0 1 0 200deg" but got "0 -1 0 160deg"
+PASS Compositing: property <rotate> underlying [1 2 3 90deg] from add [2 4 6 270deg] to replace [0 1 0 100deg] at (2) should be [y 200deg]
 FAIL Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (-1) should be [0.67 -0.06 -0.74 124.97deg] assert_equals: expected "0.67 -0.06 -0.74 124.97deg" but got "0.67 -0.06 -0.74 124.98deg"
 PASS Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (0) should be [0.71 0.71 0 90deg]
 PASS Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (0.25) should be [0.54 0.8 0.26 94.83deg]
 PASS Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (0.75) should be [0.17 0.78 0.61 118.68deg]
 PASS Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (1) should be [0 0.71 0.71 135deg]
-FAIL Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg] assert_equals: expected "-0.52 0.29 0.81 208.96deg" but got "0.52 -0.29 -0.81 151.04deg"
+PASS Compositing: property <rotate> underlying [1 0 0 0deg] from add [1 1 0 90deg] to replace [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg]
 PASS Compositing: property <rotate> underlying [none] from add [none] to replace [0 1 0 100deg] at (-1) should be [y -100deg]
 PASS Compositing: property <rotate> underlying [none] from add [none] to replace [0 1 0 100deg] at (0) should be [y 0deg]
 PASS Compositing: property <rotate> underlying [none] from add [none] to replace [0 1 0 100deg] at (0.25) should be [y 25deg]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-interpolation-expected.txt
@@ -292,25 +292,25 @@ PASS CSS Transitions: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at 
 PASS CSS Transitions: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.25) should be [0.54 0.8 0.26 94.83deg]
 PASS CSS Transitions: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.75) should be [0.17 0.78 0.61 118.68deg]
 PASS CSS Transitions: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (1) should be [0 0.71 0.71 135deg]
-FAIL CSS Transitions: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg] assert_equals: expected "- 0.52 0.29 0.81 208.96deg " but got "0.52 - 0.29 - 0.81 151.04deg "
+PASS CSS Transitions: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg]
 FAIL CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (-1) should be [0.67 -0.06 -0.74 124.97deg] assert_equals: expected "0.67 - 0.06 - 0.74 124.97deg " but got "0.67 - 0.06 - 0.74 124.98deg "
 PASS CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0) should be [0.71 0.71 0 90deg]
 PASS CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.25) should be [0.54 0.8 0.26 94.83deg]
 PASS CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.75) should be [0.17 0.78 0.61 118.68deg]
 PASS CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (1) should be [0 0.71 0.71 135deg]
-FAIL CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg] assert_equals: expected "- 0.52 0.29 0.81 208.96deg " but got "0.52 - 0.29 - 0.81 151.04deg "
+PASS CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg]
 FAIL CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (-1) should be [0.67 -0.06 -0.74 124.97deg] assert_equals: expected "0.67 - 0.06 - 0.74 124.97deg " but got "0.67 - 0.06 - 0.74 124.98deg "
 PASS CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0) should be [0.71 0.71 0 90deg]
 PASS CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.25) should be [0.54 0.8 0.26 94.83deg]
 PASS CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.75) should be [0.17 0.78 0.61 118.68deg]
 PASS CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (1) should be [0 0.71 0.71 135deg]
-FAIL CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg] assert_equals: expected "- 0.52 0.29 0.81 208.96deg " but got "0.52 - 0.29 - 0.81 151.04deg "
+PASS CSS Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg]
 FAIL Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (-1) should be [0.67 -0.06 -0.74 124.97deg] assert_equals: expected "0.67 - 0.06 - 0.74 124.97deg " but got "0.67 - 0.06 - 0.74 124.98deg "
 PASS Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0) should be [0.71 0.71 0 90deg]
 PASS Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.25) should be [0.54 0.8 0.26 94.83deg]
 PASS Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (0.75) should be [0.17 0.78 0.61 118.68deg]
 PASS Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (1) should be [0 0.71 0.71 135deg]
-FAIL Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg] assert_equals: expected "- 0.52 0.29 0.81 208.96deg " but got "0.52 - 0.29 - 0.81 151.04deg "
+PASS Web Animations: property <rotate> from [1 1 0 90deg] to [0 1 1 135deg] at (2) should be [-0.52 0.29 0.81 208.96deg]
 PASS CSS Transitions: property <rotate> from [0 1 0 0deg] to [1 0 0 450deg] at (-1) should be [1 0 0 -450deg]
 PASS CSS Transitions: property <rotate> from [0 1 0 0deg] to [1 0 0 450deg] at (0) should be [1 0 0 0deg]
 PASS CSS Transitions: property <rotate> from [0 1 0 0deg] to [1 0 0 450deg] at (0.25) should be [1 0 0 112.5deg]

--- a/Source/WebCore/platform/graphics/transforms/Quaternion.cpp
+++ b/Source/WebCore/platform/graphics/transforms/Quaternion.cpp
@@ -30,6 +30,17 @@
 
 namespace WebCore {
 
+Quaternion Quaternion::fromRotate3d(double x, double y, double z, double angle)
+{
+    double toLength = std::hypot(x, y, z);
+    if (std::abs(toLength) <= 0.00001)
+        return { 0, 0, 0, 1 };
+
+    angle = deg2rad(angle);
+    double scale = std::sin(0.5 * angle) / toLength;
+    return { scale * x, scale * y, scale * z, std::cos(0.5 * angle) };
+}
+
 // Perform a spherical linear interpolation between the two
 // passed quaternions with 0 <= t <= 1.
 

--- a/Source/WebCore/platform/graphics/transforms/Quaternion.h
+++ b/Source/WebCore/platform/graphics/transforms/Quaternion.h
@@ -37,6 +37,8 @@ struct Quaternion {
         return x == other.x && y == other.y && z == other.z && w == other.w;
     }
 
+    static Quaternion fromRotate3d(double x, double y, double z, double angle);
+
     Quaternion slerp(const Quaternion& other, double progress);
     Quaternion accumulate(const Quaternion& other);
     Quaternion interpolate(const Quaternion& other, double progress, CompositeOperation);


### PR DESCRIPTION
#### a1ce34e080b66f2318a698fbf934abb82301b61f
<pre>
Interpolate rotate3D using Quaternions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260932">https://bugs.webkit.org/show_bug.cgi?id=260932</a>
&lt;rdar://114732141&gt;

Reviewed by NOBODY (OOPS!).

Looks like the other engines are doing this (despite it not being what the spec says), and it&apos;s needed to pass tests.

Filed <a href="https://github.com/w3c/csswg-drafts/issues/9278">https://github.com/w3c/csswg-drafts/issues/9278</a> to get the spec to reflect reality here.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-composition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-interpolation-expected.txt:
* Source/WebCore/platform/graphics/transforms/Quaternion.cpp:
(WebCore::Quaternion::fromRotate3d):
* Source/WebCore/platform/graphics/transforms/Quaternion.h:
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
(WebCore::RotateTransformOperation::blend):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1ce34e080b66f2318a698fbf934abb82301b61f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17474 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18484 "Failed to compile WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17165 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/18484 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19269 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21900 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19609 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13498 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->