### PR TITLE
REGRESSION(266896@main): html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html is flaky

### DIFF
--- a/Source/WebCore/platform/ThreadTimers.cpp
+++ b/Source/WebCore/platform/ThreadTimers.cpp
@@ -102,8 +102,8 @@ void ThreadTimers::sharedTimerFiredInternal()
     m_firingTimers = true;
     m_pendingSharedTimerFireTime = MonotonicTime { };
 
-    MonotonicTime fireTime = MonotonicTime::now();
-    MonotonicTime timeToQuit = fireTime + maxDurationOfFiringTimers;
+    auto fireTime = MonotonicTime::now();
+    auto timeToQuit = ApproximateTime::now() + maxDurationOfFiringTimers;
 
     while (!m_timerHeap.isEmpty()) {
         Ref<ThreadTimerHeapItem> item = *m_timerHeap.first();
@@ -124,7 +124,7 @@ void ThreadTimers::sharedTimerFiredInternal()
         item->timer().fired();
 
         // Catch the case where the timer asked timers to fire in a nested event loop, or we are over time limit.
-        if (!m_firingTimers || timeToQuit < MonotonicTime::now())
+        if (!m_firingTimers || timeToQuit < ApproximateTime::now())
             break;
 
         if (m_shouldBreakFireLoopForRenderingUpdate)


### PR DESCRIPTION
#### 636ff0602d4c8b7ad8cea04bc604078647569f25
<pre>
REGRESSION(266896@main): html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=260929">https://bugs.webkit.org/show_bug.cgi?id=260929</a>
&lt;rdar://problem/114728332&gt;

Reviewed by Simon Fraser.

The flakiness is probably caused by the inconsistent use of MonotonicTime vs ApproximateTime in EventLoop::run
and ThreadTimers::sharedTimerFiredInternal. Always use ApproximateTime so that these two checks become consistent.

* Source/WebCore/platform/ThreadTimers.cpp:
(WebCore::ThreadTimers::sharedTimerFiredInternal):

Canonical link: <a href="https://commits.webkit.org/267570@main">https://commits.webkit.org/267570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe913ef0dba2ce1e159ca0b035c7ee9fb935e94e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17483 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19618 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15439 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22153 "4 flakes 117 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16208 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19730 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2096 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->