### PR TITLE
[ Monterey+ WK2 ] http/tests/inspector/network/xhr-request-type.html is a constant TEXT failure

### DIFF
--- a/LayoutTests/http/tests/inspector/network/xhr-request-type-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/xhr-request-type-expected.txt
@@ -6,12 +6,15 @@ Bug 68646 Bug 257407
 -- Running test case: Resource.Type.XHR.Same.As.Main.Resource.Url
 PASS: Resource should be XHR type.
 PASS: Resource should be a GET request.
+PASS: Resource should have main resource URL.
 PASS: Resource should have a 200 response.
 PASS: Resource should receive main resource in response.
 
 -- Running test case: Resource.Type.XHR.Another.Url
 PASS: Resource should be XHR type.
 PASS: Resource should be a GET request.
+PASS: Resource should have echo URL.
 PASS: Resource should have a 200 response.
-PASS: Resource should receive json in response.
+PASS: Resource should have a 200 response.
+PASS: Resource should receive text in response.
 

--- a/LayoutTests/http/tests/inspector/network/xhr-request-type.html
+++ b/LayoutTests/http/tests/inspector/network/xhr-request-type.html
@@ -6,7 +6,7 @@
 <script>
 function triggerXHR(path) {
     const x = new XMLHttpRequest();
-    x.open("GET", path || location.href, false);
+    x.open("GET", path || location.href, true);
     x.send();
 }
 
@@ -20,13 +20,14 @@ function test()
         suite.addTestCase({
             name, description,
             async test() {
-                const completeEvent = InspectorTest.awaitEvent("Completed");
                 InspectorTest.evaluateInPage(expression);
-                const event = await WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+                const [event] = await Promise.all([
+                    WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
+                    WI.Resource.awaitEvent(WI.Resource.Event.LoadingDidFinish),
+                ]);
                 const resource = event.data.resource;
                 InspectorTest.expectEqual(resource.type, WI.Resource.Type.XHR, "Resource should be XHR type.");
                 InspectorTest.expectEqual(resource.requestMethod, "GET", "Resource should be a GET request.");
-                await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
                 const content = await resource.requestContentFromBackend()
                 resourceHandler(resource, content);
             }
@@ -38,6 +39,7 @@ function test()
         description: "XHR with the same URL as main resource.",
         expression: "triggerXHR()",
         resourceHandler(resource, content) {
+            InspectorTest.expectEqual(resource.url, 'http://127.0.0.1:8000/inspector/network/xhr-request-type.html', "Resource should have main resource URL.");
             InspectorTest.expectEqual(resource.statusCode, 200, "Resource should have a 200 response.");
             InspectorTest.expectThat(content.body.includes("Tests that XHRs with the same url as a main resource have correct type"), "Resource should receive main resource in response.");
         }
@@ -46,10 +48,12 @@ function test()
     addTestCase({
         name: "Resource.Type.XHR.Another.Url",
         description: "XHR with the same URL as main resource.",
-        expression: "triggerXHR('/inspector/network/resources/data.json')",
+        expression: "triggerXHR('resources/echo.py?mimetype=text/plain&content=Hello!')",
         resourceHandler(resource, content) {
+            InspectorTest.expectEqual(resource.url, 'http://127.0.0.1:8000/inspector/network/resources/echo.py?mimetype=text/plain&content=Hello!', "Resource should have echo URL.");
             InspectorTest.expectEqual(resource.statusCode, 200, "Resource should have a 200 response.");
-            InspectorTest.expectEqual(content.body, `{"json": true, "value": 42}\n`, "Resource should receive json in response.");
+            InspectorTest.expectEqual(resource.mimeType, 'text/plain', "Resource should have a 200 response.");
+            InspectorTest.expectEqual(content.body, `Hello!`, "Resource should receive text in response.");
         }
     });
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1804,8 +1804,6 @@ webkit.org/b/259160 http/tests/privateClickMeasurement/attribution-conversion-th
 webkit.org/b/259160 http/tests/privateClickMeasurement/triggering-event-with-attribution-source-through-fetch-keepalive.html [ Pass Failure ]
 webkit.org/b/259160 http/tests/privateClickMeasurement/triggering-event-with-attribution-source-through-fetch-keepalive-ephemeral.html [ Pass Failure ]
 
-webkit.org/b/259374 http/tests/inspector/network/xhr-request-type.html [ Failure ]
-
 webkit.org/b/259379 http/wpt/webcodecs/videoFrame-video-element.html [ Pass Failure ]
 
 webkit.org/b/259403 [ x86_64 ] fast/canvas/webgl/texImage2D-video-flipY-false.html [ Failure ]


### PR DESCRIPTION
#### 59ea483f709d2732e0cdf15123f2da2750c653ab
<pre>
[ Monterey+ WK2 ] http/tests/inspector/network/xhr-request-type.html is a constant TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259374">https://bugs.webkit.org/show_bug.cgi?id=259374</a>

Reviewed by Fujii Hironori.

Unflake the test:
- use async XHR to ensure it comes after the main resource events
- use echo to ensure that resource mime type returned by the server is always text/plain
(previosly it could be application/octet-stream sometimes which caused base64 encoding of
the resource)

* LayoutTests/http/tests/inspector/network/xhr-request-type-expected.txt:
* LayoutTests/http/tests/inspector/network/xhr-request-type.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/267688@main">https://commits.webkit.org/267688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0513f01024b4bdfefb15e7d0ce24e3cc150c6eec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18165 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19642 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19956 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13761 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4152 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->