### PR TITLE
Allow using longer ancestor chains in StyleCustomPropertyData

### DIFF
--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -102,6 +102,7 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         map->forEach([&](auto& it) {
             values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, m_element->document())));
+            return IterationStatus::Continue;
         });
     }
 

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
@@ -28,30 +28,46 @@
 
 namespace WebCore {
 
-StyleCustomPropertyData::StyleCustomPropertyData(const StyleCustomPropertyData& other)
-    : RefCounted()
-{
-    // Don't reference `other` if it already has a parent of its own, to avoid
-    // creating a linked list of StyleCustomPropertyData objects.
-    bool shouldReferenceAsParentValues = !other.m_parentValues && !other.m_ownValues.isEmpty();
+static constexpr auto maximumAncestorCount = 4;
 
-    if (shouldReferenceAsParentValues) {
+StyleCustomPropertyData::StyleCustomPropertyData(const StyleCustomPropertyData& other)
+    : m_size(other.m_size)
+{
+    auto shouldReferenceAsParentValues = [&] {
+        // Always reference the root style since it likely gets shared a lot.
+        if (!other.m_parentValues && !other.m_ownValues.isEmpty())
+            return true;
+
+        // Limit the list length.
+        if (other.m_ancestorCount >= maximumAncestorCount)
+            return false;
+
+        // If the number of properties is small we just copy them to avoid creating unnecessarily long linked lists.
+        static constexpr auto parentReferencePropertyCountThreshold = 8;
+        return other.m_ownValues.size() > parentReferencePropertyCountThreshold;
+    }();
+
+    // If there are mutations on multiple levels this constructs a linked list of property data objects.
+    if (shouldReferenceAsParentValues)
         m_parentValues = &other;
-        m_ownValuesSizeExcludingOverriddenParentValues = 0;
-    } else {
-        m_parentValues = other.m_parentValues.get();
+    else {
+        m_parentValues = other.m_parentValues;
         m_ownValues = other.m_ownValues;
-        m_ownValuesSizeExcludingOverriddenParentValues = other.m_ownValuesSizeExcludingOverriddenParentValues;
     }
+
+    if (m_parentValues)
+        m_ancestorCount = m_parentValues->m_ancestorCount + 1;
+
+#if ASSERT_ENABLED
+    if (m_parentValues)
+        m_parentValues->m_hasChildren = true;
+#endif
 }
 
 const CSSCustomPropertyValue* StyleCustomPropertyData::get(const AtomString& name) const
 {
-    if (auto* value = m_ownValues.get(name))
-        return value;
-    if (m_parentValues) {
-        ASSERT(!m_parentValues->m_parentValues);
-        if (auto* value = m_parentValues->m_ownValues.get(name))
+    for (auto* propertyData = this; propertyData; propertyData = propertyData->m_parentValues.get()) {
+        if (auto* value = propertyData->m_ownValues.get(name))
             return value;
     }
     return nullptr;
@@ -59,73 +75,102 @@ const CSSCustomPropertyValue* StyleCustomPropertyData::get(const AtomString& nam
 
 void StyleCustomPropertyData::set(const AtomString& name, Ref<const CSSCustomPropertyValue>&& value)
 {
+    ASSERT(!m_hasChildren);
+    ASSERT([&] {
+        auto* existing = get(name);
+        return !existing || !existing->equals(value);
+    }());
+
     auto addResult = m_ownValues.set(name, WTFMove(value));
-    if (addResult.isNewEntry && (!m_parentValues || !m_parentValues->m_ownValues.contains(name)))
-        ++m_ownValuesSizeExcludingOverriddenParentValues;
+
+    bool isNewProperty = addResult.isNewEntry && (!m_parentValues || !m_parentValues->get(name));
+    if (isNewProperty)
+        ++m_size;
 }
 
 bool StyleCustomPropertyData::operator==(const StyleCustomPropertyData& other) const
 {
-    if (size() != other.size())
+    if (m_size != other.m_size)
         return false;
 
-    for (auto& entry : m_ownValues) {
-        auto* otherValue = other.get(entry.key);
-        if (!otherValue || !entry.value->equals(*otherValue))
+    if (m_parentValues == other.m_parentValues) {
+        // This relies on the values in m_ownValues never being equal to those in m_parentValues.
+        if (m_ownValues.size() != other.m_ownValues.size())
             return false;
-    }
 
-    if (m_parentValues) {
-        ASSERT(!m_parentValues->m_parentValues);
-        for (auto& entry : m_parentValues->m_ownValues) {
-            if (m_ownValues.contains(entry.key))
-                continue;
-            auto* otherValue = other.get(entry.key);
+        for (auto& entry : m_ownValues) {
+            auto* otherValue = other.m_ownValues.get(entry.key);
             if (!otherValue || !entry.value->equals(*otherValue))
                 return false;
         }
+        return true;
     }
 
-    return true;
+    bool isEqual = true;
+    forEachInternal([&](auto& entry) {
+        auto* otherValue = other.get(entry.key);
+        if (!otherValue || !entry.value->equals(*otherValue)) {
+            isEqual = false;
+            return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    });
+
+    return isEqual;
 }
 
-void StyleCustomPropertyData::forEach(const Function<void(const KeyValuePair<AtomString, RefPtr<const CSSCustomPropertyValue>>&)>& callback) const
+template<typename Callback>
+void StyleCustomPropertyData::forEachInternal(Callback&& callback) const
 {
-    if (m_parentValues) {
-        ASSERT(!m_parentValues->m_parentValues);
-        for (auto& entry : m_parentValues->m_ownValues) {
-            if (!m_ownValues.contains(entry.key))
-                callback(entry);
+    Vector<const StyleCustomPropertyData*, maximumAncestorCount> descendants;
+
+    auto isOverridenByDescendants = [&](auto& key) {
+        for (auto* descendant : descendants) {
+            if (descendant->m_ownValues.contains(key))
+                return true;
         }
+        return false;
+    };
+
+    auto* propertyData = this;
+    while (true) {
+        for (auto& entry : propertyData->m_ownValues) {
+            if (isOverridenByDescendants(entry.key))
+                continue;
+            auto status = callback(entry);
+            if (status == IterationStatus::Done)
+                return;
+        }
+        if (!propertyData->m_parentValues)
+            return;
+        descendants.append(propertyData);
+        propertyData = propertyData->m_parentValues.get();
     }
-    for (auto& entry : m_ownValues)
-        callback(entry);
+}
+
+void StyleCustomPropertyData::forEach(const Function<IterationStatus(const KeyValuePair<AtomString, RefPtr<const CSSCustomPropertyValue>>&)>& callback) const
+{
+    forEachInternal(callback);
 }
 
 AtomString StyleCustomPropertyData::findKeyAtIndex(unsigned index) const
 {
     unsigned currentIndex = 0;
-    if (m_parentValues) {
-        ASSERT(!m_parentValues->m_parentValues);
-        for (auto& key : m_parentValues->m_ownValues.keys()) {
-            if (!m_ownValues.contains(key)) {
-                if (currentIndex == index)
-                    return key;
-                ++currentIndex;
-            }
+    AtomString key;
+    forEachInternal([&](auto& entry) {
+        if (currentIndex == index) {
+            key = entry.key;
+            return IterationStatus::Done;
         }
-    }
-    for (auto& key : m_ownValues.keys()) {
-        if (currentIndex == index)
-            return key;
         ++currentIndex;
-    }
-    return { };
+        return IterationStatus::Continue;
+    });
+    return key;
 }
 
 unsigned StyleCustomPropertyData::size() const
 {
-    return m_ownValuesSizeExcludingOverriddenParentValues + (m_parentValues ? m_parentValues->m_ownValuesSizeExcludingOverriddenParentValues : 0); 
+    return m_size;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.h
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.h
@@ -24,6 +24,7 @@
 #include "CSSCustomPropertyValue.h"
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/IterationStatus.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/AtomStringHash.h>
@@ -45,16 +46,22 @@ public:
 
     unsigned size() const;
 
-    void forEach(const Function<void(const KeyValuePair<AtomString, RefPtr<const CSSCustomPropertyValue>>&)>&) const;
+    void forEach(const Function<IterationStatus(const KeyValuePair<AtomString, RefPtr<const CSSCustomPropertyValue>>&)>&) const;
     AtomString findKeyAtIndex(unsigned) const;
 
 private:
     StyleCustomPropertyData() = default;
     StyleCustomPropertyData(const StyleCustomPropertyData&);
 
+    template<typename Callback> void forEachInternal(Callback&&) const;
+
     RefPtr<const StyleCustomPropertyData> m_parentValues;
     CustomPropertyValueMap m_ownValues;
-    unsigned m_ownValuesSizeExcludingOverriddenParentValues { 0 };
+    unsigned m_size { 0 };
+    unsigned m_ancestorCount { 0 };
+#if ASSERT_ENABLED
+    mutable bool m_hasChildren { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -692,12 +692,11 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
         auto gatherAnimatableCustomProperties = [&](const StyleCustomPropertyData& customPropertyData) {
             customPropertyData.forEach([&](auto& customPropertyAndValuePair) {
                 auto [customProperty, customPropertyValue] = customPropertyAndValuePair;
-                if (!customPropertyValue)
-                    return;
                 auto& variantValue = customPropertyValue->value();
                 if (std::holds_alternative<CSSCustomPropertyValue::SyntaxValue>(variantValue)
                     || std::holds_alternative<CSSCustomPropertyValue::SyntaxValueList>(variantValue))
                     animatableCustomProperties.add(customProperty);
+                return IterationStatus::Continue;
             });
         };
         gatherAnimatableCustomProperties(currentStyle.inheritedCustomProperties());


### PR DESCRIPTION
#### 8b7bc22a8c879f1a47bd4966fa30b8a4ce3216ed
<pre>
Allow using longer ancestor chains in StyleCustomPropertyData
<a href="https://bugs.webkit.org/show_bug.cgi?id=261025">https://bugs.webkit.org/show_bug.cgi?id=261025</a>
rdar://114815380

Reviewed by Cameron McCormack.

Currently only one ancestor is allowed. It is typical to have many properties defined on :root.
If we have more definitions further down the tree on multiple levels then all those properties get
copied and we can get large maps duplicated to many elements. This also makes equality comparisons slow.

* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/rendering/style/StyleCustomPropertyData.cpp:
(WebCore::StyleCustomPropertyData::StyleCustomPropertyData):

If the parent has more than 8 own properties link to it instead of copying it even
if it already has a parent.
Also limit the maximum ancestor list size to 4.

(WebCore::StyleCustomPropertyData::get const):
(WebCore::StyleCustomPropertyData::set):

Add some asserts.

(WebCore::StyleCustomPropertyData::operator== const):

Shortcut the equality comparison in case the parents are the same.
Use forEach for the slow path.

(WebCore::StyleCustomPropertyData::forEachInternal const):
(WebCore::StyleCustomPropertyData::forEach const):

Traverse all ancestors.
Add IterationStatus return value so iteration can be broken early.
Add templated traversal that avoid Function&lt;&gt; for internal use.

(WebCore::StyleCustomPropertyData::findKeyAtIndex const):
(WebCore::StyleCustomPropertyData::size const):

We now always track the full size so no need to traverse ancestors for it.

* Source/WebCore/rendering/style/StyleCustomPropertyData.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/267595@main">https://commits.webkit.org/267595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c54d1db3890c5ac695d2d78730f4ae7037e22f39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17571 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19706 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15538 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20047 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16290 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15447 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4083 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->