### PR TITLE
Move WebCodecs VideoFrame serialisation out of agent cluster tests to a separate file

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6249,7 +6249,6 @@ imported/w3c/web-platform-tests/wasm/serialization/module/cross-origin-module-sh
 imported/w3c/web-platform-tests/wasm/serialization/module/share-module-cross-origin-fails.sub.html [ Skip ]
 imported/w3c/web-platform-tests/wasm/serialization/module/window-domain-success.sub.html [ Skip ]
 imported/w3c/web-platform-tests/wasm/serialization/module/window-similar-but-cross-origin-success.sub.html [ Skip ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceTransportPolicy.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-onicecandidateerror.https.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-remote-track-mute.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https-expected.txt
@@ -1,22 +1,5 @@
-CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
-CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
-CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
-CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
-CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
 
 
-Harness Error (TIMEOUT), message = null
-
-PASS Verify frames can be passed within the same agent clusters
 FAIL Verify frames cannot be passed accross the different agent clusters assert_false: expected false got true
-PASS Verify frames can be passed back and forth between main and worker
-PASS Verify frames cannot be passed to sharedworker
-PASS Verify frames cannot be passed to serviceworker
-FAIL Verify frames can be transferred within the same agent clusters assert_true: expected true got false
-PASS Verify frames cannot be transferred accross the different agent clusters
-PASS Verify frames can be transferred back and forth between main and worker
-PASS Verify frames cannot be transferred to a sharedworker
-PASS Verify frames cannot be transferred to serviceworker
-TIMEOUT Verify frames is unavailable in sharedworker Test timed out
-NOTRUN Verify frames is unavailable in serviceworker
+FAIL Verify frames cannot be transferred accross the different agent clusters assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
@@ -5,66 +5,12 @@
   <script src='/resources/testharnessreport.js'></script>
   <script src='/common/get-host-info.sub.js'></script>
   <script src='/webcodecs/utils.js'></script>
-  <script id='workerCode' type='javascript/worker'>
-    self.onmessage = (e) => {
-      let frame = e.data.frame;
-      if (e.data.transfer) {
-        postMessage(frame, [frame]);
-      } else {
-        postMessage(frame);
-      }
-    };
-  </script>
-  <script id='sharedWorkerCode' type='javascript/worker'>
-    const data = new Uint8Array([
-      1, 2, 3, 4, 5, 6, 7, 8,
-      9, 10, 11, 12, 13, 14, 15, 16,
-    ]);
-    let received = new Map();
-    self.onconnect = function (event) {
-      const port = event.ports[0];
-      port.onmessage = function (e) {
-        if (e.data == 'create-frame') {
-          let frameOrError = null;
-          try {
-            frameOrError = new VideoFrame(data, {
-              timestamp: 0,
-              codedWidth: 2,
-              codedHeight: 2,
-              format: 'RGBA',
-            });
-          } catch (error) {
-            frameOrError = error
-          }
-          port.postMessage(frameOrError);
-          return;
-        }
-        if (e.data.hasOwnProperty('id')) {
-          port.postMessage(
-            received.get(e.data.id) ? 'RECEIVED' : 'NOT_RECEIVED');
-          return;
-        }
-        if (e.data.toString() == '[object VideoFrame]') {
-          received.set(e.data.timestamp, e.data);
-        }
-      };
-    };
-  </script>
 </head>
 <body>
 <script>
 const HELPER = '/webcodecs/videoFrame-serialization.crossAgentCluster.helper.html';
-const SAMEORIGIN_BASE = get_host_info().HTTPS_ORIGIN;
 const CROSSORIGIN_BASE = get_host_info().HTTPS_NOTSAMESITE_ORIGIN;
-const SAMEORIGIN_HELPER = SAMEORIGIN_BASE + HELPER;
 const CROSSORIGIN_HELPER = CROSSORIGIN_BASE + HELPER;
-const SERVICE_WORKER = 'serialization.crossAgentCluster.serviceworker.js';
-
-promise_test(async () => {
-  const target = (await appendIframe(SAMEORIGIN_HELPER)).contentWindow;
-  let frame = createVideoFrame(10);
-  assert_true(await canSerializeVideoFrame(target, frame));
-}, 'Verify frames can be passed within the same agent clusters');
 
 promise_test(async () => {
   const target = (await appendIframe(CROSSORIGIN_HELPER)).contentWindow;
@@ -73,147 +19,10 @@ promise_test(async () => {
 }, 'Verify frames cannot be passed accross the different agent clusters');
 
 promise_test(async () => {
-  const blob = new Blob([document.querySelector('#workerCode').textContent], {
-    type: 'text/javascript',
-  });
-  const worker = new Worker(window.URL.createObjectURL(blob));
-  let frame = createVideoFrame(30);
-  worker.postMessage({frame: frame, transfer: false});
-  const received = await new Promise(resolve => worker.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_equals(received.toString(), '[object VideoFrame]');
-  assert_equals(received.timestamp, 30);
-}, 'Verify frames can be passed back and forth between main and worker');
-
-promise_test(async () => {
-  const encodedScriptText = btoa("self.onmessage = (e) => { postMessage(e.data);};");
-  const scriptURL = 'data:text/javascript;base64,' + encodedScriptText;
-  const worker = new Worker(scriptURL);
-  let frame = createVideoFrame(40);
-  worker.postMessage(frame);
-  const received = await new Promise(resolve => worker.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_equals(received.toString(), '[object VideoFrame]');
-  assert_equals(received.timestamp, 40);
-}, 'Verify frames can be passed back and forth between main and data-url worker');
-
-promise_test(async () => {
-  const blob = new Blob([document.querySelector('#sharedWorkerCode').textContent], {
-    type: 'text/javascript',
-  });
-  const worker = new SharedWorker(window.URL.createObjectURL(blob));
-  let frame = createVideoFrame(50);
-  worker.port.postMessage(frame);
-  worker.port.postMessage({'id': 50});
-  const received = await new Promise(resolve => worker.port.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_equals(received, 'NOT_RECEIVED');
-}, 'Verify frames cannot be passed to sharedworker');
-
-promise_test(async () => {
-  navigator.serviceWorker.register(SERVICE_WORKER);
-  navigator.serviceWorker.ready.then((registration) => {
-    let frame = createVideoFrame(60);
-    registration.active.postMessage(frame);
-    registration.active.postMessage({'videoFrameId': 60});
-  });
-  const received = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => {
-    resolve(e.data);
-  });
-  assert_equals(received, 'NOT_RECEIVED');
-}, 'Verify frames cannot be passed to serviceworker');
-
-promise_test(async () => {
-  const target = (await appendIframe(SAMEORIGIN_HELPER)).contentWindow;
-  let frame = createVideoFrame(70);
-  assert_true(await canTransferVideoFrame(target, frame));
-  assert_true(isFrameClosed(frame));
-}, 'Verify frames can be transferred within the same agent clusters');
-
-promise_test(async () => {
   const target = (await appendIframe(CROSSORIGIN_HELPER)).contentWindow;
   let frame = createVideoFrame(80);
   assert_false(await canTransferVideoFrame(target, frame));
 }, 'Verify frames cannot be transferred accross the different agent clusters');
-
-promise_test(async () => {
-  const blob = new Blob([document.querySelector('#workerCode').textContent], {
-    type: 'text/javascript',
-  });
-  const worker = new Worker(window.URL.createObjectURL(blob));
-  let frame = createVideoFrame(90);
-  worker.postMessage({frame: frame, transfer: true}, [frame]);
-  const received = await new Promise(resolve => worker.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_equals(received.toString(), '[object VideoFrame]');
-  assert_equals(received.timestamp, 90);
-}, 'Verify frames can be transferred back and forth between main and worker');
-
-promise_test(async () => {
-  const encodedScriptText = btoa("self.onmessage = (e) => { let f = e.data; postMessage(f, [f]); };");
-  const scriptURL = 'data:text/javascript;base64,' + encodedScriptText;
-  const worker = new Worker(scriptURL);
-  let frame = createVideoFrame(100);
-  worker.postMessage(frame, [frame]);
-  const received = await new Promise(resolve => worker.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_equals(received.toString(), '[object VideoFrame]');
-  assert_equals(received.timestamp, 100);
-}, 'Verify frames can be transferred back and forth between main and data-url worker');
-
-promise_test(async () => {
-  const blob = new Blob([document.querySelector('#sharedWorkerCode').textContent], {
-    type: 'text/javascript',
-  });
-  const worker = new SharedWorker(window.URL.createObjectURL(blob));
-  let frame = createVideoFrame(110);
-  worker.port.postMessage(frame, [frame]);
-  worker.port.postMessage({'id': 110});
-  const received = await new Promise(resolve => worker.port.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_equals(received, 'NOT_RECEIVED');
-}, 'Verify frames cannot be transferred to a sharedworker');
-
-promise_test(async () => {
-  navigator.serviceWorker.register(SERVICE_WORKER);
-  navigator.serviceWorker.ready.then((registration) => {
-    let frame = createVideoFrame(120);
-    registration.active.postMessage(frame, [frame]);
-    registration.active.postMessage({'videoFrameId': 120});
-  });
-  const received = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => {
-    resolve(e.data);
-  });
-  assert_equals(received, 'NOT_RECEIVED');
-}, 'Verify frames cannot be transferred to serviceworker');
-
-promise_test(async () => {
-  const blob = new Blob([document.querySelector('#sharedWorkerCode').textContent], {
-    type: 'text/javascript',
-  });
-  const worker = new SharedWorker(window.URL.createObjectURL(blob));
-  worker.port.postMessage('create-frame');
-  const received = await new Promise(resolve => worker.port.onmessage = e => {
-    resolve(e.data);
-  });
-  assert_true(received instanceof ReferenceError);
-}, 'Verify frames is unavailable in sharedworker');
-
-promise_test(async () => {
-  navigator.serviceWorker.register(SERVICE_WORKER);
-  let registration = await navigator.serviceWorker.ready;
-  registration.active.postMessage('create-VideoFrame');
-  const received = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => {
-    resolve(e.data);
-  });
-  assert_true(received instanceof ReferenceError);
-}, 'Verify frames is unavailable in serviceworker');
 
 function appendIframe(src) {
   const frame = document.createElement('iframe');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https-expected.txt
@@ -1,0 +1,15 @@
+
+
+PASS Verify frames can be passed within the same agent clusters
+PASS Verify frames can be passed back and forth between main and worker
+PASS Verify frames can be passed back and forth between main and data-url worker
+PASS Verify frames cannot be passed to sharedworker
+PASS Verify frames cannot be passed to serviceworker
+PASS Verify frames can be transferred within the same agent clusters
+PASS Verify frames can be transferred back and forth between main and worker
+PASS Verify frames can be transferred back and forth between main and data-url worker
+PASS Verify frames cannot be transferred to a sharedworker
+PASS Verify frames cannot be transferred to serviceworker
+PASS Verify frames is unavailable in sharedworker
+PASS Verify frames is unavailable in serviceworker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src='/resources/testharness.js'></script>
+  <script src='/resources/testharnessreport.js'></script>
+  <script src='/common/get-host-info.sub.js'></script>
+  <script src='/webcodecs/utils.js'></script>
+  <script id='workerCode' type='javascript/worker'>
+    self.onmessage = (e) => {
+      let frame = e.data.frame;
+      if (e.data.transfer) {
+        postMessage(frame, [frame]);
+      } else {
+        postMessage(frame);
+      }
+    };
+  </script>
+  <script id='sharedWorkerCode' type='javascript/worker'>
+    const data = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8,
+      9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+    let received = new Map();
+    self.onconnect = function (event) {
+      const port = event.ports[0];
+      port.onmessage = function (e) {
+        if (e.data == 'create-frame') {
+          let frameOrError = null;
+          try {
+            frameOrError = new VideoFrame(data, {
+              timestamp: 0,
+              codedWidth: 2,
+              codedHeight: 2,
+              format: 'RGBA',
+            });
+          } catch (error) {
+            frameOrError = error
+          }
+          port.postMessage(frameOrError);
+          return;
+        }
+        if (e.data.hasOwnProperty('id')) {
+          port.postMessage(
+            received.get(e.data.id) ? 'RECEIVED' : 'NOT_RECEIVED');
+          return;
+        }
+        if (e.data.toString() == '[object VideoFrame]') {
+          received.set(e.data.timestamp, e.data);
+        }
+      };
+    };
+  </script>
+</head>
+<body>
+<script>
+const HELPER = '/webcodecs/videoFrame-serialization.crossAgentCluster.helper.html';
+const SAMEORIGIN_BASE = get_host_info().HTTPS_ORIGIN;
+const CROSSORIGIN_BASE = get_host_info().HTTPS_NOTSAMESITE_ORIGIN;
+const SAMEORIGIN_HELPER = SAMEORIGIN_BASE + HELPER;
+const CROSSORIGIN_HELPER = CROSSORIGIN_BASE + HELPER;
+const SERVICE_WORKER = 'serialization.crossAgentCluster.serviceworker.js';
+
+promise_test(async (t) => {
+  const target = (await appendIframe(SAMEORIGIN_HELPER)).contentWindow;
+  let frame = createVideoFrame(10);
+  t.add_cleanup(() => frame.close());
+  assert_true(await canSerializeVideoFrame(target, frame));
+}, 'Verify frames can be passed within the same agent clusters');
+
+promise_test(async (t) => {
+  const blob = new Blob([document.querySelector('#workerCode').textContent], {
+    type: 'text/javascript',
+  });
+  const worker = new Worker(window.URL.createObjectURL(blob));
+  let frame = createVideoFrame(30);
+  t.add_cleanup(() => frame.close());
+  worker.postMessage({frame: frame, transfer: false});
+  const received = await new Promise(resolve => worker.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_equals(received.toString(), '[object VideoFrame]');
+  assert_equals(received.timestamp, 30);
+}, 'Verify frames can be passed back and forth between main and worker');
+
+promise_test(async (t) => {
+  const encodedScriptText = btoa("self.onmessage = (e) => { postMessage(e.data);};");
+  const scriptURL = 'data:text/javascript;base64,' + encodedScriptText;
+  const worker = new Worker(scriptURL);
+  let frame = createVideoFrame(40);
+  t.add_cleanup(() => frame.close());
+  worker.postMessage(frame);
+  const received = await new Promise(resolve => worker.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_equals(received.toString(), '[object VideoFrame]');
+  assert_equals(received.timestamp, 40);
+}, 'Verify frames can be passed back and forth between main and data-url worker');
+
+promise_test(async (t) => {
+  const blob = new Blob([document.querySelector('#sharedWorkerCode').textContent], {
+    type: 'text/javascript',
+  });
+  const worker = new SharedWorker(window.URL.createObjectURL(blob));
+  let frame = createVideoFrame(50);
+  t.add_cleanup(() => frame.close());
+  worker.port.postMessage(frame);
+  worker.port.postMessage({'id': 50});
+  const received = await new Promise(resolve => worker.port.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_equals(received, 'NOT_RECEIVED');
+}, 'Verify frames cannot be passed to sharedworker');
+
+promise_test(async (t) => {
+  navigator.serviceWorker.register(SERVICE_WORKER);
+  navigator.serviceWorker.ready.then((registration) => {
+    let frame = createVideoFrame(60);
+    t.add_cleanup(() => frame.close());
+    registration.active.postMessage(frame);
+    registration.active.postMessage({'videoFrameId': 60});
+  });
+  const received = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => {
+    resolve(e.data);
+  });
+  assert_equals(received, 'NOT_RECEIVED');
+}, 'Verify frames cannot be passed to serviceworker');
+
+promise_test(async (t) => {
+  const target = (await appendIframe(SAMEORIGIN_HELPER)).contentWindow;
+  let frame = createVideoFrame(70);
+  t.add_cleanup(() => frame.close());
+  assert_true(await canTransferVideoFrame(target, frame));
+  assert_true(isFrameClosed(frame));
+}, 'Verify frames can be transferred within the same agent clusters');
+
+promise_test(async (t) => {
+  const blob = new Blob([document.querySelector('#workerCode').textContent], {
+    type: 'text/javascript',
+  });
+  const worker = new Worker(window.URL.createObjectURL(blob));
+  let frame = createVideoFrame(90);
+  t.add_cleanup(() => frame.close());
+  worker.postMessage({frame: frame, transfer: true}, [frame]);
+  const received = await new Promise(resolve => worker.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_equals(received.toString(), '[object VideoFrame]');
+  assert_equals(received.timestamp, 90);
+}, 'Verify frames can be transferred back and forth between main and worker');
+
+promise_test(async (t) => {
+  const encodedScriptText = btoa("self.onmessage = (e) => { let f = e.data; postMessage(f, [f]); };");
+  const scriptURL = 'data:text/javascript;base64,' + encodedScriptText;
+  const worker = new Worker(scriptURL);
+  let frame = createVideoFrame(100);
+  t.add_cleanup(() => frame.close());
+  worker.postMessage(frame, [frame]);
+  const received = await new Promise(resolve => worker.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_equals(received.toString(), '[object VideoFrame]');
+  assert_equals(received.timestamp, 100);
+}, 'Verify frames can be transferred back and forth between main and data-url worker');
+
+promise_test(async (t) => {
+  const blob = new Blob([document.querySelector('#sharedWorkerCode').textContent], {
+    type: 'text/javascript',
+  });
+  const worker = new SharedWorker(window.URL.createObjectURL(blob));
+  let frame = createVideoFrame(110);
+  t.add_cleanup(() => frame.close());
+  worker.port.postMessage(frame, [frame]);
+  worker.port.postMessage({'id': 110});
+  const received = await new Promise(resolve => worker.port.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_equals(received, 'NOT_RECEIVED');
+}, 'Verify frames cannot be transferred to a sharedworker');
+
+promise_test(async (t) => {
+  navigator.serviceWorker.register(SERVICE_WORKER);
+  navigator.serviceWorker.ready.then((registration) => {
+    let frame = createVideoFrame(120);
+    t.add_cleanup(() => frame.close());
+    registration.active.postMessage(frame, [frame]);
+    registration.active.postMessage({'videoFrameId': 120});
+  });
+  const received = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => {
+    resolve(e.data);
+  });
+  assert_equals(received, 'NOT_RECEIVED');
+}, 'Verify frames cannot be transferred to serviceworker');
+
+promise_test(async () => {
+  const blob = new Blob([document.querySelector('#sharedWorkerCode').textContent], {
+    type: 'text/javascript',
+  });
+  const worker = new SharedWorker(window.URL.createObjectURL(blob));
+  worker.port.postMessage('create-frame');
+  const received = await new Promise(resolve => worker.port.onmessage = e => {
+    resolve(e.data);
+  });
+  assert_true(received instanceof ReferenceError);
+}, 'Verify frames is unavailable in sharedworker');
+
+promise_test(async () => {
+  navigator.serviceWorker.register(SERVICE_WORKER);
+  let registration = await navigator.serviceWorker.ready;
+  registration.active.postMessage('create-VideoFrame');
+  const received = await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => {
+    resolve(e.data);
+  });
+  assert_true(received instanceof ReferenceError);
+}, 'Verify frames is unavailable in serviceworker');
+
+function appendIframe(src) {
+  const frame = document.createElement('iframe');
+  document.body.appendChild(frame);
+  frame.src = src;
+  return new Promise(resolve => frame.onload = () => resolve(frame));
+};
+
+function createVideoFrame(ts) {
+  let data = new Uint8Array([
+    1, 2, 3, 4, 5, 6, 7, 8,
+    9, 10, 11, 12, 13, 14, 15, 16,
+  ]);
+  return new VideoFrame(data, {
+    timestamp: ts,
+    codedWidth: 2,
+    codedHeight: 2,
+    format: 'RGBA',
+  });
+}
+
+function canSerializeVideoFrame(target, vf) {
+  return canPostVideoFrame(target, vf, false);
+};
+
+function canTransferVideoFrame(target, vf) {
+  return canPostVideoFrame(target, vf, true);
+};
+
+function canPostVideoFrame(target, vf, transfer) {
+  if (transfer) {
+    target.postMessage(vf, '*', [vf]);
+    assert_true(isFrameClosed(vf));
+  } else {
+    target.postMessage(vf, '*');
+  }
+  // vf.timestamp doesn't change after vf is closed, so it's fine to use it.
+  target.postMessage({'id': vf.timestamp}, '*');
+  return new Promise(resolve => window.onmessage = e => {
+    resolve(e.data == 'RECEIVED');
+  });
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### ab6979eff99f1aa2cfe73ad7cf3c66fcad26c02c
<pre>
Move WebCodecs VideoFrame serialisation out of agent cluster tests to a separate file
<a href="https://bugs.webkit.org/show_bug.cgi?id=260954">https://bugs.webkit.org/show_bug.cgi?id=260954</a>
rdar://114750260

Reviewed by Tim Nguyen.

As per <a href="https://github.com/web-platform-tests/wpt/issues/41635">https://github.com/web-platform-tests/wpt/issues/41635</a>, we split tests in two so as to move the crossAgentCluster tests out of Interop 2023.
Move tests from videoFrame-serialization.crossAgentCluster.https.html to videoFrame-serialization.https.html.
For all tests, we are making sure to close the frame explicityl at the end of the test so that the frame does not get gced unclosed.
The remaining tests should be changed to accept transfer/serialization but that can be done as a follow-up.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https.html: Added.

Canonical link: <a href="https://commits.webkit.org/267545@main">https://commits.webkit.org/267545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fa5adee88423d8c4eec774ffcc7b450bb27e8fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15840 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17382 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19513 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15346 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19824 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16118 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4051 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->