### PR TITLE
[JSC] Use MonotonicTime for SamplingProfiler JSON dump timestamp

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp
@@ -193,7 +193,7 @@ static Ref<Protocol::ScriptProfiler::Samples> buildSamples(VM& vm, Vector<Sampli
             frames->addItem(WTFMove(frameObject));
         }
         Ref<Protocol::ScriptProfiler::StackTrace> inspectorStackTrace = Protocol::ScriptProfiler::StackTrace::create()
-            .setTimestamp(stackTrace.timestamp.seconds())
+            .setTimestamp(stackTrace.stopwatchTimestamp.seconds())
             .setStackFrames(WTFMove(frames))
             .release();
         stackTraces->addItem(WTFMove(inspectorStackTrace));
@@ -207,7 +207,7 @@ static Ref<Protocol::ScriptProfiler::Samples> buildSamples(VM& vm, Vector<Sampli
 
 void InspectorScriptProfilerAgent::trackingComplete()
 {
-    auto timestamp = m_environment.executionStopwatch().elapsedTime().seconds();
+    auto stopwatchTimestamp = m_environment.executionStopwatch().elapsedTime().seconds();
 
 #if ENABLE(SAMPLING_PROFILER)
     if (m_enabledSamplingProfiler) {
@@ -226,11 +226,11 @@ void InspectorScriptProfilerAgent::trackingComplete()
 
         m_enabledSamplingProfiler = false;
 
-        m_frontendDispatcher->trackingComplete(timestamp, WTFMove(samples));
+        m_frontendDispatcher->trackingComplete(stopwatchTimestamp, WTFMove(samples));
     } else
-        m_frontendDispatcher->trackingComplete(timestamp, nullptr);
+        m_frontendDispatcher->trackingComplete(stopwatchTimestamp, nullptr);
 #else
-    m_frontendDispatcher->trackingComplete(timestamp, nullptr);
+    m_frontendDispatcher->trackingComplete(stopwatchTimestamp, nullptr);
 #endif // ENABLE(SAMPLING_PROFILER)
 }
 

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -158,7 +158,8 @@ public:
     };
 
     struct UnprocessedStackTrace {
-        Seconds timestamp;
+        MonotonicTime timestamp;
+        Seconds stopwatchTimestamp;
         void* topPC;
         bool topFrameIsLLInt;
         void* llintPC;
@@ -167,7 +168,8 @@ public:
     };
 
     struct StackTrace {
-        Seconds timestamp;
+        MonotonicTime timestamp;
+        Seconds stopwatchTimestamp;
         Vector<StackFrame> frames;
         StackTrace()
         { }
@@ -221,7 +223,6 @@ private:
     Vector<StackTrace> m_stackTraces WTF_GUARDED_BY_LOCK(m_lock);
     Vector<UnprocessedStackTrace> m_unprocessedStackTraces WTF_GUARDED_BY_LOCK(m_lock);
     Seconds m_timingInterval;
-    Seconds m_lastTime WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<Thread> m_thread;
     RefPtr<Thread> m_jscExecutionThread WTF_GUARDED_BY_LOCK(m_lock);
     HashSet<JSCell*> m_liveCellPointers WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WTF/wtf/Stopwatch.h
+++ b/Source/WTF/wtf/Stopwatch.h
@@ -32,7 +32,7 @@
 
 namespace WTF {
 
-class Stopwatch : public RefCounted<Stopwatch> {
+class Stopwatch final : public RefCounted<Stopwatch> {
 public:
     static Ref<Stopwatch> create()
     {
@@ -45,6 +45,7 @@ public:
 
     Seconds elapsedTime() const;
     Seconds elapsedTimeSince(MonotonicTime) const;
+    std::tuple<Seconds, MonotonicTime> elapsedTimeAndTimestamp() const;
 
     std::optional<Seconds> fromMonotonicTime(MonotonicTime) const;
 
@@ -82,10 +83,16 @@ inline void Stopwatch::stop()
 
 inline Seconds Stopwatch::elapsedTime() const
 {
-    if (!isActive())
-        return m_elapsedTime;
+    return std::get<0>(elapsedTimeAndTimestamp());
+}
 
-    return m_elapsedTime + (MonotonicTime::now() - m_lastStartTime);
+inline std::tuple<Seconds, MonotonicTime> Stopwatch::elapsedTimeAndTimestamp() const
+{
+    auto timestamp = MonotonicTime::now();
+    if (!isActive())
+        return std::tuple { m_elapsedTime, timestamp };
+
+    return std::tuple { m_elapsedTime + (timestamp - m_lastStartTime), timestamp };
 }
 
 inline Seconds Stopwatch::elapsedTimeSince(MonotonicTime timeStamp) const


### PR DESCRIPTION
#### 1b8732286c537bc76aac6dd482134c7029aefbf8
<pre>
[JSC] Use MonotonicTime for SamplingProfiler JSON dump timestamp
<a href="https://bugs.webkit.org/show_bug.cgi?id=260998">https://bugs.webkit.org/show_bug.cgi?id=260998</a>
rdar://114791556

Reviewed by Justin Michaud.

Replace timestamp of SamplingProfiler JSON dump from Stopwatch&apos;s elapsedTime
to MonotonicTime to easily sync it with the system wide samples.

* Source/JavaScriptCore/inspector/agents/InspectorScriptProfilerAgent.cpp:
(Inspector::buildSamples):
(Inspector::InspectorScriptProfilerAgent::trackingComplete):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::timerLoop):
(JSC::SamplingProfiler::takeSample):
(JSC::SamplingProfiler::processUnverifiedStackTraces):
(JSC::SamplingProfiler::noticeVMEntry):
(JSC::SamplingProfiler::stackTracesAsJSON):
* Source/JavaScriptCore/runtime/SamplingProfiler.h:
* Source/WTF/wtf/Stopwatch.h:
(WTF::Stopwatch::elapsedTime const):
(WTF::Stopwatch::elapsedTimeAndTimestamp const):
(WTF::Stopwatch::create): Deleted.
(WTF::Stopwatch::isActive const): Deleted.
(WTF::Stopwatch::Stopwatch): Deleted.

Canonical link: <a href="https://commits.webkit.org/267527@main">https://commits.webkit.org/267527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f1abee58b218d86124de401c45990b47be9d736

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16849 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18631 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/15783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17048 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19433 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14540 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/19762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16076 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16049 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18406 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15221 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4298 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19585 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19631 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2078 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15880 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4150 "Passed tests") | 
<!--EWS-Status-Bubble-End-->