### PR TITLE
Align const member functions of CheckedRef/CheckedPtr with Ref/RefPtr

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -109,14 +109,11 @@ public:
     using UnspecifiedBoolType = void (CheckedPtr::*)() const;
     operator UnspecifiedBoolType() const { return m_ptr ? &CheckedPtr::unspecifiedBoolTypeInstance : nullptr; }
 
-    ALWAYS_INLINE bool operator!() const { return !PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE explicit operator bool() const { return PtrTraits::unwrap(m_ptr); }
 
-    ALWAYS_INLINE const T* get() const { return PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T* get() { return PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE const T& operator*() const { ASSERT(m_ptr); return *get(); }
-    ALWAYS_INLINE T& operator*() { ASSERT(m_ptr); return *get(); }
-    ALWAYS_INLINE const T* operator->() const { return get(); }
-    ALWAYS_INLINE T* operator->() { return get(); }
+    ALWAYS_INLINE T* get() const { return PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T& operator*() const { ASSERT(m_ptr); return *get(); }
+    ALWAYS_INLINE T* operator->() const { return get(); }
 
     bool operator==(const T* other) const { return m_ptr == other; }
     template<typename U> bool operator==(U* other) const { return m_ptr == other; }

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -90,16 +90,12 @@ public:
     const T* ptrAllowingHashTableEmptyValue() const { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
     T* ptrAllowingHashTableEmptyValue() { ASSERT(m_ptr || isHashTableEmptyValue()); return PtrTraits::unwrap(m_ptr); }
 
-    ALWAYS_INLINE const T* ptr() const { return PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T* ptr() { return PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE const T& get() const { ASSERT(ptr()); return *ptr(); }
-    ALWAYS_INLINE T& get() { ASSERT(ptr()); return *ptr(); }
-    ALWAYS_INLINE const T* operator->() const { return ptr(); }
-    ALWAYS_INLINE T* operator->() { return ptr(); }
+    ALWAYS_INLINE T* ptr() const { return PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T& get() const { ASSERT(ptr()); return *ptr(); }
+    ALWAYS_INLINE T* operator->() const { return ptr(); }
 
-    ALWAYS_INLINE operator const T&() const { return get(); }
-    ALWAYS_INLINE operator T&() { return get(); }
-    ALWAYS_INLINE bool operator!() const { return !get(); }
+    ALWAYS_INLINE operator T&() const { return get(); }
+    ALWAYS_INLINE explicit operator bool() const { return get(); }
 
     CheckedRef& operator=(T& reference)
     {


### PR DESCRIPTION
#### 643f0a10c60b19057c260f790290b9d56ecb7de1
<pre>
Align const member functions of CheckedRef/CheckedPtr with Ref/RefPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=261001">https://bugs.webkit.org/show_bug.cgi?id=261001</a>

Reviewed by Chris Dumez.

Make const members of CheckedRef/CheckedPtr return mutable T&amp;/T* instead of
const T/&amp;T* to match the corresponding functions in Ref/RefPtr.

* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::operator bool const):
(WTF::CheckedPtr::operator! const): Deleted.
(WTF::CheckedPtr::get const):
(WTF::CheckedPtr::get): Deleted.
(WTF::CheckedPtr::operator* const):
(WTF::CheckedPtr::operator*): Deleted.
(WTF::CheckedPtr::operator-&gt; const):
(WTF::CheckedPtr::operator-&gt;): Deleted.
* Source/WTF/wtf/CheckedRef.h:
(WTF::CheckedRef::ptr const):
(WTF::CheckedRef::ptr): Deleted.
(WTF::CheckedRef::get const):
(WTF::CheckedRef::get): Deleted.
(WTF::CheckedRef::operator-&gt; const):
(WTF::CheckedRef::operator-&gt;): Deleted.
(WTF::CheckedRef::operator T&amp; const):
(WTF::CheckedRef::operator const T&amp; const): Deleted.
(WTF::CheckedRef::operator bool const):
(WTF::CheckedRef::operator! const): Deleted.
(WTF::CheckedRef::operator T&amp;): Deleted.

Canonical link: <a href="https://commits.webkit.org/267543@main">https://commits.webkit.org/267543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84a33dd54b6fa01cd95ad6a755a1cace5cac3d00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15789 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19445 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15286 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14548 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19772 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16085 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16058 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18415 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15229 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4302 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19593 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19641 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2083 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15889 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4156 "Passed tests") | 
<!--EWS-Status-Bubble-End-->