### PR TITLE
[PlayStation] Hook in rendering to GPU Process

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -94,6 +94,10 @@ if (ENABLE_GAMEPAD)
     )
 endif ()
 
+if (ENABLE_WEBGL)
+    list(APPEND WebCore_SOURCES platform/graphics/angle/PlatformDisplayANGLE.cpp)
+endif ()
+
 # Find the extras needed to copy for EGL besides the libraries
 set(EGL_EXTRAS)
 foreach (EGL_EXTRA_NAME ${EGL_EXTRA_NAMES})

--- a/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
+++ b/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "GPUProcessMain.h"
 
-#include <EnvVarUtils.h>
 #include <dlfcn.h>
 #include <process-initialization/nk-gpuprocess.h>
 #include <stdio.h>
@@ -44,14 +43,25 @@ static void loadLibraryOrExit(const char* name)
 int main(int argc, char** argv)
 {
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
+    loadLibraryOrExit(ICU_LOAD_AT);
+    loadLibraryOrExit(PNG_LOAD_AT);
+#if defined(Brotli_LOAD_AT)
+    loadLibraryOrExit(Brotli_LOAD_AT);
+#endif
+    loadLibraryOrExit(Freetype_LOAD_AT);
+    loadLibraryOrExit(Fontconfig_LOAD_AT);
+    loadLibraryOrExit(HarfBuzz_LOAD_AT);
 #if USE(CAIRO) && defined(Cairo_LOAD_AT)
     loadLibraryOrExit(Cairo_LOAD_AT);
 #endif
+#if defined(WPE_LOAD_AT)
+    loadLibraryOrExit(WPE_LOAD_AT);
+#endif
+
     loadLibraryOrExit("libWebKit");
     // load backend libraries as needed here
 
     char* coreProcessIdentifier = argv[1];
-    WebKit::parseAndSetEnvVars(argv[2]);
 
     char connectionIdentifier[16];
     snprintf(connectionIdentifier, sizeof(connectionIdentifier), "%d", PlayStation::getConnectionIdentifier());

--- a/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
+++ b/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
@@ -30,10 +30,18 @@
 
 #include "GPUProcessCreationParameters.h"
 
+#if USE(WPE_RENDERER)
+#include <WebCore/PlatformDisplayLibWPE.h>
+#endif
+
 namespace WebKit {
 
 void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters&)
 {
+#if USE(WPE_RENDERER)
+    RELEASE_ASSERT(is<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()));
+    downcast<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()).initialize(0);
+#endif
 }
 
 void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameters&)

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -47,6 +47,13 @@ PageClientImpl::PageClientImpl(PlayStationWebView& view)
 {
 }
 
+#if USE(GRAPHICS_LAYER_WC) && USE(WPE_RENDERER)
+uint64_t PageClientImpl::viewWidget()
+{
+    return 0;
+}
+#endif
+
 // PageClient's pure virtual functions
 std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& webProcessProxy)
 {

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -44,6 +44,10 @@ class PageClientImpl final : public PageClient
 public:
     PageClientImpl(PlayStationWebView&);
 
+#if USE(GRAPHICS_LAYER_WC)
+    uint64_t viewWidget();
+#endif
+
 private:
     // Create a new drawing area proxy for the given page.
     std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;

--- a/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
+++ b/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
@@ -32,6 +32,10 @@
 #include <WebCore/SearchPopupMenu.h>
 #include <WebCore/UserAgent.h>
 
+#if USE(GRAPHICS_LAYER_WC)
+#include "PageClientImpl.h"
+#endif
+
 namespace WebKit {
 
 void WebPageProxy::platformInitialize()
@@ -68,5 +72,12 @@ void WebPageProxy::loadRecentSearches(const String&, CompletionHandler<void(Vect
 void WebPageProxy::didUpdateEditorState(const EditorState&, const EditorState&)
 {
 }
+
+#if USE(GRAPHICS_LAYER_WC)
+uint64_t WebPageProxy::viewWidget()
+{
+    return static_cast<PageClientImpl&>(pageClient()).viewWidget();
+}
+#endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### cd68edac9b94617cdb1a1c59ed67b2955b7fef8a
<pre>
[PlayStation] Hook in rendering to GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=261055">https://bugs.webkit.org/show_bug.cgi?id=261055</a>

Reviewed by Fujii Hironori.

Add in the plumbing to render the scene in the GPU Process.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp:
(main):
* Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
(WebKit::PageClientImpl::viewWidget):
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp:
(WebKit::WebPageProxy::viewWidget):

Canonical link: <a href="https://commits.webkit.org/278220@main">https://commits.webkit.org/278220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a95c0d3b1a20dcc48353d6ae4873b81e6a96913

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/139 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51992 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/26754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8264 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54718 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26245 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/43119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/27107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7192 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->