### PR TITLE
Reduce the amount of SVGElement::updateRelativeLengthsInformation() calls

### DIFF
--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -171,8 +171,10 @@ void SVGElement::reportAttributeParsingError(SVGParsingError error, const Qualif
 
 void SVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    if (removalType.disconnectedFromDocument)
-        updateRelativeLengthsInformation(false, *this);
+    if (removalType.disconnectedFromDocument) {
+        ASSERT(!parentNode() || !parentNode()->isConnected());
+        m_elementsWithRelativeLengths.clear();
+    }
 
     StyledElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 


### PR DESCRIPTION
#### fab91723ea6b142820bc5c7186672e122391f272
<pre>
Reduce the amount of SVGElement::updateRelativeLengthsInformation() calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=260971">https://bugs.webkit.org/show_bug.cgi?id=260971</a>

Reviewed by Ryosuke Niwa.

Reduce the amount of SVGElement::updateRelativeLengthsInformation() calls.

In SVGElement::removedFromAncestor(), if `removalType.disconnectedFromDocument`
was true, we would call `updateRelativeLengthsInformation(false, *this)` to remove
the element from m_elementsWithRelativeLengths and from our ancestor&apos;s map.

However, when SVGElement::removedFromAncestor() gets called, we know that
the element either doesn&apos;t have a parent or that it&apos;s parent is not connected
(I added an assertion to this effect). As a result, recursively calling
`updateRelativeLengthsInformation(false, element)` on the ancestors had no
effect, since the function would early return at the `!isConnected()` check.

As a result, it is sufficient to clear m_elementsWithRelativeLengths in
SVGElement::removedFromAncestor(), without calling
`updateRelativeLengthsInformation(false, *this)` or worrying about the
ancestors.

* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::removedFromAncestor):

Canonical link: <a href="https://commits.webkit.org/267517@main">https://commits.webkit.org/267517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/656dbeb740e6aebd8a81f10f2067f961d07574d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19396 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15232 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15178 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4036 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->