### PR TITLE
Move filter specific code from BitmapTextureGL to TextureMapperGL.

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h
@@ -66,19 +66,22 @@ public:
     void updateContents(const void*, const IntRect& target, const IntPoint& sourceOffset, int bytesPerLine) override;
     bool isBackedByOpenGL() const override { return true; }
 
-    RefPtr<BitmapTexture> applyFilters(TextureMapper&, const FilterOperations&, bool defersLastFilter) override;
+    RefPtr<BitmapTexture> applyFilters(TextureMapper&, const FilterOperations&, bool defersLastFilterPass) override;
     struct FilterInfo {
-        RefPtr<FilterOperation> filter;
+        RefPtr<const FilterOperation> filter;
         unsigned pass;
         RefPtr<BitmapTexture> contentTexture;
 
-        FilterInfo(RefPtr<FilterOperation>&& f = nullptr, unsigned p = 0, RefPtr<BitmapTexture>&& t = nullptr)
+        FilterInfo(RefPtr<const FilterOperation>&& f = nullptr, unsigned p = 0, RefPtr<BitmapTexture>&& t = nullptr)
             : filter(WTFMove(f))
             , pass(p)
             , contentTexture(WTFMove(t))
             { }
     };
+
     const FilterInfo* filterInfo() const { return &m_filterInfo; }
+    void setFilterInfo(FilterInfo&& filterInfo) { m_filterInfo = WTFMove(filterInfo); }
+
     ClipStack& clipStack() { return m_clipStack; }
 
     GLint internalFormat() const { return m_internalFormat; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
@@ -84,11 +84,12 @@ public:
     Ref<BitmapTexture> createTexture() override;
     void setDepthRange(double zNear, double zFar) override;
 
-    void drawFiltered(const BitmapTexture& sourceTexture, const BitmapTexture* contentTexture, const FilterOperation&, int pass);
+    RefPtr<BitmapTexture> applyFilter(RefPtr<BitmapTexture> sourceTexture, const RefPtr<const FilterOperation>&, bool defersLastPass);
 
     void drawTextureExternalOES(GLuint texture, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
 
 private:
+    void drawFilterPass(const BitmapTexture& sourceTexture, const BitmapTexture* contentTexture, const FilterOperation&, int pass);
     void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, uint32_t texture, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
     void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, const Vector<std::pair<GLuint, GLuint> >& texturesAndSamplers, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
     void draw(const FloatRect&, const TransformationMatrix& modelViewMatrix, TextureMapperShaderProgram&, GLenum drawingMode, Flags);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -676,8 +676,8 @@ void TextureMapperLayer::paintIntoSurface(TextureMapperPaintOptions& options)
 
     bool hasMask = !!m_state.maskLayer;
     bool hasReplicaMask = options.replicaLayer == this && m_state.replicaLayer->m_state.maskLayer;
-    bool defersLastFilter = !hasMask && !hasReplicaMask;
-    options.surface = options.surface->applyFilters(options.textureMapper, m_currentFilters, defersLastFilter);
+    bool defersLastFilterPass = !hasMask && !hasReplicaMask;
+    options.surface = options.surface->applyFilters(options.textureMapper, m_currentFilters, defersLastFilterPass);
     options.textureMapper.bindSurface(options.surface.get());
     if (hasMask)
         m_state.maskLayer->applyMask(options);


### PR DESCRIPTION
#### 499bdf98d4a7547259c7ed0af2486f4dff20dbd6
<pre>
Move filter specific code from BitmapTextureGL to TextureMapperGL.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261022">https://bugs.webkit.org/show_bug.cgi?id=261022</a>

Reviewed by Fujii Hironori.

This is a preparation refactoring for <a href="https://bugs.webkit.org/show_bug.cgi?id=231653.">https://bugs.webkit.org/show_bug.cgi?id=231653.</a>

To fix the issue above, we have to change the number of passes needed to
do blur filtering according to the standard deviation of the blur.
Now the number of passes for each filter is specified in
BitmapTextureGL.cpp but other parameters regarding filtering such as
shader options are specified in TextureMapperGL.cpp, which leads to the
inconsistency and low readability.

This change moves filter specific code from BitmapTextureGL.cpp
to TextureMapperGL.cpp

* Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp:
(WebCore::BitmapTextureGL::applyFilters):
(WebCore::getPassesRequiredForFilter): Deleted.
* Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h:
(WebCore::BitmapTextureGL::FilterInfo::FilterInfo):
(WebCore::BitmapTextureGL::setFilterInfo):
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::TextureMapperGL::drawTexture):
(WebCore::TextureMapperGL::drawTexturePlanarYUV):
(WebCore::TextureMapperGL::drawTextureSemiPlanarYUV):
(WebCore::TextureMapperGL::drawTexturePackedYUV):
(WebCore::TextureMapperGL::drawFilterPass):
(WebCore::getPassesRequiredForFilter):
(WebCore::TextureMapperGL::applyFilter):
(WebCore::TextureMapperGL::drawFiltered): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintIntoSurface):

Canonical link: <a href="https://commits.webkit.org/267599@main">https://commits.webkit.org/267599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a56bd9c16a0335f201c1ac5b3659c8eb35b198f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17127 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17594 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17330 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19729 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15555 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/15918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15722 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19834 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2104 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->