### PR TITLE
Remove AudioSessionCategoryOverride preference

### DIFF
--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -126,16 +126,6 @@ void DeprecatedGlobalSettings::setTrackingPreventionEnabled(bool flag)
 }
 
 #if PLATFORM(IOS_FAMILY)
-void DeprecatedGlobalSettings::setAudioSessionCategoryOverride(unsigned sessionCategory)
-{
-    AudioSession::sharedSession().setCategoryOverride(static_cast<AudioSession::CategoryType>(sessionCategory));
-}
-
-unsigned DeprecatedGlobalSettings::audioSessionCategoryOverride()
-{
-    return static_cast<unsigned>(AudioSession::sharedSession().categoryOverride());
-}
-
 void DeprecatedGlobalSettings::setNetworkDataUsageTrackingEnabled(bool trackingEnabled)
 {
     shared().m_networkDataUsageTrackingEnabled = trackingEnabled;

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -61,9 +61,6 @@ public:
     WEBCORE_EXPORT static void setTrackingPreventionEnabled(bool);
 
 #if PLATFORM(IOS_FAMILY)
-    WEBCORE_EXPORT static void setAudioSessionCategoryOverride(unsigned);
-    static unsigned audioSessionCategoryOverride();
-
     WEBCORE_EXPORT static void setNetworkDataUsageTrackingEnabled(bool);
     static bool networkDataUsageTrackingEnabled() { return shared().m_networkDataUsageTrackingEnabled; }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -140,9 +140,6 @@
 #define WebKitResourceLoadStatisticsEnabledPreferenceKey @"WebKitResourceLoadStatisticsEnabled"
 #define WebKitLargeImageAsyncDecodingEnabledPreferenceKey @"WebKitLargeImageAsyncDecodingEnabled"
 #define WebKitAnimatedImageAsyncDecodingEnabledPreferenceKey @"WebKitAnimatedImageAsyncDecodingEnabled"
-#if TARGET_OS_IPHONE
-#define WebKitAudioSessionCategoryOverride @"WebKitAudioSessionCategoryOverride"
-#endif
 #define WebKitShouldRespectImageOrientationKey @"WebKitShouldRespectImageOrientation"
 #define WebKitRequestAnimationFrameEnabledPreferenceKey @"WebKitRequestAnimationFrameEnabled"
 #define WebKitDiagnosticLoggingEnabledKey @"WebKitDiagnosticLoggingEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -422,7 +422,6 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
         @NO, WebKitStorageTrackerEnabledPreferenceKey,
-        @(static_cast<unsigned>(AudioSession::CategoryType::None)), WebKitAudioSessionCategoryOverride,
 
         // Per-Origin Quota on iOS is 25MB. When the quota is reached for a particular origin
         // the quota for that origin can be increased. See also webView:exceededApplicationCacheOriginQuotaForSecurityOrigin:totalSpaceNeeded in WebUI/WebUIDelegate.m.
@@ -1992,44 +1991,6 @@ static RetainPtr<NSString>& classIBCreatorID()
 - (void)setMediaPlaybackAllowsAirPlay:(BOOL)flag
 {
     [self _setBoolValue:flag forKey:WebKitAllowsAirPlayForMediaPlaybackPreferenceKey];
-}
-
-- (unsigned)audioSessionCategoryOverride
-{
-    return [self _unsignedIntValueForKey:WebKitAudioSessionCategoryOverride];
-}
-
-- (void)setAudioSessionCategoryOverride:(unsigned)override
-{
-    if (override > static_cast<unsigned>(AudioSession::CategoryType::AudioProcessing)) {
-        // Clients are passing us OSTypes values from AudioToolbox/AudioSession.h,
-        // which need to be translated into AudioSession::CategoryType:
-        switch (override) {
-        case WebKitAudioSessionCategoryAmbientSound:
-            override = static_cast<unsigned>(AudioSession::CategoryType::AmbientSound);
-            break;
-        case WebKitAudioSessionCategorySoloAmbientSound:
-            override = static_cast<unsigned>(AudioSession::CategoryType::SoloAmbientSound);
-            break;
-        case WebKitAudioSessionCategoryMediaPlayback:
-            override = static_cast<unsigned>(AudioSession::CategoryType::MediaPlayback);
-            break;
-        case WebKitAudioSessionCategoryRecordAudio:
-            override = static_cast<unsigned>(AudioSession::CategoryType::RecordAudio);
-            break;
-        case WebKitAudioSessionCategoryPlayAndRecord:
-            override = static_cast<unsigned>(AudioSession::CategoryType::PlayAndRecord);
-            break;
-        case WebKitAudioSessionCategoryAudioProcessing:
-            override = static_cast<unsigned>(AudioSession::CategoryType::AudioProcessing);
-            break;
-        default:
-            override = static_cast<unsigned>(AudioSession::CategoryType::None);
-            break;
-        }
-    }
-
-    [self _setUnsignedIntValue:override forKey:WebKitAudioSessionCategoryOverride];
 }
 
 - (BOOL)networkDataUsageTrackingEnabled

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -64,15 +64,6 @@ typedef enum {
     WebKitFrameFlatteningFullyEnabled
 } WebKitFrameFlattening;
 
-typedef enum : unsigned {
-    WebKitAudioSessionCategoryAmbientSound = 'ambi',
-    WebKitAudioSessionCategorySoloAmbientSound = 'solo',
-    WebKitAudioSessionCategoryMediaPlayback = 'medi',
-    WebKitAudioSessionCategoryRecordAudio = 'reca',
-    WebKitAudioSessionCategoryPlayAndRecord = 'plar',
-    WebKitAudioSessionCategoryAudioProcessing = 'proc',
-} WebKitAudioSessionCategory;
-
 typedef enum {
     WebKitPitchCorrectionAlgorithmBestAllAround = 0,
     WebKitPitchCorrectionAlgorithmBestForMusic,
@@ -258,7 +249,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 #else
 
 @property (nonatomic) BOOL storageTrackerEnabled;
-@property (nonatomic) unsigned audioSessionCategoryOverride;
 // WARNING: this affect network performance. This must not be enabled for production use.
 // Enabling this makes WebCore reports the network data usage.
 // This is a global setting.

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2918,7 +2918,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    WebCore::DeprecatedGlobalSettings::setAudioSessionCategoryOverride([preferences audioSessionCategoryOverride]);
     WebCore::DeprecatedGlobalSettings::setNetworkDataUsageTrackingEnabled([preferences networkDataUsageTrackingEnabled]);
     WebCore::DeprecatedGlobalSettings::setNetworkInterfaceName([preferences networkInterfaceName]);
 #endif


### PR DESCRIPTION
#### 5be2eb2bbfb1e05388ab4ad445f5c1f9e903101c
<pre>
Remove AudioSessionCategoryOverride preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=250240">https://bugs.webkit.org/show_bug.cgi?id=250240</a>
rdar://104244014

Reviewed by NOBODY (OOPS!).

It does not appear to be used and we want to get rid of
DeprecatedGlobalSettings.

* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::setAudioSessionCategoryOverride): Deleted.
(WebCore::DeprecatedGlobalSettings::audioSessionCategoryOverride): Deleted.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(+[WebPreferences initialize]):
(-[WebPreferences audioSessionCategoryOverride]): Deleted.
(-[WebPreferences setAudioSessionCategoryOverride:]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _preferencesChanged:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5be2eb2bbfb1e05388ab4ad445f5c1f9e903101c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19370 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15222 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19701 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13561 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15165 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->