### PR TITLE
Make libraries in Tools/Scripts/libraries installable

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -20,19 +20,24 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+from urllib.parse import urljoin
+from urllib.request import pathname2url
+
 from setuptools import setup
 
 
-def readme():
-    with open('README.md') as f:
-        return f.read()
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return f"{name} @ {file_url}"
 
 
 setup(
     name='reporelaypy',
     version='0.8.1',
     description='Library for visualizing, processing and storing test results.',
-    long_description=readme(),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Flask',
@@ -51,13 +56,13 @@ setup(
     license='Modified BSD',
     packages=[
         'reporelaypy',
-        'reporelaypy.test',
+        'reporelaypy.tests',
     ],
     install_requires=[
         'xmltodict',
-        'webkitcorepy',
-        'webkitscmpy',
-        'webkitflaskpy',
+        _get_adjacent_package_requirement('webkitcorepy'),
+        _get_adjacent_package_requirement('webkitscmpy'),
+        _get_adjacent_package_requirement('webkitflaskpy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/resultsdbpy/setup.py
+++ b/Tools/Scripts/libraries/resultsdbpy/setup.py
@@ -20,7 +20,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+from urllib.parse import urljoin
+from urllib.request import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return f'{name} @ {file_url}'
 
 
 def readme():
@@ -66,9 +77,9 @@ setup(
         'redis',
         'xmltodict',
         'selenium',
-        'webkitcorepy',
-        'webkitscmpy',
-        'webkitflaskpy',
+        _get_adjacent_package_requirement('webkitcorepy'),
+        _get_adjacent_package_requirement('webkitscmpy'),
+        _get_adjacent_package_requirement('webkitflaskpy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -20,7 +20,26 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+try:
+    from urllib.request import pathname2url
+except ImportError:
+    from urllib import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return '{} @ {}'.format(name, file_url)
 
 
 def readme():
@@ -53,7 +72,7 @@ setup(
         'webkitbugspy.tests',
     ],
     install_requires=[
-        'webkitcorepy',
+        _get_adjacent_package_requirement('webkitcorepy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -52,9 +52,10 @@ setup(
         'webkitcorepy.mocks',
         'webkitcorepy.tests',
         'webkitcorepy.tests.mocks',
+        'webkitcorepy.testing',
     ],
     install_requires=[
-        'inspect2'
+        'inspect2',
         'mock',
         'requests',
         'six',

--- a/Tools/Scripts/libraries/webkitflaskpy/setup.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/setup.py
@@ -20,7 +20,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+from urllib.parse import urljoin
+from urllib.request import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return f"{name} @ {file_url}"
 
 
 def readme():
@@ -58,7 +69,7 @@ setup(
         'Flask-Cors',
         'gunicorn',
         'redis',
-        'webkitcorepy',
+        _get_adjacent_package_requirement('webkitcorepy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/webkitscmpy/MANIFEST.in
+++ b/Tools/Scripts/libraries/webkitscmpy/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include webkitscmpy/mocks/*.json

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -20,7 +20,27 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+try:
+    from urllib.request import pathname2url
+except ImportError:
+    from urllib import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return '{} @ {}'.format(name, file_url)
+
 
 def readme():
     with open('README.md') as f:
@@ -58,7 +78,15 @@ setup(
         'webkitscmpy.test',
     ],
     scripts=['git-webkit'],
-    install_requires=['fasteners', 'jinja2', 'monotonic', 'webkitcorepy', 'webkitbugspy', 'xmltodict', 'rapidfuzz'],
+    install_requires=[
+        'fasteners',
+        'jinja2',
+        'monotonic',
+        _get_adjacent_package_requirement('webkitcorepy'),
+        _get_adjacent_package_requirement('webkitbugspy'),
+        'xmltodict',
+        'rapidfuzz',
+    ],
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
#### cf795c2d6a97
<pre>
Make libraries in Tools/Scripts/libraries installable
<a href="https://bugs.webkit.org/show_bug.cgi?id=260990">https://bugs.webkit.org/show_bug.cgi?id=260990</a>

Reviewed by NOBODY (OOPS!).

The majority of problems here are cross-dependencies between these
libraries, and declaring each other as install_requires which by
default will result in trying to fetch the other packages from
PyPI. When these packages aren&apos;t distributed on PyPI, this inevitably
fails. Instead, we declare these as dependencies of the form
`foo @ file:///path/to/foo`, thus making the installation machinary
fetch the other packages from within the repo.

* Tools/Scripts/libraries/reporelaypy/setup.py:
(_get_adjacent_package_requirement):
(readme): Deleted.
* Tools/Scripts/libraries/resultsdbpy/setup.py:
(_get_adjacent_package_requirement):
* Tools/Scripts/libraries/webkitbugspy/setup.py:
(_get_adjacent_package_requirement):
* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitflaskpy/setup.py:
(_get_adjacent_package_requirement):
* Tools/Scripts/libraries/webkitscmpy/MANIFEST.in:
* Tools/Scripts/libraries/webkitscmpy/setup.py:
(_get_adjacent_package_requirement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf795c2d6a9773f54f3d6f20d244226ab3a1fee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19996 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17531 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22481 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20308 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14061 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/17249 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->