### PR TITLE
Add mutation events tests for ContainerNode::replaceChildren and refactor the code

### DIFF
--- a/LayoutTests/fast/dom/replace-children-mutation-events-expected.txt
+++ b/LayoutTests/fast/dom/replace-children-mutation-events-expected.txt
@@ -1,0 +1,14 @@
+This tests mutating DOM in mutation event listerns during replaceChilden.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS parent.replaceChildren(span) threw exception NotFoundError: The object can not be found here..
+PASS span.replaceChildren(oldParent, em, "text") did not throw exception.
+PASS span.childNodes.length is 1
+PASS span.childNodes[0] is oldParent
+PASS span.textContent is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+some

--- a/LayoutTests/fast/dom/replace-children-mutation-events.html
+++ b/LayoutTests/fast/dom/replace-children-mutation-events.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests mutating DOM in mutation event listerns during replaceChilden.');
+    
+let oldParent = document.createElement('div');
+let span = document.createElement('span');
+oldParent.appendChild(span);
+
+let parent = document.createElement('div');
+parent.innerHTML = '<b>hello</b><i> world</i>';
+let i = parent.querySelector('i');
+span.addEventListener('DOMNodeRemoved', () => i.appendChild(span), {once: true});
+shouldThrowErrorName('parent.replaceChildren(span)', 'NotFoundError');
+
+const em = document.createElement('em');
+em.textContent = "some";
+oldParent.addEventListener('DOMNodeInserted', () => document.body.appendChild(em), {once: true});
+shouldNotThrow('span.replaceChildren(oldParent, em, "text")');
+shouldBe('span.childNodes.length', '1');
+shouldBe('span.childNodes[0]', 'oldParent');
+shouldBeEqualToString('span.textContent', '');
+
+successfullyParsed = true;
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1086,27 +1086,32 @@ ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrString>&& vector)
 // https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
 ExceptionOr<void> ContainerNode::replaceChildren(FixedVector<NodeOrString>&& vector)
 {
-    // step 1
-    auto result = convertNodesOrStringsIntoNode(WTFMove(vector));
-    if (result.hasException())
-        return result.releaseException();
-    auto node = result.releaseReturnValue();
-
-    // step 2
-    if (node) {
-        if (auto checkResult = ensurePreInsertionValidity(*node, nullptr); checkResult.hasException())
-            return checkResult;
+    auto targets = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
+    for (auto& node : targets) {
+        if (auto result = ensurePreInsertionValidity(node, nullptr); result.hasException())
+            return result.releaseException();
+        if (auto result = node->remove(); result.hasException())
+            return result.releaseException();
     }
 
     // step 3
     Ref protectedThis { *this };
     ChildListMutationScope mutation(*this);
     NodeVector removedChildren;
-    removeAllChildrenWithScriptAssertion(ChildChange::Source::API, removedChildren, DeferChildrenChanged::No);
+    auto didRemoveElements = removeAllChildrenWithScriptAssertion(ChildChange::Source::API, removedChildren, DeferChildrenChanged::Yes);
+    auto replacedAllChildren = (targets.size() && is<Element>(targets[0]))
+        || didRemoveElements == DidRemoveElements::Yes ? ReplacedAllChildren::YesIncludingElements : ReplacedAllChildren::YesNotIncludingElements;
 
-    if (node) {
-        if (auto appendResult = appendChildWithoutPreInsertionValidityCheck(*node); appendResult.hasException())
-            return appendResult;
+    for (auto& child : targets) {
+        if (child->parentNode())
+            break; // Exit early if mutation event listeners inserted child to elsewhere.
+
+        executeNodeInsertionWithScriptAssertion(*this, child, nullptr, ChildChange::Source::API, replacedAllChildren, [&] {
+            InspectorInstrumentation::willInsertDOMNode(document(), *this);
+            child->setTreeScopeRecursively(treeScope());
+            appendChildCommon(child);
+        });
+        replacedAllChildren = ReplacedAllChildren::No;
     }
 
     rebuildSVGExtensionsElementsIfNecessary();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -710,6 +710,7 @@ protected:
     void updateAncestorsForStyleRecalc();
     void markAncestorsForInvalidatedStyle();
 
+    Vector<Ref<Node>, 1> convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&&);
     ExceptionOr<RefPtr<Node>> convertNodesOrStringsIntoNode(FixedVector<NodeOrString>&&);
 
 private:


### PR DESCRIPTION
#### c177199a72c0d38878dcffa142e64ffe263e822e
<pre>
Add mutation events tests for ContainerNode::replaceChildren and refactor the code
<a href="https://bugs.webkit.org/show_bug.cgi?id=261016">https://bugs.webkit.org/show_bug.cgi?id=261016</a>

Reviewed by Chris Dumez.

Added some tests for mutating DOM during replaceChildren&apos;s tree mutating operations.

Also refactor the code in ContainerNode::replaceChildren by merging some aspects of
Node::convertNodesOrStringsIntoNode into the function so that all node removal &amp;
insertion the logic will be in one place.

* LayoutTests/fast/dom/replace-children-mutation-events-expected.txt: Added.
* LayoutTests/fast/dom/replace-children-mutation-events.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::replaceChildren):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::convertNodesOrStringsIntoNodeVector): Extracted from convertNodesOrStringsIntoNode.
(WebCore::Node::convertNodesOrStringsIntoNode):
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/267565@main">https://commits.webkit.org/267565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3520b9c701a5a475a1938c63eaf83ad61faf24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17463 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19599 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22142 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15269 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19714 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2091 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->