### PR TITLE
AX: Fix to parse edge cases of role string

### DIFF
--- a/LayoutTests/accessibility/roles-computedRoleString.html
+++ b/LayoutTests/accessibility/roles-computedRoleString.html
@@ -286,11 +286,10 @@
 <div role="foo button bar"           data-role="button" data-platform="atspi,mac" class="ex">X</div>
 <div role="foo  button  bar"         data-role="button" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Two spaces in role string -->
 
-<!-- FIXME: These two should be button but fail b/c of http://webkit.org/b/128400 -->
-<div role="foo	button	bar"         data-role="generic" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Tab chars in role string -->
+<div role="foo	button	bar"         data-role="button" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Tab chars in role string -->
 <div role="foo
 button
-bar"                                 data-role="generic" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Newlines in role string -->
+bar"                                 data-role="button" data-platform="atspi,mac" class="ex">X</div><!-- [sic] Newlines in role string -->
 
 
 <!-- ==================================================================================================== -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wai-aria/role/fallback-roles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wai-aria/role/fallback-roles-expected.txt
@@ -21,7 +21,6 @@ PASS button ignoring multiple invalid role tokens
 PASS div[role=button] ignoring invalid foo role token including punctuation-contaminated known link role
 PASS div[role=button] ignoring invalid unicode diacritics etc on link and group role tokens
 PASS div[role=button] ignoring tab char
-FAIL div[role=button] ignoring line break assert_equals: <div role="
-button" data-testname="div[role=button] ignoring line break" aria-label="x" data-expectedrole="button" class="ex">x</div> expected "button" but got "generic"
+PASS div[role=button] ignoring line break
 PASS div[role=button] ignoring braille whitespace char
 

--- a/LayoutTests/platform/mac/accessibility/roles-computedRoleString-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/roles-computedRoleString-expected.txt
@@ -185,10 +185,10 @@ PASS div[role="generic"] -> generic.
 PASS div[role="button foo"] -> button.
 PASS div[role="foo button bar"] -> button.
 PASS div[role="foo  button  bar"] -> button.
-PASS div[role="foo	button	bar"] -> generic.
+PASS div[role="foo	button	bar"] -> button.
 PASS div[role="foo
 button
-bar"] -> generic.
+bar"] -> button.
 PASS img[role="foo"] -> image.
 PASS img[role="foo bar"] -> image.
 PASS img[role="foo  bar"] -> image.

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2713,8 +2713,8 @@ AccessibilityRole AccessibilityObject::ariaRoleToWebCoreRole(const String& value
 {
     if (value.isNull() || value.isEmpty())
         return AccessibilityRole::Unknown;
-
-    for (auto roleName : StringView(value).split(' ')) {
+    auto simplifiedValue = value.simplifyWhiteSpace(isASCIIWhitespace);
+    for (auto roleName : StringView(simplifiedValue).split(' ')) {
         AccessibilityRole role = ariaRoleMap().get<ASCIICaseInsensitiveStringViewHashTranslator>(roleName);
         if (static_cast<int>(role))
             return role;


### PR DESCRIPTION
#### 3693580c14ed4a2cdb4e6d3bf958a2beccef26fc
<pre>
AX: Fix to parse edge cases of role string
<a href="https://bugs.webkit.org/show_bug.cgi?id=260216">https://bugs.webkit.org/show_bug.cgi?id=260216</a>
rdar://problem/113923520

Reviewed by Tyler Wilcock.

ARIA role parsing should ignore any leading/trailing whitespaces,
including line breaks.

* LayoutTests/accessibility/aria-fallback-roles-expected.txt:
* LayoutTests/accessibility/aria-fallback-roles.html:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::ariaRoleToWebCoreRole):

Canonical link: <a href="https://commits.webkit.org/267930@main">https://commits.webkit.org/267930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12da51c5f3ad192765977dbe8ebde9b49408b5b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20787 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23006 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20879 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4308 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->