### PR TITLE
WorkQueue should inherit from SerialFunctionDispatcher

### DIFF
--- a/Source/WTF/wtf/FunctionDispatcher.h
+++ b/Source/WTF/wtf/FunctionDispatcher.h
@@ -33,20 +33,20 @@ namespace WTF {
 // FunctionDispatcher is an abstract representation of something that functions can be
 // dispatched to. This can for example be a run loop or a work queue.
 
-class FunctionDispatcher {
+class WTF_EXPORT_PRIVATE FunctionDispatcher {
 public:
-    WTF_EXPORT_PRIVATE virtual ~FunctionDispatcher();
+    virtual ~FunctionDispatcher();
 
     virtual void dispatch(Function<void ()>&&) = 0;
 
 protected:
-    WTF_EXPORT_PRIVATE FunctionDispatcher();
+    FunctionDispatcher();
 };
 
-class WTF_CAPABILITY("is current") SerialFunctionDispatcher : public FunctionDispatcher {
+class WTF_CAPABILITY("is current") WTF_EXPORT_PRIVATE SerialFunctionDispatcher : public FunctionDispatcher {
 public:
 #if ASSERT_ENABLED
-    WTF_EXPORT_PRIVATE virtual void assertIsCurrent() const = 0;
+    virtual void assertIsCurrent() const = 0;
 #endif
 };
 

--- a/Source/WTF/wtf/SuspendableWorkQueue.cpp
+++ b/Source/WTF/wtf/SuspendableWorkQueue.cpp
@@ -42,7 +42,7 @@ SuspendableWorkQueue::SuspendableWorkQueue(const char* name, QOS qos, ShouldLog 
     ASSERT(isMainThread());
 }
 
-inline const char* SuspendableWorkQueue::stateString(State state)
+const char* SuspendableWorkQueue::stateString(State state)
 {
     switch (state) {
     case State::Running:

--- a/Source/WTF/wtf/SuspendableWorkQueue.h
+++ b/Source/WTF/wtf/SuspendableWorkQueue.h
@@ -33,16 +33,16 @@
 
 namespace WTF {
 
-class SuspendableWorkQueue final : public WorkQueue {
+class WTF_EXPORT_PRIVATE SuspendableWorkQueue final : public WorkQueue {
 public:
     using QOS = WorkQueue::QOS;
     enum class ShouldLog : bool { No, Yes };
-    WTF_EXPORT_PRIVATE static Ref<SuspendableWorkQueue> create(const char* name, QOS = QOS::Default, ShouldLog = ShouldLog::No);
-    WTF_EXPORT_PRIVATE void suspend(Function<void()>&& suspendFunction, CompletionHandler<void()>&& suspensionCompletionHandler);
-    WTF_EXPORT_PRIVATE void resume();
-    WTF_EXPORT_PRIVATE void dispatch(Function<void()>&&) final;
-    WTF_EXPORT_PRIVATE void dispatchAfter(Seconds, Function<void()>&&) final;
-    WTF_EXPORT_PRIVATE void dispatchSync(Function<void()>&&) final;
+    static Ref<SuspendableWorkQueue> create(const char* name, QOS = QOS::Default, ShouldLog = ShouldLog::No);
+    void suspend(Function<void()>&& suspendFunction, CompletionHandler<void()>&& suspensionCompletionHandler);
+    void resume();
+    void dispatch(Function<void()>&&) final;
+    void dispatchAfter(Seconds, Function<void()>&&) final;
+    void dispatchSync(Function<void()>&&) final;
 
 private:
     SuspendableWorkQueue(const char* name, QOS, ShouldLog);

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -99,15 +99,10 @@ void WorkQueueBase::platformInvalidate()
 {
 }
 
-WorkQueue::WorkQueue(OSObjectPtr<dispatch_queue_t>&& queue)
-    : WorkQueueBase(WTFMove(queue))
+WorkQueue::WorkQueue(MainTag)
+    : WorkQueueBase(dispatch_get_main_queue())
 {
     // Note: for main work queue we do not create a sequence id, the main thread id will be used.
-}
-
-Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
-{
-    return adoptRef(*new WorkQueue(dispatch_get_main_queue()));
 }
 
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -77,14 +77,9 @@ void WorkQueueBase::dispatchAfter(Seconds delay, Function<void()>&& function)
     });
 }
 
-WorkQueue::WorkQueue(RunLoop& loop)
-    : WorkQueueBase(loop)
+WorkQueue::WorkQueue(MainTag)
+    : WorkQueueBase(RunLoop::main())
 {
-}
-
-Ref<WorkQueue> WorkQueue::constructMainWorkQueue()
-{
-    return adoptRef(*new WorkQueue(RunLoop::main()));
 }
 
 #if ASSERT_ENABLED


### PR DESCRIPTION
#### 4cc06b4be14a60c0b72098fa3e32ccb98657d525
<pre>
WorkQueue should inherit from SerialFunctionDispatcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=260779">https://bugs.webkit.org/show_bug.cgi?id=260779</a>
rdar://114535523

Reviewed by Kimmo Kinnunen.

Make WorkQueue inherit from SerialFunctionDispatcher so that it can be
used similarly to RunLoop and WorkerOrWorkletThread.

Needed for this change to compile:
- Export the whole class to get the multiple inheritance to
  work across binaries.
- When exporting WorkQueue, it will export function with OSObjectPtr&lt;dispatch_queue_t&gt;.
  This has different type in Obj-C and in C++. If the type is used in both,
  then there will be unresolved symbol since C++ type is used when creating
  the library (WorkQueue.cpp), as such remove method prototype from WorkQueue
  and have a single WorkQueue constructor taking an enum instead.

Ideally, we would implement only bug 261080, but there are futher issues
getting it done. So to not block other works depending on this change,
we push this version first.

* Source/WTF/wtf/FunctionDispatcher.h:
* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::stateString):
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::WorkQueue::main):
(WTF::WorkQueue::dispatch):
(WTF::WorkQueue::assertIsCurrent const):
(WTF::ConcurrentWorkQueue::dispatch):
* Source/WTF/wtf/WorkQueue.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY): Deleted.
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueue::WorkQueue):
(WTF::WorkQueue::constructMainWorkQueue): Deleted.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueue::WorkQueue):
(WTF::WorkQueue::constructMainWorkQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/267623@main">https://commits.webkit.org/267623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b90fdcf937a5d7cac2dba4975d7970d3c6a4104c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18270 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19780 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22292 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14836 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15963 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20110 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16398 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13882 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18740 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15517 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19884 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19965 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16194 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4208 "Passed tests") | 
<!--EWS-Status-Bubble-End-->