### PR TITLE
Let the compiler generate more comparison operators in WebCore

### DIFF
--- a/Source/WebCore/Modules/highlight/AppHighlightRangeData.h
+++ b/Source/WebCore/Modules/highlight/AppHighlightRangeData.h
@@ -61,10 +61,7 @@ public:
         {
         }
 
-        bool operator==(const NodePathComponent& other) const
-        {
-            return identifier == other.identifier && nodeName == other.nodeName && textData == other.textData && pathIndex == other.pathIndex;
-        }
+        friend bool operator==(const NodePathComponent&, const NodePathComponent&) = default;
     };
 
     using NodePath = Vector<NodePathComponent>;

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
@@ -62,10 +62,7 @@ public:
         return m_databaseName.isNull();
     }
 
-    bool operator==(const IDBDatabaseIdentifier& other) const
-    {
-        return other.m_databaseName == m_databaseName && other.m_origin == m_origin && other.m_isTransient == m_isTransient;
-    }
+    friend bool operator==(const IDBDatabaseIdentifier&, const IDBDatabaseIdentifier&) = default;
 
     const String& databaseName() const { return m_databaseName; }
     const ClientOrigin& origin() const { return m_origin; }

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
@@ -55,11 +55,7 @@ public:
         return !m_resourceNumber && !m_idbConnectionIdentifier;
     }
 
-    bool operator==(const IDBResourceIdentifier& other) const
-    {
-        return m_idbConnectionIdentifier == other.m_idbConnectionIdentifier
-            && m_resourceNumber == other.m_resourceNumber;
-    }
+    friend bool operator==(const IDBResourceIdentifier&, const IDBResourceIdentifier&) = default;
     
     IDBConnectionIdentifier connectionIdentifier() const { return m_idbConnectionIdentifier; }
 

--- a/Source/WebCore/Modules/mediasession/MediaPositionState.h
+++ b/Source/WebCore/Modules/mediasession/MediaPositionState.h
@@ -36,7 +36,7 @@ struct MediaPositionState {
 
     String toJSONString() const;
 
-    bool operator==(const MediaPositionState& other) const { return duration == other.duration && playbackRate == other.playbackRate && position == other.position; }
+    friend bool operator==(const MediaPositionState&, const MediaPositionState&) = default;
 };
 
 }

--- a/Source/WebCore/Modules/permissions/PermissionDescriptor.h
+++ b/Source/WebCore/Modules/permissions/PermissionDescriptor.h
@@ -33,7 +33,7 @@ namespace WebCore {
 struct PermissionDescriptor {
     PermissionName name;
 
-    bool operator==(const PermissionDescriptor& descriptor) const { return name == descriptor.name; }
+    friend bool operator==(PermissionDescriptor, PermissionDescriptor) = default;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -317,7 +317,7 @@ private:
         TailProcessingNode& operator=(const TailProcessingNode&) = delete;
         TailProcessingNode& operator=(TailProcessingNode&&) = delete;
         AudioNode* operator->() const { return m_node.get(); }
-        bool operator==(const TailProcessingNode& other) const { return m_node == other.m_node; }
+        friend bool operator==(const TailProcessingNode&, const TailProcessingNode&) = default;
         bool operator==(const AudioNode& node) const { return m_node == &node; }
     private:
         RefPtr<AudioNode> m_node;

--- a/Source/WebCore/PAL/pal/SessionID.h
+++ b/Source/WebCore/PAL/pal/SessionID.h
@@ -70,7 +70,7 @@ public:
     bool isHashTableDeletedValue() const { return m_identifier == HashTableDeletedValueID; }
 
     uint64_t toUInt64() const { return m_identifier; }
-    bool operator==(SessionID sessionID) const { return m_identifier == sessionID.m_identifier; }
+    friend bool operator==(SessionID, SessionID) = default;
     bool isAlwaysOnLoggingAllowed() const { return !isEphemeral(); }
 
     template<class Encoder> void encode(Encoder&) const;

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -130,14 +130,6 @@ ModifyHeadersAction ModifyHeadersAction::isolatedCopy() &&
     return { crossThreadCopy(WTFMove(requestHeaders)), crossThreadCopy(WTFMove(responseHeaders)), crossThreadCopy(priority) };
 }
 
-bool ModifyHeadersAction::operator==(const ModifyHeadersAction& other) const
-{
-    return other.hashTableType == this->hashTableType
-        && other.requestHeaders == this->requestHeaders
-        && other.responseHeaders == this->responseHeaders
-        && other.priority == this->priority;
-}
-
 void ModifyHeadersAction::serialize(Vector<uint8_t>& vector) const
 {
     auto beginIndex = vector.size();
@@ -257,11 +249,6 @@ auto ModifyHeadersAction::ModifyHeaderInfo::isolatedCopy() && -> ModifyHeaderInf
     return { crossThreadCopy(WTFMove(operation)) };
 }
 
-bool ModifyHeadersAction::ModifyHeaderInfo::operator==(const ModifyHeaderInfo& other) const
-{
-    return other.operation == this->operation;
-}
-
 void ModifyHeadersAction::ModifyHeaderInfo::serialize(Vector<uint8_t>& vector) const
 {
     auto beginIndex = vector.size();
@@ -350,12 +337,6 @@ RedirectAction RedirectAction::isolatedCopy() const &
 RedirectAction RedirectAction::isolatedCopy() &&
 {
     return { crossThreadCopy(WTFMove(action)) };
-}
-
-bool RedirectAction::operator==(const RedirectAction& other) const
-{
-    return other.hashTableType == this->hashTableType
-        && other.action == this->action;
 }
 
 void RedirectAction::serialize(Vector<uint8_t>& vector) const
@@ -557,18 +538,6 @@ auto RedirectAction::URLTransformAction::isolatedCopy() && -> URLTransformAction
 {
     return { crossThreadCopy(WTFMove(fragment)), crossThreadCopy(WTFMove(host)), crossThreadCopy(WTFMove(password)), crossThreadCopy(WTFMove(path)), crossThreadCopy(WTFMove(port)),
         crossThreadCopy(WTFMove(queryTransform)), crossThreadCopy(WTFMove(scheme)), crossThreadCopy(WTFMove(username)) };
-}
-
-bool RedirectAction::URLTransformAction::operator==(const URLTransformAction& other) const
-{
-    return other.fragment == this->fragment
-        && other.host == this->host
-        && other.password == this->password
-        && other.path == this->path
-        && other.port == this->port
-        && other.queryTransform == this->queryTransform
-        && other.scheme == this->scheme
-        && other.username == this->username;
 }
 
 void RedirectAction::URLTransformAction::serialize(Vector<uint8_t>& vector) const
@@ -853,12 +822,6 @@ auto RedirectAction::URLTransformAction::QueryTransform::isolatedCopy() && -> Qu
     return { crossThreadCopy(WTFMove(addOrReplaceParams)), crossThreadCopy(WTFMove(removeParams)) };
 }
 
-bool RedirectAction::URLTransformAction::QueryTransform::operator==(const QueryTransform& other) const
-{
-    return other.addOrReplaceParams == this->addOrReplaceParams
-        && other.removeParams == this->removeParams;
-}
-
 void RedirectAction::URLTransformAction::QueryTransform::serialize(Vector<uint8_t>& vector) const
 {
     auto beginIndex = vector.size();
@@ -923,13 +886,6 @@ auto RedirectAction::URLTransformAction::QueryTransform::QueryKeyValue::parse(co
         replaceOnly = *boolean;
 
     return { { WTFMove(key), replaceOnly, WTFMove(value) } };
-}
-
-bool RedirectAction::URLTransformAction::QueryTransform::QueryKeyValue::operator==(const QueryKeyValue& other) const
-{
-    return other.key == this->key
-        && other.replaceOnly == this->replaceOnly
-        && other.value == this->value;
 }
 
 void RedirectAction::URLTransformAction::QueryTransform::QueryKeyValue::serialize(Vector<uint8_t>& vector) const

--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -43,7 +43,7 @@ using SerializedActionByte = uint8_t;
 
 template<typename T> struct ActionWithoutMetadata {
     T isolatedCopy() const { return { }; }
-    bool operator==(const ActionWithoutMetadata&) const { return true; }
+    friend bool operator==(const ActionWithoutMetadata&, const ActionWithoutMetadata&) = default;
     void serialize(Vector<uint8_t>&) const { }
     static T deserialize(std::span<const uint8_t>) { return { }; }
     static size_t serializedLength(std::span<const uint8_t>) { return 0; }
@@ -53,7 +53,7 @@ template<typename T> struct ActionWithStringMetadata {
     String string;
     T isolatedCopy() const & { return { { string.isolatedCopy() } }; }
     T isolatedCopy() && { return { { WTFMove(string).isolatedCopy() } }; }
-    bool operator==(const ActionWithStringMetadata& other) const { return other.string == this->string; }
+    friend bool operator==(const ActionWithStringMetadata&, const ActionWithStringMetadata&) = default;
     void serialize(Vector<uint8_t>& vector) const { serializeString(vector, string); }
     static T deserialize(std::span<const uint8_t> span) { return { { deserializeString(span) } }; }
     static size_t serializedLength(std::span<const uint8_t> span) { return stringSerializedLength(span); }
@@ -76,7 +76,7 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
 
             AppendOperation isolatedCopy() const & { return { header.isolatedCopy(), value.isolatedCopy() }; }
             AppendOperation isolatedCopy() && { return { WTFMove(header).isolatedCopy(), WTFMove(value).isolatedCopy() }; }
-            bool operator==(const AppendOperation& other) const { return other.header == this->header && other.value == this->value; }
+            friend bool operator==(const AppendOperation&, const AppendOperation&) = default;
         };
         struct SetOperation {
             String header;
@@ -84,14 +84,14 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
 
             SetOperation isolatedCopy() const & { return { header.isolatedCopy(), value.isolatedCopy() }; }
             SetOperation isolatedCopy() && { return { WTFMove(header).isolatedCopy(), WTFMove(value).isolatedCopy() }; }
-            bool operator==(const SetOperation& other) const { return other.header == this->header && other.value == this->value; }
+            friend bool operator==(const SetOperation&, const SetOperation&) = default;
         };
         struct RemoveOperation {
             String header;
 
             RemoveOperation isolatedCopy() const & { return { header.isolatedCopy() }; }
             RemoveOperation isolatedCopy() && { return { WTFMove(header).isolatedCopy() }; }
-            bool operator==(const RemoveOperation& other) const { return other.header == this->header; }
+            friend bool operator==(const RemoveOperation&, const RemoveOperation&) = default;
         };
         using OperationVariant = std::variant<AppendOperation, SetOperation, RemoveOperation>;
         OperationVariant operation;
@@ -99,7 +99,7 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
         static Expected<ModifyHeaderInfo, std::error_code> parse(const JSON::Value&);
         ModifyHeaderInfo isolatedCopy() const &;
         ModifyHeaderInfo isolatedCopy() &&;
-        bool operator==(const ModifyHeaderInfo&) const;
+        friend bool operator==(const ModifyHeaderInfo&, const ModifyHeaderInfo&) = default;
         void serialize(Vector<uint8_t>&) const;
         static ModifyHeaderInfo deserialize(std::span<const uint8_t>);
         static size_t serializedLength(std::span<const uint8_t>);
@@ -126,7 +126,7 @@ struct WEBCORE_EXPORT ModifyHeadersAction {
     static Expected<ModifyHeadersAction, std::error_code> parse(const JSON::Object&);
     ModifyHeadersAction isolatedCopy() const &;
     ModifyHeadersAction isolatedCopy() &&;
-    bool operator==(const ModifyHeadersAction&) const;
+    friend bool operator==(const ModifyHeadersAction&, const ModifyHeadersAction&) = default;
     void serialize(Vector<uint8_t>&) const;
     static ModifyHeadersAction deserialize(std::span<const uint8_t>);
     static size_t serializedLength(std::span<const uint8_t>);
@@ -139,7 +139,7 @@ struct WEBCORE_EXPORT RedirectAction {
 
         ExtensionPathAction isolatedCopy() const & { return { extensionPath.isolatedCopy() }; }
         ExtensionPathAction isolatedCopy() && { return { WTFMove(extensionPath).isolatedCopy() }; }
-        bool operator==(const ExtensionPathAction& other) const { return other.extensionPath == this->extensionPath; }
+        friend bool operator==(const ExtensionPathAction&, const ExtensionPathAction&) = default;
     };
     struct RegexSubstitutionAction {
         String regexSubstitution;
@@ -149,7 +149,7 @@ struct WEBCORE_EXPORT RedirectAction {
         RegexSubstitutionAction isolatedCopy() && { return { WTFMove(regexSubstitution).isolatedCopy(), WTFMove(regexFilter).isolatedCopy() }; }
         void serialize(Vector<uint8_t>&) const;
         static RegexSubstitutionAction deserialize(std::span<const uint8_t>);
-        bool operator==(const RegexSubstitutionAction& other) const { return other.regexSubstitution == this->regexSubstitution && other.regexFilter == this->regexFilter; }
+        friend bool operator==(const RegexSubstitutionAction&, const RegexSubstitutionAction&) = default;
         WEBCORE_EXPORT void applyToURL(URL&) const;
     };
     struct URLTransformAction {
@@ -162,7 +162,7 @@ struct WEBCORE_EXPORT RedirectAction {
                 static Expected<QueryKeyValue, std::error_code> parse(const JSON::Value&);
                 QueryKeyValue isolatedCopy() const & { return { key.isolatedCopy(), replaceOnly, value.isolatedCopy() }; }
                 QueryKeyValue isolatedCopy() && { return { WTFMove(key).isolatedCopy(), replaceOnly, WTFMove(value).isolatedCopy() }; }
-                bool operator==(const QueryKeyValue&) const;
+                friend bool operator==(const QueryKeyValue&, const QueryKeyValue&) = default;
                 void serialize(Vector<uint8_t>&) const;
                 static QueryKeyValue deserialize(std::span<const uint8_t>);
                 static size_t serializedLength(std::span<const uint8_t>);
@@ -174,7 +174,7 @@ struct WEBCORE_EXPORT RedirectAction {
             static Expected<QueryTransform, std::error_code> parse(const JSON::Object&);
             QueryTransform isolatedCopy() const &;
             QueryTransform isolatedCopy() &&;
-            bool operator==(const QueryTransform&) const;
+            friend bool operator==(const QueryTransform&, const QueryTransform&) = default;
             void serialize(Vector<uint8_t>&) const;
             static QueryTransform deserialize(std::span<const uint8_t>);
             static size_t serializedLength(std::span<const uint8_t>);
@@ -194,7 +194,7 @@ struct WEBCORE_EXPORT RedirectAction {
         static Expected<URLTransformAction, std::error_code> parse(const JSON::Object&);
         URLTransformAction isolatedCopy() const &;
         URLTransformAction isolatedCopy() &&;
-        bool operator==(const URLTransformAction&) const;
+        friend bool operator==(const URLTransformAction&, const URLTransformAction&) = default;
         void serialize(Vector<uint8_t>&) const;
         static URLTransformAction deserialize(std::span<const uint8_t>);
         static size_t serializedLength(std::span<const uint8_t>);
@@ -205,7 +205,7 @@ struct WEBCORE_EXPORT RedirectAction {
 
         URLAction isolatedCopy() const & { return { url.isolatedCopy() }; }
         URLAction isolatedCopy() && { return { WTFMove(url).isolatedCopy() }; }
-        bool operator==(const URLAction& other) const { return other.url == this->url; }
+        friend bool operator==(const URLAction&, const URLAction&) = default;
     };
 
     enum class HashTableType : uint8_t { Empty, Deleted, Full } hashTableType;
@@ -225,7 +225,7 @@ struct WEBCORE_EXPORT RedirectAction {
     static Expected<RedirectAction, std::error_code> parse(const JSON::Object&, const String& urlFilter);
     RedirectAction isolatedCopy() const &;
     RedirectAction isolatedCopy() &&;
-    bool operator==(const RedirectAction&) const;
+    friend bool operator==(const RedirectAction&, const RedirectAction&) = default;
     void serialize(Vector<uint8_t>&) const;
     static RedirectAction deserialize(std::span<const uint8_t>);
     static size_t serializedLength(std::span<const uint8_t>);

--- a/Source/WebCore/contentextensions/ContentExtensionRule.h
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.h
@@ -70,15 +70,7 @@ struct Trigger {
             && conditions.isEmpty();
     }
 
-    bool operator==(const Trigger& other) const
-    {
-        return urlFilter == other.urlFilter
-            && urlFilterIsCaseSensitive == other.urlFilterIsCaseSensitive
-            && topURLFilterIsCaseSensitive == other.topURLFilterIsCaseSensitive
-            && frameURLFilterIsCaseSensitive == other.frameURLFilterIsCaseSensitive
-            && flags == other.flags
-            && conditions == other.conditions;
-    }
+    friend bool operator==(const Trigger&, const Trigger&) = default;
 };
 
 inline void add(Hasher& hasher, const Trigger& trigger)
@@ -127,7 +119,7 @@ struct Action {
     Action(ActionData&& data)
         : m_data(WTFMove(data)) { }
 
-    bool operator==(const Action& other) const { return m_data == other.m_data; }
+    friend bool operator==(const Action&, const Action&) = default;
 
     const ActionData& data() const { return m_data; }
 
@@ -161,10 +153,7 @@ public:
 
     ContentExtensionRule isolatedCopy() const & { return { m_trigger.isolatedCopy(), m_action.isolatedCopy() }; }
     ContentExtensionRule isolatedCopy() && { return { WTFMove(m_trigger).isolatedCopy(), WTFMove(m_action).isolatedCopy() }; }
-    bool operator==(const ContentExtensionRule& other) const
-    {
-        return m_trigger == other.m_trigger && m_action == other.m_action;
-    }
+    friend bool operator==(const ContentExtensionRule&, const ContentExtensionRule&) = default;
 
 private:
     Trigger m_trigger;

--- a/Source/WebCore/contentextensions/NFAToDFA.cpp
+++ b/Source/WebCore/contentextensions/NFAToDFA.cpp
@@ -162,10 +162,7 @@ public:
         fastFree(m_uniqueNodeIdSetBuffer);
     }
 
-    bool operator==(const UniqueNodeIdSet& other) const
-    {
-        return m_uniqueNodeIdSetBuffer == other.m_uniqueNodeIdSetBuffer;
-    }
+    friend bool operator==(const UniqueNodeIdSet&, const UniqueNodeIdSet&) = default;
 
     bool operator==(const NodeIdSet& other) const
     {

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -158,12 +158,7 @@ private:
             return WTF::bitCount(m_characters[0]) + WTF::bitCount(m_characters[1]);
         }
         
-        bool operator==(const CharacterSet& other) const
-        {
-            return other.m_inverted == m_inverted
-                && other.m_characters[0] == m_characters[0]
-                && other.m_characters[1] == m_characters[1];
-        }
+        friend bool operator==(const CharacterSet&, const CharacterSet&) = default;
 
     private:
         friend void add(Hasher&, const CharacterSet&);
@@ -176,10 +171,7 @@ private:
     struct Group {
         Vector<Term> terms;
 
-        bool operator==(const Group& other) const
-        {
-            return other.terms == terms;
-        }
+        friend bool operator==(const Group&, const Group&) = default;
     };
     friend void add(Hasher&, const Term::Group&);
 

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -43,7 +43,7 @@ struct CSSCounterStyleDescriptors {
     struct Symbol {
         bool isCustomIdent { false };
         String text;
-        bool operator==(const Symbol& other) const { return isCustomIdent == other.isCustomIdent && text == other.text; }
+        friend bool operator==(const Symbol&, const Symbol&) = default;
         String cssText() const;
     };
     using AdditiveSymbols = Vector<std::pair<Symbol, unsigned>>;
@@ -72,13 +72,13 @@ struct CSSCounterStyleDescriptors {
     struct Pad {
         unsigned m_padMinimumLength = 0;
         Symbol m_padSymbol;
-        bool operator==(const Pad& other) const { return m_padMinimumLength == other.m_padMinimumLength && m_padSymbol == other.m_padSymbol; }
+        friend bool operator==(const Pad&, const Pad&) = default;
         String cssText() const;
     };
     struct NegativeSymbols {
         Symbol m_prefix = { false, "-"_s };
         Symbol m_suffix;
-        bool operator==(const NegativeSymbols& other) const { return m_prefix == other.m_prefix && m_suffix == other.m_suffix; }
+        friend bool operator==(const NegativeSymbols&, const NegativeSymbols&) = default;
     };
     enum class ExplicitlySetDescriptors: uint16_t {
         System = 1 << 0,
@@ -97,6 +97,7 @@ struct CSSCounterStyleDescriptors {
     static CSSCounterStyleDescriptors create(AtomString name, const StyleProperties&);
     bool operator==(const CSSCounterStyleDescriptors& other) const
     {
+        // Intentionally doesn't check m_isExtendedResolved.
         return m_name == other.m_name
             && m_system == other.m_system
             && m_negativeSymbols == other.m_negativeSymbols

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -165,6 +165,7 @@ CounterStyleMap& CSSCounterStyleRegistry::userAgentCounterStyles()
 
 bool CSSCounterStyleRegistry::operator==(const CSSCounterStyleRegistry& other) const
 {
+    // Intentionally doesn't check m_hasUnresolvedReferences.
     return m_authorCounterStyles == other.m_authorCounterStyles;
 }
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -45,7 +45,7 @@ public:
         double value;
         CSSUnitType unitType;
 
-        bool operator==(const NumericSyntaxValue& other) const { return value == other.value && unitType == other.unitType; }
+        friend bool operator==(const NumericSyntaxValue&, const NumericSyntaxValue&) = default;
     };
 
     struct TransformSyntaxValue {
@@ -59,7 +59,7 @@ public:
         Vector<SyntaxValue> values;
         ValueSeparator separator;
 
-        bool operator==(const SyntaxValueList& other) const { return values == other.values && separator == other.separator; }
+        friend bool operator==(const SyntaxValueList&, const SyntaxValueList&) = default;
     };
 
     using VariantValue = std::variant<std::monostate, Ref<CSSVariableReferenceValue>, CSSValueID, Ref<CSSVariableData>, SyntaxValue, SyntaxValueList>;

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -138,7 +138,7 @@ public:
     struct UnicodeRange {
         UChar32 from;
         UChar32 to;
-        bool operator==(const UnicodeRange& other) const { return from == other.from && to == other.to; }
+        friend bool operator==(const UnicodeRange&, const UnicodeRange&) = default;
     };
 
     bool rangesMatchCodePoint(UChar32) const;

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -280,12 +280,6 @@ static void writeColorStop(StringBuilder& builder, const CSSGradientColorStop& s
     appendSpaceSeparatedOptionalCSSPtrText(builder, stop.color, stop.position);
 }
 
-static bool operator==(const CSSGradientPosition& a, const CSSGradientPosition& b)
-{
-    return compareCSSValue(a.first, b.first)
-        && compareCSSValue(a.second, b.second);
-}
-
 static bool operator==(const std::optional<CSSGradientPosition>& a, const std::optional<CSSGradientPosition>& b)
 {
     return (!a && !b) || (a && b && *a == *b);
@@ -362,14 +356,9 @@ String CSSLinearGradientValue::customCSSText() const
     return result.toString();
 }
 
-static bool operator==(const CSSLinearGradientValue::Angle& a, const CSSLinearGradientValue::Angle& b)
+bool operator==(const CSSLinearGradientValue::Angle& a, const CSSLinearGradientValue::Angle& b)
 {
     return compareCSSValue(a.value, b.value);
-}
-
-bool operator==(const CSSLinearGradientValue::Data& a, const CSSLinearGradientValue::Data& b)
-{
-    return a.gradientLine == b.gradientLine;
 }
 
 bool CSSLinearGradientValue::equals(const CSSLinearGradientValue& other) const
@@ -437,14 +426,9 @@ String CSSPrefixedLinearGradientValue::customCSSText() const
     return result.toString();
 }
 
-static bool operator==(const CSSPrefixedLinearGradientValue::Angle& a, const CSSPrefixedLinearGradientValue::Angle& b)
+bool operator==(const CSSPrefixedLinearGradientValue::Angle& a, const CSSPrefixedLinearGradientValue::Angle& b)
 {
     return compareCSSValue(a.value, b.value);
-}
-
-bool operator==(const CSSPrefixedLinearGradientValue::Data& a, const CSSPrefixedLinearGradientValue::Data& b)
-{
-    return a.gradientLine == b.gradientLine;
 }
 
 bool CSSPrefixedLinearGradientValue::equals(const CSSPrefixedLinearGradientValue& other) const
@@ -613,59 +597,30 @@ String CSSRadialGradientValue::customCSSText() const
     return result.toString();
 }
 
-static bool operator==(const CSSRadialGradientValue::Shape& a, const CSSRadialGradientValue::Shape& b)
-{
-    return a.shape == b.shape
-        && a.position == b.position;
-}
-
-static bool operator==(const CSSRadialGradientValue::Extent& a, const CSSRadialGradientValue::Extent& b)
-{
-    return a.extent == b.extent
-        && a.position == b.position;
-}
-
-static bool operator==(const CSSRadialGradientValue::Length& a, const CSSRadialGradientValue::Length& b)
+bool operator==(const CSSRadialGradientValue::Length& a, const CSSRadialGradientValue::Length& b)
 {
     return compareCSSValue(a.length, b.length)
         && a.position == b.position;
 }
 
-static bool operator==(const CSSRadialGradientValue::CircleOfLength& a, const CSSRadialGradientValue::CircleOfLength& b)
+bool operator==(const CSSRadialGradientValue::CircleOfLength& a, const CSSRadialGradientValue::CircleOfLength& b)
 {
     return compareCSSValue(a.length, b.length)
         && a.position == b.position;
 }
 
-static bool operator==(const CSSRadialGradientValue::CircleOfExtent& a, const CSSRadialGradientValue::CircleOfExtent& b)
-{
-    return a.extent == b.extent
-        && a.position == b.position;
-}
-
-static bool operator==(const CSSRadialGradientValue::Size& a, const CSSRadialGradientValue::Size& b)
+bool operator==(const CSSRadialGradientValue::Size& a, const CSSRadialGradientValue::Size& b)
 {
     return compareCSSValue(a.size.first, b.size.first)
         && compareCSSValue(a.size.second, b.size.second)
         && a.position == b.position;
 }
 
-static bool operator==(const CSSRadialGradientValue::EllipseOfSize& a, const CSSRadialGradientValue::EllipseOfSize& b)
+bool operator==(const CSSRadialGradientValue::EllipseOfSize& a, const CSSRadialGradientValue::EllipseOfSize& b)
 {
     return compareCSSValue(a.size.first, b.size.first)
         && compareCSSValue(a.size.second, b.size.second)
         && a.position == b.position;
-}
-
-static bool operator==(const CSSRadialGradientValue::EllipseOfExtent& a, const CSSRadialGradientValue::EllipseOfExtent& b)
-{
-    return a.extent == b.extent
-        && a.position == b.position;
-}
-
-bool operator==(const CSSRadialGradientValue::Data& a, const CSSRadialGradientValue::Data& b)
-{
-    return a.gradientBox == b.gradientBox;
 }
 
 bool CSSRadialGradientValue::equals(const CSSRadialGradientValue& other) const
@@ -745,21 +700,10 @@ String CSSPrefixedRadialGradientValue::customCSSText() const
     return result.toString();
 }
 
-static bool operator==(const CSSPrefixedRadialGradientValue::ShapeAndExtent& a, const CSSPrefixedRadialGradientValue::ShapeAndExtent& b)
-{
-    return a.shape == b.shape
-        && a.extent == b.extent;
-}
-static bool operator==(const CSSPrefixedRadialGradientValue::MeasuredSize& a, const CSSPrefixedRadialGradientValue::MeasuredSize& b)
+bool operator==(const CSSPrefixedRadialGradientValue::MeasuredSize& a, const CSSPrefixedRadialGradientValue::MeasuredSize& b)
 {
     return compareCSSValue(a.size.first, b.size.first)
         && compareCSSValue(a.size.second, b.size.second);
-}
-
-bool operator==(const CSSPrefixedRadialGradientValue::Data& a, const CSSPrefixedRadialGradientValue::Data& b)
-{
-    return a.gradientBox == b.gradientBox
-        && a.position == b.position;
 }
 
 bool CSSPrefixedRadialGradientValue::equals(const CSSPrefixedRadialGradientValue& other) const
@@ -844,15 +788,9 @@ String CSSConicGradientValue::customCSSText() const
     return result.toString();
 }
 
-static bool operator==(const CSSConicGradientValue::Angle& a, const CSSConicGradientValue::Angle& b)
+bool operator==(const CSSConicGradientValue::Angle& a, const CSSConicGradientValue::Angle& b)
 {
     return compareCSSValuePtr(a.value, b.value);
-}
-
-bool operator==(const CSSConicGradientValue::Data& a, const CSSConicGradientValue::Data& b)
-{
-    return a.angle == b.angle
-        && a.position == b.position;
 }
 
 bool CSSConicGradientValue::equals(const CSSConicGradientValue& other) const

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -68,16 +68,18 @@ struct CSSGradientColorInterpolationMethod {
     {
         return { { ColorInterpolationMethod::SRGB { }, alphaPremultiplication }, Default::SRGB };
     }
-};
 
-inline bool operator==(const CSSGradientColorInterpolationMethod& a, const CSSGradientColorInterpolationMethod& b)
-{
-    return a.method == b.method && a.defaultMethod == b.defaultMethod;
-}
+    friend bool operator==(const CSSGradientColorInterpolationMethod&, const CSSGradientColorInterpolationMethod&) = default;
+};
 
 // MARK: Gradient Definitions.
 
 using CSSGradientPosition = std::pair<Ref<CSSValue>, Ref<CSSValue>>;
+
+inline bool operator==(const CSSGradientPosition& a, const CSSGradientPosition& b)
+{
+    return compareCSSValue(a.first, b.first) && compareCSSValue(a.second, b.second);
+}
 
 // MARK: - Linear.
 
@@ -85,11 +87,15 @@ class CSSLinearGradientValue final : public CSSValue {
 public:
     enum class Horizontal { Left, Right };
     enum class Vertical { Top, Bottom };
-    struct Angle { Ref<CSSPrimitiveValue> value; };
+    struct Angle {
+        Ref<CSSPrimitiveValue> value;
+        friend bool operator==(const Angle&, const Angle&);
+    };
     using GradientLine = std::variant<std::monostate, Angle, Horizontal, Vertical, std::pair<Horizontal, Vertical>>;
 
     struct Data {
         GradientLine gradientLine;
+        friend bool operator==(const Data&, const Data&) = default;
     };
 
     static Ref<CSSLinearGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -128,17 +134,19 @@ private:
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
-bool operator==(const CSSLinearGradientValue::Data&, const CSSLinearGradientValue::Data&);
-
 class CSSPrefixedLinearGradientValue final : public CSSValue {
 public:
     enum class Horizontal { Left, Right };
     enum class Vertical { Top, Bottom };
-    struct Angle { Ref<CSSPrimitiveValue> value; };
+    struct Angle {
+        Ref<CSSPrimitiveValue> value;
+        friend bool operator==(const Angle&, const Angle&);
+    };
     using GradientLine = std::variant<std::monostate, Angle, Horizontal, Vertical, std::pair<Horizontal, Vertical>>;
 
     struct Data {
         GradientLine gradientLine;
+        friend bool operator==(const Data&, const Data&) = default;
     };
 
     static Ref<CSSPrefixedLinearGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -176,8 +184,6 @@ private:
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
-
-bool operator==(const CSSPrefixedLinearGradientValue::Data&, const CSSPrefixedLinearGradientValue::Data&);
 
 class CSSDeprecatedLinearGradientValue final : public CSSValue {
 public:
@@ -232,38 +238,48 @@ public:
     struct Shape {
         ShapeKeyword shape;
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const Shape&, const Shape&) = default;
     };
     struct Extent {
         ExtentKeyword extent;
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const Extent&, const Extent&) = default;
     };
     struct Length {
         Ref<CSSPrimitiveValue> length; // <length [0,∞]>
         std::optional<CSSGradientPosition> position;
+
+        friend bool operator==(const Length&, const Length&);
     };
     struct CircleOfLength {
         Ref<CSSPrimitiveValue> length; // <length [0,∞]>
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const CircleOfLength&, const CircleOfLength&);
     };
     struct CircleOfExtent {
         ExtentKeyword extent;
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const CircleOfExtent&, const CircleOfExtent&) = default;
     };
     struct Size {
         std::pair<Ref<CSSPrimitiveValue>, Ref<CSSPrimitiveValue>> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const Size&, const Size&);
     };
     struct EllipseOfSize {
         std::pair<Ref<CSSPrimitiveValue>, Ref<CSSPrimitiveValue>> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const EllipseOfSize&, const EllipseOfSize&);
     };
     struct EllipseOfExtent {
         ExtentKeyword extent;
         std::optional<CSSGradientPosition> position;
+        friend bool operator==(const EllipseOfExtent&, const EllipseOfExtent&) = default;
     };
     using GradientBox = std::variant<std::monostate, Shape, Extent, Length, Size, CircleOfLength, CircleOfExtent, EllipseOfSize, EllipseOfExtent, CSSGradientPosition>;
     struct Data {
         GradientBox gradientBox;
+        friend bool operator==(const Data&, const Data&) = default;
     };
 
     static Ref<CSSRadialGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -302,8 +318,6 @@ private:
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
 
-bool operator==(const CSSRadialGradientValue::Data&, const CSSRadialGradientValue::Data&);
-
 class CSSPrefixedRadialGradientValue final : public CSSValue {
 public:
     enum class ShapeKeyword { Circle, Ellipse };
@@ -311,9 +325,11 @@ public:
     struct ShapeAndExtent {
         ShapeKeyword shape;
         ExtentKeyword extent;
+        friend bool operator==(const ShapeAndExtent&, const ShapeAndExtent&) = default;
     };
     struct MeasuredSize {
         std::pair<Ref<CSSPrimitiveValue>, Ref<CSSPrimitiveValue>> size; // <length-percentage [0,∞]>, <length-percentage [0,∞]>
+        friend bool operator==(const MeasuredSize&, const MeasuredSize&);
     };
 
     using GradientBox = std::variant<std::monostate, ShapeKeyword, ExtentKeyword, ShapeAndExtent, MeasuredSize>;
@@ -321,6 +337,8 @@ public:
     struct Data {
         GradientBox gradientBox;
         std::optional<CSSGradientPosition> position;
+
+        friend bool operator==(const Data&, const Data&) = default;
     };
 
     static Ref<CSSPrefixedRadialGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -358,8 +376,6 @@ private:
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
-
-bool operator==(const CSSPrefixedRadialGradientValue::Data&, const CSSPrefixedRadialGradientValue::Data&);
 
 class CSSDeprecatedRadialGradientValue final : public CSSValue {
 public:
@@ -411,11 +427,16 @@ bool operator==(const CSSDeprecatedRadialGradientValue::Data&, const CSSDeprecat
 
 class CSSConicGradientValue final : public CSSValue {
 public:
-    struct Angle { RefPtr<CSSPrimitiveValue> value; };
+    struct Angle {
+        RefPtr<CSSPrimitiveValue> value;
+        friend bool operator==(const Angle&, const Angle&);
+    };
 
     struct Data {
         Angle angle;
         std::optional<CSSGradientPosition> position;
+
+        friend bool operator==(const Data&, const Data&) = default;
     };
 
     static Ref<CSSConicGradientValue> create(Data data, CSSGradientRepeat repeating, CSSGradientColorInterpolationMethod colorInterpolationMethod, CSSGradientColorStopList stops)
@@ -453,8 +474,6 @@ private:
     CSSGradientColorInterpolationMethod m_colorInterpolationMethod;
     mutable RefPtr<StyleImage> m_cachedStyleImage;
 };
-
-bool operator==(const CSSConicGradientValue::Data&, const CSSConicGradientValue::Data&);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 32a30dfe6ffb0b6380bca678439c115b60da5be9
<pre>
Let the compiler generate more comparison operators in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=260943">https://bugs.webkit.org/show_bug.cgi?id=260943</a>

Reviewed by Timothy Hatcher, Ryosuke Niwa and Darin Adler.

Let the compiler generate more comparison operators in WebCore now that we
support C++20.

* Source/WebCore/Modules/highlight/AppHighlightRangeData.h:
(WebCore::AppHighlightRangeData::NodePathComponent::operator== const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h:
(WebCore::IDBDatabaseIdentifier::operator== const): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h:
(WebCore::IDBResourceIdentifier::operator== const): Deleted.
* Source/WebCore/Modules/mediasession/MediaPositionState.h:
(WebCore::MediaPositionState::operator== const): Deleted.
* Source/WebCore/Modules/permissions/PermissionDescriptor.h:
(WebCore::PermissionDescriptor::operator== const): Deleted.
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/PAL/pal/SessionID.h:
(PAL::SessionID::operator== const): Deleted.
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::ModifyHeadersAction::operator== const): Deleted.
(WebCore::ContentExtensions::ModifyHeadersAction::ModifyHeaderInfo::operator== const): Deleted.
(WebCore::ContentExtensions::RedirectAction::operator== const): Deleted.
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::operator== const): Deleted.
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::QueryTransform::operator== const): Deleted.
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::QueryTransform::QueryKeyValue::operator== const): Deleted.
* Source/WebCore/contentextensions/ContentExtensionActions.h:
(WebCore::ContentExtensions::ActionWithoutMetadata::operator== const): Deleted.
(WebCore::ContentExtensions::ActionWithStringMetadata::operator== const): Deleted.
* Source/WebCore/contentextensions/ContentExtensionRule.h:
(WebCore::ContentExtensions::Trigger::operator== const): Deleted.
(WebCore::ContentExtensions::Action::operator== const): Deleted.
(WebCore::ContentExtensions::ContentExtensionRule::operator== const): Deleted.
* Source/WebCore/contentextensions/NFAToDFA.cpp:
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::CharacterSet::operator== const): Deleted.
(WebCore::ContentExtensions::Term::Group::operator== const): Deleted.
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
(WebCore::CSSCounterStyleDescriptors::operator== const):
(WebCore::CSSCounterStyleDescriptors::Symbol::operator== const): Deleted.
(WebCore::CSSCounterStyleDescriptors::Pad::operator== const): Deleted.
(WebCore::CSSCounterStyleDescriptors::NegativeSymbols::operator== const): Deleted.
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::operator== const):
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::CSSLinearGradientValue::Angle::operator==):
(WebCore::CSSPrefixedLinearGradientValue::operator==):
(WebCore::CSSRadialGradientValue::operator==):
(WebCore::CSSPrefixedRadialGradientValue::operator==):
(WebCore::CSSConicGradientValue::operator==):
* Source/WebCore/css/CSSGradientValue.h:
(WebCore::CSSGradientColorInterpolationMethod::legacyMethod):
(WebCore::operator==):

Canonical link: <a href="https://commits.webkit.org/267512@main">https://commits.webkit.org/267512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b89dcf61ab25cde0a567c60498a976ab89d572a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17266 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15234 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19714 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13572 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15179 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4026 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->