### PR TITLE
Use memcpy in SVGPathByteStreamSource::readType

### DIFF
--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -26,17 +26,6 @@
 
 namespace WebCore {
 
-// Type definitions for the byte stream data
-typedef union {
-    bool value;
-    unsigned char bytes[sizeof(bool)];
-} BoolByte;
-
-typedef union {
-    float value;
-    unsigned char bytes[sizeof(float)];
-} FloatByte;
-
 class SVGPathByteStream {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.cpp
@@ -34,7 +34,7 @@ SVGPathByteStreamBuilder::SVGPathByteStreamBuilder(SVGPathByteStream& byteStream
 
 void SVGPathByteStreamBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ?  SVGPathSegType::MoveToRel : SVGPathSegType::MoveToAbs);
+    writeType(mode == RelativeCoordinates ?  SVGPathSegType::MoveToRel : SVGPathSegType::MoveToAbs);
     writeFloatPoint(targetPoint);
 }
 
@@ -46,19 +46,19 @@ void SVGPathByteStreamBuilder::lineTo(const FloatPoint& targetPoint, PathCoordin
 
 void SVGPathByteStreamBuilder::lineToHorizontal(float x, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::LineToHorizontalRel : SVGPathSegType::LineToHorizontalAbs);
-    writeFloat(x);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::LineToHorizontalRel : SVGPathSegType::LineToHorizontalAbs);
+    writeType(x);
 }
 
 void SVGPathByteStreamBuilder::lineToVertical(float y, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::LineToVerticalRel : SVGPathSegType::LineToVerticalAbs);
-    writeFloat(y);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::LineToVerticalRel : SVGPathSegType::LineToVerticalAbs);
+    writeType(y);
 }
 
 void SVGPathByteStreamBuilder::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::CurveToCubicRel : SVGPathSegType::CurveToCubicAbs);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToCubicRel : SVGPathSegType::CurveToCubicAbs);
     writeFloatPoint(point1);
     writeFloatPoint(point2);
     writeFloatPoint(targetPoint);
@@ -66,38 +66,38 @@ void SVGPathByteStreamBuilder::curveToCubic(const FloatPoint& point1, const Floa
 
 void SVGPathByteStreamBuilder::curveToCubicSmooth(const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::CurveToCubicSmoothRel : SVGPathSegType::CurveToCubicSmoothAbs);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToCubicSmoothRel : SVGPathSegType::CurveToCubicSmoothAbs);
     writeFloatPoint(point2);
     writeFloatPoint(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::curveToQuadratic(const FloatPoint& point1, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::CurveToQuadraticRel : SVGPathSegType::CurveToQuadraticAbs);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToQuadraticRel : SVGPathSegType::CurveToQuadraticAbs);
     writeFloatPoint(point1);
     writeFloatPoint(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::curveToQuadraticSmooth(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::CurveToQuadraticSmoothRel : SVGPathSegType::CurveToQuadraticSmoothAbs);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToQuadraticSmoothRel : SVGPathSegType::CurveToQuadraticSmoothAbs);
     writeFloatPoint(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::arcTo(float r1, float r2, float angle, bool largeArcFlag, bool sweepFlag, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
-    writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::ArcRel : SVGPathSegType::ArcAbs);
-    writeFloat(r1);
-    writeFloat(r2);
-    writeFloat(angle);
-    writeFlag(largeArcFlag);
-    writeFlag(sweepFlag);
+    writeType(mode == RelativeCoordinates ? SVGPathSegType::ArcRel : SVGPathSegType::ArcAbs);
+    writeType(r1);
+    writeType(r2);
+    writeType(angle);
+    writeType(largeArcFlag);
+    writeType(sweepFlag);
     writeFloatPoint(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::closePath()
 {
-    writeSegmentType(SVGPathSegType::ClosePath);
+    writeType(SVGPathSegType::ClosePath);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.h
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.h
@@ -51,30 +51,22 @@ private:
     void curveToQuadraticSmooth(const FloatPoint&, PathCoordinateMode) final;
     void arcTo(float, float, float, bool largeArcFlag, bool sweepFlag, const FloatPoint&, PathCoordinateMode) final;
 
-    template<typename ByteType>
-    void writeType(const ByteType& type)
+    template<typename DataType>
+    void writeType(const DataType& data)
     {
+        typedef union {
+            DataType value;
+            uint8_t bytes[sizeof(DataType)];
+        } ByteType;
+
+        ByteType type = { data };
         m_byteStream.append(std::span { type.bytes, sizeof(ByteType) });
-    }
-
-    void writeFlag(bool value)
-    {
-        BoolByte data;
-        data.value = value;
-        writeType(data);
-    }
-
-    void writeFloat(float value)
-    {
-        FloatByte data;
-        data.value = value;
-        writeType(data);
     }
 
     void writeFloatPoint(const FloatPoint& point)
     {
-        writeFloat(point.x());
-        writeFloat(point.y());
+        writeType(point.x());
+        writeType(point.y());
     }
 
     void writeSegmentType(SVGPathSegType type)

--- a/Source/WebCore/svg/SVGPathByteStreamSource.h
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.h
@@ -48,43 +48,38 @@ private:
 #if COMPILER(MSVC)
 #pragma warning(disable: 4701)
 #endif
-    template<typename DataType, typename ByteType>
+    template<typename DataType>
     DataType readType()
     {
-        ByteType data;
-        size_t typeSize = sizeof(ByteType);
+        DataType data;
+        size_t dataSize = sizeof(DataType);
 
-        for (size_t i = 0; i < typeSize; ++i) {
-            ASSERT_WITH_SECURITY_IMPLICATION(m_streamCurrent < m_streamEnd);
-            data.bytes[i] = *m_streamCurrent;
-            ++m_streamCurrent;
-        }
-
-        return data.value;
+        ASSERT_WITH_SECURITY_IMPLICATION(m_streamCurrent + dataSize <= m_streamEnd);
+        memcpy(&data, m_streamCurrent, dataSize);
+        m_streamCurrent += dataSize;
+        return data;
     }
 
     bool readFlag()
     {
-        return readType<bool, BoolByte>();
+        return readType<bool>();
     }
 
     float readFloat()
     {
-        return readType<float, FloatByte>();
+        return readType<float>();
     }
 
     SVGPathSegType readSVGSegmentType()
     {
         static_assert(std::is_same_v<std::underlying_type_t<SVGPathSegType>, uint8_t>);
-        uint8_t byte = *m_streamCurrent;
-        ++m_streamCurrent;
-        return static_cast<SVGPathSegType>(byte);
+        return static_cast<SVGPathSegType>(readType<uint8_t>());
     }
 
     FloatPoint readFloatPoint()
     {
-        float x = readType<float, FloatByte>();
-        float y = readType<float, FloatByte>();
+        float x = readType<float>();
+        float y = readType<float>();
         return FloatPoint(x, y);
     }
 


### PR DESCRIPTION
#### e2aa0c20fc47b29231c6e5413347d827c36d4186
<pre>
Use memcpy in SVGPathByteStreamSource::readType
<a href="https://bugs.webkit.org/show_bug.cgi?id=250676">https://bugs.webkit.org/show_bug.cgi?id=250676</a>
rdar://104552389

Reviewed by Ryosuke Niwa.

Use memcpy in SVGPathByteStreamSource::readType and simplify the
SVGPathByteStreamBuilder::writeType() logic.

* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::append):
(): Deleted.
* Source/WebCore/svg/SVGPathByteStreamBuilder.cpp:
(WebCore::SVGPathByteStreamBuilder::moveTo):
(WebCore::SVGPathByteStreamBuilder::lineTo):
(WebCore::SVGPathByteStreamBuilder::lineToHorizontal):
(WebCore::SVGPathByteStreamBuilder::lineToVertical):
(WebCore::SVGPathByteStreamBuilder::curveToCubic):
(WebCore::SVGPathByteStreamBuilder::curveToCubicSmooth):
(WebCore::SVGPathByteStreamBuilder::curveToQuadratic):
(WebCore::SVGPathByteStreamBuilder::curveToQuadraticSmooth):
(WebCore::SVGPathByteStreamBuilder::arcTo):
(WebCore::SVGPathByteStreamBuilder::closePath):
* Source/WebCore/svg/SVGPathByteStreamBuilder.h:
* Source/WebCore/svg/SVGPathByteStreamSource.h:

Canonical link: <a href="https://commits.webkit.org/267523@main">https://commits.webkit.org/267523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/668d2f42ebe848f72c67ec7bb5565a7046f02579

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16830 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17291 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19412 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15256 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15624 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19741 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16030 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15203 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->