### PR TITLE
maybePauseDisplayRefreshCallbacks doesn't wait for MissedCommit.

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -448,11 +448,11 @@ void RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator()
 
 bool RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks()
 {
-    if (m_webPageProxyProcessState.commitLayerTreeMessageState == NeedsDisplayDidRefresh)
+    if (m_webPageProxyProcessState.commitLayerTreeMessageState == NeedsDisplayDidRefresh || m_webPageProxyProcessState.commitLayerTreeMessageState == CommitLayerTreePending)
         return false;
 
     for (auto pair : m_remotePageProcessState) {
-        if (pair.value.commitLayerTreeMessageState == NeedsDisplayDidRefresh)
+        if (pair.value.commitLayerTreeMessageState == NeedsDisplayDidRefresh || pair.value.commitLayerTreeMessageState == CommitLayerTreePending)
             return false;
     }
 
@@ -493,9 +493,6 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connect
     if (!m_webPageProxy.hasRunningProcess())
         return;
 
-    if (maybePauseDisplayRefreshCallbacks())
-        return;
-
     if (connection) {
         ProcessState& state = processStateForConnection(*connection);
         didRefreshDisplay(state, *connection);
@@ -507,6 +504,9 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connect
                 didRefreshDisplay(pair.value, *pair.key.process().connection());
         }
     }
+
+    if (maybePauseDisplayRefreshCallbacks())
+        return;
 
     m_webPageProxy.didUpdateActivityState();
 }


### PR DESCRIPTION
#### dae026f290e6c19fcb068c7daee43f05d00568ef
<pre>
maybePauseDisplayRefreshCallbacks doesn&apos;t wait for MissedCommit.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260996">https://bugs.webkit.org/show_bug.cgi?id=260996</a>
&lt;rdar://114606581&gt;

Reviewed by Dan Glastonbury.

maybePauseDisplayRefreshCallbacks is pausing callbacks if nothing is in NeedsDisplayDidRefresh, but we
also want to keep callbacks enabled for CommitLayerTreePending so that we transition to MissedCommit state.

MissedCommit is required to trigger ASAP compositing when we&apos;re failing to reach the desired refresh rate, and
so we instead fall back to half refresh rate. This fixes a 6% regression in TodoMVC-React-Complex-DOM.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):

Canonical link: <a href="https://commits.webkit.org/267614@main">https://commits.webkit.org/267614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b9fcd57b376e64d97a57b8844c557c91c70041a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18062 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19458 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14674 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22034 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19779 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13626 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15239 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->