### PR TITLE
[CMake] Turn off pkg-config on PlayStation

### DIFF
--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -31,7 +31,15 @@ endif ()
 
 if (DEFINED ENV{WEBKIT_IGNORE_PATH})
     set(CMAKE_IGNORE_PATH $ENV{WEBKIT_IGNORE_PATH})
+    message(STATUS "Ignoring paths at ${CMAKE_IGNORE_PATH}")
 endif ()
+
+# Turn off pkg-config when finding PlayStation libraries
+# Prevent CMake from accidentally using the perl install's .pc files
+message(STATUS "Disabling pkgconfig")
+set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig ON)
+macro(pkg_check_modules _prefix _module0)
+endmacro()
 
 list(APPEND CMAKE_PREFIX_PATH ${WEBKIT_LIBRARIES_DIR})
 


### PR DESCRIPTION
#### 53a54cd39755b3ea25db0a1064f102f920f16236
<pre>
[CMake] Turn off pkg-config on PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=260983">https://bugs.webkit.org/show_bug.cgi?id=260983</a>

Reviewed by Michael Catanzaro.

The CMake find modules use pkg-config to get hints for a library&apos;s
location. With a Windows host it can pick up .pc files in the perl
install accidentally. PlayStation isn&apos;t using .pc files so just turn it
completely off.

Prevent the find module from running and override `pkg_check_modules`
so it doesn&apos;t return anything.

* Source/cmake/OptionsPlayStation.cmake:

Canonical link: <a href="https://commits.webkit.org/267519@main">https://commits.webkit.org/267519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dba68ded521a494709ff0704805b34efceee54a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15752 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17278 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19398 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14625 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14509 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15410 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13584 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18374 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15190 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19554 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19598 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15848 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4145 "Passed tests") | 
<!--EWS-Status-Bubble-End-->