### PR TITLE
Create a helper for targeting domain names in Quirks.cpp

### DIFF
--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -176,6 +176,7 @@ public:
 
 private:
     bool needsQuirks() const;
+    bool isDomain(const String&) const;
 
 #if ENABLE(TOUCH_EVENTS)
     bool isAmazon() const;


### PR DESCRIPTION
#### 2d5d6f169a10b77912924eef14c9954ee545e693
<pre>
Create a helper for targeting domain names in Quirks.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=260938">https://bugs.webkit.org/show_bug.cgi?id=260938</a>
rdar://114737751

Reviewed by Timothy Hatcher.

Adds the helper isDomain() to give more regularity to the code and have
a uniform way of testing the domain name. There is probably more to do
to be able to address the other cases.

This also uses this new helper to convert the current domain matchings.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::isDomain const):
(WebCore::Quirks::needsFormControlToBeMouseFocusable const):
(WebCore::Quirks::needsSeekingSupportDisabled const):
(WebCore::Quirks::needsPerDocumentAutoplayBehavior const):
(WebCore::Quirks::shouldAutoplayWebAudioForArbitraryUserGesture const):
(WebCore::Quirks::hasBrokenEncryptedMediaAPISupportQuirk const):
(WebCore::Quirks::shouldDisableContentChangeObserver const):
(WebCore::Quirks::shouldDisableContentChangeObserverTouchEventAdjustment const):
(WebCore::Quirks::shouldTooltipPreventFromProceedingWithClick const):
(WebCore::Quirks::isNeverRichlyEditableForTouchBar const):
(WebCore::Quirks::shouldDispatchSyntheticMouseEventsWhenModifyingSelection const):
(WebCore::Quirks::shouldDispatchSimulatedMouseEvents const):
(WebCore::Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented const):
(WebCore::Quirks::simulatedMouseEventTypeForTarget const):
(WebCore::Quirks::shouldPreventPointerMediaQueryFromEvaluatingToCoarse const):
(WebCore::Quirks::shouldPreventDispatchOfTouchEvent const): Deleted.
(WebCore::Quirks::shouldSynthesizeTouchEvents const): Deleted.
(WebCore::Quirks::shouldAvoidResizingWhenInputViewBoundsChange const): Deleted.
(WebCore::Quirks::shouldDisablePointerEventsQuirk const): Deleted.
(WebCore::Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand const): Deleted.
(WebCore::Quirks::needsGMailOverflowScrollQuirk const): Deleted.
(WebCore::Quirks::needsYouTubeOverflowScrollQuirk const): Deleted.
(WebCore::Quirks::needsFullscreenDisplayNoneQuirk const): Deleted.
(WebCore::Quirks::needsWeChatScrollingQuirk const): Deleted.
(WebCore::Quirks::shouldOmitHTMLDocumentSupportedPropertyNames): Deleted.
(WebCore::Quirks::shouldSilenceResizeObservers const): Deleted.
(WebCore::Quirks::shouldSilenceWindowResizeEvents const): Deleted.
(WebCore::Quirks::shouldSilenceMediaQueryListChangeEvents const): Deleted.
(WebCore::Quirks::shouldAvoidScrollingWhenFocusedContentIsVisible const): Deleted.
(WebCore::Quirks::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation const): Deleted.
(WebCore::Quirks::shouldIgnoreAriaForFastPathContentObservationCheck const): Deleted.
(WebCore::isWikipediaDomain): Deleted.
(WebCore::Quirks::shouldIgnoreViewportArgumentsToAvoidExcessiveZoom const): Deleted.
(WebCore::Quirks::shouldOpenAsAboutBlank const): Deleted.
(WebCore::Quirks::needsPreloadAutoQuirk const): Deleted.
(WebCore::Quirks::shouldBypassBackForwardCache const): Deleted.
(WebCore::Quirks::shouldBypassAsyncScriptDeferring const): Deleted.
(WebCore::Quirks::shouldMakeEventListenerPassive): Deleted.
(WebCore::Quirks::shouldEnableLegacyGetUserMediaQuirk const): Deleted.
(WebCore::Quirks::needsCanPlayAfterSeekedQuirk const): Deleted.
(WebCore::Quirks::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints const): Deleted.
(WebCore::Quirks::shouldAvoidPastingImagesAsWebContent const): Deleted.
(WebCore::isKinjaLoginAvatarElement): Deleted.
(WebCore::Quirks::isMicrosoftTeamsRedirectURL): Deleted.
(WebCore::isStorageAccessQuirkDomainAndElement): Deleted.
(WebCore::Quirks::hasStorageAccessForAllLoginDomains): Deleted.
(WebCore::Quirks::staticRadioPlayerURLString): Deleted.
(WebCore::Quirks::requestStorageAccessAndHandleClick const): Deleted.
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const): Deleted.
(WebCore::Quirks::needsVP9FullRangeFlagQuirk const): Deleted.
(WebCore::Quirks::requiresUserGestureToPauseInPictureInPicture const): Deleted.
(WebCore::Quirks::requiresUserGestureToLoadInPictureInPicture const): Deleted.
(WebCore::Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk const): Deleted.
(WebCore::Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk const): Deleted.
(WebCore::Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk const): Deleted.
(WebCore::Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk const): Deleted.
(WebCore::Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture): Deleted.
(WebCore::Quirks::allowLayeredFullscreenVideos const): Deleted.
(WebCore::Quirks::shouldEnableApplicationCacheQuirk const): Deleted.
(WebCore::Quirks::shouldEnableFontLoadingAPIQuirk const): Deleted.
(WebCore::Quirks::needsVideoShouldMaintainAspectRatioQuirk const): Deleted.
(WebCore::Quirks::shouldExposeShowModalDialog const): Deleted.
(WebCore::Quirks::shouldNavigatorPluginsBeEmpty const): Deleted.
(WebCore::Quirks::shouldDisableLazyIframeLoadingQuirk const): Deleted.
(WebCore::Quirks::shouldDisableFetchMetadata const): Deleted.
(WebCore::Quirks::shouldDisablePushStateFilePathRestrictions const): Deleted.
(WebCore::Quirks::shouldDisablePopoverAttributeQuirk const): Deleted.
(WebCore::Quirks::needsConfigurableIndexedPropertiesQuirk const): Deleted.
(WebCore::Quirks::shouldEnableCanvas2DAdvancedPrivacyProtectionQuirk const): Deleted.
(WebCore::Quirks::advancedPrivacyProtectionSubstituteDataURLForText const): Deleted.
(WebCore::Quirks::needsResettingTransitionCancelsRunningTransitionQuirk const): Deleted.
(WebCore::Quirks::shouldStarBeFeaturePolicyDefaultValue const): Deleted.
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/267907@main">https://commits.webkit.org/267907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f26adbc54a166dfabb57cea3c1b879646679fb6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18142 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19610 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15435 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22150 "3 flakes 120 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19928 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15359 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4290 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->