### PR TITLE
LibWebRTCSocket does no longer need to check for buffered data size

### DIFF
--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -87,15 +87,7 @@ void LibWebRTCSocket::signalReadPacket(const uint8_t* data, size_t size, rtc::So
 
 void LibWebRTCSocket::signalSentPacket(int rtcPacketID, int64_t sendTimeMs)
 {
-    if (m_beingSentPacketSizes.isEmpty())
-        return;
-
-    m_availableSendingBytes += m_beingSentPacketSizes.takeFirst();
     SignalSentPacket(this, rtc::SentPacket(rtcPacketID, sendTimeMs));
-    if (m_shouldSignalReadyToSend) {
-        m_shouldSignalReadyToSend = false;
-        SignalReadyToSend(this);
-    }
 }
 
 void LibWebRTCSocket::signalConnect()
@@ -115,22 +107,10 @@ void LibWebRTCSocket::signalUsedInterface(String&& name)
     LibWebRTCNetworkManager::signalUsedInterface(m_contextIdentifier, WTFMove(name));
 }
 
-bool LibWebRTCSocket::willSend(size_t size)
-{
-    if (size > m_availableSendingBytes) {
-        m_shouldSignalReadyToSend = true;
-        setError(EWOULDBLOCK);
-        return false;
-    }
-    m_availableSendingBytes -= size;
-    m_beingSentPacketSizes.append(size);
-    return true;
-}
-
 int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAddress& address, const rtc::PacketOptions& options)
 {
     auto* connection = m_factory.connection();
-    if (!connection || !willSend(size))
+    if (!connection)
         return -1;
 
     if (m_isSuspended)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -29,7 +29,6 @@
 
 #include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
-#include <wtf/Deque.h>
 #include <wtf/Forward.h>
 
 ALLOW_COMMA_BEGIN
@@ -101,9 +100,6 @@ private:
     static const unsigned MAX_SOCKET_OPTION { rtc::Socket::OPT_RTP_SENDTIME_EXTN_ID + 1 };
     std::optional<int> m_options[MAX_SOCKET_OPTION];
 
-    Deque<size_t> m_beingSentPacketSizes;
-    size_t m_availableSendingBytes { 65536 };
-    bool m_shouldSignalReadyToSend { false };
     bool m_isSuspended { false };
     WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;
 };


### PR DESCRIPTION
#### 2f1c609b53d2ae9b253324c9685f46cd5d5cb94a
<pre>
LibWebRTCSocket does no longer need to check for buffered data size
<a href="https://bugs.webkit.org/show_bug.cgi?id=261021">https://bugs.webkit.org/show_bug.cgi?id=261021</a>
rdar://problem/114810113

Reviewed by Jean-Yves Avenard.

We used to check for buffered size to prevent excessive memory allocation in case the main thread is blocked.
We no longer need to do this since we are doing IPC straight from the networking thread.
The backpressure mechanism (via nw callback and libwebrtc SignalSentPacket) should be sufficient.
This might reduce a case where we would loose some UDP packets if there is a burst of packet sending on libwebrtc side and a slowdown in nw or network process.

* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::signalSentPacket):
(WebKit::LibWebRTCSocket::SendTo):
(WebKit::LibWebRTCSocket::willSend): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:

Canonical link: <a href="https://commits.webkit.org/267634@main">https://commits.webkit.org/267634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eac23b50fb182833bcb510247d247ee01da3f50a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15843 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18089 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19516 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14721 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22069 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13658 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15284 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->