### PR TITLE
SerialFunctionDispatcher should implement isCurrent()

### DIFF
--- a/Source/WTF/wtf/FunctionDispatcher.h
+++ b/Source/WTF/wtf/FunctionDispatcher.h
@@ -45,16 +45,13 @@ protected:
 
 class WTF_CAPABILITY("is current") WTF_EXPORT_PRIVATE SerialFunctionDispatcher : public FunctionDispatcher {
 public:
-#if ASSERT_ENABLED
-    virtual void assertIsCurrent() const = 0;
-#endif
+    virtual bool isCurrent() const = 0;
 };
 
 inline void assertIsCurrent(const SerialFunctionDispatcher& queue) WTF_ASSERTS_ACQUIRED_CAPABILITY(queue)
 {
-#if ASSERT_ENABLED
-    queue.assertIsCurrent();
-#else
+    ASSERT(queue.isCurrent());
+#if !ASSERT_ENABLED
     UNUSED_PARAM(queue);
 #endif
 }

--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -37,6 +37,7 @@
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Threading.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -203,11 +203,4 @@ void RunLoop::threadWillExit()
     }
 }
 
-#if ASSERT_ENABLED
-void RunLoop::assertIsCurrent() const
-{
-    ASSERT(this == &current());
-}
-#endif
-
 } // namespace WTF

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -109,10 +109,6 @@ public:
 
     WTF_EXPORT_PRIVATE void threadWillExit();
 
-#if ASSERT_ENABLED
-    void assertIsCurrent() const final;
-#endif
-
 #if USE(GLIB_EVENT_LOOP)
     WTF_EXPORT_PRIVATE GMainContext* mainContext() const { return m_mainContext.get(); }
     enum class Event { WillDispatch, DidDispatch };

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -200,17 +200,10 @@ void WorkQueue::dispatch(Function<void()>&& function)
     WorkQueueBase::dispatch(WTFMove(function));
 }
 
-#if ASSERT_ENABLED
-void WorkQueue::assertIsCurrent() const
+bool WorkQueue::isCurrent() const
 {
-    WTF::assertIsCurrent(threadLikeAssertion());
+    return currentSequence() == m_threadID;
 }
-
-ThreadLikeAssertion WorkQueue::threadLikeAssertion() const
-{
-    return createThreadLikeAssertion(m_threadID);
-}
-#endif
 
 ConcurrentWorkQueue::ConcurrentWorkQueue(const char* name, QOS qos)
     : WorkQueueBase(name, Type::Concurrent, qos)

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -73,9 +73,7 @@ protected:
 #else
     RunLoop* m_runLoop;
 #endif
-#if ASSERT_ENABLED
     uint32_t m_threadID { 0 };
-#endif
 private:
     void platformInitialize(const char* name, Type, QOS);
     void platformInvalidate();
@@ -93,13 +91,7 @@ public:
     static WorkQueue& main();
     static Ref<WorkQueue> create(const char* name, QOS = QOS::Default);
     void dispatch(Function<void()>&&) override;
-#if ASSERT_ENABLED
-    void assertIsCurrent() const final;
-    ThreadLikeAssertion threadLikeAssertion() const; // public as used in API tests.
-#else
-    ThreadLikeAssertion threadLikeAssertion() const { return { }; }; // NOLINT
-#endif
-
+    bool isCurrent() const override;
 #if !USE(COCOA_EVENT_LOOP)
     RunLoop& runLoop() const { return *m_runLoop; }
 #endif
@@ -130,4 +122,3 @@ private:
 
 using WTF::WorkQueue;
 using WTF::ConcurrentWorkQueue;
-using WTF::assertIsCurrent;

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -78,9 +78,7 @@ void WorkQueueBase::dispatchSync(Function<void()>&& function)
 
 WorkQueueBase::WorkQueueBase(OSObjectPtr<dispatch_queue_t>&& dispatchQueue)
     : m_dispatchQueue(WTFMove(dispatchQueue))
-#if ASSERT_ENABLED
     , m_threadID(mainThreadID)
-#endif
 {
 }
 
@@ -90,14 +88,12 @@ void WorkQueueBase::platformInitialize(const char* name, Type type, QOS qos)
     attr = dispatch_queue_attr_make_with_qos_class(attr, Thread::dispatchQOSClass(qos), 0);
     m_dispatchQueue = adoptOSObject(dispatch_queue_create(name, attr));
     dispatch_set_context(m_dispatchQueue.get(), this);
-#if ASSERT_ENABLED
     // We use &s_uid for the key, since it's convenient. Dispatch does not dereference it.
     // We use s_uid to generate the id so that WorkQueues and Threads share the id namespace.
     // This makes it possible to assert that code runs in the expected sequence, regardless of if it is
     // in a thread or a work queue.
     m_threadID = ++s_uid;
     dispatch_queue_set_specific(m_dispatchQueue.get(), &s_uid, reinterpret_cast<void*>(m_threadID), nullptr);
-#endif
 }
 
 void WorkQueueBase::platformInvalidate()
@@ -107,7 +103,6 @@ void WorkQueueBase::platformInvalidate()
 WorkQueue::WorkQueue(MainTag)
     : WorkQueueBase(dispatch_get_main_queue())
 {
-    // Note: for main work queue we do not create a sequence id, the main thread id will be used.
 }
 
 void ConcurrentWorkQueue::apply(size_t iterations, WTF::Function<void(size_t index)>&& function)

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -36,23 +36,19 @@ namespace WTF {
 
 WorkQueueBase::WorkQueueBase(RunLoop& runLoop)
     : m_runLoop(&runLoop)
-#if ASSERT_ENABLED
     , m_threadID(mainThreadID)
-#endif
 {
 }
 
 void WorkQueueBase::platformInitialize(const char* name, Type, QOS qos)
 {
     m_runLoop = RunLoop::create(name, ThreadType::Unknown, qos).ptr();
-#if ASSERT_ENABLED
     BinarySemaphore semaphore;
     m_runLoop->dispatch([&] {
         m_threadID = Thread::current().uid();
         semaphore.signal();
     });
     semaphore.wait();
-#endif
 }
 
 void WorkQueueBase::platformInvalidate()

--- a/Source/WebCore/page/scrolling/ScrollingThread.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingThread.cpp
@@ -52,7 +52,7 @@ ScrollingThread::ScrollingThread()
 
 bool ScrollingThread::isCurrentThread()
 {
-    return ScrollingThread::singleton().m_runLoop.ptr() == &RunLoop::current();
+    return ScrollingThread::singleton().m_runLoop->isCurrent();
 }
 
 void ScrollingThread::dispatch(Function<void ()>&& function)

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -253,7 +253,7 @@ GstFlowReturn AudioFileReader::handleSample(GstAppSink* sink)
 
 void AudioFileReader::handleMessage(GstMessage* message)
 {
-    ASSERT(&m_runLoop == &RunLoop::current());
+    assertIsCurrent(m_runLoop);
 
     GUniqueOutPtr<GError> error;
     GUniqueOutPtr<gchar> debug;
@@ -389,7 +389,7 @@ void AudioFileReader::plugDeinterleave(GstPad* pad)
 
 void AudioFileReader::decodeAudioForBusCreation()
 {
-    ASSERT(&m_runLoop == &RunLoop::current());
+    assertIsCurrent(m_runLoop);
 
     // Build the pipeline giostreamsrc ! decodebin
     // A deinterleave element is added once a src pad becomes available in decodebin.
@@ -400,7 +400,7 @@ void AudioFileReader::decodeAudioForBusCreation()
     ASSERT(bus);
     gst_bus_set_sync_handler(bus.get(), [](GstBus*, GstMessage* message, gpointer userData) {
         auto& reader = *static_cast<AudioFileReader*>(userData);
-        if (&reader.m_runLoop == &RunLoop::current())
+        if (reader.m_runLoop.isCurrent())
             reader.handleMessage(message);
         else {
             GRefPtr<GstMessage> protectMessage(message);

--- a/Source/WebCore/platform/glib/FileMonitorGLib.cpp
+++ b/Source/WebCore/platform/glib/FileMonitorGLib.cpp
@@ -49,7 +49,7 @@ FileMonitor::FileMonitor(const String& path, Ref<WorkQueue>&& handlerQueue, Func
     };
 
     // The monitor can be created in the work queue thread.
-    if (&m_handlerQueue->runLoop() == &RunLoop::current()) {
+    if (m_handlerQueue->isCurrent()) {
         createPlatformMonitor();
         return;
     }
@@ -62,7 +62,7 @@ FileMonitor::FileMonitor(const String& path, Ref<WorkQueue>&& handlerQueue, Func
 FileMonitor::~FileMonitor()
 {
     // The monitor can be destroyed in the work queue thread.
-    if (&m_handlerQueue->runLoop() == &RunLoop::current()) {
+    if (m_handlerQueue->isCurrent()) {
         cancel();
         return;
     }

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -64,7 +64,7 @@ ImageSource::ImageSource(Ref<NativeImage>&& nativeImage)
 ImageSource::~ImageSource()
 {
     ASSERT(!hasAsyncDecodingQueue());
-    ASSERT(&m_runLoop == &RunLoop::current());
+    assertIsCurrent(m_runLoop);
 }
 
 bool ImageSource::ensureDecoderAvailable(FragmentedSharedBuffer* data)
@@ -432,7 +432,7 @@ const ImageFrame& ImageSource::frameAtIndexCacheIfNeeded(size_t index, ImageFram
 {
     if (index >= m_frames.size())
         return ImageFrame::defaultFrame();
-    
+
     ImageFrame& frame = m_frames[index];
     if (!isDecoderAvailable() || frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(index, DecodingOptions(DecodingMode::Asynchronous)))
         return frame;
@@ -599,7 +599,7 @@ IntSize ImageSource::sourceSize(ImageOrientation orientation)
     else
 #endif
         size = firstFrameMetadataCacheIfNeeded(m_size, MetadataType::Size, &ImageFrame::size, ImageFrame::Caching::Metadata, SubsamplingLevel::Default);
-    
+
     if (orientation == ImageOrientation::Orientation::FromImage)
         orientation = this->orientation();
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -88,12 +88,10 @@ void WorkerOrWorkletThread::dispatch(Function<void()>&& func)
     });
 }
 
-#if ASSERT_ENABLED
-void WorkerOrWorkletThread::assertIsCurrent() const
+bool WorkerOrWorkletThread::isCurrent() const
 {
-    return WTF::assertIsCurrent(*thread());
+    return thread() ? thread()->uid() == Thread::current().uid() : false;
 }
-#endif
 
 void WorkerOrWorkletThread::startRunningDebuggerTasks()
 {

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -47,10 +47,9 @@ class WorkerOrWorkletThread : public SerialFunctionDispatcher, public ThreadSafe
 public:
     virtual ~WorkerOrWorkletThread();
 
+    // SerialFunctionDispatcher methods
     void dispatch(Function<void()>&&) final;
-#if ASSERT_ENABLED
-    void assertIsCurrent() const final;
-#endif
+    bool isCurrent() const final;
 
     Thread* thread() const { return m_thread.get(); }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
@@ -165,13 +165,10 @@ void StreamConnectionWorkQueue::processStreams()
     } while (hasMoreToProcess);
 }
 
-#if ASSERT_ENABLED
-void StreamConnectionWorkQueue::assertIsCurrent() const
+bool StreamConnectionWorkQueue::isCurrent() const
 {
     Locker locker { m_lock };
-    ASSERT(m_processingThread);
-    WTF::assertIsCurrent(*m_processingThread);
+    return m_processingThread ? m_processingThread->uid() == Thread::current().uid() : false;
 }
-#endif
 
 }

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -53,9 +53,7 @@ public:
 
     // SerialFunctionDispatcher
     void dispatch(WTF::Function<void()>&&) final;
-#if ASSERT_ENABLED
-    void assertIsCurrent() const final;
-#endif
+    bool isCurrent() const final;
 
 private:
     void startProcessingThread() WTF_REQUIRES_LOCK(m_lock);
@@ -71,14 +69,6 @@ private:
     Deque<Function<void()>> m_functions WTF_GUARDED_BY_LOCK(m_lock);
     WTF::Function<void()> m_cleanupFunction WTF_GUARDED_BY_LOCK(m_lock);
     Vector<Ref<StreamServerConnection>> m_connections WTF_GUARDED_BY_LOCK(m_lock);
-    friend void assertIsCurrent(const StreamConnectionWorkQueue&);
 };
-
-inline void assertIsCurrent(const StreamConnectionWorkQueue& queue) WTF_ASSERTS_ACQUIRED_CAPABILITY(queue)
-{
-#if ASSERT_ENABLED
-    queue.assertIsCurrent();
-#endif
-}
 
 }

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp
@@ -54,7 +54,7 @@ CompositingRunLoop::~CompositingRunLoop()
 {
     ASSERT(RunLoop::isMain());
     // Make sure the RunLoop is stopped after the CompositingRunLoop, because m_updateTimer has a reference.
-    RunLoop::main().dispatch([runLoop = Ref { m_runLoop }] {
+    RunLoop::main().dispatch([runLoop = m_runLoop] {
         runLoop->stop();
         runLoop->dispatch([] {
             RunLoop::current().stop();
@@ -64,7 +64,7 @@ CompositingRunLoop::~CompositingRunLoop()
 
 bool CompositingRunLoop::isCurrent() const
 {
-    return m_runLoop.ptr() == &RunLoop::current();
+    return m_runLoop->isCurrent();
 }
 
 void CompositingRunLoop::performTask(Function<void ()>&& function)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -180,9 +180,7 @@ private:
 
     // SerialFunctionDispatcher
     void dispatch(Function<void()>&& function) final { m_dispatcher.dispatch(WTFMove(function)); }
-#if ASSERT_ENABLED
-    void assertIsCurrent() const final { m_dispatcher.assertIsCurrent(); }
-#endif
+    bool isCurrent() const final { return m_dispatcher.isCurrent(); }
     RefPtr<IPC::Connection> m_connection;
     RefPtr<IPC::StreamClientConnection> m_streamConnection;
     RemoteRenderingBackendCreationParameters m_parameters;


### PR DESCRIPTION
#### cce771ba53901785917c014f762b1fe0a4d52df6
<pre>
SerialFunctionDispatcher should implement isCurrent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261008">https://bugs.webkit.org/show_bug.cgi?id=261008</a>
rdar://114801460

Reviewed by Kimmo Kinnunen.

- Expose isCurrent() to all existing SerialFunctionDispatcher and make
  assertIsCurrent() use isCurrent().
- Make use of assertIsCurrent() in places that were performing similar tests
  and streamline its use for consistency.

* Source/WTF/wtf/FunctionDispatcher.cpp:
(WTF::SerialFunctionDispatcher::assertIsCurrent const):
* Source/WTF/wtf/FunctionDispatcher.h:
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::assertIsCurrent const): Deleted.
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::WorkQueue::isCurrent const):
(WTF::WorkQueue::assertIsCurrent const): Deleted.
(WTF::WorkQueue::threadLikeAssertion const): Deleted.
* Source/WTF/wtf/WorkQueue.h:
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::WorkQueueBase::platformInitialize):
(WTF::WorkQueue::WorkQueue):
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::WorkQueueBase::platformInitialize):
* Source/WebCore/page/scrolling/ScrollingThread.cpp:
(WebCore::ScrollingThread::isCurrentThread):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::handleMessage):
(WebCore::AudioFileReader::decodeAudioForBusCreation):
* Source/WebCore/platform/glib/FileMonitorGLib.cpp:
(WebCore::FileMonitor::FileMonitor):
(WebCore::FileMonitor::~FileMonitor):
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::~ImageSource):
(WebCore::ImageSource::frameAtIndexCacheIfNeeded):
(WebCore::ImageSource::sourceSize):
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::isCurrent const):
(WebCore::WorkerOrWorkletThread::assertIsCurrent const): Deleted.
* Source/WebCore/workers/WorkerOrWorkletThread.h:
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::isCurrent const):
(IPC::StreamConnectionWorkQueue::assertIsCurrent const): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
(IPC::WTF_ASSERTS_ACQUIRED_CAPABILITY): Deleted.
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.cpp:
(WebKit::CompositingRunLoop::~CompositingRunLoop):
(WebKit::CompositingRunLoop::isCurrent const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267808@main">https://commits.webkit.org/267808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a49e8eaf1b2d36b5419c33148675fedd2c6d2021

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19561 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20425 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16164 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15342 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20590 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16949 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16898 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/19307 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16012 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5204 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20376 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/20550 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16743 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5049 "Passed tests") | 
<!--EWS-Status-Bubble-End-->