### PR TITLE
Ignore leading '+' and trailing '.' in input[type=number]

### DIFF
--- a/LayoutTests/fast/forms/number/number-validity-badinput-expected.txt
+++ b/LayoutTests/fast/forms/number/number-validity-badinput-expected.txt
@@ -28,6 +28,21 @@ The element losts a renderer. The element state should not be changed.
 PASS number.style.display = "none"; number.validity.badInput is true
 A bad input should be cleared by value="".
 PASS number.value = ""; document.execCommand("SelectAll"); document.getSelection().toString() is ""
+' ' is not a badInput.
+PASS number.validity.badInput is false
+PASS number.value is ""
+' +' is a badInput.
+PASS number.validity.badInput is true
+PASS number.value is ""
+' +1' is not a badInput.
+PASS number.validity.badInput is false
+PASS number.value is "1"
+' +1.' is not a badInput.
+PASS number.validity.badInput is false
+PASS number.value is "1"
+' +1. ' is not a badInput.
+PASS number.validity.badInput is false
+PASS number.value is "1"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/number/number-validity-badinput.html
+++ b/LayoutTests/fast/forms/number/number-validity-badinput.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <style>
 :invalid {
   background-color: #ff0000;
@@ -70,8 +70,29 @@ number.focus();
 debug('A bad input should be cleared by value="".');
 shouldBeEqualToString('number.value = ""; document.execCommand("SelectAll"); document.getSelection().toString()', '');
 
+number.value = '';
+debug("' ' is not a badInput.");
+document.execCommand('InsertText', false, ' ');
+shouldBeFalse('number.validity.badInput');
+shouldBeEqualToString('number.value', '');
+debug("' +' is a badInput.");
+document.execCommand('InsertText', false, '+');
+shouldBeTrue('number.validity.badInput');
+shouldBeEqualToString('number.value', '');
+debug("' +1' is not a badInput.");
+document.execCommand('InsertText', false, '1');
+shouldBeFalse('number.validity.badInput');
+shouldBeEqualToString('number.value', '1');
+debug("' +1.' is not a badInput.");
+document.execCommand('InsertText', false, '.');
+shouldBeFalse('number.validity.badInput');
+shouldBeEqualToString('number.value', '1');
+debug("' +1. ' is not a badInput.");
+document.execCommand('InsertText', false, ' ');
+shouldBeFalse('number.validity.badInput');
+shouldBeEqualToString('number.value', '1');
+
 document.getElementById('parent').innerHTML = '';
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011,2012 Google Inc. All rights reserved.
+ * Copyright (C) 2011-2016 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -307,6 +307,10 @@ String Locale::convertFromLocalizedNumber(const String& localized)
     if (!detectSignAndGetDigitRange(input, isNegative, startIndex, endIndex))
         return input;
 
+    // Ignore leading '+', but will reject '+'-only string later.
+    if (!isNegative && endIndex - startIndex >= 2 && input[startIndex] == '+')
+        ++startIndex;
+
     StringBuilder builder;
     builder.reserveCapacity(input.length());
     if (isNegative)
@@ -322,7 +326,11 @@ String Locale::convertFromLocalizedNumber(const String& localized)
         else
             builder.append(static_cast<UChar>('0' + symbolIndex));
     }
-    return builder.toString();
+    String converted = builder.toString();
+    // Ignore trailing '.', but will reject '.'-only string later.
+    if (converted.length() >= 2 && converted[converted.length() - 1] == '.')
+        converted = converted.left(converted.length() - 1);
+    return converted;
 }
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)


### PR DESCRIPTION
#### 4835336f30b5fee8fac0874b85920929f4ed4970
<pre>
Ignore leading &apos;+&apos; and trailing &apos;.&apos; in input[type=number]

<a href="https://bugs.webkit.org/show_bug.cgi?id=254077">https://bugs.webkit.org/show_bug.cgi?id=254077</a>
rdar://problem/107187010

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/040a94e06971c4272408375ea1cffe1aeae2a316">https://chromium.googlesource.com/chromium/src.git/+/040a94e06971c4272408375ea1cffe1aeae2a316</a>

This PR enables `input` number type to output value after decimal input
rather than &apos;emptyString&apos;. This doesn&apos;t affect `value` content attribute and
`value` IDL attribute.

* Source/WebCore/platform/text/PlatformLocale.cpp:
(Locale::convertFromLocalizedNumber):
* LayoutTests/fast/forms/number/number-validity-badinput.html: Add Test Case
* LayoutTests/fast/forms/number/number-validity-badinput-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/267581@main">https://commits.webkit.org/267581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7b5aedb8ea3ad49fabd3474000fd8d6a3387e7c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19636 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22167 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19946 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15301 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->