### PR TITLE
[Simple text codepath] Shadow TextRun's direction within WidthIterator so we can make local changes to it

### DIFF
--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003 - 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Holger Hans Peter Freyther
  *
  * This library is free software; you can redistribute it and/or
@@ -23,6 +23,7 @@
 #define WidthIterator_h
 
 #include "GlyphBuffer.h"
+#include "TextDirection.h"
 #include <unicode/umachine.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
@@ -90,6 +91,10 @@ private:
     AdditionalWidth calculateAdditionalWidth(GlyphBuffer&, GlyphBufferStringOffset currentCharacterIndex, unsigned leadingGlyphIndex, unsigned trailingGlyphIndex, float position) const;
     void applyAdditionalWidth(GlyphBuffer&, GlyphIndexRange, float leftAdditionalWidth, float rightAdditionalWidth, float leftExpansionAdditionalWidth, float rightExpansionAdditionalWidth);
 
+    TextDirection direction() const { return m_direction; }
+    bool rtl() const { return m_direction == TextDirection::RTL; }
+    bool ltr() const { return m_direction == TextDirection::LTR; }
+
     const FontCascade& m_font;
     const TextRun& m_run;
     HashSet<const Font*>* m_fallbackFonts { nullptr };
@@ -105,6 +110,7 @@ private:
     float m_minGlyphBoundingBoxY { std::numeric_limits<float>::max() };
     float m_firstGlyphOverflow { 0 };
     float m_lastGlyphOverflow { 0 };
+    TextDirection m_direction { TextDirection::LTR };
     bool m_containsTabs { false };
     bool m_isAfterExpansion { false };
     bool m_accountForGlyphBounds { false };
@@ -113,6 +119,6 @@ private:
     bool m_forTextEmphasis { false };
 };
 
-}
+} // namespace WebCore
 
 #endif


### PR DESCRIPTION
#### 0c0e78b43702e1cc5c8d020f90bfcb200182c94b
<pre>
[Simple text codepath] Shadow TextRun&apos;s direction within WidthIterator so we can make local changes to it
<a href="https://bugs.webkit.org/show_bug.cgi?id=261058">https://bugs.webkit.org/show_bug.cgi?id=261058</a>
rdar://114857993

Reviewed by Cameron McCormack.

This patch is in preparation for a future patch, where WidthIterator
is going to need to operate on LTR runs and RTL runs at the same time.
For example, when we do line breaking, we haven&apos;t done bidi yet (which
is wrong, but that&apos;s a whole nother story), which means there are some
circumstances where we have to measure text of different
directionalities before those directionalities can be passed in to
WidthIterator as arguments.

As a temporary fix, WidthIterator can do its own directionality
discovery, similar to how the complex path does right now. This
wouldn&apos;t be a long-term fix (the long term fix is to do shaping before
we measure anything), but allowing WidthIterator to have its own
copy of the direction information makes it easy to iterate on
temporary short-term solutions.

There&apos;s no memory use concern, because there&apos;s only ever a single
WidthIterator alive at a time.

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::WidthIterator):
(WebCore::WidthIterator::applyFontTransforms):
(WebCore::WidthIterator::applyInitialAdvance):
(WebCore::WidthIterator::advanceInternal):
(WebCore::WidthIterator::calculateAdditionalWidth const):
(WebCore::WidthIterator::applyAdditionalWidth):
(WebCore::WidthIterator::applyExtraSpacingAfterShaping):
(WebCore::WidthIterator::finalize):
* Source/WebCore/platform/graphics/WidthIterator.h:
(WebCore::WidthIterator::direction const):
(WebCore::WidthIterator::rtl const):
(WebCore::WidthIterator::ltr const):

Canonical link: <a href="https://commits.webkit.org/267582@main">https://commits.webkit.org/267582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5465c932c53d7d1679759f36dbad8f0683e4190

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19665 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15493 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13780 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15408 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4074 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->