### PR TITLE
RemoteImageBufferProxy re-populates backend info after getting the backend handle

### DIFF
--- a/LayoutTests/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -240,11 +240,9 @@ Testing 1x16384 forced 'Accelerated' (area: 16384)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 1x32768 forced 'Accelerated' (area: 32768)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1x32769 forced 'Accelerated' (area: 32769)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1000x1 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
@@ -264,11 +262,9 @@ Testing 1000x16384 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 2048x1 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
@@ -288,11 +284,9 @@ Testing 2048x16384 forced 'Accelerated' (area: 33554432)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 2048x32768 forced 'Accelerated' (area: 67108864)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 2048x32769 forced 'Accelerated' (area: 67110912)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 4096x1 forced 'Accelerated' (area: 4096)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
@@ -312,11 +306,9 @@ Testing 4096x16384 forced 'Accelerated' (area: 67108864)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 4096x32768 forced 'Accelerated' (area: 134217728)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 4096x32769 forced 'Accelerated' (area: 134221824)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 8192x1 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
@@ -336,8 +328,7 @@ Testing 8192x16384 forced 'Accelerated' (area: 134217728)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 8192x32768 forced 'Accelerated' (area: 268435456)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 8192x32769 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Accelerated' (area: 16384)
@@ -363,20 +354,15 @@ PASS Context was lost
 Testing 16384x32769 forced 'Accelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Accelerated' (area: 32768)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32768x1000 forced 'Accelerated' (area: 32768000)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32768x2048 forced 'Accelerated' (area: 67108864)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32768x4096 forced 'Accelerated' (area: 134217728)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32768x8192 forced 'Accelerated' (area: 268435456)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32768x16384 forced 'Accelerated' (area: 536870912)
 PASS Context was lost
 Testing 32768x32768 forced 'Accelerated' (area: 1073741824)
@@ -384,17 +370,13 @@ PASS Context was lost
 Testing 32768x32769 forced 'Accelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Accelerated' (area: 32769)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32769x1000 forced 'Accelerated' (area: 32769000)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32769x2048 forced 'Accelerated' (area: 67110912)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32769x4096 forced 'Accelerated' (area: 134221824)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32769x8192 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 32769x16384 forced 'Accelerated' (area: 536887296)

--- a/LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -285,14 +285,11 @@ Testing 1x8192 forced 'Accelerated' (area: 8192)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 1x16384 forced 'Accelerated' (area: 16384)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1x32768 forced 'Accelerated' (area: 32768)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1x32769 forced 'Accelerated' (area: 32769)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1000x1 forced 'Accelerated' (area: 1000)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
@@ -309,8 +306,7 @@ Testing 1000x8192 forced 'Accelerated' (area: 8192000)
 PASS imageData.data is red
 PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
 Testing 1000x16384 forced 'Accelerated' (area: 16384000)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
 PASS Context was lost
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
@@ -376,11 +372,9 @@ PASS Context was lost
 Testing 8192x32769 forced 'Accelerated' (area: 268443648)
 PASS Context was lost
 Testing 16384x1 forced 'Accelerated' (area: 16384)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 16384x1000 forced 'Accelerated' (area: 16384000)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 16384x2048 forced 'Accelerated' (area: 33554432)
 PASS Context was lost
 Testing 16384x4096 forced 'Accelerated' (area: 67108864)
@@ -394,8 +388,7 @@ PASS Context was lost
 Testing 16384x32769 forced 'Accelerated' (area: 536887296)
 PASS Context was lost
 Testing 32768x1 forced 'Accelerated' (area: 32768)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32768x1000 forced 'Accelerated' (area: 32768000)
 PASS Context was lost
 Testing 32768x2048 forced 'Accelerated' (area: 67108864)
@@ -411,8 +404,7 @@ PASS Context was lost
 Testing 32768x32769 forced 'Accelerated' (area: 1073774592)
 PASS Context was lost
 Testing 32769x1 forced 'Accelerated' (area: 32769)
-PASS imageData.data is red
-FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+PASS Context was lost
 Testing 32769x1000 forced 'Accelerated' (area: 32769000)
 PASS Context was lost
 Testing 32769x2048 forced 'Accelerated' (area: 67110912)

--- a/LayoutTests/platform/mac-wk1/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -1,0 +1,603 @@
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+Test enumerates the behavior of canvas with respect to dimensions and backends
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Testing 1x1 (area: 1)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1x1000 (area: 1000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1x2048 (area: 2048)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1x4096 (area: 4096)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1x8192 (area: 8192)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1x16384 (area: 16384)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1x32768 (area: 32768)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 1x32769 (area: 32769)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 1000x1 (area: 1000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1000x1000 (area: 1000000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1000x2048 (area: 2048000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1000x4096 (area: 4096000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1000x8192 (area: 8192000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 1000x16384 (area: 16384000)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 1000x32768 (area: 32768000)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 1000x32769 (area: 32769000)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 2048x1 (area: 2048)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 2048x1000 (area: 2048000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 2048x2048 (area: 4194304)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 2048x4096 (area: 8388608)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 2048x8192 (area: 16777216)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 2048x16384 (area: 33554432)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 2048x32768 (area: 67108864)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 2048x32769 (area: 67110912)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 4096x1 (area: 4096)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 4096x1000 (area: 4096000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 4096x2048 (area: 8388608)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 4096x4096 (area: 16777216)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 4096x8192 (area: 33554432)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 4096x16384 (area: 67108864)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 4096x32768 (area: 134217728)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 4096x32769 (area: 134221824)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 8192x1 (area: 8192)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 8192x1000 (area: 8192000)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 8192x2048 (area: 16777216)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 8192x4096 (area: 33554432)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 8192x8192 (area: 67108864)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 8192x16384 (area: 134217728)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 8192x32768 (area: 268435456)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 8192x32769 (area: 268443648)
+PASS Context was lost
+Testing 16384x1 (area: 16384)
+PASS imageData.data is red
+Effective renderingMode: Accelerated
+Testing 16384x1000 (area: 16384000)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 16384x2048 (area: 33554432)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 16384x4096 (area: 67108864)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 16384x8192 (area: 134217728)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 16384x16384 (area: 268435456)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 16384x32768 (area: 536870912)
+PASS Context was lost
+Testing 16384x32769 (area: 536887296)
+PASS Context was lost
+Testing 32768x1 (area: 32768)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32768x1000 (area: 32768000)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32768x2048 (area: 67108864)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32768x4096 (area: 134217728)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32768x8192 (area: 268435456)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32768x16384 (area: 536870912)
+PASS Context was lost
+Testing 32768x32768 (area: 1073741824)
+PASS Context was lost
+Testing 32768x32769 (area: 1073774592)
+PASS Context was lost
+Testing 32769x1 (area: 32769)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32769x1000 (area: 32769000)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32769x2048 (area: 67110912)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32769x4096 (area: 134221824)
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
+Testing 32769x8192 (area: 268443648)
+PASS Context was lost
+Testing 32769x16384 (area: 536887296)
+PASS Context was lost
+Testing 32769x32768 (area: 1073774592)
+PASS Context was lost
+Testing 32769x32769 (area: 1073807361)
+PASS Context was lost
+Testing 0x0 (area: 0)
+PASS Context was lost
+Testing 0x100 (area: 0)
+PASS Context was lost
+Testing 100x0 (area: 0)
+PASS Context was lost
+Testing 1x1 forced 'Accelerated' (area: 1)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1x1000 forced 'Accelerated' (area: 1000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1x2048 forced 'Accelerated' (area: 2048)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1x4096 forced 'Accelerated' (area: 4096)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1x8192 forced 'Accelerated' (area: 8192)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1x16384 forced 'Accelerated' (area: 16384)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1x32768 forced 'Accelerated' (area: 32768)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 1x32769 forced 'Accelerated' (area: 32769)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 1000x1 forced 'Accelerated' (area: 1000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1000x1000 forced 'Accelerated' (area: 1000000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1000x2048 forced 'Accelerated' (area: 2048000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1000x4096 forced 'Accelerated' (area: 4096000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1000x8192 forced 'Accelerated' (area: 8192000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1000x16384 forced 'Accelerated' (area: 16384000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 1000x32768 forced 'Accelerated' (area: 32768000)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 1000x32769 forced 'Accelerated' (area: 32769000)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 2048x1 forced 'Accelerated' (area: 2048)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 2048x1000 forced 'Accelerated' (area: 2048000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 2048x2048 forced 'Accelerated' (area: 4194304)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 2048x4096 forced 'Accelerated' (area: 8388608)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 2048x8192 forced 'Accelerated' (area: 16777216)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 2048x16384 forced 'Accelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 2048x32768 forced 'Accelerated' (area: 67108864)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 2048x32769 forced 'Accelerated' (area: 67110912)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 4096x1 forced 'Accelerated' (area: 4096)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 4096x1000 forced 'Accelerated' (area: 4096000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 4096x2048 forced 'Accelerated' (area: 8388608)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 4096x4096 forced 'Accelerated' (area: 16777216)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 4096x8192 forced 'Accelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 4096x16384 forced 'Accelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 4096x32768 forced 'Accelerated' (area: 134217728)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 4096x32769 forced 'Accelerated' (area: 134221824)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 8192x1 forced 'Accelerated' (area: 8192)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 8192x1000 forced 'Accelerated' (area: 8192000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 8192x2048 forced 'Accelerated' (area: 16777216)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 8192x4096 forced 'Accelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 8192x8192 forced 'Accelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 8192x16384 forced 'Accelerated' (area: 134217728)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 8192x32768 forced 'Accelerated' (area: 268435456)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 8192x32769 forced 'Accelerated' (area: 268443648)
+PASS Context was lost
+Testing 16384x1 forced 'Accelerated' (area: 16384)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 16384x1000 forced 'Accelerated' (area: 16384000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 16384x2048 forced 'Accelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 16384x4096 forced 'Accelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 16384x8192 forced 'Accelerated' (area: 134217728)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 16384x16384 forced 'Accelerated' (area: 268435456)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Accelerated'
+Testing 16384x32768 forced 'Accelerated' (area: 536870912)
+PASS Context was lost
+Testing 16384x32769 forced 'Accelerated' (area: 536887296)
+PASS Context was lost
+Testing 32768x1 forced 'Accelerated' (area: 32768)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32768x1000 forced 'Accelerated' (area: 32768000)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32768x2048 forced 'Accelerated' (area: 67108864)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32768x4096 forced 'Accelerated' (area: 134217728)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32768x8192 forced 'Accelerated' (area: 268435456)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32768x16384 forced 'Accelerated' (area: 536870912)
+PASS Context was lost
+Testing 32768x32768 forced 'Accelerated' (area: 1073741824)
+PASS Context was lost
+Testing 32768x32769 forced 'Accelerated' (area: 1073774592)
+PASS Context was lost
+Testing 32769x1 forced 'Accelerated' (area: 32769)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32769x1000 forced 'Accelerated' (area: 32769000)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32769x2048 forced 'Accelerated' (area: 67110912)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32769x4096 forced 'Accelerated' (area: 134221824)
+PASS imageData.data is red
+FAIL context.getEffectiveRenderingModeForTesting() should be Accelerated. Was Unaccelerated.
+Testing 32769x8192 forced 'Accelerated' (area: 268443648)
+PASS Context was lost
+Testing 32769x16384 forced 'Accelerated' (area: 536887296)
+PASS Context was lost
+Testing 32769x32768 forced 'Accelerated' (area: 1073774592)
+PASS Context was lost
+Testing 32769x32769 forced 'Accelerated' (area: 1073807361)
+PASS Context was lost
+Testing 0x0 forced 'Accelerated' (area: 0)
+PASS Context was lost
+Testing 0x100 forced 'Accelerated' (area: 0)
+PASS Context was lost
+Testing 100x0 forced 'Accelerated' (area: 0)
+PASS Context was lost
+Testing 1x1 forced 'Unaccelerated' (area: 1)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x1000 forced 'Unaccelerated' (area: 1000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x2048 forced 'Unaccelerated' (area: 2048)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x4096 forced 'Unaccelerated' (area: 4096)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x8192 forced 'Unaccelerated' (area: 8192)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x16384 forced 'Unaccelerated' (area: 16384)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x32768 forced 'Unaccelerated' (area: 32768)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1x32769 forced 'Unaccelerated' (area: 32769)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x1 forced 'Unaccelerated' (area: 1000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x1000 forced 'Unaccelerated' (area: 1000000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x2048 forced 'Unaccelerated' (area: 2048000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x4096 forced 'Unaccelerated' (area: 4096000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x8192 forced 'Unaccelerated' (area: 8192000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x16384 forced 'Unaccelerated' (area: 16384000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x32768 forced 'Unaccelerated' (area: 32768000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 1000x32769 forced 'Unaccelerated' (area: 32769000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x1 forced 'Unaccelerated' (area: 2048)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x1000 forced 'Unaccelerated' (area: 2048000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x2048 forced 'Unaccelerated' (area: 4194304)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x4096 forced 'Unaccelerated' (area: 8388608)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x8192 forced 'Unaccelerated' (area: 16777216)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x16384 forced 'Unaccelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x32768 forced 'Unaccelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 2048x32769 forced 'Unaccelerated' (area: 67110912)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x1 forced 'Unaccelerated' (area: 4096)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x1000 forced 'Unaccelerated' (area: 4096000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x2048 forced 'Unaccelerated' (area: 8388608)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x4096 forced 'Unaccelerated' (area: 16777216)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x8192 forced 'Unaccelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x16384 forced 'Unaccelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x32768 forced 'Unaccelerated' (area: 134217728)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 4096x32769 forced 'Unaccelerated' (area: 134221824)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x1 forced 'Unaccelerated' (area: 8192)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x1000 forced 'Unaccelerated' (area: 8192000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x2048 forced 'Unaccelerated' (area: 16777216)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x4096 forced 'Unaccelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x8192 forced 'Unaccelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x16384 forced 'Unaccelerated' (area: 134217728)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x32768 forced 'Unaccelerated' (area: 268435456)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 8192x32769 forced 'Unaccelerated' (area: 268443648)
+PASS Context was lost
+Testing 16384x1 forced 'Unaccelerated' (area: 16384)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 16384x1000 forced 'Unaccelerated' (area: 16384000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 16384x2048 forced 'Unaccelerated' (area: 33554432)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 16384x4096 forced 'Unaccelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 16384x8192 forced 'Unaccelerated' (area: 134217728)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 16384x16384 forced 'Unaccelerated' (area: 268435456)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 16384x32768 forced 'Unaccelerated' (area: 536870912)
+PASS Context was lost
+Testing 16384x32769 forced 'Unaccelerated' (area: 536887296)
+PASS Context was lost
+Testing 32768x1 forced 'Unaccelerated' (area: 32768)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32768x1000 forced 'Unaccelerated' (area: 32768000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32768x2048 forced 'Unaccelerated' (area: 67108864)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32768x4096 forced 'Unaccelerated' (area: 134217728)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32768x8192 forced 'Unaccelerated' (area: 268435456)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32768x16384 forced 'Unaccelerated' (area: 536870912)
+PASS Context was lost
+Testing 32768x32768 forced 'Unaccelerated' (area: 1073741824)
+PASS Context was lost
+Testing 32768x32769 forced 'Unaccelerated' (area: 1073774592)
+PASS Context was lost
+Testing 32769x1 forced 'Unaccelerated' (area: 32769)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32769x1000 forced 'Unaccelerated' (area: 32769000)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32769x2048 forced 'Unaccelerated' (area: 67110912)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32769x4096 forced 'Unaccelerated' (area: 134221824)
+PASS imageData.data is red
+PASS context.getEffectiveRenderingModeForTesting() is 'Unaccelerated'
+Testing 32769x8192 forced 'Unaccelerated' (area: 268443648)
+PASS Context was lost
+Testing 32769x16384 forced 'Unaccelerated' (area: 536887296)
+PASS Context was lost
+Testing 32769x32768 forced 'Unaccelerated' (area: 1073774592)
+PASS Context was lost
+Testing 32769x32769 forced 'Unaccelerated' (area: 1073807361)
+PASS Context was lost
+Testing 0x0 forced 'Unaccelerated' (area: 0)
+PASS Context was lost
+Testing 0x100 forced 'Unaccelerated' (area: 0)
+PASS Context was lost
+Testing 100x0 forced 'Unaccelerated' (area: 0)
+PASS Context was lost
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1948,6 +1948,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/Model.h
     platform/graphics/NativeImage.h
     platform/graphics/NullGraphicsContext.h
+    platform/graphics/NullImageBufferBackend.h
     platform/graphics/Path.h
     platform/graphics/PathElement.h
     platform/graphics/PathImpl.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2284,6 +2284,7 @@ platform/graphics/MediaPlayerPrivate.cpp
 platform/graphics/MediaSourcePrivate.cpp
 platform/graphics/Model.cpp
 platform/graphics/NamedImageGeneratedImage.cpp
+platform/graphics/NullImageBufferBackend.cpp
 platform/graphics/NativeImage.cpp
 platform/graphics/Path.cpp
 platform/graphics/PathImpl.cpp

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2869,8 +2869,7 @@ OptionSet<ImageBufferOptions> CanvasRenderingContext2DBase::adjustImageBufferOpt
 std::optional<CanvasRenderingContext2DBase::RenderingMode> CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting()
 {
     if (auto* buffer = canvasBase().buffer()) {
-        bool success = buffer->ensureBackendCreated(); // FIXME: Ensure we get the response for now, since the backend might change (!).
-        ASSERT_UNUSED(success, success);
+        buffer->ensureBackendCreated();
         return buffer->renderingMode();
     }
     return std::nullopt;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -466,21 +466,22 @@ Vector<uint8_t> ImageBuffer::toData(Ref<ImageBuffer> source, const String& mimeT
 
 RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const
 {
-    auto* backend = ensureBackendCreated();
-    if (!backend)
-        return nullptr;
     ASSERT(PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat));
     auto sourceRectScaled = sourceRect;
     sourceRectScaled.scale(resolutionScale());
     auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
     if (!destination)
         return nullptr;
-    backend->getPixelBuffer(sourceRectScaled, *destination);
+    if (auto* backend = ensureBackendCreated())
+        backend->getPixelBuffer(sourceRectScaled, *destination);
+    else
+        destination->zeroFill();
     return destination;
 }
 
 void ImageBuffer::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationFormat)
 {
+    ASSERT(resolutionScale() == 1);
     auto* backend = ensureBackendCreated();
     if (!backend)
         return;

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020-2021 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NullImageBufferBackend.h"
+
+#include "PixelBuffer.h"
+#include <wtf/text/TextStream.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+std::unique_ptr<NullImageBufferBackend> NullImageBufferBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+{
+    return std::unique_ptr<NullImageBufferBackend> { new NullImageBufferBackend { parameters } };
+}
+
+NullImageBufferBackend::~NullImageBufferBackend() = default;
+
+NullGraphicsContext& NullImageBufferBackend::context()
+{
+    return m_context;
+}
+
+RefPtr<NativeImage> NullImageBufferBackend::copyNativeImage(BackingStoreCopy)
+{
+    return nullptr;
+}
+
+void NullImageBufferBackend::getPixelBuffer(const IntRect&, PixelBuffer& destination)
+{
+    destination.zeroFill();
+}
+
+void NullImageBufferBackend::putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication)
+{
+}
+
+unsigned NullImageBufferBackend::bytesPerRow() const
+{
+    return 0;
+}
+
+String NullImageBufferBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "NullImageBufferBackend " << this;
+    return stream.release();
+}
+
+}

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ImageBufferBackend.h"
+#include "NullGraphicsContext.h"
+#include <memory.h>
+
+namespace WebCore {
+
+// Used for ImageBuffers that return NullGraphicsContext as the ImageBuffer::context().
+// Solves the problem of holding NullGraphicsContext similarly to holding other
+// GraphicsContext instances, via a ImageBuffer reference.
+class NullImageBufferBackend final : public ImageBufferBackend {
+public:
+    WEBCORE_EXPORT static std::unique_ptr<NullImageBufferBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    WEBCORE_EXPORT ~NullImageBufferBackend();
+    static size_t calculateMemoryCost(const Parameters&) { return 0; }
+    static size_t calculateExternalMemoryCost(const Parameters&) { return 0; }
+
+    NullGraphicsContext& context() final;
+    RefPtr<NativeImage> copyNativeImage(BackingStoreCopy) final;
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final;
+    void putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication) final;
+
+protected:
+    using ImageBufferBackend::ImageBufferBackend;
+
+    unsigned bytesPerRow() const final;
+    String debugDescription() const final;
+
+    NullGraphicsContext m_context;
+};
+
+}

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -52,7 +52,7 @@ public:
     virtual RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const = 0;
 
     bool setRange(const uint8_t* data, size_t dataByteLength, size_t byteOffset);
-    bool zeroRange(size_t byteOffset, size_t rangeByteLength);
+    WEBCORE_EXPORT bool zeroRange(size_t byteOffset, size_t rangeByteLength);
     void zeroFill() { zeroRange(0, sizeInBytes()); }
 
     WEBCORE_EXPORT uint8_t item(size_t index) const;

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -29,9 +29,12 @@
 
 #include "PathImpl.h"
 #include "PlatformPath.h"
+#include "WindRule.h"
+#include <wtf/Function.h>
 
 namespace WebCore {
 
+class GraphicsContext;
 class PathStream;
 
 class PathCG final : public PathImpl {

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -52,6 +52,7 @@
 #include "SwapBuffersDisplayRequirement.h"
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/HTMLCanvasElement.h>
+#include <WebCore/NullImageBufferBackend.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/RunLoop.h>
@@ -163,16 +164,25 @@ uint64_t RemoteRenderingBackend::messageSenderDestinationID() const
     return m_renderingBackendIdentifier.toUInt64();
 }
 
+void RemoteRenderingBackend::didFailCreateImageBuffer(RenderingResourceIdentifier imageBufferIdentifier)
+{
+    // On failure to create a remote image buffer we still create a null display list recorder.
+    // Commands to draw to the failed image might have already be issued and we must process
+    // them.
+    auto errorImage = ImageBuffer::create<NullImageBufferBackend>({ 0, 0 }, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, RenderingPurpose::Unspecified, { }, imageBufferIdentifier);
+    RELEASE_ASSERT(errorImage);
+    m_remoteDisplayLists.add(imageBufferIdentifier, RemoteDisplayListRecorder::create(*errorImage, imageBufferIdentifier, *this));
+    m_remoteImageBuffers.add(imageBufferIdentifier, RemoteImageBuffer::create(errorImage.releaseNonNull(), *this));
+    send(Messages::RemoteImageBufferProxy::DidCreateBackend(std::nullopt), imageBufferIdentifier);
+}
+
 void RemoteRenderingBackend::didCreateImageBuffer(Ref<ImageBuffer> imageBuffer)
 {
-    assertIsCurrent(workQueue());
     auto imageBufferIdentifier = imageBuffer->renderingResourceIdentifier();
-    auto remoteDisplayList = RemoteDisplayListRecorder::create(imageBuffer.get(), imageBufferIdentifier, *this);
-    m_remoteDisplayLists.add(imageBufferIdentifier, WTFMove(remoteDisplayList));
     auto* sharing = imageBuffer->backend()->toBackendSharing();
     auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
-    auto remoteImageBuffer = RemoteImageBuffer::create(WTFMove(imageBuffer), *this);
-    m_remoteImageBuffers.add(imageBufferIdentifier, WTFMove(remoteImageBuffer));
+    m_remoteDisplayLists.add(imageBufferIdentifier, RemoteDisplayListRecorder::create(imageBuffer.get(), imageBufferIdentifier, *this));
+    m_remoteImageBuffers.add(imageBufferIdentifier, RemoteImageBuffer::create(WTFMove(imageBuffer), *this));
     send(Messages::RemoteImageBufferProxy::DidCreateBackend(WTFMove(*handle)), imageBufferIdentifier);
 }
 
@@ -227,16 +237,15 @@ void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, Ren
 #endif
         if (!imageBuffer)
             imageBuffer = ImageBuffer::create<AcceleratedImageBufferShareableMappedBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
-    }
-
-    if (!imageBuffer)
+    } else
         imageBuffer = ImageBuffer::create<UnacceleratedImageBufferShareableBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
 
-    if (!imageBuffer) {
-        ASSERT_NOT_REACHED();
-        return;
+    if (imageBuffer)
+        didCreateImageBuffer(imageBuffer.releaseNonNull());
+    else {
+        RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteRenderingBackend::createImageBuffer - failed to allocate image buffer %" PRIu64, m_renderingBackendIdentifier.toUInt64(), imageBufferIdentifier.toUInt64());
+        didFailCreateImageBuffer(imageBufferIdentifier);
     }
-    didCreateImageBuffer(imageBuffer.releaseNonNull());
 }
 
 void RemoteRenderingBackend::releaseImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -93,8 +93,6 @@ public:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void didCreateImageBuffer(Ref<WebCore::ImageBuffer>);
-
     // Runs Function in RemoteRenderingBackend task queue.
     void dispatch(Function<void()>&&);
 
@@ -161,6 +159,9 @@ private:
     void releaseRemoteFaceDetector(ShapeDetectionIdentifier);
     void createRemoteTextDetector(ShapeDetectionIdentifier);
     void releaseRemoteTextDetector(ShapeDetectionIdentifier);
+
+    void didFailCreateImageBuffer(WebCore::RenderingResourceIdentifier) WTF_REQUIRES_CAPABILITY(workQueue());
+    void didCreateImageBuffer(Ref<WebCore::ImageBuffer>) WTF_REQUIRES_CAPABILITY(workQueue());
 
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     Ref<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -148,6 +148,7 @@ def types_that_must_be_moved():
         'WebKit::ConsumerSharedCARingBuffer::Handle',
         'WebKit::GPUProcessConnectionParameters',
         'WebKit::ImageBufferBackendHandle',
+        'std::optional<WebKit::ImageBufferBackendHandle>',
         'WebKit::ShareableBitmap::Handle',
         'WebKit::ShareableResource::Handle',
         'WebKit::SharedMemory::Handle',

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -193,19 +193,26 @@ void RemoteImageBufferProxy::backingStoreWillChange()
     prepareForBackingStoreChange();
 }
 
-void RemoteImageBufferProxy::didCreateBackend(ImageBufferBackendHandle&& handle)
+void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHandle> handle)
 {
     ASSERT(!m_backend);
-    if (renderingMode() == RenderingMode::Accelerated && std::holds_alternative<ShareableBitmap::Handle>(handle))
-        m_backendInfo = ImageBuffer::populateBackendInfo<UnacceleratedImageBufferShareableBackend>(parameters());
-
+    if (!handle) {
+        m_remoteDisplayList.disconnect();
+        m_remoteRenderingBackendProxy->remoteResourceCacheProxy().forgetImageBuffer(renderingResourceIdentifier());
+        m_remoteRenderingBackendProxy->releaseImageBuffer(renderingResourceIdentifier());
+        m_remoteRenderingBackendProxy = nullptr;
+        return;
+    }
+    // This should match RemoteImageBufferProxy::create<>() call site and RemoteImageBuffer::create<>() call site.
+    // FIXME: this will be removed and backend be constructed in the contructor.
     std::unique_ptr<ImageBufferBackend> backend;
-    if (renderingMode() == RenderingMode::Unaccelerated)
-        backend = UnacceleratedImageBufferShareableBackend::create(parameters(), WTFMove(handle));
-    else if (canMapBackingStore())
-        backend = AcceleratedImageBufferShareableMappedBackend::create(parameters(), WTFMove(handle));
-    else
-        backend = AcceleratedImageBufferRemoteBackend::create(parameters(), WTFMove(handle));
+    if (renderingMode() == RenderingMode::Accelerated) {
+        if (canMapBackingStore())
+            backend = AcceleratedImageBufferShareableMappedBackend::create(parameters(), WTFMove(*handle));
+        else
+            backend = AcceleratedImageBufferRemoteBackend::create(parameters(), WTFMove(*handle));
+    } else
+        backend = UnacceleratedImageBufferShareableBackend::create(parameters(), WTFMove(*handle));
 
     setBackend(WTFMove(backend));
 }
@@ -274,22 +281,20 @@ RefPtr<Image> RemoteImageBufferProxy::filteredImage(Filter& filter)
     return m_remoteRenderingBackendProxy->getFilteredImage(m_renderingResourceIdentifier, filter);
 }
 
-RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& srcRect, const ImageBufferAllocator& allocator) const
+RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const
 {
     if (canMapBackingStore()) {
         const_cast<RemoteImageBufferProxy&>(*this).flushDrawingContext();
-        return ImageBuffer::getPixelBuffer(destinationFormat, srcRect, allocator);
+        return ImageBuffer::getPixelBuffer(destinationFormat, sourceRect, allocator);
     }
-
-    if (UNLIKELY(!m_remoteRenderingBackendProxy))
+    auto pixelBuffer = allocator.createPixelBuffer(destinationFormat, sourceRect.size());
+    if (UNLIKELY(!pixelBuffer))
         return nullptr;
-    IntRect sourceRectScaled = srcRect;
-    sourceRectScaled.scale(resolutionScale());
-    auto pixelBuffer = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
-    if (!pixelBuffer)
-        return nullptr;
-    if (!m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, srcRect, { pixelBuffer->bytes(), pixelBuffer->sizeInBytes() }))
-        return nullptr;
+    if (LIKELY(m_remoteRenderingBackendProxy)) {
+        if (m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, sourceRect, { pixelBuffer->bytes(), pixelBuffer->sizeInBytes() }))
+            return pixelBuffer;
+    }
+    pixelBuffer->zeroFill();
     return pixelBuffer;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -70,7 +70,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     // Messages
-    void didCreateBackend(ImageBufferBackendHandle&&);
+    void didCreateBackend(std::optional<ImageBufferBackendHandle>);
 
 private:
     RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteImageBufferProxy NotRefCounted  {
-    DidCreateBackend(WebKit::ImageBufferBackendHandle handle) CanDispatchOutOfOrder
+    DidCreateBackend(std::optional<WebKit::ImageBufferBackendHandle> handle) CanDispatchOutOfOrder
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -159,9 +159,7 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
             imageBuffer = RemoteImageBufferProxy::create<AcceleratedImageBufferShareableMappedBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheck);
         else
             imageBuffer = RemoteImageBufferProxy::create<AcceleratedImageBufferRemoteBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheck);
-    }
-
-    if (!imageBuffer)
+    } else
         imageBuffer = RemoteImageBufferProxy::create<UnacceleratedImageBufferShareableBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this, avoidBackendSizeCheck);
 
     if (imageBuffer) {


### PR DESCRIPTION
#### a76cf096e26a991fd54bbffbad5b828a2bf368b3
<pre>
RemoteImageBufferProxy re-populates backend info after getting the backend handle
<a href="https://bugs.webkit.org/show_bug.cgi?id=261027">https://bugs.webkit.org/show_bug.cgi?id=261027</a>
rdar://114816328

Reviewed by Matt Woodrow.

The code is structured as if it would make sense that Caller calls
  * RemoteImageBufferProxy::create&lt;AcceleratedImageBufferShareableMappedBackend&gt;
  * GPUP sends ShareableBitmap::Handle

It is better that the backend type being used during ImageBuffer
creation is respected during didCreateBackend.

Implements error handling for cases where the allocation fails in GPUP.
Before, the allocation failure would result in WP hang.

This is work towards being able to create the backend during
construction, so that most operations needing the backend would not
block until the handle has been communicated.

* LayoutTests/fast/canvas/image-buffer-iosurface-disabled-expected.txt:
* LayoutTests/fast/canvas/image-buffer-iosurface-disabled.html:
Fix the test to ensure that the tested command, creating too big accelerated
image buffer, would reach the GPUP within the test. Otherwise,
failing to do so would result in failure of the next test, as this test
would finish before its commands were run on GPUP.
Next test is typically fast/canvas/image-object-in-canvas.html.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::getPixelBuffer const):
(WebCore::ImageBuffer::putPixelBuffer):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::toBackendCoordinates const): Deleted.
* Source/WebCore/platform/graphics/PixelBuffer.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::putPixelBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
(WebKit::RemoteDisplayListRecorder::create):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didFailCreateImageBuffer):
(WebKit::RemoteRenderingBackend::didCreateImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBuffer):
(WebKit::RemoteRenderingBackend::releaseImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateBackend):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):

Canonical link: <a href="https://commits.webkit.org/268244@main">https://commits.webkit.org/268244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0aae0cf29f3d1500331281e7fcfbc0ef954a3fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19501 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21703 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19122 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23680 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21618 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18020 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15284 "1 flakes 44 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17101 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4559 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->