### PR TITLE
[WebCodecs] AudioDecoder follow-up after 267403@main

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
@@ -1,14 +1,44 @@
 
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Empty codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Unrecognized codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Video codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
-PASS Test that AudioDecoder.configure() rejects invalid config:Empty codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Unrecognized codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Video codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Ambiguous codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Codec with MIME type
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Video codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future aac codec string
+FAIL Test that AudioDecoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Video codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Ambiguous codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Codec with MIME type assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 PASS Test AudioDecoder construction
 PASS Verify unconfigured AudioDecoder operations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
@@ -1,14 +1,44 @@
 
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Empty codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Unrecognized codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Video codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Ambiguous codec
-PASS Test that AudioDecoder.isConfigSupported() rejects invalid config:Codec with MIME type
-PASS Test that AudioDecoder.configure() rejects invalid config:Empty codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Unrecognized codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Video codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Ambiguous codec
-PASS Test that AudioDecoder.configure() rejects invalid config:Codec with MIME type
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Video codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future aac codec string
+FAIL Test that AudioDecoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Video codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Ambiguous codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Codec with MIME type assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 PASS Test AudioDecoder construction
 PASS Verify unconfigured AudioDecoder operations
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1135,15 +1135,6 @@ imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?h
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]
 
-# Failing after resync, probably needs a rebasing
-imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.html [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker.html [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av1 [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.html [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker.html [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html [ Pass Failure ]
-
 # HEVC support
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_annexb [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_hevc [ Pass ]
@@ -1160,6 +1151,8 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worke
 # Likely bugs related with dav1ddec.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?av1 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av1 [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 [ Pass Failure ]
 
 # Our MP3 decoder is not yet spec-compliant.
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
@@ -1174,6 +1167,8 @@ imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/audio-data-serialization.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.html [ Pass ]
+imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.worker.html [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?opus [ Pass ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -1,15 +1,56 @@
 
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 0
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
-PASS VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode
-PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
-PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
-PASS VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters
-PASS VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Empty codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Width is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Height is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: displayWidth is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: displayHeight is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: Missing codec
+PASS Test that VideoEncoder.configure() rejects invalid config: Empty codec
+PASS Test that VideoEncoder.configure() rejects invalid config: Width is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: Height is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd sized frames for H264
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string assert_false: expected false got true
+FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264 assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
 FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -1,15 +1,56 @@
 
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 0
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
-PASS VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode
-PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
-PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
-PASS VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters
-PASS VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Empty codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Width is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: Height is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: displayWidth is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config: displayHeight is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: Missing codec
+PASS Test that VideoEncoder.configure() rejects invalid config: Empty codec
+PASS Test that VideoEncoder.configure() rejects invalid config: Width is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: Height is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 0
+PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd sized frames for H264
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string assert_false: expected false got true
+FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264 assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
 FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -63,9 +63,15 @@ WebCodecsAudioDecoder::~WebCodecsAudioDecoder()
 {
 }
 
-static bool isValidDecoderConfig(const WebCodecsAudioDecoderConfig& config, const Settings::Values&)
+static bool isValidDecoderConfig(const WebCodecsAudioDecoderConfig& config)
 {
-    return AudioDecoder::isCodecSupported(config.codec);
+    if (StringView(config.codec).trim(isASCIIWhitespace<UChar>).isEmpty())
+        return false;
+
+    // FIXME: We might need to check numberOfChannels and sampleRate here. See
+    // https://github.com/w3c/webcodecs/issues/714.
+
+    return true;
 }
 
 static AudioDecoder::Config createAudioDecoderConfig(const WebCodecsAudioDecoderConfig& config)
@@ -82,16 +88,12 @@ static AudioDecoder::Config createAudioDecoderConfig(const WebCodecsAudioDecoder
             description = { data, length };
     }
 
-    return {
-        description,
-        config.sampleRate.value_or(0),
-        config.numberOfChannels.value_or(0)
-    };
+    return { description, config.sampleRate, config.numberOfChannels };
 }
 
-ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext& context, WebCodecsAudioDecoderConfig&& config)
+ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext&, WebCodecsAudioDecoderConfig&& config)
 {
-    if (!isValidDecoderConfig(config, context.settingsValues()))
+    if (!isValidDecoderConfig(config))
         return Exception { TypeError, "Config is not valid"_s };
 
     if (m_state == WebCodecsCodecState::Closed || !scriptExecutionContext())
@@ -100,7 +102,8 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext& conte
     m_state = WebCodecsCodecState::Configured;
     m_isKeyChunkRequired = true;
 
-    queueControlMessageAndProcess([this, config = WTFMove(config), identifier = scriptExecutionContext()->identifier()]() mutable {
+    bool isSupportedCodec = AudioDecoder::isCodecSupported(config.codec);
+    queueControlMessageAndProcess([this, config = WTFMove(config), isSupportedCodec, identifier = scriptExecutionContext()->identifier()]() mutable {
         m_isMessageQueueBlocked = true;
         AudioDecoder::PostTaskCallback postTaskCallback = [identifier, weakThis = WeakPtr { *this }](auto&& task) {
             ScriptExecutionContext::postTaskTo(identifier, [weakThis, task = WTFMove(task)](auto&) mutable {
@@ -111,6 +114,11 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext& conte
                 });
             });
         };
+
+        if (!isSupportedCodec) {
+            closeDecoder(Exception { NotSupportedError, "Codec is not supported"_s });
+            return;
+        }
 
         AudioDecoder::create(config.codec, createAudioDecoderConfig(config), [this](auto&& result) {
             if (!result.has_value()) {
@@ -195,8 +203,13 @@ ExceptionOr<void> WebCodecsAudioDecoder::close()
 
 void WebCodecsAudioDecoder::isConfigSupported(ScriptExecutionContext& context, WebCodecsAudioDecoderConfig&& config, Ref<DeferredPromise>&& promise)
 {
-    if (!isValidDecoderConfig(config, context.settingsValues())) {
+    if (!isValidDecoderConfig(config)) {
         promise->reject(Exception { TypeError, "Config is not valid"_s });
+        return;
+    }
+
+    if (!AudioDecoder::isCodecSupported(config.codec)) {
+        promise->template resolve<IDLDictionary<WebCodecsAudioDecoderSupport>>(WebCodecsAudioDecoderSupport { false, WTFMove(config) });
         return;
     }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.h
@@ -36,8 +36,8 @@ namespace WebCore {
 struct WebCodecsAudioDecoderConfig {
     String codec;
     std::optional<BufferSource::VariantType> description;
-    std::optional<size_t> sampleRate;
-    std::optional<size_t> numberOfChannels;
+    size_t sampleRate;
+    size_t numberOfChannels;
 
     WebCodecsAudioDecoderConfig isolatedCopyWithoutDescription() && { return { WTFMove(codec).isolatedCopy(), { }, sampleRate, numberOfChannels }; }
     WebCodecsAudioDecoderConfig isolatedCopyWithoutDescription() const & { return { codec.isolatedCopy(), { }, sampleRate, numberOfChannels }; }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long WebCodecsAudioDecoderConfigSize;
     JSGenerateToJSObject,
 ] dictionary WebCodecsAudioDecoderConfig {
     required DOMString codec;
-    WebCodecsAudioDecoderConfigSize sampleRate;
-    WebCodecsAudioDecoderConfigSize numberOfChannels;
+    required WebCodecsAudioDecoderConfigSize sampleRate;
+    required WebCodecsAudioDecoderConfigSize numberOfChannels;
     (ArrayBufferView or ArrayBuffer) description;
 };

--- a/Source/WebCore/platform/AudioDecoder.cpp
+++ b/Source/WebCore/platform/AudioDecoder.cpp
@@ -41,8 +41,9 @@ namespace WebCore {
 
 bool AudioDecoder::isCodecSupported(const StringView& codec)
 {
-    // FIXME: Check codec more accurately.
-    bool isCodecAllowed = codec.startsWith("mp4a."_s) || codec == "mp3"_s || codec == "opus"_s
+    bool isMPEG4AAC = codec == "mp4a.40.2"_s || codec == "mp4a.40.02"_s || codec == "mp4a.40.5"_s
+        || codec == "mp4a.40.05"_s || codec == "mp4a.40.29"_s || codec == "mp4a.40.42"_s;
+    bool isCodecAllowed = isMPEG4AAC || codec == "mp3"_s || codec == "opus"_s
         || codec == "alaw"_s || codec == "ulaw"_s || codec == "flac"_s
         || codec == "vorbis"_s || codec.startsWith("pcm-"_s);
 


### PR DESCRIPTION
#### 1fb4cdd856dd56a4c6b7973ed2a798f8d2e3a793
<pre>
[WebCodecs] AudioDecoder follow-up after 267403@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=260958">https://bugs.webkit.org/show_bug.cgi?id=260958</a>

Reviewed by Youenn Fablet.

The AudioDecoder config validation now follows the spec more closely. Some tests still fail, not
catching the exception raised when configuring the decoder with an invalid config, but the same
failures happen in the VideoDecoder, so both should be addressed in a separate patch.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::isValidDecoderConfig):
(WebCore::createAudioDecoderConfig):
(WebCore::WebCodecsAudioDecoder::configure):
(WebCore::WebCodecsAudioDecoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoderConfig.idl:
* Source/WebCore/platform/AudioDecoder.cpp:
(WebCore::AudioDecoder::isCodecSupported):

Canonical link: <a href="https://commits.webkit.org/267743@main">https://commits.webkit.org/267743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/327f89e7f58ad36004c86fe91a02d8234a9c5cb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17624 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18250 "16 flakes 150 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19759 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22273 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20091 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13862 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15497 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4182 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->