### PR TITLE
Add tox.ini files to everything in Tools/Scripts/libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,10 @@ tags
 .cache
 .clangd
 compile_commands.json
-__pycache__
+__pycache__/
+.coverage
+.tox/
+*.egg-info
 
 # Ignore CMake caches outside of the build directory.
 __cmake_systeminformation/
@@ -71,3 +74,6 @@ Source/ThirdParty/ANGLE/parsetab.py
 
 # Ignore user CMake presets
 CMakeUserPresets.json
+
+# Ignore built Python packages
+/Tools/Scripts/libraries/*/build/

--- a/Tools/Scripts/libraries/reporelaypy/conftest.py
+++ b/Tools/Scripts/libraries/reporelaypy/conftest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(
+    os.path.join(
+        libraries,
+        "autoinstalled",
+        "python-{}-{}".format(sys.version_info[0], platform.machine()),
+    )
+)
+
+
+def pytest_collection_finish(session):
+    AutoInstall.install_everything()

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -20,19 +20,24 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+from urllib.parse import urljoin
+from urllib.request import pathname2url
+
 from setuptools import setup
 
 
-def readme():
-    with open('README.md') as f:
-        return f.read()
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return f"{name} @ {file_url}"
 
 
 setup(
     name='reporelaypy',
     version='0.8.1',
     description='Library for visualizing, processing and storing test results.',
-    long_description=readme(),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Flask',
@@ -51,13 +56,13 @@ setup(
     license='Modified BSD',
     packages=[
         'reporelaypy',
-        'reporelaypy.test',
+        'reporelaypy.tests',
     ],
     install_requires=[
         'xmltodict',
-        'webkitcorepy',
-        'webkitscmpy',
-        'webkitflaskpy',
+        _get_adjacent_package_requirement('webkitcorepy'),
+        _get_adjacent_package_requirement('webkitscmpy'),
+        _get_adjacent_package_requirement('webkitflaskpy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/reporelaypy/tox.ini
+++ b/Tools/Scripts/libraries/reporelaypy/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py36,py37,py38,py39,py310,py311
+# virtualenv 20.22.0 dropped support for Python < 3.6
+requires = virtualenv<20.22.0
+
+[testenv]
+deps =
+    pytest
+    pytest-xdist
+commands =
+    pytest {posargs}
+
+[pytest]
+python_files=*_unittest.py
+xfail_strict=true
+addopts = -rfEX --strict-markers

--- a/Tools/Scripts/libraries/resultsdbpy/conftest.py
+++ b/Tools/Scripts/libraries/resultsdbpy/conftest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(
+    os.path.join(
+        libraries,
+        "autoinstalled",
+        "python-{}-{}".format(sys.version_info[0], platform.machine()),
+    )
+)
+
+
+from cassandra.cqlengine.management import CQLENG_ALLOW_SCHEMA_MANAGEMENT  # noqa: E402
+
+os.environ["slow_tests"] = "0"
+os.environ["web_server"] = "1"
+os.environ["selenium"] = "0"
+os.environ[CQLENG_ALLOW_SCHEMA_MANAGEMENT] = "1"
+
+
+def pytest_collection_finish(session):
+    AutoInstall.install_everything()

--- a/Tools/Scripts/libraries/resultsdbpy/setup.py
+++ b/Tools/Scripts/libraries/resultsdbpy/setup.py
@@ -20,7 +20,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+from urllib.parse import urljoin
+from urllib.request import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return f'{name} @ {file_url}'
 
 
 def readme():
@@ -66,9 +77,9 @@ setup(
         'redis',
         'xmltodict',
         'selenium',
-        'webkitcorepy',
-        'webkitscmpy',
-        'webkitflaskpy',
+        _get_adjacent_package_requirement('webkitcorepy'),
+        _get_adjacent_package_requirement('webkitscmpy'),
+        _get_adjacent_package_requirement('webkitflaskpy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/resultsdbpy/tox.ini
+++ b/Tools/Scripts/libraries/resultsdbpy/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py36,py37,py38,py39,py310,py311
+# virtualenv 20.22.0 dropped support for Python < 3.6
+requires = virtualenv<20.22.0
+
+[testenv]
+deps =
+    pytest
+    pytest-xdist
+commands =
+    pytest {posargs}
+
+[pytest]
+python_files=*_unittest.py
+xfail_strict=true
+addopts = -rfEX --strict-markers

--- a/Tools/Scripts/libraries/webkitbugspy/conftest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/conftest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(
+    os.path.join(
+        libraries,
+        "autoinstalled",
+        "python-{}-{}".format(sys.version_info[0], platform.machine()),
+    )
+)
+
+
+def pytest_collection_finish(session):
+    AutoInstall.install_everything()

--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -20,7 +20,26 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+try:
+    from urllib.request import pathname2url
+except ImportError:
+    from urllib import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return '{} @ {}'.format(name, file_url)
 
 
 def readme():
@@ -53,7 +72,7 @@ setup(
         'webkitbugspy.tests',
     ],
     install_requires=[
-        'webkitcorepy',
+        _get_adjacent_package_requirement('webkitcorepy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/webkitbugspy/tox.ini
+++ b/Tools/Scripts/libraries/webkitbugspy/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,py36,py37,py38,py39,py310,py311
+# virtualenv 20.22.0 dropped support for Python < 3.6
+requires = virtualenv<20.22.0
+
+[testenv]
+deps =
+    pytest
+    pytest-xdist
+commands =
+    pytest {posargs}
+
+[pytest]
+python_files=*_unittest.py
+xfail_strict=true
+addopts = -rfEX --strict-markers

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -52,9 +52,10 @@ setup(
         'webkitcorepy.mocks',
         'webkitcorepy.tests',
         'webkitcorepy.tests.mocks',
+        'webkitcorepy.testing',
     ],
     install_requires=[
-        'inspect2'
+        'inspect2',
         'mock',
         'requests',
         'six',

--- a/Tools/Scripts/libraries/webkitcorepy/tox.ini
+++ b/Tools/Scripts/libraries/webkitcorepy/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,py36,py37,py38,py39,py310,py311
+# virtualenv 20.22.0 dropped support for Python < 3.6
+requires = virtualenv<20.22.0
+
+[testenv]
+deps =
+    pytest
+    pytest-xdist
+commands =
+    pytest {posargs}
+
+[pytest]
+python_files=*_unittest.py
+xfail_strict=true
+addopts = -rfEX --strict-markers

--- a/Tools/Scripts/libraries/webkitflaskpy/conftest.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/conftest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(
+    os.path.join(
+        libraries,
+        "autoinstalled",
+        "python-{}-{}".format(sys.version_info[0], platform.machine()),
+    )
+)
+
+
+def pytest_collection_finish(session):
+    AutoInstall.install_everything()

--- a/Tools/Scripts/libraries/webkitflaskpy/setup.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/setup.py
@@ -20,7 +20,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+from urllib.parse import urljoin
+from urllib.request import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return f"{name} @ {file_url}"
 
 
 def readme():
@@ -58,7 +69,7 @@ setup(
         'Flask-Cors',
         'gunicorn',
         'redis',
-        'webkitcorepy',
+        _get_adjacent_package_requirement('webkitcorepy'),
     ],
     include_package_data=True,
     zip_safe=False,

--- a/Tools/Scripts/libraries/webkitflaskpy/tox.ini
+++ b/Tools/Scripts/libraries/webkitflaskpy/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py36,py37,py38,py39,py310,py311
+# virtualenv 20.22.0 dropped support for Python < 3.6
+requires = virtualenv<20.22.0
+
+[testenv]
+deps =
+    pytest
+    pytest-xdist
+commands =
+    pytest {posargs}
+
+[pytest]
+python_files=*_unittest.py
+xfail_strict=true
+addopts = -rfEX --strict-markers

--- a/Tools/Scripts/libraries/webkitscmpy/MANIFEST.in
+++ b/Tools/Scripts/libraries/webkitscmpy/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include webkitscmpy/mocks/*.json

--- a/Tools/Scripts/libraries/webkitscmpy/conftest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/conftest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(
+    os.path.join(
+        libraries,
+        "autoinstalled",
+        "python-{}-{}".format(sys.version_info[0], platform.machine()),
+    )
+)
+
+
+def pytest_collection_finish(session):
+    AutoInstall.install_everything()

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -20,7 +20,27 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from os.path import abspath, dirname, join
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+try:
+    from urllib.request import pathname2url
+except ImportError:
+    from urllib import pathname2url
+
 from setuptools import setup
+
+
+def _get_adjacent_package_requirement(name):
+    d = abspath(dirname(__file__))
+    package_path = join(d, "..", name)
+    file_url = urljoin("file://localhost", pathname2url(package_path))
+    return '{} @ {}'.format(name, file_url)
+
 
 def readme():
     with open('README.md') as f:
@@ -58,7 +78,15 @@ setup(
         'webkitscmpy.test',
     ],
     scripts=['git-webkit'],
-    install_requires=['fasteners', 'jinja2', 'monotonic', 'webkitcorepy', 'webkitbugspy', 'xmltodict', 'rapidfuzz'],
+    install_requires=[
+        'fasteners',
+        'jinja2',
+        'monotonic',
+        _get_adjacent_package_requirement('webkitcorepy'),
+        _get_adjacent_package_requirement('webkitbugspy'),
+        'xmltodict',
+        'rapidfuzz',
+    ],
     include_package_data=True,
     zip_safe=False,
 )

--- a/Tools/Scripts/libraries/webkitscmpy/tox.ini
+++ b/Tools/Scripts/libraries/webkitscmpy/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,py36,py37,py38,py39,py310,py311
+# virtualenv 20.22.0 dropped support for Python < 3.6
+requires = virtualenv<20.22.0
+
+[testenv]
+deps =
+    pytest
+    pytest-xdist
+commands =
+    pytest {posargs}
+
+[pytest]
+python_files=*_unittest.py
+xfail_strict=true
+addopts = -rfEX --strict-markers


### PR DESCRIPTION
#### a19eaba1fbe5
<pre>
Add tox.ini files to everything in Tools/Scripts/libraries
<a href="https://bugs.webkit.org/show_bug.cgi?id=261004">https://bugs.webkit.org/show_bug.cgi?id=261004</a>

Reviewed by NOBODY (OOPS!).

This adds everything necessary to test these with tox &amp; pytest.

* .gitignore:
* Tools/Scripts/libraries/reporelaypy/conftest.py: Added.
(pytest_collection_finish):
* Tools/Scripts/libraries/reporelaypy/tox.ini: Added.
* Tools/Scripts/libraries/resultsdbpy/conftest.py: Added.
(pytest_collection_finish):
* Tools/Scripts/libraries/resultsdbpy/tox.ini: Added.
* Tools/Scripts/libraries/webkitbugspy/conftest.py: Added.
(pytest_collection_finish):
* Tools/Scripts/libraries/webkitbugspy/tox.ini: Added.
* Tools/Scripts/libraries/webkitcorepy/tox.ini: Added.
* Tools/Scripts/libraries/webkitflaskpy/conftest.py: Added.
(pytest_collection_finish):
* Tools/Scripts/libraries/webkitflaskpy/tox.ini: Added.
* Tools/Scripts/libraries/webkitscmpy/conftest.py: Added.
(pytest_collection_finish):
* Tools/Scripts/libraries/webkitscmpy/tox.ini: Added.
</pre>
----------------------------------------------------------------------
#### cf795c2d6a97
<pre>
Make libraries in Tools/Scripts/libraries installable
<a href="https://bugs.webkit.org/show_bug.cgi?id=260990">https://bugs.webkit.org/show_bug.cgi?id=260990</a>

Reviewed by NOBODY (OOPS!).

The majority of problems here are cross-dependencies between these
libraries, and declaring each other as install_requires which by
default will result in trying to fetch the other packages from
PyPI. When these packages aren&apos;t distributed on PyPI, this inevitably
fails. Instead, we declare these as dependencies of the form
`foo @ file:///path/to/foo`, thus making the installation machinary
fetch the other packages from within the repo.

* Tools/Scripts/libraries/reporelaypy/setup.py:
(_get_adjacent_package_requirement):
(readme): Deleted.
* Tools/Scripts/libraries/resultsdbpy/setup.py:
(_get_adjacent_package_requirement):
* Tools/Scripts/libraries/webkitbugspy/setup.py:
(_get_adjacent_package_requirement):
* Tools/Scripts/libraries/webkitcorepy/setup.py:
* Tools/Scripts/libraries/webkitflaskpy/setup.py:
(_get_adjacent_package_requirement):
* Tools/Scripts/libraries/webkitscmpy/MANIFEST.in:
* Tools/Scripts/libraries/webkitscmpy/setup.py:
(_get_adjacent_package_requirement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a19eaba1fbe558117416951cefa421510785a50f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18752 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18114 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19566 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17099 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22109 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19872 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13694 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/16833 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->