### PR TITLE
[GTK] `TestWebViewEditor` `/webkit/WebKitWebView/editable/editable` is flaky

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
@@ -42,6 +42,11 @@ using namespace WebKit;
  */
 
 enum {
+    CHANGED,
+    LAST_SIGNAL
+};
+
+enum {
     PROP_0,
     PROP_TYPING_ATTRIBUTES,
     N_PROPERTIES,
@@ -58,6 +63,8 @@ struct _WebKitEditorStatePrivate {
     unsigned isUndoAvailable : 1;
     unsigned isRedoAvailable : 1;
 };
+
+static guint signals[LAST_SIGNAL] = { 0, };
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitEditorState, webkit_editor_state, G_TYPE_OBJECT, GObject)
 
@@ -96,6 +103,23 @@ static void webkit_editor_state_class_init(WebKitEditorStateClass* editorStateCl
             WEBKIT_PARAM_READABLE);
 
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+
+    /**
+     * WebKitEditorState::changed:
+     * @editor_state: the #WebKitEditorState on which the signal is emitted
+     *
+     * Emitted when the #WebKitEdtorState is changed.
+     *
+     * Since: 2.44
+     */
+    signals[CHANGED] =
+        g_signal_new("changed",
+            G_TYPE_FROM_CLASS(editorStateClass),
+            G_SIGNAL_RUN_LAST,
+            0, 0,
+            nullptr,
+            g_cclosure_marshal_VOID__VOID,
+            G_TYPE_NONE, 0);
 }
 
 static void webkitEditorStateSetTypingAttributes(WebKitEditorState* editorState, unsigned typingAttributes)
@@ -140,6 +164,8 @@ void webkitEditorStateChanged(WebKitEditorState* editorState, const EditorState&
 
     editorState->priv->isUndoAvailable = editorState->priv->page->canUndo();
     editorState->priv->isRedoAvailable = editorState->priv->page->canRedo();
+
+    g_signal_emit(editorState, signals[CHANGED], 0, NULL);
 }
 
 /**

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -69,13 +69,6 @@
             }
         }
     },
-    "TestWebViewEditor": {
-        "subtests": {
-            "/webkit/WebKitWebView/editable/editable": {
-                "expected": {"gtk@Debug": {"status": ["FAIL"], "bug": "webkit.org/b/134580"}}
-            }
-        }
-    },
     "TestWebProcessExtensions": {
         "subtests": {
             "/webkit/WebKitWebProcessExtension/form-submission-steps": {


### PR DESCRIPTION
#### 9cc46b09b21f4b584ef5b4ea9d89519df6968462
<pre>
[GTK] `TestWebViewEditor` `/webkit/WebKitWebView/editable/editable` is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=261028">https://bugs.webkit.org/show_bug.cgi?id=261028</a>

Reviewed by Carlos Garcia Campos.

It seems like waiting for the `WebKitWebView`&apos;s `draw` signal doesn&apos;t
guarantee that `WebKitEditorState` will be updated after setting
`WebKitWebView` as editable. This leads to flakiness.

The better way to make sure `WebKitEditorState` has been updated is to
wait until the cut action becomes available. To achieve this, this patch
introduces a new `WebKitEditorState`&apos;s `changed` signal.

The test uses this new signal to ensure that `WebKitWebView` is indeed
editable before attempting to cut the selection.

* Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp:
(webkit_editor_state_class_init):
(webkitEditorStateChanged):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp:
(loadContentsAndTryToCutSelection):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/267671@main">https://commits.webkit.org/267671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffa8ca839f8fb077a508f059e3c0a8f4a2105ec8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18412 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22455 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20282 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14032 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15685 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4145 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->