### PR TITLE
Rebaseline

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,11 @@ DECLARE_SYSTEM_HEADER
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <nw/private.h>
+
+#if PLATFORM(MAC) && defined(__OBJC__)
+// Only needed for running tests.
+#import <NetworkExtension/NEPolicySession.h>
+#endif
 
 #else
 
@@ -75,5 +80,53 @@ const char* nw_webtransport_metadata_get_session_error_message(nw_protocol_metad
 void nw_webtransport_metadata_set_session_error_message(nw_protocol_metadata_t, const char*);
 
 WTF_EXTERN_C_END
+
+// ------------------------------------------------------------
+// The following declarations are only needed for running tests.
+
+WTF_EXTERN_C_BEGIN
+
+typedef enum {
+    nw_resolver_protocol_dns53 = 0,
+} nw_resolver_protocol_t;
+
+typedef enum {
+    nw_resolver_class_designated_direct = 2,
+} nw_resolver_class_t;
+
+nw_resolver_config_t nw_resolver_config_create(void);
+void nw_resolver_config_set_protocol(nw_resolver_config_t, nw_resolver_protocol_t);
+void nw_resolver_config_set_class(nw_resolver_config_t, nw_resolver_class_t);
+void nw_resolver_config_add_match_domain(nw_resolver_config_t, const char *);
+void nw_resolver_config_add_name_server(nw_resolver_config_t, const char *name_server);
+void nw_resolver_config_set_identifier(nw_resolver_config_t, const uuid_t identifier);
+bool nw_resolver_config_publish(nw_resolver_config_t);
+
+WTF_EXTERN_C_END
+
+#if defined(__OBJC__)
+typedef NS_ENUM(NSInteger, NEPolicySessionPriority) {
+    NEPolicySessionPriorityHigh = 300,
+};
+
+@interface NEPolicyCondition : NSObject
++ (NEPolicyCondition *)domain:(NSString *)domain;
+@end
+
+@interface NEPolicyResult : NSObject
++ (NEPolicyResult *)netAgentUUID:(NSUUID *)agentUUID;
+@end
+
+@interface NEPolicy : NSObject
+- (instancetype)initWithOrder:(uint32_t)order result:(NEPolicyResult *)result conditions:(NSArray<NEPolicyCondition *> *)conditions;
+@end
+
+@interface NEPolicySession : NSObject
+@property NEPolicySessionPriority priority;
+- (NSUInteger)addPolicy:(NEPolicy *)policy;
+- (BOOL)apply;
+@end
+#endif // defined(__OBJC__)
+// ------------------------------------------------------------
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,6 +58,8 @@
 #import "ExtensionKitSPI.h"
 #import "WKProcessExtension.h"
 #endif
+
+#import <pal/spi/cocoa/NetworkSPI.h>
 
 namespace WebKit {
 
@@ -118,6 +120,18 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
     m_enableModernDownloadProgress = parameters.enableModernDownloadProgress;
 
     increaseFileDescriptorLimit();
+
+#if PLATFORM(IOS_FAMILY)
+    // See TestController::cocoaPlatformInitialize for supporting a local DNS resolver on Mac.
+    if (!parameters.localhostAliasesForTesting.isEmpty()) {
+        nw_resolver_config_t resolverConfig = nw_resolver_config_create();
+        nw_resolver_config_set_protocol(resolverConfig, nw_resolver_protocol_dns53);
+        nw_resolver_config_set_class(resolverConfig, nw_resolver_class_designated_direct);
+        nw_resolver_config_add_name_server(resolverConfig, "127.0.0.1:8053");
+        nw_resolver_config_add_match_domain(resolverConfig, "test");
+        nw_privacy_context_require_encrypted_name_resolution(NW_DEFAULT_PRIVACY_CONTEXT, true, resolverConfig);
+    }
+#endif
 }
 
 RetainPtr<CFDataRef> NetworkProcess::sourceApplicationAuditData() const

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2008-2020 Andrey Petrov and contributors.
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -78,6 +78,7 @@ AutoInstall.register(Package('bs4', Version(4, 12, 0), pypi_name='beautifulsoup4
 AutoInstall.register(Package('configparser', Version(4, 0, 2), implicit_deps=['pyparsing'], aliases=['backports.configparser']))
 AutoInstall.register(Package('contextlib2', Version(0, 6, 0)))
 AutoInstall.register(Package('coverage', Version(7, 6, 1), wheel=True))
+AutoInstall.register(Package('dnslib', Version(0, 9, 26)))
 AutoInstall.register(Package('funcsigs', Version(1, 0, 2)))
 AutoInstall.register(Package('html5lib', Version(1, 1)))
 AutoInstall.register(Package('iniconfig', Version(1, 1, 1)))

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2010 Google Inc. All rights reserved.
 # Copyright (C) 2010 Gabor Rapcsanyi (rgabor@inf.u-szeged.hu), University of Szeged
-# Copyright (C) 2011, 2016, 2019 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -377,6 +377,7 @@ def parse_args(args):
     option_group_definitions.append(("Web Platform Test Server Options", [
         optparse.make_option("--disable-wpt-hostname-aliases", action="store_true", default=False, help="Disable running tests from WPT against the web-platform.test domain, if the port supports it."),
         optparse.make_option("--wptserver-doc-root", type="string", help=("Set web platform server document root, relative to LayoutTests directory")),
+        optparse.make_option("--local-dns-resolver", action="store_true", default=False, help="Run and use a local DNS resolver, if the port supports it.")
     ]))
 
     option_group_definitions.append(('Upload Options', upload_options()))

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -377,7 +377,7 @@ def parse_args(args):
     option_group_definitions.append(("Web Platform Test Server Options", [
         optparse.make_option("--disable-wpt-hostname-aliases", action="store_true", default=False, help="Disable running tests from WPT against the web-platform.test domain, if the port supports it."),
         optparse.make_option("--wptserver-doc-root", type="string", help=("Set web platform server document root, relative to LayoutTests directory")),
-        optparse.make_option("--local-dns-resolver", action="store_true", default=False, help="Run and use a local DNS resolver, if the port supports it.")
+        optparse.make_option("--local-dns-resolver", action="store_true", default=True, help="Run and use a local DNS resolver, if the port supports it.")
     ]))
 
     option_group_definitions.append(('Upload Options', upload_options()))

--- a/Tools/Scripts/webkitpy/layout_tests/servers/basic_dns_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/basic_dns_server.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from dnslib import CLASS, QTYPE, RR, RCODE
+from dnslib.server import BaseResolver, DNSServer
+import logging
+from threading import Thread
+
+_log = logging.getLogger(__name__)
+
+
+class Resolver(BaseResolver):
+    def __init__(self, allowed_hosts=[]):
+        super().__init__()
+        self.hosts = list(map(lambda x: x if x.endswith(".") else x + ".", allowed_hosts))
+        _log.debug("Initializing Resolver with hosts: {}".format(self.hosts))
+
+    def resolve(self, request, handler):
+        question = request.q
+        reply = request.reply()
+        _log.debug("Received request for {}".format(question.qname))
+        if question.qtype == QTYPE.A and (question.qname in self.hosts or question.qname.matchSuffix("localhost")):
+            reply.add_answer(*RR.fromZone("{} 3600 A 127.0.0.1".format(question.qname)))
+        else:
+            reply.header.rcode = getattr(RCODE, "NXDOMAIN")
+        return reply
+
+
+if __name__ == "__main__":
+    # This script is not intended to be run on its own, and should only be used for testing purposes.
+    server = DNSServer(Resolver(["site.example"]), port=8053, address="127.0.0.1")
+    server.start_thread()
+    try:
+        Thread.join()
+    except Exception:
+        pass
+    finally:
+        server.stop()

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2014, Canon Inc. All rights reserved.
+#  Copyright (c) 2014 Canon Inc. All rights reserved.
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions
 #  are met:
@@ -27,6 +27,7 @@ import sys
 import time
 
 from webkitpy.layout_tests.servers import http_server_base
+from webkitpy.layout_tests.servers.basic_dns_server import DNSServer, Resolver
 
 _log = logging.getLogger(__name__)
 
@@ -127,6 +128,11 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         self._output_log_path = None
         self._wsout = None
         self._process = None
+        self._dns_server = None
+        if port_obj.supports_localhost_aliases and port_obj.get_option('local_dns_resolver') and not port_obj.get_option('disable_wpt_hostname_aliases'):
+            self._dns_server = DNSServer(Resolver(
+                allowed_hosts=port_obj.localhost_aliases()), port=8053, address="127.0.0.1")
+
         self._pid_file = pidfile
         if not self._pid_file:
             self._pid_file = self._filesystem.join(self._runtime_path, '%s.pid' % self._name)
@@ -178,6 +184,9 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         self._process = self._executive.popen(self._start_cmd, cwd=self._doc_root_path, shell=False, stdin=self._executive.PIPE, stdout=self._wsout, stderr=self._wsout)
         self._filesystem.write_text_file(self._pid_file, str(self._process.pid))
 
+        if self._dns_server:
+            self._dns_server.start_thread()
+
         # Wait a second for the server to actually start so that tests do not start until server is running.
         time.sleep(1)
 
@@ -201,6 +210,9 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         if self._wsout:
             self._wsout.close()
             self._wsout = None
+
+        if self._dns_server and hasattr(self._dns_server, "thread") and self._dns_server.isAlive():
+            self._dns_server.stop()
 
         if self._process is not None:
             self._process.poll()

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -83,6 +83,7 @@ class ApplePort(Port):
 
         port_name = port_name.replace('-wk2', '')
         self._version = self._strip_port_name_prefix(port_name)
+        self.supports_localhost_aliases = False
 
     def setup_test_run(self, device_type=None):
         self._crash_logs_to_skip_for_host[self.host] = self.host.filesystem.files_under(self.path_to_crash_logs())

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2011 Google Inc. All rights reserved.
-# Copyright (c) 2015-2019 Apple Inc. All rights reserved.
+# Copyright (c) 2015-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -582,6 +582,8 @@ class Driver(object):
             cmd.append('--show-window')
         if self._port.get_option('accessibility_isolated_tree'):
             cmd.append('--accessibility-isolated-tree')
+        if self._port.get_option('local_dns_resolver'):
+            cmd.append('--local-dns-resolver')
 
         for allowed_host in self._port.allowed_hosts():
             cmd.append('--allowed-host')

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -30,7 +30,8 @@ import time
 
 from webkitcorepy import string_utils
 
-from webkitpy.port import Port, Driver, DriverOutput
+from webkitpy.port.base import Port
+from webkitpy.port.driver import Driver, DriverOutput
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.common.system.crashlogs import CrashLogs
 from webkitpy.common.version_name_map import PUBLIC_TABLE, VersionNameMap

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
@@ -8,6 +8,12 @@
 	</array>
 	<key>com.apple.private.webkit.adattributiond.testing</key>
 	<true/>
+	<key>com.apple.private.nehelper.privileged</key>
+	<true/>
+	<key>com.apple.private.neagent</key>
+	<true/>
+	<key>com.apple.networkd.persistent_interface</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.sbpl</key>
 	<array>
 		<string>(allow mach-issue-extension (require-all (extension-class &quot;com.apple.webkit.extension.mach&quot;)))</string>

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 University of Szeged. All rights reserved.
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -192,6 +192,12 @@ static bool handleOptionWPELegacyAPI(Options& options, const char*, const char*)
 }
 #endif
 
+static bool handleOptionLocalDNSResolver(Options& options, const char*, const char*)
+{
+    options.useLocalDNSResolver = true;
+    return true;
+}
+
 static bool handleOptionUnmatched(Options& options, const char* option, const char*)
 {
     if (option[0] && option[1] && option[0] == '-' && option[1] == '-')
@@ -232,6 +238,7 @@ OptionsHandler::OptionsHandler(Options& o)
 #if PLATFORM(WPE)
     optionList.append(Option("--wpe-legacy-api", "Use the WPE legacy API (libwpe)", handleOptionWPELegacyAPI));
 #endif
+    optionList.append(Option("--local-dns-resolver", "Enable using a local DNS resolver, if the port supports it", handleOptionLocalDNSResolver));
 
     optionList.append(Option(0, 0, handleOptionUnmatched));
 }

--- a/Tools/WebKitTestRunner/Options.h
+++ b/Tools/WebKitTestRunner/Options.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 University of Szeged. All rights reserved.
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,6 +54,7 @@ struct Options {
 #if PLATFORM(WPE)
     bool useWPELegacyAPI { false };
 #endif
+    bool useLocalDNSResolver { false };
     std::vector<std::string> paths;
     std::set<std::string> allowedHosts;
     std::set<std::string> localhostAliases;

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -497,6 +497,9 @@ private:
 
 #if PLATFORM(COCOA)
     void cocoaPlatformInitialize(const Options&);
+#if PLATFORM(MAC)
+    void localDNSInitialize();
+#endif
     void cocoaResetStateToConsistentValues(const TestOptions&);
     void setApplicationBundleIdentifier(const std::string&);
     void clearApplicationBundleIdentifierTestingOverride();

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -160,6 +160,9 @@
 		BCC997A411D3C8F60017BCA2 /* InjectedBundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCC997A011D3C8F60017BCA2 /* InjectedBundle.cpp */; };
 		BCC997A511D3C8F60017BCA2 /* InjectedBundlePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCC997A211D3C8F60017BCA2 /* InjectedBundlePage.cpp */; };
 		C0CE720B1247C93300BC0EC4 /* TestRunnerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0CE720A1247C93300BC0EC4 /* TestRunnerMac.mm */; };
+		D2D99AEE2A9EF3F500000BBF /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2D99AED2A9EF3F500000BBF /* Network.framework */; };
+		D2D99AF72AA21E6800000BBF /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2D99AF62AA21E6800000BBF /* NetworkExtension.framework */; platformFilters = (maccatalyst, macos, ); };
+		D2D99AFC2AA27BA800000BBF /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2D99AED2A9EF3F500000BBF /* Network.framework */; };
 		DD4671AE2A6B136200E49DBD /* WebCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD4671AD2A6B136200E49DBD /* WebCore.framework */; };
 		E132AA3A17CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */; };
 		E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3B17CE776F00611DF0 /* WebKitTestRunnerEvent.mm */; };
@@ -486,6 +489,8 @@
 		BCD7D2F711921278006DB7EE /* TestInvocation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestInvocation.cpp; sourceTree = "<group>"; };
 		BCDA2B991191051F00C3BC47 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0CE720A1247C93300BC0EC4 /* TestRunnerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = TestRunnerMac.mm; path = mac/TestRunnerMac.mm; sourceTree = "<group>"; };
+		D2D99AED2A9EF3F500000BBF /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/PrivateFrameworks/Network.framework; sourceTree = SDKROOT; };
+		D2D99AF62AA21E6800000BBF /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		DD4671AD2A6B136200E49DBD /* WebCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WebCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitTestRunnerDraggingInfo.mm; sourceTree = "<group>"; };
 		E132AA3917CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitTestRunnerDraggingInfo.h; sourceTree = "<group>"; };
@@ -524,6 +529,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2D99AFC2AA27BA800000BBF /* Network.framework in Frameworks */,
 				57A0062F22976EF800AD08BD /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -533,6 +539,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				51058AD51D678820009A538C /* libWebCoreTestSupport.dylib in Frameworks */,
+				D2D99AEE2A9EF3F500000BBF /* Network.framework in Frameworks */,
+				D2D99AF72AA21E6800000BBF /* NetworkExtension.framework in Frameworks */,
 				57A0062E22976EEB00AD08BD /* Security.framework in Frameworks */,
 				DD4671AE2A6B136200E49DBD /* WebCore.framework in Frameworks */,
 				51058AD61D678825009A538C /* WebKit.framework in Frameworks */,
@@ -814,6 +822,8 @@
 				2EE52CE41890A9A80010ED21 /* CoreGraphics.framework */,
 				2EE52CE21890A9A80010ED21 /* Foundation.framework */,
 				0F73B5571BA7929E004B3EF4 /* JavaScriptCore.framework */,
+				D2D99AED2A9EF3F500000BBF /* Network.framework */,
+				D2D99AF62AA21E6800000BBF /* NetworkExtension.framework */,
 				570E75A42152DA2C00324B6E /* Security.framework */,
 				DD4671AD2A6B136200E49DBD /* WebCore.framework */,
 			);
@@ -1515,6 +1525,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 			};
 			name = Debug;
 		};
@@ -1522,6 +1536,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 			};
 			name = Release;
 		};
@@ -1548,6 +1566,10 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1559,6 +1581,10 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -1570,6 +1596,10 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Production;
@@ -1668,6 +1698,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 			};
 			name = Production;
 		};

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -36,6 +36,7 @@
 #import "TestWebsiteDataStoreDelegate.h"
 #import "WebCoreTestSupport.h"
 #import <Foundation/Foundation.h>
+#import <Network/Network.h>
 #import <Security/SecItem.h>
 #import <WebKit/WKContentRuleListStorePrivate.h>
 #import <WebKit/WKContextConfigurationRef.h>
@@ -59,6 +60,7 @@
 #import <WebKit/_WKApplicationManifest.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
+#import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/MainThread.h>
@@ -192,11 +194,56 @@ void TestController::cocoaPlatformInitialize(const Options& options)
     m_appStoreURLSwizzler = makeUnique<InstanceMethodSwizzler>(NSURL.class, @selector(iTunesStoreURL), reinterpret_cast<IMP>(swizzledAppStoreURL));
 #endif
 
+
     String resourceMonitorContentRuleListStoreFolder = makeString(String::fromUTF8(dumpRenderTreeTemp), "/ResourceMonitorContentRuleList/"_s, getpid());
     RetainPtr<NSURL> url = [NSURL fileURLWithPath:resourceMonitorContentRuleListStoreFolder.createNSString().get()];
 
     [WKContentRuleListStore _setContentRuleListStoreForResourceMonitorURLsControllerForTesting:[WKContentRuleListStore storeWithURL:url.get()]];
+
+#if PLATFORM(MAC)
+    // See NetworkProcess::platformInitializeNetworkProcessCocoa for supporting a local DNS resolver on iOS.
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        if (!options.useLocalDNSResolver)
+            return;
+        localDNSInitialize();
+    });
+#endif
 }
+
+#if PLATFORM(MAC)
+void TestController::localDNSInitialize()
+{
+    auto agentUUID = adoptNS([[NSUUID alloc] init]);
+    uuid_t agentUUIDBytes;
+    [agentUUID.get() getUUIDBytes:agentUUIDBytes];
+    NSLog(@"useLocalDNSResolver: agent UUID: %@.", agentUUID.get());
+
+    static nw_resolver_config_t resolverConfig = nw_resolver_config_create();
+    nw_resolver_config_set_protocol(resolverConfig, nw_resolver_protocol_dns53);
+    nw_resolver_config_set_class(resolverConfig, nw_resolver_class_designated_direct);
+    nw_resolver_config_add_name_server(resolverConfig, "127.0.0.1:8053");
+    nw_resolver_config_add_match_domain(resolverConfig, "test");
+    nw_resolver_config_set_identifier(resolverConfig, agentUUIDBytes);
+    bool published = nw_resolver_config_publish(resolverConfig);
+    if (!published) {
+        NSLog(@"Failed to register DNS resolver agent UUID: %@. Using local DNS resolver failed.", agentUUID.get());
+        return;
+    }
+
+    // The following NetworkExtension policy is needed so we can run tests while a VPN is connected
+    RetainPtr policySession = adoptNS([[NEPolicySession alloc] init]);
+    RetainPtr domainPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:@"test"] ]]);
+    [policySession.get() addPolicy:domainPolicy.get()];
+
+    NSString *agentString = agentUUID.get().UUIDString;
+    RetainPtr agentPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:agentString] ]]);
+    [policySession.get() addPolicy:agentPolicy.get()];
+
+    policySession.get().priority = NEPolicySessionPriorityHigh;
+    [policySession.get() apply];
+}
+#endif
 
 #if ENABLE(IMAGE_ANALYSIS)
 


### PR DESCRIPTION
#### 25f472a6b8b0ef4c14e12d1417995654720ef317
<pre>
Rebaseline

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/url/multi-global-origin-serialization.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/historical.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/historical.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/historical.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-no-referrer-when-downgrade.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-origin-when-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-same-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-strict-origin-when-cross-origin.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-strict-origin.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/beacon/headers/header-referrer-unsafe-url.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-beacon-redirect-to-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-allowed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-match-allowed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-none-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-self-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-star-allow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-url-allow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-same-url-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-self-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-star-allow-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-url-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-same-document-meta.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-same-document.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/worklet-audio-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/worklet-audio-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/worklet-audio-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/worklet-audio-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/script-tag.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/worklet-audio-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/script-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/worklet-audio-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/worklet-audio.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/directive-name-case-insensitive.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/generic-0_10.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/generic-0_8.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src/style-src-injected-stylesheet-allowed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/animation/offset-path-interpolation-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-header-policy-allowed-for-some.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/feature-policy/feature-policy-header-policy-declined.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/mode-no-cors.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/mode-no-cors.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/mode-same-origin.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/mode-same-origin.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-url.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/response-url.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/scheme-blob.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/scheme-blob.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/scheme-others.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/scheme-others.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/scheme-others.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/basic/scheme-others.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-cookies.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-multiple-origins.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-multiple-origins.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-multiple-origins.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/cors/cors-multiple-origins.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-init-001.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/fetch.https.sub.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.https.sub.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/css-font-face.sub.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/element-script.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/fetch-via-serviceworker.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/fetch.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-dynamic.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-static.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constructor.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-importscripts.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/metadata/portal.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/orb/tentative/script-unlabeled.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/security/dangling-markup-mitigation-data-url.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/hr-time/timeOrigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/child-navigates-parent-cross-origin.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-without-user-activation.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-failure.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-multi-globals.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-same-origin-domain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/multiple-globals/context-for-location-assign-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-assign-user-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-mouseup-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-nav-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_pushstate_url_rewriting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/allow_prototype_cycle_through_location.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-prototype-setting-same-origin-domain.sub-expected.txt:
</pre>
----------------------------------------------------------------------
#### a3a2dd4062f14b8d7a0e949b24d1d4402b14db33
<pre>
Add support for running a local DNS resolver for WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=261038">https://bugs.webkit.org/show_bug.cgi?id=261038</a>
<a href="https://rdar.apple.com/82927182">rdar://82927182</a>

Reviewed by NOBODY (OOPS!).

Some ports don&apos;t have support for resolving arbitrary domains, but Web Platform
Tests rely on this capability. Currently, we only use localhost and 127.0.0.1
as a workaround where it&apos;s necessary, but this affects our test coverage. This
patch adds a very basic DNS resolver and introduces a new command-line argument
for run-webkit-tests that enables and uses this resolver on Apple ports.

In 254273@main, glib ports gained support for resolving arbitrary domains, and
this moves Apple ports closer to supporting that.

Previous attempts were made in <a href="https://bugs.webkit.org/show_bug.cgi?id=245294">https://bugs.webkit.org/show_bug.cgi?id=245294</a>,
and 264076@main introduced part of that behavior for a different reason. In
some situations, name resolutions falls back on that SPI, as well.

The basic DNS resolver only resolves A records for names ending with
&quot;localhost&quot; and for the host names defines by the port&apos;s localhost_aliases.
The server always returns 127.0.0.1 as the answer for those hosts. All other
queries return NXDomain. This resolver depends on the dnslib python library.

On Apple ports, the iOS simulator and Mac use different implementations. The
iOS simulator part is in the Network process because we need to define the
resolver in-process otherwise it won&apos;t be used. The way the resolver is
configured on Mac isn&apos;t supported on the simulator. On Mac, we use SPI and a
Network Extensions policy so this works when a VPN is enabled. We do this in
WebKitTestRunner so we don&apos;t need to add additional entitlements and weaken the
sandbox for the network process.

* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):
* Tools/Scripts/webkitpy/__init__.py:
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
* Tools/Scripts/webkitpy/layout_tests/servers/basic_dns_server.py: Added.
(Resolver):
(Resolver.__init__):
(Resolver.resolve):
* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py:
(WebPlatformTestServer.__init__):
(WebPlatformTestServer._spawn_process):
(WebPlatformTestServer._stop_running_server):
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.cmd_line):
* Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements:
* Tools/WebKitTestRunner/Options.cpp:
(WTR::handleOptionLocalDNSResolver):
(WTR::OptionsHandler::OptionsHandler):
* Tools/WebKitTestRunner/Options.h:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaPlatformInitialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b875fd80398331397ad9cde84160aeb34b758c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70164 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5368ce8b-3bc2-4b61-ad4e-f0e5ba19f0c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46385 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89639 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59269 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c37e8c12-090b-4617-a85f-381137ba6e1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70132 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c54496be-b791-4056-bbd2-60c5d3da2b20) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/117485 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29729 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/24331 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67947 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100086 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24520 "233 new passes 11 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127357 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98317 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98103 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43499 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21769 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41473 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50574 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44360 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46049 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->