### PR TITLE
Import webvtt/api WPT

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -457,6 +457,7 @@
     "web-platform-tests/webusb": "skip",
     "web-platform-tests/webvr": "skip",
     "web-platform-tests/webvtt": "skip",
+    "web-platform-tests/webvtt/api": "import",
     "web-platform-tests/webxr": "import",
     "web-platform-tests/workers": "import",
     "web-platform-tests/worklets": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align-expected.txt
@@ -1,0 +1,4 @@
+
+PASS VTTCue.align, script-created cue
+FAIL VTTCue.align, parsed cue null is not an object (evaluating 't.track.cues[0]')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<title>VTTCue.align</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-align">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+
+    var cue = new VTTCue(0, 1, 'text');
+    assert_true('align' in cue, 'align is not supported');
+    assert_equals(cue.align, 'center');
+
+    var track = document.createElement('track');
+    var t = track.track;
+    t.addCue(cue);
+
+    assert_equals(cue.align, 'center');
+
+    video.appendChild(track);
+    assert_equals(cue.align, 'center');
+
+    t.mode = 'showing';
+    assert_equals(cue.align, 'center');
+
+    cue.align = 'start';
+    assert_equals(cue.align, 'start');
+
+    cue.align = 'end';
+    assert_equals(cue.align, 'end');
+
+    ['start\u0000', 'centre', 'middle'].forEach(function(invalid) {
+        cue.align = invalid;
+        assert_equals(cue.align, 'end');
+    });
+}, document.title+', script-created cue');
+
+var t_parsed = async_test(document.title+', parsed cue');
+t_parsed.step(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+    var t = document.createElement('track');
+    t.onload = this.step_func(function(){
+        var c1 = t.track.cues[0];
+        var c2 = t.track.cues[1];
+        var c3 = t.track.cues[2];
+        var c4 = t.track.cues[3];
+        assert_equals(c1.align, 'center');
+        assert_equals(c2.align, 'start');
+        assert_equals(c3.align, 'center');
+        assert_equals(c4.align, 'end');
+        this.done();
+    });
+    t.onerror = this.step_func(function() {
+      assert_unreached('got error event');
+    });
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 align:start\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 align:center\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 align:end\ntest', this);
+    t.track.mode = 'showing';
+    video.appendChild(t);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/categories.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/categories.json
@@ -1,0 +1,3 @@
+{
+    "region.html": "regions"
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/common.js
@@ -1,0 +1,8 @@
+function make_vtt_track(contents, test) {
+    var track_blob = new Blob([contents], { type: 'text/vtt' });
+    var track_url = URL.createObjectURL(track_blob);
+    test.add_cleanup(function() {
+        URL.revokeObjectURL(track_url);
+    });
+    return track_url;
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions-expected.txt
@@ -1,0 +1,5 @@
+
+PASS VTTCue constructor exceptions, invalid start time
+PASS VTTCue constructor exceptions, invalid end time
+PASS VTTCue constructor exceptions, valueOf
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>VTTCue constructor exceptions</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+test(function() {
+    assert_throws_js(TypeError, function() { new VTTCue(NaN, 0, 'foo'); });
+    assert_throws_js(TypeError, function() { new VTTCue(Infinity, 0, 'foo'); });
+    assert_throws_js(TypeError, function() { new VTTCue('tomorrow', 0, 'foo'); });
+}, document.title+', invalid start time');
+test(function() {
+    assert_throws_js(TypeError, function() { new VTTCue(0, NaN, 'foo'); });
+    assert_throws_js(TypeError, function() { new VTTCue(0, -Infinity, 'foo'); });
+    assert_throws_js(TypeError, function() { new VTTCue(0, 'tomorrow', 'foo'); });
+}, document.title+', invalid end time');
+test(function() {
+    var start = { valueOf: function() { return 42; } };
+    var end = { valueOf: function() { return 84; } };
+    var cue = new VTTCue(start, end, 'bar');
+    assert_equals(cue.startTime, 42);
+    assert_equals(cue.endTime, 84);
+    assert_equals(cue.text, 'bar');
+}, document.title+', valueOf');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-expected.txt
@@ -1,0 +1,7 @@
+
+PASS VTTCue(), initial values
+PASS VTTCue(), bad start time
+PASS VTTCue(), bad end time
+FAIL VTTCue(), unbounded end time The provided value is non-finite
+PASS VTTCue(), text formatting
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<title>VTTCue()</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-vttcue">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var cue = new VTTCue(3, 12, 'foo bar');
+
+    assert_equals(cue.startTime, 3);
+    assert_equals(cue.endTime, 12);
+    assert_equals(cue.text, 'foo bar');
+    assert_equals(cue.id, '');
+    assert_equals(cue.region, null);
+    assert_equals(cue.pauseOnExit, false);
+    assert_equals(cue.snapToLines, true);
+    assert_equals(cue.line, 'auto');
+    assert_equals(cue.lineAlign, 'start');
+    assert_equals(cue.position, 'auto');
+    assert_equals(cue.positionAlign, 'auto');
+    assert_equals(cue.size, 100);
+    assert_equals(cue.align, 'center');
+}, document.title + ', initial values');
+
+test(function() {
+    var cue = new VTTCue(-1, 12, 'foo bar');
+
+    assert_equals(cue.startTime, -1);
+    assert_equals(cue.endTime, 12);
+}, document.title + ', bad start time');
+
+
+test(function() {
+    var cue = new VTTCue(2, -1, 'foo bar');
+
+    assert_equals(cue.startTime, 2);
+    assert_equals(cue.endTime, -1);
+}, document.title + ', bad end time');
+
+test(function() {
+    var cue = new VTTCue(2, +Infinity, 'foo bar');
+
+    assert_equals(cue.startTime, 2);
+    assert_equals(cue.endTime, +Infinity);
+}, document.title + ', unbounded end time');
+
+test(function() {
+    var cue = new VTTCue(3, 12, '<i>foo bar</i>');
+
+    var frag = cue.getCueAsHTML();
+    assert_equals(frag.childNodes.length, 1);
+    assert_equals(frag.childNodes[0].localName, 'i');
+    assert_equals(frag.childNodes[0].textContent, 'foo bar');
+}, document.title + ', text formatting');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
@@ -1,0 +1,14 @@
+
+PASS VTTCue.getCueAsHTML(), creating the cue
+PASS VTTCue.getCueAsHTML(), <c>
+PASS VTTCue.getCueAsHTML(), <c.a.b>
+PASS VTTCue.getCueAsHTML(), <i>
+PASS VTTCue.getCueAsHTML(), <b>
+PASS VTTCue.getCueAsHTML(), <u>
+PASS VTTCue.getCueAsHTML(), <ruby>
+PASS VTTCue.getCueAsHTML(), <rt>
+PASS VTTCue.getCueAsHTML(), <v>
+PASS VTTCue.getCueAsHTML(), <v a b>
+FAIL VTTCue.getCueAsHTML(), <1:00:00.500> assert_equals: data expected "01:00:00.500" but got "1:00:00.500"
+FAIL VTTCue.getCueAsHTML(), x\0 assert_equals: data expected "x\0" but got "x\ufffd"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<title>VTTCue.getCueAsHTML()</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-getcueashtml">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var video = document.createElement('video');
+    var t1 = video.addTextTrack('subtitles');
+    document.body.appendChild(video);
+    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><1:00:00.500>x\0');
+    t1.addCue(c1);
+    window.frag = c1.getCueAsHTML();
+    assert_equals(frag.childNodes.length, 10, 'childNodes.length');
+    assert_true(frag instanceof DocumentFragment, 'getCueAsHTML() should return DocumentFragment');
+}, document.title+', creating the cue');
+test(function(){
+    assert_equals(frag.childNodes[0].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[0].localName, 'span', 'localName');
+    assert_equals(frag.childNodes[0].attributes.length, 0, 'attributes');
+    assert_false(frag.childNodes[0].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[0] instanceof HTMLElement, 'instanceof');
+}, document.title+', <c>');
+test(function(){
+    assert_equals(frag.childNodes[1].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[1].localName, 'span', 'localName');
+    assert_equals(frag.childNodes[1].attributes.length, 1, 'attributes');
+    assert_equals(frag.childNodes[1].getAttributeNS('', 'class'), 'a b', 'class attribute');
+    assert_false(frag.childNodes[1].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[1] instanceof HTMLElement, 'instanceof');
+}, document.title+', <c.a.b>');
+test(function(){
+    assert_equals(frag.childNodes[2].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[2].localName, 'i', 'localName');
+    assert_equals(frag.childNodes[2].attributes.length, 0, 'attributes');
+    assert_false(frag.childNodes[2].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[2] instanceof HTMLElement, 'instanceof');
+}, document.title+', <i>');
+test(function(){
+    assert_equals(frag.childNodes[3].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[3].localName, 'b', 'localName');
+    assert_equals(frag.childNodes[3].attributes.length, 0, 'attributes');
+    assert_false(frag.childNodes[3].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[3] instanceof HTMLElement, 'instanceof');
+}, document.title+', <b>');
+test(function(){
+    assert_equals(frag.childNodes[4].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[4].localName, 'u', 'localName');
+    assert_equals(frag.childNodes[4].attributes.length, 0, 'attributes');
+    assert_false(frag.childNodes[4].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[4] instanceof HTMLElement, 'instanceof');
+}, document.title+', <u>');
+test(function(){
+    assert_equals(frag.childNodes[5].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[5].localName, 'ruby', 'localName');
+    assert_equals(frag.childNodes[5].attributes.length, 0, 'attributes');
+    assert_true(frag.childNodes[5].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[5] instanceof HTMLElement, 'instanceof');
+}, document.title+', <ruby>');
+test(function(){
+    assert_equals(frag.childNodes[5].firstChild.namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[5].firstChild.localName, 'rt', 'localName');
+    assert_equals(frag.childNodes[5].firstChild.attributes.length, 0, 'attributes');
+    assert_false(frag.childNodes[5].firstChild.hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[5].firstChild instanceof HTMLElement, 'instanceof');
+}, document.title+', <rt>');
+test(function(){
+    assert_equals(frag.childNodes[6].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[6].localName, 'span', 'localName');
+    assert_equals(frag.childNodes[6].attributes.length, 1, 'attributes');
+    assert_equals(frag.childNodes[6].getAttributeNS('', 'title'), '', 'title attribute');
+    assert_false(frag.childNodes[6].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[6] instanceof HTMLElement, 'instanceof');
+}, document.title+', <v>');
+test(function(){
+    assert_equals(frag.childNodes[7].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[7].localName, 'span', 'localName');
+    assert_equals(frag.childNodes[7].attributes.length, 1, 'attributes');
+    assert_equals(frag.childNodes[7].getAttributeNS('', 'title'), 'a b', 'title attribute');
+    assert_false(frag.childNodes[7].hasChildNodes(), 'hasChildNodes()');
+    assert_true(frag.childNodes[7] instanceof HTMLElement, 'instanceof');
+}, document.title+', <v a b>');
+test(function(){
+    assert_equals(frag.childNodes[8].target, 'timestamp', 'target');
+    assert_equals(frag.childNodes[8].data, '01:00:00.500', 'data');
+    assert_true(frag.childNodes[8] instanceof ProcessingInstruction, 'instanceof');
+}, document.title+', <1:00:00.500>');
+test(function(){
+    assert_equals(frag.childNodes[9].data, 'x\0', 'data');
+    assert_true(frag.childNodes[9] instanceof Text, 'instanceof');
+}, document.title+', x\\0');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line-expected.txt
@@ -1,0 +1,4 @@
+
+PASS VTTCue.line, script-created cue
+FAIL VTTCue.line, parsed cue null is not an object (evaluating 't.track.cues[0]')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<title>VTTCue.line</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-line">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+    var c1 = new VTTCue(0, 1, 'text1');
+    assert_true('line' in c1, 'line is not supported');
+    assert_equals(c1.line, "auto");
+    var track = document.createElement('track');
+    var t = track.track;
+    t.addCue(c1);
+    assert_equals(c1.line, "auto");
+    video.appendChild(track);
+    assert_equals(c1.line, "auto");
+    t.mode = 'showing';
+    assert_equals(c1.line, "auto");
+    var c2 = new VTTCue(0, 1, 'text2');
+    var track2 = document.createElement('track');
+    var t2 = track2.track;
+    t2.addCue(c2);
+    assert_equals(c2.line, "auto");
+    video.appendChild(track2);
+    t2.mode = 'showing';
+    assert_equals(c2.line, "auto");
+    assert_equals(c1.line, "auto");
+    c1.line = -5;
+    assert_equals(c1.line, -5);
+    assert_equals(c2.line, "auto");
+    c1.line = 0;
+    c1.snapToLines = false;
+    assert_equals(c1.line, 0);
+    assert_equals(c2.line, "auto");
+}, document.title+', script-created cue');
+
+var t_parsed = async_test(document.title+', parsed cue');
+t_parsed.step(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+    var t = document.createElement('track');
+    t.onload = this.step_func(function(){
+        var c1 = t.track.cues[0];
+        var c2 = t.track.cues[1];
+        var c3 = t.track.cues[2];
+        assert_equals(c1.line, "auto");
+        assert_equals(c2.line, 0);
+        assert_equals(c3.line, 0);
+
+        this.done();
+    });
+    t.onerror = this.step_func(function() {
+      assert_unreached('got error event');
+    });
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0%\ntest', this);
+    t.track.mode = 'showing';
+    video.appendChild(t);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTCue.lineAlign, script-created cue
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<title>VTTCue.lineAlign</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-linealign">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+
+    var cue = new VTTCue(0, 1, 'text');
+    assert_true('lineAlign' in cue, 'lineAlign is not supported');
+    assert_equals(cue.lineAlign, 'start');
+
+    var track = document.createElement('track');
+    var t = track.track;
+    t.addCue(cue);
+
+    assert_equals(cue.lineAlign, 'start');
+
+    video.appendChild(track);
+    assert_equals(cue.lineAlign, 'start');
+
+    t.mode = 'showing';
+    assert_equals(cue.lineAlign, 'start');
+
+    cue.lineAlign = 'center';
+    assert_equals(cue.lineAlign, 'center');
+
+    cue.lineAlign = 'end';
+    assert_equals(cue.lineAlign, 'end');
+
+    ['start\u0000', 'centre', 'middle'].forEach(function(invalid) {
+        cue.lineAlign = invalid;
+        assert_equals(cue.lineAlign, 'end');
+    });
+}, document.title+', script-created cue');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTCue.position, script-created cue
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<title>VTTCue.position</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-position">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var cue = new VTTCue(0, 1, 'text');
+    assert_true('position' in cue, 'position is not supported');
+
+    cue.position = 'auto';
+    assert_equals(cue.position, 'auto');
+
+    for (i = 0; i <= 100; i++) {
+        cue.position = i;
+        assert_equals(cue.position, i);
+    }
+
+    [-1, -100, -101, 101, 200, 201].forEach(function(invalid) {
+        assert_throws_dom('IndexSizeError', function() {
+            cue.position = invalid;
+        });
+    });
+
+    cue.position = 1.5;
+    assert_equals(cue.position, 1.5);
+
+    cue.position = 'auto';
+    assert_equals(cue.position, 'auto');
+}, document.title+', script-created cue');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTCue.positionAlign, script-created cue
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>VTTCue.positionAlign</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-positionalign">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var cue = new VTTCue(0, 1, 'text');
+    assert_true('positionAlign' in cue, 'positionAlign is not supported');
+
+    ['line-left', 'center', 'line-right', 'auto'].forEach(function(valid) {
+        cue.positionAlign = valid;
+        assert_equals(cue.positionAlign, valid);
+    });
+
+    cue.positionAlign = 'center';
+    ['auto\u0000', 'centre', 'middle'].forEach(function(invalid) {
+        cue.positionAlign = invalid;
+        assert_equals(cue.positionAlign, 'center');
+    });
+}, document.title+', script-created cue');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL VTTCue.region, script-created cue The VTTCue.region attribute must be an instance of VTTRegion
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<title>VTTCue.region</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-region">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+
+    var cue = new VTTCue(0, 1, 'text');
+    assert_true('region' in cue, 'region is not supported');
+    assert_equals(cue.region, null);
+
+    var track = document.createElement('track');
+    var t = track.track;
+    t.addCue(cue);
+
+    assert_equals(cue.region, null);
+
+    video.appendChild(track);
+    assert_equals(cue.region, null);
+
+    t.mode = 'showing';
+    assert_equals(cue.region, null);
+
+    var region = new VTTRegion();
+    cue.region = region;
+    assert_equals(cue.region, region);
+
+    cue.region = 'foo';
+    assert_equals(cue.region, region);
+
+    cue.region = null;
+    assert_equals(cue.region, null);
+}, document.title+', script-created cue');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt
@@ -1,0 +1,4 @@
+
+PASS VTTCue.snapToLines, script-created cue
+FAIL VTTCue.snapToLines, parsed cue null is not an object (evaluating 't.track.cues[0]')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<title>VTTCue.snapToLines</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-snaptolines">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<div id=log></div>
+<script>
+setup(function(){
+    window.video = document.createElement('video');
+    window.t1 = video.addTextTrack('subtitles');
+    document.body.appendChild(video);
+});
+test(function(){
+    var c1 = new VTTCue(0, 1, 'text1');
+    assert_true('snapToLines' in c1, 'snapToLines is not supported');
+    assert_true(c1.snapToLines);
+    c1.line = 101;
+    c1.snapToLines = false;
+    assert_false(c1.snapToLines);
+    c1.snapToLines = true;
+    assert_true(c1.snapToLines);
+    c1.line = -1;
+    c1.snapToLines = false;
+    assert_false(c1.snapToLines);
+    c1.snapToLines = true;
+    assert_true(c1.snapToLines);
+    c1.line = 0;
+    c1.snapToLines = false;
+    assert_false(c1.snapToLines);
+}, document.title+', script-created cue');
+
+var t_parsed = async_test(document.title+', parsed cue');
+t_parsed.step(function(){
+    var t = document.createElement('track');
+    t.onload = this.step_func(function(){
+        var c1 = t.track.cues[0];
+        assert_true(c1.snapToLines);
+        c1.line = 101;
+        c1.snapToLines = false;
+        assert_false(c1.snapToLines);
+        c1.snapToLines = true;
+        assert_true(c1.snapToLines);
+        c1.line = -1;
+        c1.snapToLines = false;
+        assert_false(c1.snapToLines);
+        c1.snapToLines = true;
+        assert_true(c1.snapToLines);
+        c1.line = 0;
+        c1.snapToLines = false;
+        assert_false(c1.snapToLines);
+
+        var c2 = t.track.cues[1];
+        assert_true(c2.snapToLines);
+        c2.line = 101;
+        c2.snapToLines = false;
+        assert_false(c2.snapToLines);
+        c2.snapToLines = true;
+        assert_true(c2.snapToLines);
+        c2.line = -1;
+        c2.snapToLines = false;
+        assert_false(c2.snapToLines);
+        c2.snapToLines = true;
+        assert_true(c2.snapToLines);
+        c2.line = 0;
+        c2.snapToLines = false;
+        assert_false(c2.snapToLines);
+
+        var c3 = t.track.cues[2];
+        assert_false(c3.snapToLines);
+        c3.snapToLines = false;
+        assert_false(c3.snapToLines);
+        c3.snapToLines = true;
+        assert_true(c3.snapToLines);
+        c3.line = 101;
+        c3.snapToLines = false;
+        assert_false(c3.snapToLines);
+        c3.snapToLines = true;
+        assert_true(c3.snapToLines);
+        c3.line = -1;
+        c3.snapToLines = false;
+        assert_false(c3.snapToLines);
+        c3.snapToLines = true;
+        assert_true(c3.snapToLines);
+        c3.line = 0;
+        c3.snapToLines = false;
+        assert_false(c3.snapToLines);
+
+        this.done();
+    });
+    t.onerror = this.step_func(function() {
+      assert_unreached('got error event');
+    });
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0%\ntest', this);
+    t.track.mode = 'showing';
+    video.appendChild(t);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text-expected.txt
@@ -1,0 +1,4 @@
+
+PASS VTTCue.text, script-created cue
+FAIL VTTCue.text, parsed cue null is not an object (evaluating 'c[0]')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<title>VTTCue.text</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-text">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<div id=log></div>
+<script>
+setup(function(){
+    window.video = document.createElement('video');
+    window.t1 = video.addTextTrack('subtitles');
+    document.body.appendChild(video);
+});
+test(function(){
+    var c1 = new VTTCue(0, 1, 'text1\r\n\n\u0000');
+    assert_true('text' in c1, 'text is not supported');
+    assert_equals(c1.text, 'text1\r\n\n\u0000');
+    c1.text = c1.text;
+    assert_equals(c1.text, 'text1\r\n\n\u0000');
+    c1.text = null;
+    assert_equals(c1.text, 'null');
+}, document.title+', script-created cue');
+
+var t_parsed = async_test(document.title+', parsed cue');
+t_parsed.step(function(){
+    var t = document.createElement('track');
+    t.onload = this.step_func(function(){
+        var c = t.track.cues;
+        assert_equals(c[0].text, '');
+        assert_equals(c[1].text, 'test');
+        this.done();
+    });
+    t.onerror = this.step_func(function() {
+      assert_unreached('got error event');
+    });
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\n'+
+                           '\n\nfoobar\n00:00:00.000 --> 00:00:00.001\ntest', this);
+    t.track.mode = 'showing';
+    video.appendChild(t);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical-expected.txt
@@ -1,0 +1,4 @@
+
+PASS VTTCue.vertical, script-created cue
+FAIL VTTCue.vertical, parsed cue null is not an object (evaluating 't.track.cues[0]')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<title>VTTCue.vertical</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-vertical">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<div id=log></div>
+<script>
+setup(function(){
+    window.video = document.createElement('video');
+    window.t1 = video.addTextTrack('subtitles');
+    document.body.appendChild(video);
+});
+test(function(){
+    var video = document.createElement('video');
+    document.body.appendChild(video);
+    var c1 = new VTTCue(0, 1, 'text1');
+    assert_true('vertical' in c1, 'vertical is not supported');
+    assert_equals(c1.vertical, '');
+    var track = document.createElement('track');
+    var t = track.track;
+    t.addCue(c1);
+    assert_equals(c1.vertical, '');
+    video.appendChild(track);
+    assert_equals(c1.vertical, '');
+    t.mode = 'showing';
+    assert_equals(c1.vertical, '');
+    c1.vertical = 'rl';
+    assert_equals(c1.vertical, 'rl');
+    c1.vertical = 'lr';
+    assert_equals(c1.vertical, 'lr');
+    c1.vertical = 'rl\u0000';
+    assert_equals(c1.vertical, 'lr');
+}, document.title+', script-created cue');
+
+var t_parsed = async_test(document.title+', parsed cue');
+t_parsed.step(function(){
+    var t = document.createElement('track');
+    t.onload = this.step_func(function(){
+        var c1 = t.track.cues[0];
+        var c2 = t.track.cues[1];
+        var c3 = t.track.cues[2];
+        assert_equals(c1.vertical, '');
+        assert_equals(c2.vertical, 'rl');
+        assert_equals(c3.vertical, 'lr');
+        this.done();
+    });
+    t.onerror = this.step_func(function() {
+      assert_unreached('got error event');
+    });
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 vertical:rl\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 vertical:lr\ntest', this);
+    t.track.mode = 'showing';
+    video.appendChild(t);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/w3c-import.log
@@ -1,0 +1,31 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/categories.json
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/common.js
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/size.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor-expected.txt
@@ -1,0 +1,4 @@
+
+PASS VTTRegion() initial values
+FAIL VTTRegion() mutations The string did not match the expected pattern.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<title>VTTRegion()</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-vttregion">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true(region instanceof VTTRegion, "instanceof");
+
+    assert_equals(region.scroll, "");
+    assert_equals(region.viewportAnchorX, 0);
+    assert_equals(region.viewportAnchorY, 100);
+    assert_equals(region.regionAnchorX, 0);
+    assert_equals(region.regionAnchorY, 100);
+    assert_equals(region.lines, 3);
+    assert_equals(region.width, 100);
+}, document.title + " initial values");
+
+test(function() {
+    var region = new VTTRegion();
+    region.scroll = "invalid-scroll-value";
+    assert_equals(region.scroll, "");
+
+    checkValues([-1, 101], "IndexSizeError");
+    checkValues([-Infinity, Infinity, NaN], TypeError);
+
+    function assert_throws_something(error, func) {
+        if (typeof error == "string") {
+            assert_throws_dom(error, func);
+        } else {
+            assert_throws_js(error, func);
+        }
+    }
+
+    function checkValues(invalidValues, exception) {
+        for (var value of invalidValues) {
+            assert_throws_something(exception, function() { region.viewportAnchorX = value; });
+            assert_equals(region.viewportAnchorX, 0);
+            assert_throws_something(exception, function() { region.viewportAnchorY = value; });
+            assert_equals(region.viewportAnchorY, 100);
+            assert_throws_something(exception, function() { region.regionAnchorX = value; });
+            assert_equals(region.regionAnchorX, 0);
+            assert_throws_something(exception, function() { region.regionAnchorY = value; });
+            assert_equals(region.regionAnchorY, 100);
+            assert_throws_something(exception, function() { region.width = value; });
+            assert_equals(region.width, 100);
+        }
+    }
+
+    assert_equals(region.lines, 3);
+
+    region.lines = 130;
+    assert_equals(region.lines, 130);
+    region.viewportAnchorX = 64;
+    assert_equals(region.viewportAnchorX, 64);
+    region.viewportAnchorY = 32;
+    assert_equals(region.viewportAnchorY, 32);
+    region.regionAnchorX = 16;
+    assert_equals(region.regionAnchorX, 16);
+    region.regionAnchorY = 8;
+    assert_equals(region.regionAnchorY, 8);
+    region.width = 42;
+    assert_equals(region.width, 42);
+}, document.title + " mutations");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTRegion.id script-created region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>VTTRegion.id</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-id">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('id' in region, 'id is not supported');
+
+    assert_equals(region.id, '', 'initial value');
+
+    region.id = '1';
+    assert_equals(region.id, '1', 'value after setting to "1"');
+
+    region.id = '';
+    assert_equals(region.id, '', 'value after setting to the empty string');
+
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL VTTRegion.lines script-created region The index is not in the allowed range.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>VTTRegion.lines</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-lines">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('lines' in region, 'lines is not supported');
+
+    for (var i = 1; i <= 100; i++) {
+        region.lines = i;
+        assert_equals(region.lines, i);
+    }
+
+    // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
+    [[0, 0],
+     [-0, 0],
+     [-1, 4294967295],
+     [-100, 4294967196],
+     [101, 101],
+     [-2147483648, 2147483648],
+     [2147483647, 2147483647],
+     [2147483648, 2147483648],
+     [NaN, 0],
+     [Infinity, 0],
+     [-Infinity, 0]].forEach(function (pair) {
+        var input = pair[0];
+        var expected = pair[1];
+        region.lines = input;
+        assert_equals(region.lines, expected);
+    });
+
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Box-less VTTCue attached to VTTRegion
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Box-less VTTCue attached to VTTRegion</title>
+<script src="/common/media.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<video></video>
+<script>
+setup(function() {
+  window.video = document.querySelector('video');
+  video.src = getVideoURI('/media/test');
+});
+async_test(function(t) {
+  let track = video.addTextTrack('subtitles');
+  let cue = new VTTCue(0, 1, '');
+  cue.region = new VTTRegion();
+  cue.onexit = t.step_func_done(function() {
+    video.pause();
+  });
+  track.addCue(cue);
+  video.onloadedmetadata = t.step_func(function() {
+    video.currentTime = 0.8;
+    video.play();
+  });
+  video.onended = t.unreached_func('test ends before video');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTRegion.regionAnchorX script-created region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>VTTRegion.regionAnchorX</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-regionanchorx">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('regionAnchorX' in region, 'regionAnchorX is not supported');
+
+    for (var i = 0; i <= 100; i++) {
+        region.regionAnchorX = i;
+        assert_equals(region.regionAnchorX, i);
+    }
+
+    region.regionAnchorX = 1.5;
+    assert_equals(region.regionAnchorX, 1.5);
+
+    [-1, -100, -150, 101, 200, 250].forEach(function (invalid) {
+        assert_throws_dom('IndexSizeError', function() {
+            region.regionAnchorX = invalid;
+        });
+    });
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTRegion.regionAnchorY script-created region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>VTTRegion.regionAnchorY</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-regionanchory">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('regionAnchorY' in region, 'regionAnchorY is not supported');
+
+    for (var i = 0; i <= 100; i++) {
+        region.regionAnchorY = i;
+        assert_equals(region.regionAnchorY, i);
+    }
+
+    region.regionAnchorX = 1.5;
+    assert_equals(region.regionAnchorX, 1.5);
+
+    [-1, -100, -150, 101, 200, 250].forEach(function (invalid) {
+        assert_throws_dom('IndexSizeError', function() {
+            region.regionAnchorY = invalid;
+        });
+    });
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL VTTRegion.scroll script-created region The string did not match the expected pattern.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>VTTRegion.scroll</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-scroll">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('scroll' in region, 'scroll is not supported');
+
+    region.scroll = '';
+    assert_equals(region.scroll, '');
+
+    region.scroll = 'up';
+    assert_equals(region.scroll, 'up');
+
+    region.scroll = 'down';
+    assert_equals(region.scroll, 'up');
+
+    region.scroll = '';
+    for (var invalid in ['left', 'right', 'center', 'top', 'bottom', 'down']) {
+        region.scroll = invalid;
+        assert_equals(region.scroll, '');
+    }
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTRegion.viewportAnchorX script-created region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>VTTRegion.viewportAnchorX</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-viewportanchorx">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('viewportAnchorX' in region, 'viewportAnchorX is not supported');
+
+    for (var i = 0; i <= 100; i++) {
+        region.viewportAnchorX = i;
+        assert_equals(region.viewportAnchorX, i);
+    }
+
+    region.viewportAnchorX = 1.5;
+    assert_equals(region.viewportAnchorX, 1.5);
+
+    [-1, -100, -150, 101, 200, 250].forEach(function (invalid) {
+        assert_throws_dom('IndexSizeError', function() {
+            region.viewportAnchorX = invalid;
+        });
+    });
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTRegion.viewportAnchorY script-created region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>VTTRegion.viewportAnchorY</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-viewportanchory">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function() {
+    var region = new VTTRegion();
+    assert_true('viewportAnchorY' in region, 'viewportAnchorY is not supported');
+
+    for (var i = 0; i <= 100; i++) {
+        region.viewportAnchorY = i;
+        assert_equals(region.viewportAnchorY, i);
+    }
+
+    region.viewportAnchorY = 1.5;
+    assert_equals(region.viewportAnchorY, 1.5);
+
+    [-1, -100, -150, 101, 200, 250].forEach(function (invalid) {
+        assert_throws_dom('IndexSizeError', function() {
+            region.viewportAnchorY = invalid;
+        });
+    });
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/w3c-import.log
@@ -1,0 +1,26 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width.html

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VTTRegion.width script-created region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>VTTRegion.width</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#dom-vttregion-width">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var region = new VTTRegion();
+    assert_true('width' in region, 'width is not supported');
+
+    for (var i = 0; i <= 100; i++) {
+        region.width = i;
+        assert_equals(region.width, i);
+    }
+
+    region.width = 1.5;
+    assert_equals(region.width, 1.5);
+
+    [-1, -100, -150, 101, 200, 250].forEach(function (invalid) {
+        assert_throws_dom('IndexSizeError', function() {
+            region.width = invalid;
+        });
+    });
+}, document.title + ' script-created region');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/categories.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/categories.json
@@ -1,0 +1,5 @@
+{
+    ":subcategories": ["VTTCue/categories.json"],
+    "VTTCue/*": "cues",
+    "VTTRegion/*": "regions"
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical-expected.txt
@@ -1,0 +1,8 @@
+
+PASS VTTCue regionId member must be nuked
+FAIL TextTrack regions member must be nuked assert_false: expected false got true
+FAIL TextTrack addRegion member must be nuked assert_false: expected false got true
+FAIL TextTrack removeRegion member must be nuked assert_false: expected false got true
+FAIL VTTRegion track member must be nuked assert_false: expected false got true
+PASS VTTRegionList interface must be nuked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Historical WebVTT APIs must not be supported</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+// Also see /html/semantics/embedded-content/media-elements/historical.html
+
+[
+  // https://github.com/w3c/webvtt/pull/31
+  ['VTTCue', 'regionId'],
+  ['TextTrack', 'regions'],
+  ['TextTrack', 'addRegion'],
+  ['TextTrack', 'removeRegion'],
+  ['VTTRegion', 'track'],
+  // id re-introduced in https://github.com/w3c/webvtt/pull/349/files
+
+].forEach(function(feature) {
+  var interf = feature[0];
+  var member = feature[1];
+  test(function() {
+    assert_true(interf in window, interf + ' is not supported');
+    assert_false(member in window[interf].prototype);
+  }, interf + ' ' + member + ' member must be nuked');
+});
+
+[
+  // https://github.com/w3c/webvtt/pull/31
+  'VTTRegionList',
+
+].forEach(function(interf) {
+  test(function() {
+    assert_false(interf in window);
+  }, interf + ' interface must be nuked');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window-expected.txt
@@ -1,0 +1,58 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS VTTCue interface: existence and properties of interface object
+PASS VTTCue interface object length
+PASS VTTCue interface object name
+PASS VTTCue interface: existence and properties of interface prototype object
+PASS VTTCue interface: existence and properties of interface prototype object's "constructor" property
+PASS VTTCue interface: existence and properties of interface prototype object's @@unscopables property
+PASS VTTCue interface: attribute region
+PASS VTTCue interface: attribute vertical
+PASS VTTCue interface: attribute snapToLines
+PASS VTTCue interface: attribute line
+PASS VTTCue interface: attribute lineAlign
+PASS VTTCue interface: attribute position
+PASS VTTCue interface: attribute positionAlign
+PASS VTTCue interface: attribute size
+PASS VTTCue interface: attribute align
+PASS VTTCue interface: attribute text
+PASS VTTCue interface: operation getCueAsHTML()
+PASS VTTCue must be primary interface of new VTTCue(0, 0, "")
+PASS Stringification of new VTTCue(0, 0, "")
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "region" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "vertical" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "snapToLines" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "line" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "lineAlign" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "position" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "positionAlign" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "size" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "align" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "text" with the proper type
+PASS VTTCue interface: new VTTCue(0, 0, "") must inherit property "getCueAsHTML()" with the proper type
+PASS VTTRegion interface: existence and properties of interface object
+PASS VTTRegion interface object length
+PASS VTTRegion interface object name
+PASS VTTRegion interface: existence and properties of interface prototype object
+PASS VTTRegion interface: existence and properties of interface prototype object's "constructor" property
+PASS VTTRegion interface: existence and properties of interface prototype object's @@unscopables property
+PASS VTTRegion interface: attribute id
+PASS VTTRegion interface: attribute width
+PASS VTTRegion interface: attribute lines
+PASS VTTRegion interface: attribute regionAnchorX
+PASS VTTRegion interface: attribute regionAnchorY
+PASS VTTRegion interface: attribute viewportAnchorX
+PASS VTTRegion interface: attribute viewportAnchorY
+PASS VTTRegion interface: attribute scroll
+PASS VTTRegion must be primary interface of new VTTRegion()
+PASS Stringification of new VTTRegion()
+PASS VTTRegion interface: new VTTRegion() must inherit property "id" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "width" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "lines" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "regionAnchorX" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "regionAnchorY" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "viewportAnchorX" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "viewportAnchorY" with the proper type
+PASS VTTRegion interface: new VTTRegion() must inherit property "scroll" with the proper type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.js
@@ -1,0 +1,15 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+idl_test(
+  ['webvtt'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      VTTCue: ['new VTTCue(0, 0, "")'],
+      VTTRegion: ['new VTTRegion()'],
+    });
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/w3c-import.log
@@ -1,0 +1,19 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/categories.json
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical.html
+/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.js


### PR DESCRIPTION
#### 2848e7016e7337f3b4365a42d73e51d05935cea6
<pre>
Import webvtt/api WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=260953">https://bugs.webkit.org/show_bug.cgi?id=260953</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c01dec4d9339a58fcd5e433cc7fc002aa38f9261">https://github.com/web-platform-tests/wpt/commit/c01dec4d9339a58fcd5e433cc7fc002aa38f9261</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/categories.json: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/common.js: Added.
(make_vtt_track):
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-exceptions.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/constructor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/lineAlign.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/position.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/positionAlign.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/region.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/id.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorX.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/regionAnchorY.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorX.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/viewportAnchorY.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/width.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/categories.json: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/idlharness.window.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/w3c-import.log: Added.

Canonical link: <a href="https://commits.webkit.org/267574@main">https://commits.webkit.org/267574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ca29277a326335e1713ea7e705caa70afe847d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15829 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18080 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19500 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22060 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19815 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13649 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4069 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->