### PR TITLE
Some code incorrectly compares Document objects using CSSParserContext's comparison operator

### DIFF
--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -109,46 +109,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 {
 }
 
-bool operator==(const CSSParserContext& a, const CSSParserContext& b)
-{
-    return a.baseURL == b.baseURL
-        && a.charset == b.charset
-        && a.mode == b.mode
-        && a.enclosingRuleType == b.enclosingRuleType
-        && a.isHTMLDocument == b.isHTMLDocument
-        && a.hasDocumentSecurityOrigin == b.hasDocumentSecurityOrigin
-        && a.isContentOpaque == b.isContentOpaque
-        && a.useSystemAppearance == b.useSystemAppearance
-        && a.shouldIgnoreImportRules == b.shouldIgnoreImportRules
-        && a.colorContrastEnabled == b.colorContrastEnabled
-        && a.colorMixEnabled == b.colorMixEnabled
-        && a.constantPropertiesEnabled == b.constantPropertiesEnabled
-        && a.counterStyleAtRuleImageSymbolsEnabled == b.counterStyleAtRuleImageSymbolsEnabled
-        && a.cssColor4 == b.cssColor4
-        && a.relativeColorSyntaxEnabled == b.relativeColorSyntaxEnabled
-        && a.springTimingFunctionEnabled == b.springTimingFunctionEnabled
-#if ENABLE(CSS_TRANSFORM_STYLE_OPTIMIZED_3D)
-        && a.transformStyleOptimized3DEnabled == b.transformStyleOptimized3DEnabled
-#endif
-        && a.useLegacyBackgroundSizeShorthandBehavior == b.useLegacyBackgroundSizeShorthandBehavior
-        && a.focusVisibleEnabled == b.focusVisibleEnabled
-        && a.hasPseudoClassEnabled == b.hasPseudoClassEnabled
-        && a.cascadeLayersEnabled == b.cascadeLayersEnabled
-        && a.overflowClipEnabled == b.overflowClipEnabled
-        && a.gradientPremultipliedAlphaInterpolationEnabled == b.gradientPremultipliedAlphaInterpolationEnabled
-        && a.gradientInterpolationColorSpacesEnabled == b.gradientInterpolationColorSpacesEnabled
-        && a.subgridEnabled == b.subgridEnabled
-        && a.masonryEnabled == b.masonryEnabled
-        && a.cssNestingEnabled == b.cssNestingEnabled
-        && a.cssPaintingAPIEnabled == b.cssPaintingAPIEnabled
-        && a.cssTextUnderlinePositionLeftRightEnabled == b.cssTextUnderlinePositionLeftRightEnabled
-        && a.cssTextWrapNewValuesEnabled == b.cssTextWrapNewValuesEnabled
-        && a.cssWordBreakAutoEnabled == b.cssWordBreakAutoEnabled
-        && a.sidewaysWritingModesEnabled == b.sidewaysWritingModesEnabled
-        && a.propertySettings == b.propertySettings
-    ;
-}
-
 void add(Hasher& hasher, const CSSParserContext& context)
 {
     uint64_t bits = context.isHTMLDocument                  << 0

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -104,9 +104,9 @@ struct CSSParserContext {
     CSSParserContext(CSSParserMode, const URL& baseURL = URL());
     WEBCORE_EXPORT CSSParserContext(const Document&, const URL& baseURL = URL(), const String& charset = emptyString());
     ResolvedURL completeURL(const String&) const;
-};
 
-bool operator==(const CSSParserContext&, const CSSParserContext&);
+    bool operator==(const CSSParserContext&) const = default;
+};
 
 void add(Hasher&, const CSSParserContext&);
 

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -342,7 +342,7 @@ static void maybeCopyNodeAttributesToFragment(const Node& node, DocumentFragment
 
 void Editor::replaceNodeFromPasteboard(Node& node, const String& pasteboardName, EditAction action)
 {
-    if (node.document() != m_document)
+    if (&node.document() != &m_document)
         return;
 
     auto range = makeRangeSelectingNode(node);

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1249,7 +1249,7 @@ static ExceptionOr<bool> checkPopoverValidity(HTMLElement& element, PopoverVisib
     if (!element.isConnected())
         return Exception { InvalidStateError, "Element is not connected"_s };
 
-    if (expectedDocument && element.document() != *expectedDocument)
+    if (expectedDocument && &element.document() != expectedDocument)
         return Exception { InvalidStateError, "Invalid when the document changes while showing or hiding a popover element"_s };
 
     if (is<HTMLDialogElement>(element) && downcast<HTMLDialogElement>(element).isModal())

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -894,7 +894,7 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
         m_client->enqueueSecurityPolicyViolationEvent(WTFMove(violationEventInit));
     else {
         auto& document = downcast<Document>(*m_scriptExecutionContext);
-        if (element && element->document() == document)
+        if (element && &element->document() == &document)
             element->enqueueSecurityPolicyViolationEvent(WTFMove(violationEventInit));
         else
             document.enqueueSecurityPolicyViolationEvent(WTFMove(violationEventInit));


### PR DESCRIPTION
#### 1dc257f3194c1771300e2b81f8edce1f41cd7e62
<pre>
Some code incorrectly compares Document objects using CSSParserContext&apos;s comparison operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=261044">https://bugs.webkit.org/show_bug.cgi?id=261044</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Use a named operator==() in CSSParserContext to avoid so that can no longer
happen and fix code doing bad comparisons.

* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::operator==): Deleted.
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::replaceNodeFromPasteboard):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::checkPopoverValidity):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportViolation const):

Canonical link: <a href="https://commits.webkit.org/267577@main">https://commits.webkit.org/267577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a3a5cd432293057de621b30f91ffaf9afbc41dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17512 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19647 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15470 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16236 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15394 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->