### PR TITLE
[motion-path] Update "<coord-box>" implementation for offset-path

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5290,11 +5290,8 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-011.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-014.html [ ImageOnlyFailure ]
 
-# CSS motion path tests for missing <coord-box> support.
+# CSS motion path tests for missing <coord-box> support with border-radius.
 imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-004.html [ ImageOnlyFailure ]
 
 # CSS motion path tests for missing parsing support for <coord-box> with ray.
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-015.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -29,6 +29,7 @@
 
 namespace WebCore {
 
+class BoxPathOperation;
 class RenderElement;
 class PathOperation;
 class RayPathOperation;
@@ -44,6 +45,7 @@ public:
     static std::optional<MotionPathData> motionPathDataForRenderer(const RenderElement&);
     static bool needsUpdateAfterContainingBlockLayout(const PathOperation&);
     static void applyMotionPathTransform(const RenderStyle&, const TransformOperationData&, TransformationMatrix&);
+    WEBCORE_EXPORT static std::optional<Path> computePathForBox(const BoxPathOperation&, const TransformOperationData&);
     static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&);
     static double lengthForRayPath(const RayPathOperation&, const MotionPathData&);
     static double lengthForRayContainPath(const FloatRect& elementRect, double computedPathLength);

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -173,15 +173,9 @@ public:
         return adoptRef(*new BoxPathOperation(referenceBox));
     }
 
-    static Ref<BoxPathOperation> create(Path&& path, CSSBoxType referenceBox)
-    {
-        return adoptRef(*new BoxPathOperation(WTFMove(path), referenceBox));
-    }
-
     Ref<PathOperation> clone() const final
     {
-        auto path = m_path;
-        return adoptRef(*new BoxPathOperation(WTFMove(path), m_referenceBox));
+        return adoptRef(*new BoxPathOperation(m_referenceBox));
     }
 
     const Path pathForReferenceRect(const FloatRoundedRect& boundingRect) const
@@ -191,8 +185,10 @@ public:
         return path;
     }
     
-    const std::optional<Path> getPath(const TransformOperationData&) const final { return m_path; }
-    const Path& path() const { return m_path; }
+    const std::optional<Path> getPath(const TransformOperationData& data) const final
+    {
+        return MotionPath::computePathForBox(*this, data);
+    }
     CSSBoxType referenceBox() const { return m_referenceBox; }
 
 private:
@@ -209,15 +205,6 @@ private:
         , m_referenceBox(referenceBox)
     {
     }
-
-    BoxPathOperation(Path&& path, CSSBoxType referenceBox)
-        : PathOperation(Box)
-        , m_path(WTFMove(path))
-        , m_referenceBox(referenceBox)
-    {
-    }
-
-    Path m_path;
     CSSBoxType m_referenceBox;
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2702,7 +2702,6 @@ header: <WebCore/PathOperation.h>
 }
 
 [RefCounted, CustomHeader] class WebCore::BoxPathOperation {
-    WebCore::Path path();
     WebCore::CSSBoxType referenceBox();
 }
 


### PR DESCRIPTION
#### c377f2da36eb80d46bc851a8090f020bab79752f
<pre>
[motion-path] Update &quot;&lt;coord-box&gt;&quot; implementation for offset-path
<a href="https://bugs.webkit.org/show_bug.cgi?id=260944">https://bugs.webkit.org/show_bug.cgi?id=260944</a>
rdar://110938788

Reviewed by Tim Nguyen.

Update coord-box to use the containing block&apos;s bounding rect if it
 exists. We also need to take into account the containing block&apos;s
border radius.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::offsetFromContainer):
(WebCore::MotionPath::motionPathDataForRenderer):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::BoxPathOperation::getPath const):
* Source/WebCore/rendering/PathOperation.h:

Canonical link: <a href="https://commits.webkit.org/267524@main">https://commits.webkit.org/267524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/479a6fddfbe1b9c393fba3a8fe375200a78ad4a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17384 "Passed tests") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14562 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19402 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15246 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19557 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2076 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->