### PR TITLE
Fix content-visibility-048.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Fragment navigation with content-visibility; single text assert_equals: expected "text" but got "undefined"
+PASS Fragment navigation with content-visibility; single text
 FAIL Fragment navigation with content-visibility; range across blocks assert_equals: expected "text2" but got "unknown"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
@@ -1,0 +1,41 @@
+
+PASS Test navigation with fragment: Empty hash should scroll to top.
+PASS Test navigation with fragment: Text directive with invalid syntax (context terms without "-") should not parse as a text directive.
+PASS Test navigation with fragment: Generic fragment directive with existing element fragment should scroll to element.
+PASS Test navigation with fragment: Uppercase TEXT directive should not parse as a text directive.
+PASS Test navigation with fragment: Exact text with no context should match text.
+PASS Test navigation with fragment: Exact text with prefix should match text.
+PASS Test navigation with fragment: Exact text with suffix should match text.
+PASS Test navigation with fragment: Exact text with prefix and suffix should match text.
+PASS Test navigation with fragment: Exact text with prefix and suffix and query equals prefix..
+PASS Test navigation with fragment: Text range with no context should match text.
+PASS Test navigation with fragment: Text range with prefix should match text.
+PASS Test navigation with fragment: Text range with suffix should match text.
+PASS Test navigation with fragment: Text range with prefix and suffix should match text.
+PASS Test navigation with fragment: Text range with non-matching endText should not match.
+PASS Test navigation with fragment: Text range with non-matching startText should not match.
+PASS Test navigation with fragment: Text range with prefix and nonmatching suffix should not match.
+PASS Test navigation with fragment: Text range with nonmatching prefix and matching suffix should not match.
+PASS Test navigation with fragment: Exact text with percent encoded spaces should match text.
+PASS Test navigation with fragment: Non-whole-word exact text with spaces should not match.
+PASS Test navigation with fragment: Fragment directive with percent encoded syntactical characters "&,-" should match text.
+PASS Test navigation with fragment: Fragment directive with percent encoded non-ASCII unicode character should match text.
+PASS Test navigation with fragment: Fragment directive with all TextMatchChars should match text.
+PASS Test navigation with fragment: Multiple matching exact texts should match text.
+PASS Test navigation with fragment: Multiple non-whole-word exact texts should not match.
+PASS Test navigation with fragment: A non-matching text directive followed by a matching text directive should match and scroll into view the second text directive.
+PASS Test navigation with fragment: Text directive followed by non-text directive should match text.
+PASS Test navigation with fragment: Multiple text directives and a non-text directive should match text.
+PASS Test navigation with fragment: Text directive with existing element fragment should match and scroll into view text.
+PASS Test navigation with fragment: Text directive with nonexistent element fragment should match and scroll into view text.
+PASS Test navigation with fragment: Non-matching text directive with existing element fragment should scroll to element.
+PASS Test navigation with fragment: Non-matching text directive with nonexistent element fragment should not match and not scroll.
+PASS Test navigation with fragment: Multiple match text directive disambiguated by prefix should match the prefixed text.
+PASS Test navigation with fragment: Multiple match text directive disambiguated by suffix should match the suffixed text.
+PASS Test navigation with fragment: Multiple match text directive disambiguated by prefix and suffix should match the text with the given context.
+PASS Test navigation with fragment: Text directive should match when context terms are separated by node boundaries.
+FAIL Test navigation with fragment: Text directive should match text within shadow DOM. assert_equals: Expected #:~:text=shadow%20text (Text directive should match text within shadow DOM) to scroll to shadow. expected "shadow" but got "top"
+PASS Test navigation with fragment: Text directive should not scroll to hidden text.
+PASS Test navigation with fragment: Text directive should not scroll to display none text.
+FAIL Test navigation with fragment: Text directive should horizontally scroll into view. assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-target.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<title>Navigating to a text fragment anchor</title>
+<script src="stash.js"></script>
+<script>
+function isInView(element) {
+  let rect = element.getBoundingClientRect();
+  return rect.top >= 0 && rect.top <= window.innerHeight
+      && rect.left >= 0 && rect.left <= window.innerWidth;
+}
+
+function checkScroll() {
+  let position = 'unknown';
+  if (window.scrollY == 0)
+    position = 'top';
+  else if (isInView(document.getElementById('element')))
+    position = 'element';
+  else if (isInView(document.getElementById('text')))
+    position = 'text';
+  else if (isInView(document.getElementById('more-text')))
+    position = 'more-text';
+  else if (isInView(document.getElementById('cross-node-context')))
+    position = 'cross-node-context';
+  else if (isInView(document.getElementById('text-directive-parameters')))
+    position = 'text-directive-parameters';
+  else if (isInView(document.getElementById('shadow-parent')))
+    position = 'shadow-parent';
+  else if (isInView(document.getElementById('hidden')))
+    position = 'hidden';
+  else if (isInView(document.getElementById('horizontal-scroll')) && window.scrollX > 0)
+    position = 'horizontal-scroll';
+
+  let target = document.querySelector(":target");
+
+  if (!target && position == 'shadow-parent') {
+    let shadow = document.getElementById("shadow-parent").shadowRoot.firstElementChild;
+    if (shadow.matches(":target")) {
+      target = shadow;
+      position = 'shadow';
+    }
+  }
+
+  let results = {
+    scrollPosition: position,
+    href: window.location.href,
+    target: target ? target.id : 'undefined'
+  };
+
+  let key = (new URL(document.location)).searchParams.get("key");
+  stashResultsThenClose(key, results);
+}
+
+// Ensure two animation frames on load to test the fallback to element anchor,
+// which gets queued for the next frame if the text fragment is not found.
+window.onload = function() {
+  window.requestAnimationFrame(function() {
+    window.requestAnimationFrame(checkScroll);
+  })
+}
+</script>
+<style>
+  .scroll-section {
+    /* 1000px margin on top and bottom so only one section can be in view. */
+    margin: 1000px 0px;
+  }
+  #hidden {
+    visibility: hidden;
+  }
+  #horizontal-scroll {
+    margin-left: 2000px;
+  }
+  #display-none {
+    display: none;
+  }
+</style>
+<body>
+  <div id="element" class="scroll-section">Element</div>
+  <p id="text" class="scroll-section">
+    This is a test page !$'()*+./:;=?@_~ &,- &#x30cd;&#x30b3;
+    <br>
+    foo foo foo bar bar bar
+  </p>
+  <p id="more-text" class="scroll-section">More test page text</p>
+  <div class="scroll-section">
+    <div>
+      <p>prefix</p>
+      <p id="cross-node-context">test page</p>
+    </div>
+    <div><p>suffix</p></div>
+  </div>
+  <p id="text-directive-parameters" class="scroll-section">this,is,test,page</p>
+  <div id="shadow-parent" class="scroll-section"></div>
+  <script>
+    let shadow = document.getElementById("shadow-parent").attachShadow({mode: 'open'});
+    shadow.innerHTML = '<p id="shadow">shadow text</p>';
+  </script>
+  <p id="hidden" class="scroll-section">hidden text</p>
+  <p id="horizontal-scroll" class="scroll-section">horizontally scrolled text</p>
+  <p id="display-none" class="scroll-section">display none</p>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<title>Navigating to a text fragment directive</title>
+<meta charset=utf-8>
+<link rel="help" href="https://wicg.github.io/ScrollToTextFragment/">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/common/utils.js"></script>
+<script src="stash.js"></script>
+<!--
+  This test suite performs scroll to text navigations to
+  scroll-to-text-fragment-target.html and then checks the results, which are
+  communicated back from the target page via the WPT Stash server (see stash.py).
+  This structure is necessary because scroll to text security restrictions
+  specifically restrict the navigator from being able to observe the result of
+  the navigation, e.g. the target page cannot have a window opener.
+-->
+<script>
+let test_cases = [
+  // Test non-text fragment directives
+  {
+    fragment: '#',
+    expect_position: 'top',
+    description: 'Empty hash should scroll to top'
+  },
+  {
+    fragment: '#:~:text=this,is,test,page',
+    expect_position: 'top',
+    description: 'Text directive with invalid syntax (context terms without "-") should not parse as a text directive'
+  },
+  {
+    fragment: '#element:~:directive',
+    expect_position: 'element',
+    description: 'Generic fragment directive with existing element fragment should scroll to element'
+  },
+  {
+    fragment: '#:~:TEXT=test',
+    expect_position: 'top',
+    description: 'Uppercase TEXT directive should not parse as a text directive'
+  },
+  // Test exact text matching, with all combinations of context terms
+  {
+    fragment: '#:~:text=test',
+    expect_position: 'text',
+    description:  'Exact text with no context should match text'
+  },
+  {
+    fragment: '#:~:text=this is a-,test',
+    expect_position: 'text',
+    description: 'Exact text with prefix should match text'
+  },
+  {
+    fragment: '#:~:text=test,-page',
+    expect_position: 'text',
+    description: 'Exact text with suffix should match text'
+  },
+  {
+    fragment: '#:~:text=this is a-,test,-page',
+    expect_position: 'text',
+    description: 'Exact text with prefix and suffix should match text'
+  },
+  // Test tricky edge case where prefix and query are equal
+  {
+    fragment: '#:~:text=foo-,foo,-bar',
+    expect_position: 'text',
+    description: 'Exact text with prefix and suffix and query equals prefix.'
+  },
+  // Test text range matching, with all combinations of context terms
+  {
+    fragment: '#:~:text=this,page',
+    expect_position: 'text',
+    description: 'Text range with no context should match text'
+  },
+  {
+    fragment: '#:~:text=this-,is,test',
+    expect_position: 'text',
+    description: 'Text range with prefix should match text'
+  },
+  {
+    fragment: '#:~:text=this,test,-page',
+    expect_position: 'text',
+    description: 'Text range with suffix should match text'
+  },
+  {
+    fragment: '#:~:text=this-,is,test,-page',
+    expect_position: 'text',
+    description: 'Text range with prefix and suffix should match text'
+  },
+  // Test partially non-matching text ranges
+  {
+    fragment: '#:~:text=this,none',
+    expect_position: 'top',
+    description: 'Text range with non-matching endText should not match'
+  },
+  {
+    fragment: '#:~:text=none,page',
+    expect_position: 'top',
+    description: 'Text range with non-matching startText should not match'
+  },
+  // Test non-matching context terms
+  {
+    fragment: '#:~:text=this-,is,page,-none',
+    expect_position: 'top',
+    description: 'Text range with prefix and nonmatching suffix should not match'
+  },
+  {
+    fragment: '#:~:text=none-,this,test,-page',
+    expect_position: 'top',
+    description: 'Text range with nonmatching prefix and matching suffix should not match'
+  },
+  // Test percent encoded characters
+  {
+    fragment: '#:~:text=this%20is%20a%20test%20page',
+    expect_position: 'text',
+    description: 'Exact text with percent encoded spaces should match text'
+  },
+  {
+    fragment: '#:~:text=test%20pag',
+    expect_position: 'top',
+    description: 'Non-whole-word exact text with spaces should not match'
+  },
+  {
+    fragment: '#:~:text=%26%2C%2D',
+    expect_position: 'text',
+    description: 'Fragment directive with percent encoded syntactical characters "&,-" should match text'
+  },
+  {
+    fragment: '#:~:text=%E3%83%8D%E3%82%B3',
+    expect_position: 'text',
+    description: 'Fragment directive with percent encoded non-ASCII unicode character should match text'
+  },
+  {
+    fragment: '#:~:text=!$\'()*+./:;=?@_~',
+    expect_position: 'text',
+    description: 'Fragment directive with all TextMatchChars should match text'
+  },
+  // Test multiple text directives
+  {
+    fragment: '#:~:text=this&text=test,page',
+    expect_position: 'text',
+    description: 'Multiple matching exact texts should match text'
+  },
+  {
+    fragment: '#:~:text=tes&text=age',
+    expect_position: 'top',
+    description: 'Multiple non-whole-word exact texts should not match'
+  },
+  {
+    fragment: '#:~:text=none&text=test%20page',
+    expect_position: 'text',
+    description: 'A non-matching text directive followed by a matching text directive should match and scroll into view the second text directive'
+  },
+  {
+    fragment: '#:~:text=test%20page&directive',
+    expect_position: 'text',
+    description: 'Text directive followed by non-text directive should match text'
+  },
+  {
+    fragment: '#:~:text=test&directive&text=page',
+    expect_position: 'text',
+    description: 'Multiple text directives and a non-text directive should match text'
+  },
+  // Test text directive behavior when there's an element fragment identifier
+  {
+    fragment: '#element:~:text=test',
+    expect_position: 'text',
+    description: 'Text directive with existing element fragment should match and scroll into view text'
+  },
+  {
+    fragment: '#pagestate:~:text=test',
+    expect_position: 'text',
+    description: 'Text directive with nonexistent element fragment should match and scroll into view text'
+  },
+  {
+    fragment: '#element:~:text=nomatch',
+    expect_position: 'element',
+    description: 'Non-matching text directive with existing element fragment should scroll to element'
+  },
+  {
+    fragment: '#pagestate:~:text=nomatch',
+    expect_position: 'top',
+    description: 'Non-matching text directive with nonexistent element fragment should not match and not scroll'
+  },
+  // Test ambiguous text matches disambiguated by context terms
+  {
+    fragment: '#:~:text=more-,test%20page',
+    expect_position: 'more-text',
+    description: 'Multiple match text directive disambiguated by prefix should match the prefixed text'
+  },
+  {
+    fragment: '#:~:text=test%20page,-text',
+    expect_position: 'more-text',
+    description: 'Multiple match text directive disambiguated by suffix should match the suffixed text'
+  },
+  {
+    fragment: '#:~:text=more-,test%20page,-text',
+    expect_position: 'more-text',
+    description: 'Multiple match text directive disambiguated by prefix and suffix should match the text with the given context'
+  },
+  // Test context terms separated by node boundaries
+  {
+    fragment: '#:~:text=prefix-,test%20page,-suffix',
+    expect_position: 'cross-node-context',
+    description: 'Text directive should match when context terms are separated by node boundaries'
+  },
+  // Test text directive within shadow DOM
+  {
+    fragment: '#:~:text=shadow%20text',
+    expect_position: 'shadow',
+    description: 'Text directive should match text within shadow DOM'
+  },
+  // Test text directive within hidden and display none elements. These cases should not scroll into
+  // view, but still "match" in that they should be highlighted or otherwise visibly indicated
+  // if they were to become visible.
+  {
+    fragment: '#:~:text=hidden%20text',
+    expect_position: 'top',
+    description: 'Text directive should not scroll to hidden text'
+  },
+  {
+    fragment: '#:~:text=display%20none',
+    expect_position: 'top',
+    description: 'Text directive should not scroll to display none text'
+  },
+  // Test horizontal scroll into view
+  {
+    fragment: '#:~:text=horizontally%20scrolled%20text',
+    expect_position: 'horizontal-scroll',
+    description: 'Text directive should horizontally scroll into view'
+  }
+];
+
+for (const test_case of test_cases) {
+  promise_test(t => new Promise((resolve, reject) => {
+    let key = token();
+
+    test_driver.bless('Open a URL with a text fragment directive', () => {
+      window.open(`scroll-to-text-fragment-target.html?key=${key}${test_case.fragment}`, '_blank', 'noopener');
+    });
+
+    fetchResults(key, resolve, reject);
+  }).then(data => {
+    // If the position is not 'top', the :target element should be the positioned element.
+    assert_true(data.scrollPosition == 'top' || data.target == data.scrollPosition);
+    assert_equals(data.href.indexOf(':~:'), -1, 'Expected fragment directive to be stripped from the URL.');
+    assert_equals(data.scrollPosition, test_case.expect_position,
+                  `Expected ${test_case.fragment} (${test_case.description}) to scroll to ${test_case.expect_position}.`);
+  }), `Test navigation with fragment: ${test_case.description}.`);
+}
+</script>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
@@ -1,0 +1,41 @@
+
+PASS Test navigation with fragment: Empty hash should scroll to top.
+PASS Test navigation with fragment: Text directive with invalid syntax (context terms without "-") should not parse as a text directive.
+PASS Test navigation with fragment: Generic fragment directive with existing element fragment should scroll to element.
+PASS Test navigation with fragment: Uppercase TEXT directive should not parse as a text directive.
+PASS Test navigation with fragment: Exact text with no context should match text.
+PASS Test navigation with fragment: Exact text with prefix should match text.
+PASS Test navigation with fragment: Exact text with suffix should match text.
+PASS Test navigation with fragment: Exact text with prefix and suffix should match text.
+PASS Test navigation with fragment: Exact text with prefix and suffix and query equals prefix..
+PASS Test navigation with fragment: Text range with no context should match text.
+PASS Test navigation with fragment: Text range with prefix should match text.
+PASS Test navigation with fragment: Text range with suffix should match text.
+PASS Test navigation with fragment: Text range with prefix and suffix should match text.
+PASS Test navigation with fragment: Text range with non-matching endText should not match.
+PASS Test navigation with fragment: Text range with non-matching startText should not match.
+PASS Test navigation with fragment: Text range with prefix and nonmatching suffix should not match.
+PASS Test navigation with fragment: Text range with nonmatching prefix and matching suffix should not match.
+PASS Test navigation with fragment: Exact text with percent encoded spaces should match text.
+PASS Test navigation with fragment: Non-whole-word exact text with spaces should not match.
+PASS Test navigation with fragment: Fragment directive with percent encoded syntactical characters "&,-" should match text.
+PASS Test navigation with fragment: Fragment directive with percent encoded non-ASCII unicode character should match text.
+PASS Test navigation with fragment: Fragment directive with all TextMatchChars should match text.
+PASS Test navigation with fragment: Multiple matching exact texts should match text.
+PASS Test navigation with fragment: Multiple non-whole-word exact texts should not match.
+PASS Test navigation with fragment: A non-matching text directive followed by a matching text directive should match and scroll into view the second text directive.
+PASS Test navigation with fragment: Text directive followed by non-text directive should match text.
+PASS Test navigation with fragment: Multiple text directives and a non-text directive should match text.
+PASS Test navigation with fragment: Text directive with existing element fragment should match and scroll into view text.
+PASS Test navigation with fragment: Text directive with nonexistent element fragment should match and scroll into view text.
+PASS Test navigation with fragment: Non-matching text directive with existing element fragment should scroll to element.
+PASS Test navigation with fragment: Non-matching text directive with nonexistent element fragment should not match and not scroll.
+PASS Test navigation with fragment: Multiple match text directive disambiguated by prefix should match the prefixed text.
+PASS Test navigation with fragment: Multiple match text directive disambiguated by suffix should match the suffixed text.
+PASS Test navigation with fragment: Multiple match text directive disambiguated by prefix and suffix should match the text with the given context.
+PASS Test navigation with fragment: Text directive should match when context terms are separated by node boundaries.
+FAIL Test navigation with fragment: Text directive should match text within shadow DOM. assert_equals: Expected #:~:text=shadow%20text (Text directive should match text within shadow DOM) to scroll to shadow. expected "shadow" but got "top"
+PASS Test navigation with fragment: Text directive should not scroll to hidden text.
+PASS Test navigation with fragment: Text directive should not scroll to display none text.
+PASS Test navigation with fragment: Text directive should horizontally scroll into view.
+

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2326,6 +2326,11 @@ bool LocalFrameView::scrollToFragment(const URL& url)
             
             if (highlightRanges.size()) {
                 auto range = highlightRanges.first();
+                RefPtr commonAncestor = commonInclusiveAncestor<ComposedTree>(range);
+                if (commonAncestor && !is<Element>(commonAncestor))
+                    commonAncestor = commonAncestor->parentElement();
+                if (commonAncestor)
+                    document->setCSSTarget(downcast<Element>(commonAncestor));
                 // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
                 TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
                 maintainScrollPositionAtScrollToTextFragmentRange(range);


### PR DESCRIPTION
#### d72e06f60a0cc794bb5299e2c0394aa10e3ed662
<pre>
Fix content-visibility-048.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=261032">https://bugs.webkit.org/show_bug.cgi?id=261032</a>

Reviewed by Ryosuke Niwa.

Fix content-visibility-048.html by implementing [1], i.e. set the CSS target given the range.

The remaining failure in content-visibility-048.html is because the range resulting from the
fragment text directive is centered in the selection, but the same thing happens without
content-visibility.

[1] <a href="https://wicg.github.io/scroll-to-text-fragment/#invoking-text-directives">https://wicg.github.io/scroll-to-text-fragment/#invoking-text-directives</a> (Monkeypatching HTML § 7.4.6.3 Scrolling to a fragment)

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-target.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragment):

Canonical link: <a href="https://commits.webkit.org/267744@main">https://commits.webkit.org/267744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/725eda64bca6b8d13d23b9520540ae92e6a56ca3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18049 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20218 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22609 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20461 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4183 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->