### PR TITLE
Correct dynamic handling of <base> elements

### DIFF
--- a/LayoutTests/fetch/fetch-url-serialization-expected.txt
+++ b/LayoutTests/fetch/fetch-url-serialization-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Blocked setting data:, as the base URL because it does not have an allowed scheme.
 
 PASS Testing Request url 'http://example	.
 org' with base 'http://example.org/foo/bar'
@@ -273,7 +272,6 @@ PASS Testing Request url 'http://[google.com]' with base 'http://other.com/'
 PASS Testing Request url 'http://foo:💩@example.com/bar' with base 'http://other.com/'
 PASS Testing Request url '#' with base 'test:test'
 PASS Testing Request url '#x' with base 'mailto:x@x.com'
-FAIL Testing Request url '#x' with base 'data:,' assert_equals: expected "data:,#x" but got "mailto:x@x.com#x"
 PASS Testing Request url '#x' with base 'about:blank'
 PASS Testing Request url '#' with base 'test:test?test'
 PASS Testing Request url 'https://@test@test@example:800/' with base 'http://doesnotmatter/'

--- a/LayoutTests/fetch/fetch-urls.json
+++ b/LayoutTests/fetch/fetch-urls.json
@@ -3640,21 +3640,6 @@ executeTests(
   },
   {
     "input": "#x",
-    "base": "data:,",
-    "href": "data:,#x",
-    "origin": "null",
-    "protocol": "data:",
-    "username": "",
-    "password": "",
-    "host": "",
-    "hostname": "",
-    "port": "",
-    "pathname": ",",
-    "search": "",
-    "hash": "#x"
-  },
-  {
-    "input": "#x",
     "base": "about:blank",
     "href": "about:blank#x",
     "origin": "null",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Blocked setting data:/,test as the base URL because it does not have an allowed scheme.
+CONSOLE MESSAGE: Blocked setting data:/,test as the base URL because it does not have an allowed scheme.
+CONSOLE MESSAGE: Blocked setting data:/,more-test as the base URL because it does not have an allowed scheme.
+
+PASS First <base> has a data: URL so fallback is used
+PASS First <base> is removed so second is used
+PASS Dynamically inserted first <base> has a data: URL so fallback is used
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data.html
@@ -1,0 +1,32 @@
+<!-- Please update base-javascript.html together with this -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;base> and data: URLs</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<base href="data:/,test">
+<base href="https://example.com/">
+<div id=log></div>
+<script>
+test(() => {
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+}, "First <base> has a data: URL so fallback is used");
+
+test(() => {
+  document.querySelector("base").remove();
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", "https://example.com/").href);
+}, "First <base> is removed so second is used");
+
+test(() => {
+  const base = document.createElement("base");
+  base.href = "data:/,more-test";
+  document.head.prepend(base);
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+}, "Dynamically inserted first <base> has a data: URL so fallback is used");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Blocked setting javascript:/,test as the base URL because it does not have an allowed scheme.
+CONSOLE MESSAGE: Blocked setting javascript:/,test as the base URL because it does not have an allowed scheme.
+CONSOLE MESSAGE: Blocked setting javascript:/,more-test as the base URL because it does not have an allowed scheme.
+
+PASS First <base> has a javascript: URL so fallback is used
+PASS First <base> is removed so second is used
+PASS Dynamically inserted first <base> has a javascript: URL so fallback is used
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript.html
@@ -1,0 +1,32 @@
+<!-- Please update base-data.html together with this -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;base> and javascript: URLs</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<base href="javascript:/,test">
+<base href="https://example.com/">
+<div id=log></div>
+<script>
+test(() => {
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+}, "First <base> has a javascript: URL so fallback is used");
+
+test(() => {
+  document.querySelector("base").remove();
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", "https://example.com/").href);
+}, "First <base> is removed so second is used");
+
+test(() => {
+  const base = document.createElement("base");
+  base.href = "javascript:/,more-test";
+  document.head.prepend(base);
+  const link = document.createElement("a");
+  link.href = "blah";
+  assert_equals(link.href, new URL("blah", document.URL).href);
+}, "Dynamically inserted first <base> has a javascript: URL so fallback is used");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base_about_blank.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base_href_empty.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base_href_invalid.html

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Blocked setting data:, as the base URL because it does not have an allowed scheme.
 
 PASS Loading data…
 PASS Parsing origin: <http://example	.
@@ -225,7 +224,6 @@ PASS Parsing origin: <h://.> against <about:blank>
 PASS Parsing origin: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing origin: <#> against <test:test>
 PASS Parsing origin: <#x> against <mailto:x@x.com>
-PASS Parsing origin: <#x> against <data:,>
 PASS Parsing origin: <#x> against <about:blank>
 PASS Parsing origin: <#x:y> against <about:blank>
 PASS Parsing origin: <#> against <test:test?test>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Blocked setting data:, as the base URL because it does not have an allowed scheme.
 
 PASS Loading data…
 PASS Parsing origin: <http://example	.
@@ -225,7 +224,6 @@ PASS Parsing origin: <h://.> against <about:blank>
 PASS Parsing origin: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing origin: <#> against <test:test>
 PASS Parsing origin: <#x> against <mailto:x@x.com>
-PASS Parsing origin: <#x> against <data:,>
 PASS Parsing origin: <#x> against <about:blank>
 PASS Parsing origin: <#x:y> against <about:blank>
 PASS Parsing origin: <#> against <test:test?test>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Blocked setting data:, as the base URL because it does not have an allowed scheme.
 
 PASS Loading data…
 PASS Parsing: <http://example	.
@@ -279,7 +278,6 @@ PASS Parsing: <http://[::%31]> against <http://other.com/>
 PASS Parsing: <http://%5B::1]> against <http://other.com/>
 PASS Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing: <#> against <test:test>
-FAIL Parsing: <#x> against <data:,> assert_equals: href expected "data:,#x" but got "test:test#x"
 PASS Parsing: <#x> against <about:blank>
 PASS Parsing: <#x:y> against <about:blank>
 PASS Parsing: <#> against <test:test?test>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Blocked setting data:, as the base URL because it does not have an allowed scheme.
 
 PASS Loading data…
 PASS Parsing: <http://example	.
@@ -279,7 +278,6 @@ PASS Parsing: <http://[::%31]> against <http://other.com/>
 PASS Parsing: <http://%5B::1]> against <http://other.com/>
 PASS Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing: <#> against <test:test>
-FAIL Parsing: <#x> against <data:,> assert_equals: href expected "data:,#x" but got "test:test#x"
 PASS Parsing: <#x> against <about:blank>
 PASS Parsing: <#x:y> against <about:blank>
 PASS Parsing: <#> against <test:test?test>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/a-element-origin.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/a-element-origin.js
@@ -21,6 +21,10 @@ function runURLTests(urlTests) {
     if (expected.base === null && expected.input.startsWith("#"))
       continue;
 
+    // HTML special cases data: and javascript: URLs in <base>
+    if (expected.base !== null && (expected.base.startsWith("data:") || expected.base.startsWith("javascript:")))
+      continue;
+
     // We cannot use a null base for HTML tests
     const base = expected.base === null ? "about:blank" : expected.base;
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/a-element.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/a-element.js
@@ -21,6 +21,10 @@ function runURLTests(urlTests) {
     if (expected.relativeTo === "any-base")
       continue;
 
+    // HTML special cases data: and javascript: URLs in <base>
+    if (expected.base !== null && (expected.base.startsWith("data:") || expected.base.startsWith("javascript:")))
+      continue;
+
     // We cannot use a null base for HTML tests
     const base = expected.base === null ? "about:blank" : expected.base;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3720,13 +3720,15 @@ void Document::processBaseElement()
         if (!trimmedHref.isEmpty())
             baseElementURL = URL(fallbackBaseURL(), trimmedHref);
     }
-    if (m_baseElementURL != baseElementURL && contentSecurityPolicy()->allowBaseURI(baseElementURL)) {
-        if (settings().shouldRestrictBaseURLSchemes() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL))
+    if (m_baseElementURL != baseElementURL) {
+        if (!contentSecurityPolicy()->allowBaseURI(baseElementURL))
+            m_baseElementURL = { };
+        else if (settings().shouldRestrictBaseURLSchemes() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL)) {
+            m_baseElementURL = { };
             addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked setting " + baseElementURL.stringCenterEllipsizedToLength() + " as the base URL because it does not have an allowed scheme.");
-        else {
+        } else
             m_baseElementURL = baseElementURL;
-            updateBaseURL();
-        }
+        updateBaseURL();
     }
 
     m_baseTarget = target ? *target : nullAtom();

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -48,9 +48,10 @@ Ref<HTMLBaseElement> HTMLBaseElement::create(const QualifiedName& tagName, Docum
 
 void HTMLBaseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == hrefAttr || name == targetAttr)
-        document().processBaseElement();
-    else
+    if (name == hrefAttr || name == targetAttr) {
+        if (isConnected())
+            document().processBaseElement();
+    } else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 


### PR DESCRIPTION
#### 94fe30e306b57acc3a62e6bd75351fee3a393972
<pre>
Correct dynamic handling of &lt;base&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=260959">https://bugs.webkit.org/show_bug.cgi?id=260959</a>
rdar://114756660

Reviewed by Chris Dumez.

Document::processBaseElement did not call Document::updateBaseURL when
there was something wrong with the new base URL. However, that meant
that a newly inserted &quot;blocked&quot; &lt;base&gt; would not impact the document
base URL and instead whatever was the prior document base URL would
continue to be used.

This goes against the HTML standard which requires the first &lt;base&gt;
element to be used at all times and if that is &quot;blocked&quot; the fallback
base URL would have to be used (typically the document&apos;s URL).

Tests are upstreamed via
<a href="https://github.com/web-platform-tests/wpt/pull/41731.">https://github.com/web-platform-tests/wpt/pull/41731.</a> Chromium matches
our failure, but given that it&apos;s an edge case I don&apos;t foresee any
issues.

While we&apos;re in the general area, stop invoking
Document::processBaseElement for &lt;base&gt; elements not connected to a
document as that results in a no-op tree traversal.

* LayoutTests/fetch/fetch-url-serialization-expected.txt:
* LayoutTests/fetch/fetch-urls.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-data.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/base-javascript.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-base-element/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/resources/a-element-origin.js:
(runURLTests):
* LayoutTests/imported/w3c/web-platform-tests/url/resources/a-element.js:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processBaseElement):
* Source/WebCore/html/HTMLBaseElement.cpp:
(WebCore::HTMLBaseElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/267498@main">https://commits.webkit.org/267498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a01671ae0b419c4a0d37f90f35d336281d44856

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17245 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19363 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15213 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13555 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4018 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->