### PR TITLE
Deploy more smart pointers in Source/WebKit/UIProcess/Notifications and Source/WebKit/UIProcess/PDF

### DIFF
--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -56,8 +56,8 @@ Ref<WebNotificationManagerProxy> WebNotificationManagerProxy::create(WebProcessP
 WebNotificationManagerProxy& WebNotificationManagerProxy::sharedServiceWorkerManager()
 {
     ASSERT(isMainRunLoop());
-    static WebNotificationManagerProxy* sharedManager = new WebNotificationManagerProxy(nullptr);
-    return *sharedManager;
+    static NeverDestroyed<Ref<WebNotificationManagerProxy>> sharedManager = adoptRef(*new WebNotificationManagerProxy(nullptr));
+    return sharedManager->get();
 }
 
 WebNotificationManagerProxy::WebNotificationManagerProxy(WebProcessPool* processPool)
@@ -243,7 +243,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
         // Handle both.
 
         std::optional<WTF::UUID> coreNotificationID;
-        auto* intValue = globalNotificationIDs->at<API::UInt64>(i);
+        RefPtr intValue = globalNotificationIDs->at<API::UInt64>(i);
         if (intValue) {
             auto it = m_globalNotificationMap.find(intValue->value());
             if (it == m_globalNotificationMap.end())
@@ -251,7 +251,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
 
             coreNotificationID = it->value;
         } else {
-            auto* dataValue = globalNotificationIDs->at<API::Data>(i);
+            RefPtr dataValue = globalNotificationIDs->at<API::Data>(i);
             if (!dataValue)
                 continue;
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
@@ -105,7 +105,7 @@ HashMap<WTF::String, bool> WebNotificationProvider::notificationPermissions()
 
     Ref<API::Array> knownOrigins = knownPermissions->keys();
     for (size_t i = 0; i < knownOrigins->size(); ++i) {
-        API::String* origin = knownOrigins->at<API::String>(i);
+        RefPtr origin = knownOrigins->at<API::String>(i);
         permissions.set(origin->string(), knownPermissions->get<API::Boolean>(origin->string())->value());
     }
     return permissions;

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -166,7 +166,8 @@ static NSArray<NSString *> *controlArray()
 - (NSView *)hitTest:(NSPoint)point
 {
     ASSERT(_page);
-    return _page ? _page->cocoaView().autorelease() : self;
+    RefPtr page = _page.get();
+    return page ? page->cocoaView().autorelease() : self;
 }
 
 - (void)mouseMoved:(NSEvent *)event
@@ -247,7 +248,7 @@ static NSArray<NSString *> *controlArray()
 {
     if (!_visible)
         return;
-    auto* page = _page.get();
+    RefPtr page = _page.get();
     if (!page)
         return;
     if ([control isEqualToString:PDFHUDZoomInControl])


### PR DESCRIPTION
#### dc328646ce2fb251e968f41ac2c54f5dac601358
<pre>
Deploy more smart pointers in Source/WebKit/UIProcess/Notifications and Source/WebKit/UIProcess/PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=260952">https://bugs.webkit.org/show_bug.cgi?id=260952</a>

Reviewed by Chris Dumez.

Deployed more smart pointers as found by clang static analyzer.

* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::sharedServiceWorkerManager):
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp:
(WebKit::WebNotificationProvider::notificationPermissions):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView hitTest:]):
(-[WKPDFHUDView _performActionForControl:]):

Canonical link: <a href="https://commits.webkit.org/267528@main">https://commits.webkit.org/267528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99b132a34397eafbf973e32bd3e769d51f35a3e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15696 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17985 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19330 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14567 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21935 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19657 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19498 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2079 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->