### PR TITLE
Compare pointers first in CSSCustomPropertyValue::equals()

### DIFF
--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -56,11 +56,13 @@ bool CSSCustomPropertyValue::equals(const CSSCustomPropertyValue& other) const
     return WTF::switchOn(m_value, [&](const std::monostate&) {
         return true;
     }, [&](const Ref<CSSVariableReferenceValue>& value) {
-        return value.get() == std::get<Ref<CSSVariableReferenceValue>>(other.m_value).get();
+        auto& otherValue = std::get<Ref<CSSVariableReferenceValue>>(other.m_value);
+        return value.ptr() == otherValue.ptr() || value.get() == otherValue.get();
     }, [&](const CSSValueID& value) {
         return value == std::get<CSSValueID>(other.m_value);
     }, [&](const Ref<CSSVariableData>& value) {
-        return value.get() == std::get<Ref<CSSVariableData>>(other.m_value).get();
+        auto& otherValue = std::get<Ref<CSSVariableData>>(other.m_value);
+        return value.ptr() == otherValue.ptr() || value.get() == otherValue.get();
     }, [&](const SyntaxValue& value) {
         return value == std::get<SyntaxValue>(other.m_value);
     }, [&](const SyntaxValueList& value) {


### PR DESCRIPTION
#### 1f4519fc48941d23c7d19b67abe97afbd9aa638e
<pre>
Compare pointers first in CSSCustomPropertyValue::equals()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261057">https://bugs.webkit.org/show_bug.cgi?id=261057</a>
rdar://114854431

Reviewed by Chris Dumez.

When CSSCustomPropertyValue holds a variant type that is a pointer, do pointer comparison first
before comparing values. This avoids calls to the expensive `CSSVariableData::operator==`, which
gives a measurable perf boost on some Speedometer 3 subtests with lots of custom properties.

* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::equals const):

Canonical link: <a href="https://commits.webkit.org/267578@main">https://commits.webkit.org/267578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86d57b7e40e3989525f0222f00aa5dc26b370473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19646 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22178 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19961 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16235 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15393 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4071 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->