### PR TITLE
REGRESSION(267119@main): [ macOS wk2 release ] fast/repaint/placeholder-after-caps-lock-hidden.html is a constant timeout.

### DIFF
--- a/LayoutTests/fast/events/detect-caps-lock.html
+++ b/LayoutTests/fast/events/detect-caps-lock.html
@@ -5,69 +5,66 @@
 </head>
     <body>
         <p>This test verifies that the function WebCore::currentCapsLockState() returns true when Caps Lock is on.</p>
-        <input type="password"></input>
+        <input id="input" type="password"></input>
         <div id="log"></div>
         
         <script>
             function log(msg) {
                 document.getElementById("log").innerHTML+= msg + "<br>";
             }
-        
-            function keyDown(e) {
-                if (e.key == "q")
-                    return;
-                if (window.internals) {
-                    log(messages[messageCount++]);
-                    if (window.internals.capsLockIsOn())
-                        log("CapsLock is on.");
-                    else
-                        log("CapsLock is not on.");
-                }
+
+            function TestCase(message, testFunction) {
+                this.message = message;
+                this.testFunction = testFunction;
             }
 
-            function keyUp(e) {
-                if (e.key == "q")
-                    testRunner.notifyDone();
-                if (window.internals) {
-                    if (window.internals.capsLockIsOn())
-                        log("CapsLock is on.");
-                    else
-                        log("CapsLock is not on.");
-                }
+            function makeTestCase(message, testFunction) {
+                return new TestCase(message, testFunction);
             }
 
-            var messages = ["1. Press Caps Lock key when view is active, make view inactive, make view active again, press Caps Lock key.",
-                            "2. Press Caps Lock key in inactive view, make view active, press Caps Lock key.",
-                            "3. Press Caps Lock key when view is active, press Caps Lock key when view is active.",
-                            "4. Press Caps Lock key when view is inactive, press Caps Lock key when view inactive."];
-            var messageCount = 0;
-        
-            var input = document.getElementsByTagName("input")[0];
-            input.addEventListener('keydown', keyDown, false);
-            input.addEventListener('keyup', keyUp, false);
-            input.focus();
+            async function toggleCapsLockandLogCapsLockState() {
+                await UIHelper.toggleCapsLock();
+                await UIHelper.ensureStablePresentationUpdate();
+                if (window.internals.capsLockIsOn())
+                    log("CapsLock is on.");
+                else
+                    log("CapsLock is not on.");
+            }
+
+            const testCases = [
+                makeTestCase("1. Press Caps Lock key when view is active, make view inactive, make view active again, press Caps Lock key.", async () => {
+                    await toggleCapsLockandLogCapsLockState();
+                    testRunner.setWindowIsKey(false);
+                    testRunner.setWindowIsKey(true);
+                    await toggleCapsLockandLogCapsLockState();
+                }),
+                makeTestCase("2. Press Caps Lock key in inactive view, make view active, press Caps Lock key.", async () => {
+                    testRunner.setWindowIsKey(false);
+                    await toggleCapsLockandLogCapsLockState();
+                    testRunner.setWindowIsKey(true);
+                    await toggleCapsLockandLogCapsLockState();
+                }),
+                makeTestCase("3. Press Caps Lock key when view is active, press Caps Lock key when view is active.", async () => {
+                    testRunner.setWindowIsKey(true);
+                    await toggleCapsLockandLogCapsLockState();
+                    await toggleCapsLockandLogCapsLockState();
+                }),
+                makeTestCase("4. Press Caps Lock key when view is inactive, press Caps Lock key when view inactive.", async () => {
+                    testRunner.setWindowIsKey(false);
+                    await toggleCapsLockandLogCapsLockState();
+                    await toggleCapsLockandLogCapsLockState();
+                }),
+            ];
 
             async function runTest()
             {
-                await UIHelper.toggleCapsLock();
-                testRunner.setWindowIsKey(false);
-                testRunner.setWindowIsKey(true);
-                await UIHelper.toggleCapsLock();
-                
-                testRunner.setWindowIsKey(false);
-                await UIHelper.toggleCapsLock();
-                testRunner.setWindowIsKey(true);
-                await UIHelper.toggleCapsLock();
-
-                testRunner.setWindowIsKey(true);
-                await UIHelper.toggleCapsLock();
-                await UIHelper.toggleCapsLock();
-
-                testRunner.setWindowIsKey(false);
-                await UIHelper.toggleCapsLock();
-                await UIHelper.toggleCapsLock();
-
-                eventSender.keyDown("q", []);
+                await UIHelper.activateElementAndWaitForInputSession(document.getElementById("input"));
+                for (const testCase of testCases) {
+                    await UIHelper.ensureStablePresentationUpdate();
+                    log(testCase.message);
+                    await testCase.testFunction();
+                }
+                testRunner.notifyDone();
             }
 
             if (window.testRunner) {

--- a/LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html
+++ b/LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html
@@ -14,9 +14,7 @@ async function runTest()
         return;
     let input = document.getElementById("input");
     await UIHelper.activateElementAndWaitForInputSession(input);
-    await UIHelper.callFunctionAndWaitForEvent(async () => {
-        await UIHelper.toggleCapsLock();
-    }, input, "keyup");
+    await UIHelper.toggleCapsLock();
 
     await UIHelper.callFunctionAndWaitForEvent(async () => {
         await UIHelper.keyDown("a");
@@ -26,10 +24,9 @@ async function runTest()
         await UIHelper.keyDown("\b");
     }, input, "keyup");
 
+    await UIHelper.ensureStablePresentationUpdate();
     internals.startTrackingRepaints();
-    await UIHelper.callFunctionAndWaitForEvent(async () => {
-        await UIHelper.toggleCapsLock();
-    }, input, "keyup");
+    await UIHelper.toggleCapsLock();
     document.getElementById("result").textContent = internals.repaintRectsAsText();
     internals.stopTrackingRepaints();
     testRunner.notifyDone();

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -122,8 +122,7 @@ fast/events/detect-caps-lock.html [ Pass ]
 fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html [ Pass ]
 fast/forms/password-scrolled-after-caps-lock-toggled.html [ Pass ]
 
-# previously: webkit.org/b/194170
-webkit.org/b/260974 [ Release ] fast/repaint/placeholder-after-caps-lock-hidden.html [ Pass Failure Timeout ]
+fast/repaint/placeholder-after-caps-lock-hidden.html [ Pass ]
 
 fast/events/inactive-window-no-mouse-event.html [ Pass ]
 

--- a/LayoutTests/platform/mac-wk2/fast/repaint/placeholder-after-caps-lock-hidden-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/repaint/placeholder-after-caps-lock-hidden-expected.txt
@@ -1,0 +1,26 @@
+Tests that the placeholder text is repainted when the caps lock indicator is hidden.
+
+
+(repaint rects
+  (rect 25 46 27 27)
+  (rect 30 51 17 17)
+  (rect 6 46 29 23)
+  (rect 11 53 19 13)
+  (rect 6 46 46 23)
+  (rect 11 53 36 13)
+  (rect 25 46 27 23)
+  (rect 30 53 17 13)
+  (rect 6 44 46 27)
+  (rect 11 51 36 17)
+  (rect 6 44 46 23)
+  (rect 11 51 36 13)
+  (rect 6 46 46 27)
+  (rect 11 51 36 17)
+  (rect 6 48 46 23)
+  (rect 11 53 36 13)
+  (rect 6 48 29 23)
+  (rect 11 53 19 13)
+  (rect 6 48 46 23)
+  (rect 11 53 36 13)
+)
+

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -270,17 +270,21 @@ void UIScriptControllerMac::toggleCapsLock(JSValueRef callback)
 {
     m_capsLockOn = !m_capsLockOn;
     NSWindow *window = [webView() window];
-    NSEvent *fakeEvent = [NSEvent keyEventWithType:NSEventTypeFlagsChanged
-        location:NSZeroPoint
-        modifierFlags:m_capsLockOn ? NSEventModifierFlagCapsLock : 0
-        timestamp:0
-        windowNumber:window.windowNumber
-        context:nullptr
-        characters:@""
-        charactersIgnoringModifiers:@""
-        isARepeat:NO
-        keyCode:57];
-    [window sendEvent:fakeEvent];
+    const auto makeFakeCapsLockKeyEventWithType = [capsLockOn = m_capsLockOn, window] (NSEventType eventType) {
+        return [NSEvent keyEventWithType:eventType
+            location:NSZeroPoint
+            modifierFlags:capsLockOn ? NSEventModifierFlagCapsLock : 0
+            timestamp:0
+            windowNumber:window.windowNumber
+            context:nullptr
+            characters:@""
+            charactersIgnoringModifiers:@""
+            isARepeat:NO
+            keyCode:57];
+    };
+    NSArray<NSEvent *> *fakeEventsToBeSent = @[ makeFakeCapsLockKeyEventWithType(NSEventTypeKeyDown), makeFakeCapsLockKeyEventWithType(NSEventTypeKeyUp), makeFakeCapsLockKeyEventWithType(NSEventTypeFlagsChanged) ];
+    for (NSEvent *fakeEvent in fakeEventsToBeSent)
+        [window sendEvent:fakeEvent];
     doAsyncTask(callback);
 }
 


### PR DESCRIPTION
#### f40c7929020c005654d58d882a552b06f0e3d856
<pre>
REGRESSION(267119@main): [ macOS wk2 release ] fast/repaint/placeholder-after-caps-lock-hidden.html is a constant timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260974">https://bugs.webkit.org/show_bug.cgi?id=260974</a>
rdar://114772162

Reviewed by Aditya Keerthi.

267119@main fixed the fast/repaint/placeholder-after-caps-lock-hidden.html
layout test to correctly wait on keyboard events, but this inadvertently
changed this test&apos;s failure mode to timeouts on macOS. This patch is a
two part fix that addresses two separate issues in play:

1. The macOS implementation for `toggleCapsLock` does not respect the
   (rather undocumented) contract exercised by its callees, which is that
   it mimics toggling of the capslock key by virtue of pressing the
   appropriate keys on a hardware keyboard. This was most recently
   addressed in the iOS implementation in 267119@main. We fix this in
   macOS by sending a sequence of keyDown/keyUp/flagsChanged events with
   keycode 57 (capslock) to better reflect the sequence of events
   happening when the capslock is toggled on the Mac.

2. Layout tests exercising capslock toggles were incorrect in that they
   were not correctly calling the async `UIHelper.toggleCapsLock` method
   (were not awaiting on it) or they were listening for key events as a
   signal that capslock has been toggled. The latter is not inherently a
   problem except when a callee does not also await on `toggleCapsLock`,
   their test results become dependent on the ordering of asynchronous
   operations. We rework fast/events/detect-caps-lock.html and
   fast/repaint/placeholder-after-caps-lock-hidden.html to address this.

We also update macOS test expectations for the
fast/repaint/placeholder-after-caps-lock-hidden test. This update is
prompted by the fact that the original expectations are not applicable
for the mac platform anymore.

* LayoutTests/fast/events/detect-caps-lock.html:
* LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/fast/repaint/placeholder-after-caps-lock-hidden-expected.txt: Added.
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::toggleCapsLock):

Canonical link: <a href="https://commits.webkit.org/267666@main">https://commits.webkit.org/267666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/370ba6f543ea569a563125f05878898c70b7d2a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17806 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19944 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22439 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->