### PR TITLE
Potential WPT canvas fixes: Better measurement precision in LayoutUnits, always use OS/2 sTypo, read baselines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.baseline.hanging-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.baseline.hanging-expected.txt
@@ -3,5 +3,5 @@ Actual output:
 Expected output:
 
 
-FAIL Canvas test: 2d.text.draw.baseline.hanging assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 2 but got 255
+PASS Canvas test: 2d.text.draw.baseline.hanging
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.baseline.ideographic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.draw.baseline.ideographic-expected.txt
@@ -3,5 +3,5 @@ Actual output:
 Expected output:
 
 
-FAIL Canvas test: 2d.text.draw.baseline.ideographic assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 2 but got 128
+PASS Canvas test: 2d.text.draw.baseline.ideographic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
@@ -2,5 +2,5 @@
 Testing baselines
 Actual output:
 
-FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -39[number], expected 6.25[number]) expected 6.25 but got -39
+PASS Testing baselines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.emHeights-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.emHeights-expected.txt
@@ -2,5 +2,5 @@
 Testing emHeights
 Actual output:
 
-FAIL Testing emHeights assert_equals: ctx.measureText('A').emHeightAscent === 37.5 (got 85[number], expected 37.5[number]) expected 37.5 but got 85
+FAIL Testing emHeights assert_equals: ctx.measureText('A').emHeightAscent === 37.5 (got 85.203125[number], expected 37.5[number]) expected 37.5 but got 85.203125
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.hanging-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.hanging-expected.txt
@@ -1,5 +1,5 @@
 2d.text.draw.baseline.hanging
 
 
-FAIL OffscreenCanvas test: 2d.text.draw.baseline.hanging assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 2 but got 255
+PASS OffscreenCanvas test: 2d.text.draw.baseline.hanging
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.hanging.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.hanging.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 2 but got 255
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.ideographic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.ideographic-expected.txt
@@ -1,5 +1,5 @@
 2d.text.draw.baseline.ideographic
 
 
-FAIL OffscreenCanvas test: 2d.text.draw.baseline.ideographic assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 2 but got 128
+PASS OffscreenCanvas test: 2d.text.draw.baseline.ideographic
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.ideographic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.draw.baseline.ideographic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 2d assert_approx_equals: Red channel of the pixel at (5, 5) expected 0 +/- 2 but got 128
+PASS 2d
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
@@ -3,5 +3,5 @@
 Testing baselines
 
 
-FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -39[number], expected 6.25[number]) expected 6.25 but got -39
+PASS Testing baselines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -39[number], expected 6.25[number]) expected 6.25 but got -39
+PASS Testing baselines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.emHeights-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.emHeights-expected.txt
@@ -3,5 +3,5 @@
 Testing emHeights
 
 
-FAIL Testing emHeights assert_equals: ctx.measureText('A').emHeightAscent === 37.5 (got 85[number], expected 37.5[number]) expected 37.5 but got 85
+FAIL Testing emHeights assert_equals: ctx.measureText('A').emHeightAscent === 37.5 (got 85.203125[number], expected 37.5[number]) expected 37.5 but got 85.203125
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.emHeights.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.emHeights.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing emHeights assert_equals: ctx.measureText('A').emHeightAscent === 37.5 (got 85[number], expected 37.5[number]) expected 37.5 but got 85
+FAIL Testing emHeights assert_equals: ctx.measureText('A').emHeightAscent === 37.5 (got 85.203125[number], expected 37.5[number]) expected 37.5 but got 85.203125
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2799,18 +2799,18 @@ Ref<TextMetrics> CanvasRenderingContext2DBase::measureTextInternal(const TextRun
 
     FloatPoint offset = textOffset(fontWidth, textRun.direction());
 
-    metrics->setActualBoundingBoxAscent(glyphOverflow.top - offset.y());
-    metrics->setActualBoundingBoxDescent(glyphOverflow.bottom + offset.y());
-    metrics->setFontBoundingBoxAscent(fontMetrics.ascent() - offset.y());
-    metrics->setFontBoundingBoxDescent(fontMetrics.descent() + offset.y());
-    metrics->setEmHeightAscent(fontMetrics.ascent() - offset.y());
-    metrics->setEmHeightDescent(fontMetrics.descent() + offset.y());
-    metrics->setHangingBaseline(fontMetrics.ascent() - offset.y());
-    metrics->setAlphabeticBaseline(-offset.y());
-    metrics->setIdeographicBaseline(-fontMetrics.descent() - offset.y());
+    metrics->setActualBoundingBoxAscent(LayoutUnit::fromFloatRound(glyphOverflow.top - offset.y()));
+    metrics->setActualBoundingBoxDescent(LayoutUnit::fromFloatRound(glyphOverflow.bottom + offset.y()));
+    metrics->setFontBoundingBoxAscent(LayoutUnit::fromFloatRound(fontMetrics.floatAscent() - offset.y()));
+    metrics->setFontBoundingBoxDescent(LayoutUnit::fromFloatRound(fontMetrics.floatDescent() + offset.y()));
+    metrics->setEmHeightAscent(LayoutUnit::fromFloatRound(fontMetrics.floatAscent() - offset.y()));
+    metrics->setEmHeightDescent(LayoutUnit::fromFloatRound(fontMetrics.floatDescent() + offset.y()));
+    metrics->setHangingBaseline(LayoutUnit::fromFloatRound(fontMetrics.hangBaselineAboveAlpha() - offset.y()));
+    metrics->setAlphabeticBaseline(LayoutUnit::fromFloatRound(-offset.y()));
+    metrics->setIdeographicBaseline(LayoutUnit::fromFloatRound(fontMetrics.ideogramBaselineAboveAlpha() - offset.y()));
 
-    metrics->setActualBoundingBoxLeft(glyphOverflow.left - offset.x());
-    metrics->setActualBoundingBoxRight(fontWidth + glyphOverflow.right + offset.x());
+    metrics->setActualBoundingBoxLeft(LayoutUnit::fromFloatRound(glyphOverflow.left - offset.x()));
+    metrics->setActualBoundingBoxRight(LayoutUnit::fromFloatRound(fontWidth + glyphOverflow.right + offset.x()));
 
     return metrics;
 }
@@ -2822,15 +2822,19 @@ FloatPoint CanvasRenderingContext2DBase::textOffset(float width, TextDirection d
 
     switch (state().textBaseline) {
     case TopTextBaseline:
+        offset.setY(LayoutUnit::fromFloatRound(fontMetrics.floatAscent()));
+        break;
     case HangingTextBaseline:
-        offset.setY(fontMetrics.ascent());
+        offset.setY(LayoutUnit::fromFloatRound(fontMetrics.hangBaselineAboveAlpha()));
         break;
     case BottomTextBaseline:
+        offset.setY(-LayoutUnit::fromFloatRound(fontMetrics.floatDescent()));
+        break;
     case IdeographicTextBaseline:
-        offset.setY(-fontMetrics.descent());
+        offset.setY(LayoutUnit::fromFloatRound(fontMetrics.ideogramBaselineAboveAlpha()));
         break;
     case MiddleTextBaseline:
-        offset.setY(fontMetrics.height() / 2 - fontMetrics.descent());
+        offset.setY(LayoutUnit::fromFloatRound((fontMetrics.floatAscent() - fontMetrics.floatDescent()) / 2));
         break;
     case AlphabeticTextBaseline:
     default:

--- a/Source/WebCore/platform/graphics/FontMetrics.h
+++ b/Source/WebCore/platform/graphics/FontMetrics.h
@@ -125,6 +125,12 @@ public:
     float ideogramWidth() const { return m_ideogramWidth; }
     void setIdeogramWidth(float ideogramWidth) { m_ideogramWidth = ideogramWidth; }
 
+    float ideogramBaselineAboveAlpha() const { return m_ideogramBaselineAboveAlpha; }
+    void setIdeogramBaselineAboveAlpha(float ideogramBaselineAboveAlpha) { m_ideogramBaselineAboveAlpha = ideogramBaselineAboveAlpha; }
+
+    float hangBaselineAboveAlpha() const { return m_hangBaselineAboveAlpha; }
+    void setHangBaselineAboveAlpha(float hangBaselineAboveAlpha) { m_hangBaselineAboveAlpha = hangBaselineAboveAlpha; }
+
     float underlinePosition() const { return m_underlinePosition; }
     void setUnderlinePosition(float underlinePosition) { m_underlinePosition = underlinePosition; }
 
@@ -150,6 +156,8 @@ private:
         m_xHeight = 0;
         m_zeroWidth = std::nullopt;
         m_ideogramWidth = 0;
+        m_ideogramBaselineAboveAlpha = 0;
+        m_hangBaselineAboveAlpha = 0;
         m_underlinePosition = 0;
         m_underlineThickness = 0;
     }
@@ -171,6 +179,8 @@ private:
 
     std::optional<float> m_zeroWidth;
     float m_ideogramWidth { 0 };
+    float m_ideogramBaselineAboveAlpha { 0 };
+    float m_hangBaselineAboveAlpha { 0 };
     float m_xHeight { 0 };
     float m_underlinePosition { 0 };
     float m_underlineThickness { 0 };

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeCG.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeCG.cpp
@@ -28,39 +28,285 @@
 #include "OpenTypeCG.h"
 
 #include "OpenTypeTypes.h"
+#include <span>
 
 namespace WebCore {
 namespace OpenType {
 
-static inline short readShortFromTable(const UInt8* os2Data, CFIndex offset)
+// From https://learn.microsoft.com/en-us/typography/opentype/spec/os2
+struct OS2 {
+    UInt16 version;
+    Int16 xAvgCharWidth;
+    UInt16 usWeightClass;
+    UInt16 usWidthClass;
+    UInt16 fsType;
+    Int16 ySubscriptXSize;
+    Int16 ySubscriptYSize;
+    Int16 ySubscriptXOffset;
+    Int16 ySubscriptYOffset;
+    Int16 ySuperscriptXSize;
+    Int16 ySuperscriptYSize;
+    Int16 ySuperscriptXOffset;
+    Int16 ySuperscriptYOffset;
+    Int16 yStrikeoutSize;
+    Int16 yStrikeoutPosition;
+    Int16 sFamilyClass;
+    UInt8 panose[10];
+    UInt32 ulUnicodeRange1;
+    UInt32 ulUnicodeRange2;
+    UInt32 ulUnicodeRange3;
+    UInt32 ulUnicodeRange4;
+    UInt8 achVendID[4];
+    UInt16 fsSelection;
+    UInt16 usFirstCharIndex;
+    UInt16 usLastCharIndex;
+    Int16 sTypoAscender;
+    Int16 sTypoDescender;
+    Int16 sTypoLineGap;
+    UInt16 usWinAscent;
+    UInt16 usWinDescent;
+
+    // New in v1.
+    UInt32 ulCodePageRange1;
+    UInt32 ulCodePageRange2;
+
+    // New in v2.
+    Int16 sxHeight;
+    Int16 sCapHeight;
+    UInt16 usDefaultChar;
+    UInt16 usBreakChar;
+    UInt16 usMaxContext;
+
+    // New in v5.
+    UInt16 usLowerOpticalPointSize;
+    UInt16 usUpperOpticalPointSize;
+};
+
+struct Offset16 {
+    UInt16 offset;
+    explicit operator size_t() const { return static_cast<size_t>(offset); }
+};
+
+struct Offset32 {
+    UInt32 offset;
+    explicit operator size_t() const { return static_cast<size_t>(offset); }
+};
+
+struct Tag4 {
+    static constexpr size_t tagSize = 4;
+    unsigned char ch1;
+    unsigned char ch2;
+    unsigned char ch3;
+    unsigned char ch4;
+
+    constexpr Tag4(char c1, char c2, char c3, char c4) : ch1(c1), ch2(c2), ch3(c3), ch4(c4) { }
+    constexpr Tag4(const char *ch) : Tag4(ch ? ch[0] : '?', ch ? ch[1] : '?', ch ? ch[2] : '?', ch ? ch[3] : '?') { }
+
+    constexpr bool operator==(const Tag4& other) const { return ch1 == other.ch1 && ch2 == other.ch2 && ch3 == other.ch3 && ch4 == other.ch4; }
+};
+static_assert(sizeof(Tag4) == Tag4::tagSize);
+static_assert(alignof(Tag4) == 1);
+
+// From https://learn.microsoft.com/en-us/typography/opentype/spec/base
+struct BASE {
+    UInt16 majorVersion;
+    UInt16 minorVersion;
+    Offset16 horizAxisOffset;
+    Offset16 vertAxisOffset;
+    Offset32 itemVarStoreOffset;
+};
+
+struct BaseAxis {
+    Offset16 baseTagListOffset;
+    Offset16 baseScriptListOffset;
+};
+
+struct BaseTagList {
+    UInt16 baseTagCount;
+    Tag4 firstBaselineTag; // First of effectively Tag[baseTagCount].
+};
+
+struct BaseScriptList {
+    UInt16 baseScriptCount;
+    // First of effectively BaseScriptRecord[baseScriptCount]:
+    Tag4 firstBaseScriptTag;
+    Offset16 firstBaseScriptOffset;
+};
+
+struct BaseScript {
+    Offset16 baseValuesOffset;
+    // Unused here:
+    // Offset16 defaultMinMaxOffset;
+    // UInt16 baseLangSysCount;
+    // BaseLangSysRecord baseLangSysRecords;
+};
+
+struct BaseValues {
+    UInt16 defaultBaselineIndex;
+    UInt16 baseCoordCount;
+    Offset16 firstBaseCoordOffset; // First of effectively Offset16[baseCoordCount].
+};
+
+struct BaseCoord {
+    UInt16 baseCoordFormat;
+    Int16 coordinate;
+    // More fields below depending on format, unused here.
+};
+
+template <typename Value>
+inline std::optional<Value> readFromTable(const std::span<const UInt8>& buffer, size_t offsetOfValueInBuffer)
 {
-    return *(reinterpret_cast<const OpenType::Int16*>(os2Data + offset));
+    std::optional<Value> result;
+    if ((sizeof(Value) > buffer.size()) || (offsetOfValueInBuffer > buffer.size() - sizeof(Value)))
+        return result;
+
+    memcpy(&result.emplace(Value { 0 }), buffer.data() + offsetOfValueInBuffer, sizeof(Value));
+    return result;
 }
+
+#define READ(span_, struct_, member_) readFromTable<decltype(struct_::member_)>(span_, offsetof(struct_, member_))
+
+#define READ_INDEXED(span_, struct_, member_, index_) readFromTable<decltype(struct_::member_)>(span_, offsetof(struct_, member_) + (index_) * sizeof(struct_::member_))
+
+template <typename Offset>
+std::span<const UInt8> followOffset(const std::span<const UInt8>& buffer, size_t offsetOfOffsetInBuffer)
+{
+    auto maybeOffset = readFromTable<Offset>(buffer, offsetOfOffsetInBuffer);
+    if (!maybeOffset)
+        return { };
+    auto offset = static_cast<size_t>(*maybeOffset);
+    if (!offset || offset > buffer.size())
+        return { };
+    return buffer.subspan(offset);
+}
+
+#define FOLLOW_OFFSET(span_, struct_, member_) followOffset<decltype(struct_::member_)>(span_, offsetof(struct_, member_))
 
 bool tryGetTypoMetrics(CTFontRef font, short& ascent, short& descent, short& lineGap)
 {
-    bool result = false;
-    if (auto os2Table = adoptCF(CTFontCopyTable(font, kCTFontTableOS2, kCTFontTableOptionNoOptions))) {
-        // For the structure of the OS/2 table, see
-        // https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6OS2.html
-        const CFIndex fsSelectionOffset = 16 * 2 + 10 + 4 * 4 + 4 * 1;
-        const CFIndex sTypoAscenderOffset = fsSelectionOffset + 3 * 2;
-        const CFIndex sTypoDescenderOffset = sTypoAscenderOffset + 2;
-        const CFIndex sTypoLineGapOffset = sTypoDescenderOffset + 2;
-        if (CFDataGetLength(os2Table.get()) >= sTypoLineGapOffset + 2) {
-            const UInt8* os2Data = CFDataGetBytePtr(os2Table.get());
-            // We test the use typo bit on the least significant byte of fsSelection.
-            const UInt8 useTypoMetricsMask = 1 << 7;
-            if (*(os2Data + fsSelectionOffset + 1) & useTypoMetricsMask) {
-                ascent = readShortFromTable(os2Data, sTypoAscenderOffset);
-                descent = readShortFromTable(os2Data, sTypoDescenderOffset);
-                lineGap = readShortFromTable(os2Data, sTypoLineGapOffset);
-                result = true;
-            }
-        }
-    }
-    return result;
+    auto os2Table = adoptCF(CTFontCopyTable(font, kCTFontTableOS2, kCTFontTableOptionNoOptions));
+    if (!os2Table)
+        return false;
+    auto os2Span = std::span<const UInt8>(CFDataGetBytePtr(os2Table.get()), CFDataGetLength(os2Table.get()));
+
+    auto maybeFsSelection = READ(os2Span, OS2, fsSelection);
+    if (!maybeFsSelection)
+        return false;
+    const unsigned useTypoMetrics = 7;
+    if (!(*maybeFsSelection & (1u << useTypoMetrics)))
+        return false;
+
+    auto maybeAscent = READ(os2Span, OS2, sTypoAscender);
+    if (!maybeAscent)
+        return false;
+    auto maybedescent = READ(os2Span, OS2, sTypoAscender);
+    if (!maybedescent)
+        return false;
+    auto maybeLineGap = READ(os2Span, OS2, sTypoLineGap);
+    if (!maybeLineGap)
+        return false;
+
+    ascent = *maybeAscent;
+    descent = *maybedescent;
+    lineGap = *maybeLineGap;
+
+    return true;
 }
+
+Baselines tryGetBaselineMetrics(CTFontRef font)
+{
+    Baselines baselines;
+
+    auto baseTable = adoptCF(CTFontCopyTable(font, kCTFontTableBASE, kCTFontTableOptionNoOptions));
+    if (!baseTable)
+        return baselines;
+    auto baseSpan = std::span<const UInt8>(CFDataGetBytePtr(baseTable.get()), CFDataGetLength(baseTable.get()));
+
+    auto horizAxisSpan = FOLLOW_OFFSET(baseSpan, BASE, horizAxisOffset);
+    if (horizAxisSpan.empty())
+        return baselines;
+
+    auto baseTagListSpan = FOLLOW_OFFSET(horizAxisSpan, BaseAxis, baseTagListOffset);
+    if (baseTagListSpan.empty())
+        return baselines;
+
+    auto maybeBaseTagCount = READ(baseTagListSpan, BaseTagList, baseTagCount);
+    if (!maybeBaseTagCount)
+        return baselines;
+    size_t baseTagCount = *maybeBaseTagCount;
+    if (!baseTagCount)
+        return baselines;
+
+    const Tag4 ideoTag = Tag4("ideo");
+    const Tag4 hangTag = Tag4("hang");
+    const Tag4 romnTag = Tag4("romn");
+
+    size_t ideoIndex = size_t(-1);
+    size_t hangIndex = size_t(-1);
+    size_t romnIndex = size_t(-1);
+
+    for (size_t tagIndex = 0; tagIndex < baseTagCount; ++tagIndex) {
+        auto maybeTag = READ_INDEXED(baseTagListSpan, BaseTagList, firstBaselineTag, tagIndex);
+        if (!maybeTag)
+            return baselines;
+        if (*maybeTag == ideoTag)
+            ideoIndex = tagIndex;
+        else if (*maybeTag == hangTag)
+            hangIndex = tagIndex;
+        else if (*maybeTag == romnTag)
+            romnIndex = tagIndex;
+    }
+
+    if (ideoIndex == size_t(-1) && hangIndex == size_t(-1) && romnIndex == size_t(-1))
+        return baselines;
+
+    auto baseScriptListSpan = FOLLOW_OFFSET(horizAxisSpan, BaseAxis, baseScriptListOffset);
+    if (baseScriptListSpan.empty())
+        return baselines;
+
+    auto maybeBaseScriptCount = READ(baseScriptListSpan, BaseScriptList, baseScriptCount);
+    if (!maybeBaseScriptCount)
+        return baselines;
+    size_t baseScriptCount = *maybeBaseScriptCount;
+    if (!baseScriptCount)
+        return baselines;
+
+    // Only look at the first record.
+    auto baseScriptSpan = FOLLOW_OFFSET(baseScriptListSpan, BaseScriptList, firstBaseScriptOffset);
+    if (baseScriptSpan.empty())
+        return baselines;
+
+    auto baseValuesSpan = FOLLOW_OFFSET(baseScriptSpan, BaseScript, baseValuesOffset);
+    if (baseValuesSpan.empty())
+        return baselines;
+
+    auto maybeBaseCoordCount = READ(baseValuesSpan, BaseValues, baseCoordCount);
+    if (!maybeBaseCoordCount)
+        return baselines;
+    size_t baseCoordCount = *maybeBaseCoordCount;
+    if (!baseCoordCount)
+        return baselines;
+
+    for (size_t coordIndex = 0; coordIndex < baseCoordCount; ++coordIndex) {
+        using BaseCoordOffset = decltype(BaseValues::firstBaseCoordOffset);
+        auto baseCoordSpan = followOffset<BaseCoordOffset>(baseValuesSpan, offsetof(BaseValues, firstBaseCoordOffset) + coordIndex * sizeof(BaseCoordOffset));
+        if (baseCoordSpan.empty())
+            continue;
+        auto maybeCoordinate = READ(baseCoordSpan, BaseCoord, coordinate);
+        if (!maybeCoordinate)
+            continue;
+        if (coordIndex == ideoIndex)
+            baselines.ideo.emplace(*maybeCoordinate);
+        else if (coordIndex == hangIndex)
+            baselines.hang.emplace(*maybeCoordinate);
+        else if (coordIndex == romnIndex)
+            baselines.romn.emplace(*maybeCoordinate);
+    }
+
+    return baselines;
+}
+
+#undef READ
 
 } // namespace OpenType
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeCG.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeCG.h
@@ -30,10 +30,20 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <CoreText/CoreText.h>
 
+#include <optional>
+
 namespace WebCore {
 namespace OpenType {
 
 bool tryGetTypoMetrics(CTFontRef, short& ascent, short& descent, short& lineGap);
+
+struct Baselines {
+    std::optional<short> ideo;
+    std::optional<short> hang;
+    std::optional<short> romn;
+};
+Baselines tryGetBaselineMetrics(CTFontRef);
+
 
 } // namespace OpenType
 } // namespace WebCore


### PR DESCRIPTION
#### 029c8989d7245a02349e102be08bc7c82ca9f751
<pre>
Potential WPT canvas fixes: Better measurement precision in LayoutUnits, always use OS/2 sTypo, read baselines
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::measureTextInternal):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformInit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/029c8989d7245a02349e102be08bc7c82ca9f751

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17610 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18238 "12 flakes 155 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17346 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17693 "2 new passes 4 flakes 3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19745 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14933 "3 flakes 3 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15572 "9 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22260 "32 flakes 81 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15932 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15739 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16329 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13850 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->