### PR TITLE
Small optimization of FloatPoint serialization in SVGPathByteStream

### DIFF
--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.cpp
@@ -35,13 +35,13 @@ SVGPathByteStreamBuilder::SVGPathByteStreamBuilder(SVGPathByteStream& byteStream
 void SVGPathByteStreamBuilder::moveTo(const FloatPoint& targetPoint, bool, PathCoordinateMode mode)
 {
     writeType(mode == RelativeCoordinates ?  SVGPathSegType::MoveToRel : SVGPathSegType::MoveToAbs);
-    writeFloatPoint(targetPoint);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::lineTo(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     writeSegmentType(mode == RelativeCoordinates ? SVGPathSegType::LineToRel : SVGPathSegType::LineToAbs);
-    writeFloatPoint(targetPoint);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::lineToHorizontal(float x, PathCoordinateMode mode)
@@ -59,29 +59,29 @@ void SVGPathByteStreamBuilder::lineToVertical(float y, PathCoordinateMode mode)
 void SVGPathByteStreamBuilder::curveToCubic(const FloatPoint& point1, const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToCubicRel : SVGPathSegType::CurveToCubicAbs);
-    writeFloatPoint(point1);
-    writeFloatPoint(point2);
-    writeFloatPoint(targetPoint);
+    writeType(point1);
+    writeType(point2);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::curveToCubicSmooth(const FloatPoint& point2, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToCubicSmoothRel : SVGPathSegType::CurveToCubicSmoothAbs);
-    writeFloatPoint(point2);
-    writeFloatPoint(targetPoint);
+    writeType(point2);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::curveToQuadratic(const FloatPoint& point1, const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToQuadraticRel : SVGPathSegType::CurveToQuadraticAbs);
-    writeFloatPoint(point1);
-    writeFloatPoint(targetPoint);
+    writeType(point1);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::curveToQuadraticSmooth(const FloatPoint& targetPoint, PathCoordinateMode mode)
 {
     writeType(mode == RelativeCoordinates ? SVGPathSegType::CurveToQuadraticSmoothRel : SVGPathSegType::CurveToQuadraticSmoothAbs);
-    writeFloatPoint(targetPoint);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::arcTo(float r1, float r2, float angle, bool largeArcFlag, bool sweepFlag, const FloatPoint& targetPoint, PathCoordinateMode mode)
@@ -92,7 +92,7 @@ void SVGPathByteStreamBuilder::arcTo(float r1, float r2, float angle, bool large
     writeType(angle);
     writeType(largeArcFlag);
     writeType(sweepFlag);
-    writeFloatPoint(targetPoint);
+    writeType(targetPoint);
 }
 
 void SVGPathByteStreamBuilder::closePath()

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.h
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.h
@@ -63,12 +63,6 @@ private:
         m_byteStream.append(std::span { type.bytes, sizeof(ByteType) });
     }
 
-    void writeFloatPoint(const FloatPoint& point)
-    {
-        writeType(point.x());
-        writeType(point.y());
-    }
-
     void writeSegmentType(SVGPathSegType type)
     {
         static_assert(std::is_same_v<std::underlying_type_t<SVGPathSegType>, uint8_t>);

--- a/Source/WebCore/svg/SVGPathByteStreamSource.h
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.h
@@ -78,9 +78,7 @@ private:
 
     FloatPoint readFloatPoint()
     {
-        float x = readType<float>();
-        float y = readType<float>();
-        return FloatPoint(x, y);
+        return readType<FloatPoint>();
     }
 
     SVGPathByteStream::DataIterator m_streamCurrent;


### PR DESCRIPTION
#### 256613d5471864884f5520800eba1bc934978ee5
<pre>
Small optimization of FloatPoint serialization in SVGPathByteStream
<a href="https://bugs.webkit.org/show_bug.cgi?id=261034">https://bugs.webkit.org/show_bug.cgi?id=261034</a>

Reviewed by Timothy Hatcher and Ryosuke Niwa.

Serialize FloatPoint directly as a FloatPoint instead of doing
is as two separate floats. Since we end up appending to a byte Vector, it
helps to know how many bytes we&apos;re going to append in advance.
A FloatPoint only has 2 float data members anyway.

* Source/WebCore/svg/SVGPathByteStreamBuilder.h:
* Source/WebCore/svg/SVGPathByteStreamSource.h:

Canonical link: <a href="https://commits.webkit.org/267563@main">https://commits.webkit.org/267563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/331d4facfa2e3cd163685d8ab34645468f030bb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17427 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19562 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22104 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19866 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13690 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15321 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->