### PR TITLE
WebGLFramebuffer uses renderbuffer and texture attachments via WebGLObject

### DIFF
--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -112,9 +112,6 @@ public:
 
     Lock& objectGraphLockForContext();
 
-    virtual bool isRenderbuffer() const { return false; }
-    virtual bool isTexture() const { return false; }
-
 protected:
     WebGLObject(WebGLRenderingContextBase&, PlatformGLObject);
 

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.h
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.h
@@ -66,8 +66,6 @@ private:
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
-    bool isRenderbuffer() const override { return true; }
-
     GCGLenum m_internalFormat { GraphicsContextGL::RGBA4 };
     GCGLsizei m_width { 0 };
     GCGLsizei m_height { 0 };

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -264,7 +264,7 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
     }
 #endif
 
-    RefPtr object = m_framebufferBinding->getAttachmentObject(attachment);
+    auto object = m_framebufferBinding->getAttachmentObject(attachment);
     if (!object) {
         if (pname == GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)
             return static_cast<unsigned>(GraphicsContextGL::NONE);
@@ -274,18 +274,19 @@ WebGLAny WebGLRenderingContext::getFramebufferAttachmentParameter(GCGLenum targe
         return nullptr;
     }
 
+    const bool isTexture = std::holds_alternative<RefPtr<WebGLTexture>>(*object);
     switch (pname) {
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE:
-        if (object->isTexture())
+        if (isTexture)
             return static_cast<unsigned>(GraphicsContextGL::TEXTURE);
         return static_cast<unsigned>(GraphicsContextGL::RENDERBUFFER);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME:
-        if (object->isTexture())
-            return static_pointer_cast<WebGLTexture>(WTFMove(object));
-        return static_pointer_cast<WebGLRenderbuffer>(WTFMove(object));
+        if (isTexture)
+            return std::get<RefPtr<WebGLTexture>>(WTFMove(*object));
+        return std::get<RefPtr<WebGLRenderbuffer>>(WTFMove(*object));
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL:
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE:
-        if (!object->isTexture())
+        if (!isTexture)
             break;
         return m_context->getFramebufferAttachmentParameteri(target, attachment, pname);
     case GraphicsContextGL::FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1950,10 +1950,10 @@ void WebGLRenderingContextBase::framebufferRenderbuffer(GCGLenum target, GCGLenu
     }
 #endif
 
-    framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, buffer);
+    framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, RefPtr { buffer });
 }
 
-void WebGLRenderingContextBase::framebufferTexture2D(GCGLenum target, GCGLenum attachment, GCGLenum textarget, WebGLTexture* texture, GCGLint level)
+void WebGLRenderingContextBase::framebufferTexture2D(GCGLenum target, GCGLenum attachment, GCGLenum texTarget, WebGLTexture* texture, GCGLint level)
 {
     if (isContextLost() || !validateFramebufferFuncParameters("framebufferTexture2D", target, attachment))
         return;
@@ -1979,7 +1979,7 @@ void WebGLRenderingContextBase::framebufferTexture2D(GCGLenum target, GCGLenum a
     }
 #endif
 
-    framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, textarget, texture, level, 0);
+    framebufferBinding->setAttachmentForBoundFramebuffer(target, attachment, WebGLFramebuffer::TextureAttachment { texture, texTarget, level });
 }
 
 void WebGLRenderingContextBase::frontFace(GCGLenum mode)

--- a/Source/WebCore/html/canvas/WebGLTexture.h
+++ b/Source/WebCore/html/canvas/WebGLTexture.h
@@ -56,7 +56,6 @@ public:
 private:
     WebGLTexture(WebGLRenderingContextBase&, PlatformGLObject);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
-    bool isTexture() const override { return true; }
     int mapTargetToIndex(GCGLenum) const;
 
     GCGLenum m_target { 0 };


### PR DESCRIPTION
#### 0dcc7a680e6c5e7bf96006e9c3bd17d185861520
<pre>
WebGLFramebuffer uses renderbuffer and texture attachments via WebGLObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=260955">https://bugs.webkit.org/show_bug.cgi?id=260955</a>
rdar://114750589

Reviewed by Dan Glastonbury.

Framebuffer attachments can be 2d textures, 3d texture layers or
renderbuffers. Use std::variant to encode this instead of
a virtual base class. This removes a lot of unneeded complexity in
the code. This also enables future bugfixes related to non-typesafe
handling of these variants.

When obtaining a pointer to the attached object, use std::variant
instead of WebGLObject*. This way future commits may break the
dependency to a common base class. The objects do not have intrinsic
polymorphic operations, rather their types are always known at the
invocation site, from JS through WebGLRenderingContextBase.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::framebufferTextureLayer):
(WebCore::WebGL2RenderingContext::getFramebufferAttachmentParameter):
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::entryAddMembersToOpaqueRoots):
(WebCore::entryDetachAndClear):
(WebCore::entryAttach):
(WebCore::entryContextSetAttachment):
(WebCore::entryObject):
(WebCore::entryHasObject):
(WebCore::WebGLFramebuffer::setAttachmentForBoundFramebuffer):
(WebCore::WebGLFramebuffer::getAttachmentObject const):
(WebCore::WebGLFramebuffer::removeAttachmentFromBoundFramebuffer):
(WebCore::WebGLFramebuffer::deleteObjectImpl):
(WebCore::WebGLFramebuffer::drawBuffersIfNecessary):
(WebCore::WebGLFramebuffer::addMembersToOpaqueRoots):
(WebCore::WebGLFramebuffer::setAttachmentInternal):
(WebCore::WebGLFramebuffer::TextureAttachment::operator== const):
(WebCore::WebGLFramebuffer::TextureLayerAttachment::operator== const):
(): Deleted.
(WebCore::WebGLFramebuffer::attach): Deleted.
(WebCore::WebGLFramebuffer::getAttachment const): Deleted.
(WebCore::WebGLFramebuffer::removeAttachmentInternal): Deleted.
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLObject.h:
(WebCore::WebGLObject::isRenderbuffer const): Deleted.
(WebCore::WebGLObject::isTexture const): Deleted.
* Source/WebCore/html/canvas/WebGLRenderbuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::getFramebufferAttachmentParameter):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::framebufferRenderbuffer):
(WebCore::WebGLRenderingContextBase::framebufferTexture2D):
* Source/WebCore/html/canvas/WebGLTexture.h:

Canonical link: <a href="https://commits.webkit.org/267535@main">https://commits.webkit.org/267535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ab78e2bfecf1ff0a3272ea9f3fca29c2bb5dd17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19358 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21955 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19680 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13540 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15140 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->