### PR TITLE
Add some libwebrtc logging in case of packet loss triggering bandwidth estimation reduction

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/congestion_controller/goog_cc/send_side_bandwidth_estimation.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/congestion_controller/goog_cc/send_side_bandwidth_estimation.cc
@@ -585,6 +585,11 @@ void SendSideBandwidthEstimation::UpdateEstimate(Timestamp at_time) {
                static_cast<double>(512 - last_fraction_loss_)) /
               512.0);
           has_decreased_since_last_fraction_loss_ = true;
+
+#if defined(WEBRTC_WEBKIT_BUILD)
+          RTC_LOG(LS_INFO) << "Loss " << loss << " above high loss threshold " << high_loss_threshold_ << ", reducing rate from " << current_target_.bps() << " to " << new_bitrate.bps();
+#endif
+
           UpdateTargetBitrate(new_bitrate, at_time);
           return;
         }


### PR DESCRIPTION
#### 630bb64e52ef650fa4d6c60b9ea3547db20d31e5
<pre>
Add some libwebrtc logging in case of packet loss triggering bandwidth estimation reduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=260950">https://bugs.webkit.org/show_bug.cgi?id=260950</a>
rdar://problem/114747794

Reviewed by Jean-Yves Avenard.

In case of ex excessive packet loss, bandwidth gets reduced, we now log this at info level.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/congestion_controller/goog_cc/send_side_bandwidth_estimation.cc:

Canonical link: <a href="https://commits.webkit.org/267500@main">https://commits.webkit.org/267500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e601be16ece270dcf212a62a37fd8c9fe1e26a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17981 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19328 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21930 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19648 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15131 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4021 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->