### PR TITLE
Some ImageBufferBackend implementations use resolutionScale

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -237,6 +237,7 @@ protected:
     std::unique_ptr<ImageBufferBackend> m_backend;
     RenderingResourceIdentifier m_renderingResourceIdentifier;
     unsigned m_backendGeneration { 0 };
+    mutable bool m_hasInitializedContext { false }; // FIXME: will be replaced with std::unique_ptr<GraphicsContext>.
 };
 
 class SerializedImageBuffer {

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -147,7 +147,6 @@ public:
     virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() { return nullptr; }
 
     static constexpr bool isOriginAtBottomLeftCorner = false;
-    virtual bool originAtBottomLeftCorner() const { return isOriginAtBottomLeftCorner; }
 
     static constexpr bool canMapBackingStore = true;
     static constexpr RenderingMode renderingMode = RenderingMode::Unaccelerated;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -70,15 +70,9 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
 
 ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
-bool ImageBufferCGBackend::originAtBottomLeftCorner() const
-{
-    return isOriginAtBottomLeftCorner;
-}
-
 void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
 {
     context.applyDeviceScaleFactor(m_parameters.resolutionScale);
-    context.setCTM(calculateBaseTransform(m_parameters, originAtBottomLeftCorner()));
 }
 
 String ImageBufferCGBackend::debugDescription() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -49,7 +49,6 @@ protected:
 
     String debugDescription() const override;
 
-    bool originAtBottomLeftCorner() const override;
     mutable std::unique_ptr<GraphicsContextCG> m_context;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -108,11 +108,6 @@ ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const Param
     , m_bitmap(WTFMove(bitmap))
     , m_context(WTFMove(context))
 {
-    // ShareableBitmap ensures that the coordinate space in the context that we're adopting
-    // has a top-left origin, so we don't ever need to flip here, so we don't call setupContext().
-    // However, ShareableBitmap does not have a notion of scale, so we must apply the device
-    // scale factor to the context ourselves.
-    m_context->applyDeviceScaleFactor(resolutionScale());
 }
 
 ImageBufferBackendHandle ImageBufferShareableBitmapBackend::createBackendHandle(SharedMemory::Protection protection) const

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -65,8 +65,6 @@ private:
     void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
-    bool originAtBottomLeftCorner() const final { return isOriginAtBottomLeftCorner; }
-
     unsigned bytesPerRow() const final;
 
     WebCore::VolatilityState volatilityState() const final { return m_volatilityState; }

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -55,7 +55,6 @@ public:
     ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
     void setOwnershipIdentity(const WebCore::ProcessIdentity&) final;
     WebCore::GraphicsContext& context() final;
-    bool originAtBottomLeftCorner() const override { return isOriginAtBottomLeftCorner; }
 private:
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }


### PR DESCRIPTION
#### b8769a5cf417b26f5883b32059d1fa1a29986703
<pre>
Some ImageBufferBackend implementations use resolutionScale
<a href="https://bugs.webkit.org/show_bug.cgi?id=255983">https://bugs.webkit.org/show_bug.cgi?id=255983</a>
rdar://108554761

Reviewed by Matt Woodrow.

The resolutionScale is used to set up the initial transformation matrix
of the graphics context used to draw to ImageBuffer. This is
ImageBuffer logic.

Move the creation signal of the GraphicsContext to ImageBuffer.
When ImageBuffer knows when the context is being created, it can also
apply the needed state to the new GraphicsContext. The transformation
is already known statically due to the Info::baseTransform.

This is work towards making the ImageBufferBackend implementations
less rendundant and error-prone. This allows further commits to remove
logicalSize and resolutionScale from ImageBufferBackend and removing
unneeded virtual functions related to size concepts.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::context const):
(WebCore::ImageBuffer::setBackend):
(WebCore::ImageBuffer::releaseGraphicsContext):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::originAtBottomLeftCorner const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::applyBaseTransform const):
(WebCore::ImageBufferCGBackend::originAtBottomLeftCorner const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:

Canonical link: <a href="https://commits.webkit.org/267604@main">https://commits.webkit.org/267604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d0c3632ac6fdfa49daa8fd432d0c45494f20b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18096 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19528 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22081 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13666 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15293 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4093 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->