### PR TITLE
Allow makeString() to work with UChar32

### DIFF
--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -59,6 +59,28 @@ private:
     char m_character;
 };
 
+template<> class StringTypeAdapter<LChar, void> {
+public:
+    StringTypeAdapter(LChar character)
+        : m_character { character }
+    {
+    }
+
+    unsigned length() const { return 1; }
+    bool is8Bit() const { return true; }
+
+    void writeTo(LChar* destination) const
+    {
+        ASSERT(is8Bit());
+        *destination = m_character;
+    }
+
+    void writeTo(UChar* destination) const { *destination = m_character; }
+
+private:
+    LChar m_character;
+};
+
 template<> class StringTypeAdapter<UChar, void> {
 public:
     StringTypeAdapter(UChar character)
@@ -79,6 +101,42 @@ public:
 
 private:
     UChar m_character;
+};
+
+template<> class StringTypeAdapter<UChar32, void> {
+public:
+    StringTypeAdapter(UChar32 character)
+        : m_character { character }
+    {
+    }
+
+    unsigned length() const
+    {
+        return U_IS_SUPPLEMENTARY(m_character) ? 2 : 1;
+    }
+
+    bool is8Bit() const
+    {
+        return isLatin1(m_character);
+    }
+
+    void writeTo(LChar* destination) const
+    {
+        ASSERT(is8Bit());
+        *destination = m_character;
+    }
+
+    void writeTo(UChar* destination) const
+    {
+        size_t offset = 0;
+        bool isError = false;
+        U16_APPEND(destination, offset, length(), m_character, isError);
+        ASSERT(offset == length());
+        ASSERT_UNUSED(isError, !isError);
+    }
+
+private:
+    UChar32 m_character;
 };
 
 template<> class StringTypeAdapter<const LChar*, void> {

--- a/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
@@ -63,6 +63,19 @@ TEST(WTF, StringConcatenate)
     EXPECT_STREQ("hello world", makeString("hello", " ", "world").utf8().data());
 }
 
+TEST(WTF, StringConcatenate_Char)
+{
+    EXPECT_STREQ("abc", makeString("a", 'b', "c").utf8().data());
+    EXPECT_STREQ("abc", makeString("a", static_cast<LChar>('b'), "c").utf8().data());
+    EXPECT_STREQ("abc", makeString("a", static_cast<UChar>('b'), "c").utf8().data());
+    EXPECT_STREQ("abc", makeString("a", static_cast<UChar32>('b'), "c").utf8().data());
+
+    EXPECT_STREQ("aاc", makeString("a", static_cast<UChar>(0x0627), "c").utf8().data());
+    EXPECT_STREQ("aاc", makeString("a", static_cast<UChar32>(0x0627), "c").utf8().data());
+
+    EXPECT_STREQ("a😊c", makeString("a", static_cast<UChar32>(0x1F60A), "c").utf8().data());
+}
+
 TEST(WTF, StringConcatenate_Int)
 {
     EXPECT_EQ(5u, WTF::lengthOfIntegerAsString(17890));
@@ -216,4 +229,4 @@ TEST(WTF, StringConcatenate_Tuple)
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42), ' ', "world")).utf8().data());
 }
 
-}
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### a6945bc30d6b26e131188c2405bf7657f44cac98
<pre>
Allow makeString() to work with UChar32
<a href="https://bugs.webkit.org/show_bug.cgi?id=260946">https://bugs.webkit.org/show_bug.cgi?id=260946</a>
rdar://114743013

Reviewed by NOBODY (OOPS!).

I guess no one ever needed this before?

* Source/WTF/wtf/text/StringConcatenate.h:
* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6945bc30d6b26e131188c2405bf7657f44cac98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18520 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16937 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/19309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/19309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/14437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/19309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/15968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/15940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18297 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/4279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19519 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15770 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/4126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->