### PR TITLE
Add option to force HaveABadTime mode all the time for testing.

### DIFF
--- a/JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js
+++ b/JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $architecture == "mips"
+
 const array = [];
 for (let i = 0; i < 100; ++i)
     array.push(new Array(1e4).join('—' + i).slice(1));

--- a/JSTests/microbenchmarks/large-empty-array-join.js
+++ b/JSTests/microbenchmarks/large-empty-array-join.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $memoryLimited or $architecture == "mips"
 const array = [];
 for (let i = 0; i < 100; ++i)
     array.push(new Array(1e6).join('—' + i));

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-404.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-404.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $architecture == "mips"
+
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $architecture == "mips"
+
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-end.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-end.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $architecture == "mips"
+
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $architecture == "mips"
+
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/stress/array-slice-cow.js
+++ b/JSTests/stress/array-slice-cow.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/array-unshift-should-not-race-against-compiler-thread.js
+++ b/JSTests/stress/array-unshift-should-not-race-against-compiler-thread.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 let x = [];
 for (let i = 0; i < 30; ++i) {
     for (let j = 0; j < 20000; ++j) {

--- a/JSTests/stress/arrayprofile-should-not-convert-get-by-val-cow.js
+++ b/JSTests/stress/arrayprofile-should-not-convert-get-by-val-cow.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 function assertEq(a, b) {
     if (a !== b)
         throw new Error("values not the same: " + a + " and " + b);

--- a/JSTests/stress/dollarVM-have-a-bad-time-no-params.js
+++ b/JSTests/stress/dollarVM-have-a-bad-time-no-params.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 if ($vm.isHavingABadTime())
     throw new Error();
 $vm.haveABadTime();

--- a/JSTests/stress/dollarVM-have-a-bad-time-works-for-non-global-object-params.js
+++ b/JSTests/stress/dollarVM-have-a-bad-time-works-for-non-global-object-params.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 let OtherArray = $vm.createGlobalObject().Array;
 if ($vm.isHavingABadTime(OtherArray))
     throw new Error();

--- a/JSTests/stress/out-of-memory-handle-in-join.js
+++ b/JSTests/stress/out-of-memory-handle-in-join.js
@@ -17,5 +17,8 @@ function shouldThrow(func, errorMessage) {
 
 shouldThrow(() => {
     let x = { toString: () => ''.padEnd(2 ** 31 - 1, 10..toLocaleString()) };
-    [x].join();
+    let y = [x].join();
+    // This is to force the resolution of the rope returned by x.toString() so that we'll
+    // get the OOME even if the slowJoin path is taken.
+    y[y.length - 1];
 }, `RangeError: Out of memory`);

--- a/JSTests/stress/regress-189028.js
+++ b/JSTests/stress/regress-189028.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 function assert(x, y) {
     if (x != y) {
         $vm.print("actual: ", x);

--- a/JSTests/stress/typed-array-from-array-iterator-protocol.js
+++ b/JSTests/stress/typed-array-from-array-iterator-protocol.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown
+
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich (cwzwarich@uwaterloo.ca)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1820,6 +1820,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     }
 
     fixupPrototypeChainWithObjectPrototype(vm);
+
+    if (UNLIKELY(Options::alwaysHaveABadTime()))
+        this->haveABadTime(vm);
 }
 
 bool JSGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -365,6 +365,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, forceWeakRandomSeed, false, Normal, nullptr) \
     v(Unsigned, forcedWeakRandomSeed, 0, Normal, nullptr) \
     \
+    v(Bool, alwaysHaveABadTime, false, Normal, "debugging option to test HaveABadTime mode") \
     v(Bool, allowDoubleShape, true, Normal, "debugging option to test disabling use of DoubleShape") \
     v(Bool, useZombieMode, false, Normal, "debugging option to scribble over dead objects with 0xbadbeef0") \
     v(Bool, useImmortalObjects, false, Normal, "debugging option to keep all objects alive forever") \

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2013-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1307,6 +1307,7 @@ BASE_MODES = [
             "--useLLIntICs=false",
             "--useZombieMode=true",
             "--allowDoubleShape=false",
+            "--alwaysHaveABadTime=true",
         ]
     ],
     [


### PR DESCRIPTION
#### de6009438089855b49bfd7e2aa639e2a37224abc
<pre>
Add option to force HaveABadTime mode all the time for testing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261059">https://bugs.webkit.org/show_bug.cgi?id=261059</a>
rdar://114858622

Reviewed by Yusuke Suzuki.

Added the --alwaysHaveABadTime option, which will make is easier to test HaveABadTime mode
by enabling the option in one of the JSC stress tests configurations.

Also skipped some tests that rely on HaveABadTime mode or expected Array IndexingTypes.

Fixed out-of-memory-handle-in-join.js to always trigger a rope resolution.  The test is
relying on Array.prototype.join() to throw an OOME due to rope resolution.  However, join&apos;s
slow path does not do rope resolution in this one scenario.  So, we change the test so that
it yields the same result regardless of whether join&apos;s fast or slow path is taken.

Skipped the array-unshift-should-not-race-against-compiler-thread.js test because it runs
prohibitively slow when in HaveABadTime mode.

These tests were skipped on armv7 or mips because they were failing on those bots presumably
due to memory exhaustion or timeouts:
    JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js
    JSTests/microbenchmarks/large-empty-array-join.js
    JSTests/microbenchmarks/u16-string-index-of-1000001-404.js
    JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js
    JSTests/microbenchmarks/u16-string-index-of-1000001-end.js
    JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js

* JSTests/microbenchmarks/large-empty-array-join-resolve-rope.js:
* JSTests/microbenchmarks/large-empty-array-join.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-404.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-beg.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-end.js:
* JSTests/microbenchmarks/u16-string-index-of-1000001-mid.js:
* JSTests/stress/array-slice-cow.js:
* JSTests/stress/array-unshift-should-not-race-against-compiler-thread.js:
* JSTests/stress/arrayprofile-should-not-convert-get-by-val-cow.js:
* JSTests/stress/dollarVM-have-a-bad-time-no-params.js:
* JSTests/stress/dollarVM-have-a-bad-time-works-for-non-global-object-params.js:
* JSTests/stress/out-of-memory-handle-in-join.js:
(shouldThrow):
* JSTests/stress/regress-189028.js:
* JSTests/stress/typed-array-from-array-iterator-protocol.js:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/267584@main">https://commits.webkit.org/267584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24a2f903fd109483667d3a989bfca239d6148c33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17637 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19676 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14733 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15876 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16295 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16260 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18637 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15417 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4345 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19782 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19862 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2101 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16093 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4200 "Passed tests") | 
<!--EWS-Status-Bubble-End-->