### PR TITLE
REGRESSION(266896@main): html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html is flaky

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6666,5 +6666,3 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/im
 [ Debug ] imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html [ Pass Failure ]
 
 webkit.org/b/260823 http/tests/workers/service/self_registration.html [ Pass Failure ]
-
-webkit.org/b/260929 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html [ Pass Failure ]

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -127,6 +127,8 @@ public:
     void invalidateNextTimerFireTimeCache() { m_nextTimerFireTimeCache = std::nullopt; }
     Markable<MonotonicTime> nextTimerFireTime() const;
 
+    void runAllTasksScheduledPriorToTimer(EventLoopTimer&) { run(); }
+
 protected:
     EventLoop();
     void scheduleToRunIfNeeded();
@@ -213,7 +215,7 @@ public:
     void runAtEndOfMicrotaskCheckpoint(EventLoop::TaskFunction&&);
 
     EventLoopTimerHandle scheduleTask(Seconds timeout, TaskSource, EventLoop::TaskFunction&&);
-    void didExecuteScheduledTask(EventLoopTimer&);
+    void executeScheduledTask(EventLoopTimer&);
     void removeScheduledTimer(EventLoopTimer&);
 
     EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TaskSource, EventLoop::TaskFunction&&);


### PR DESCRIPTION
#### a1db43ee741f8bfc1ef53baa644e895f84600ad9
<pre>
REGRESSION(266896@main): html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=260929">https://bugs.webkit.org/show_bug.cgi?id=260929</a>

Reviewed by NOBODY (OOPS!).

The flakiness was caused by a 0s timer (e.g. setTimeout) executing before an EventLoop task (e.g. media playback)
when the proceeding EventLoop::run has ran out of time (i.e. reached deadline). Because WindowEventLoop&apos;s
scheduleToRunIfNeeded uses a new 0s timer to schedule itself again, any other 0s timer that had already been
scheduled at that point will execute before the remaining tasks have a chance to complete.

This PR updates EventLoopTimer::fired to execute any remaining tasks deferred in the previous call to EventLoop::run
via EventLoop::runAllTasksScheduledPriorToTimer before executing the timer&apos;s task to avoid this ordering problem.
We don&apos;t set a deadline for this run of event loop as deferring those tasks until a later time is not an option
in this scenario (as deferring timer&apos;s task would violate its ordering with respect to other timers).

* LayoutTests/TestExpectations:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTimer::fired):
(WebCore::EventLoopTaskGroup::executeScheduledTask):
* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoop::runAllTasksScheduledPriorToTimer): Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1db43ee741f8bfc1ef53baa644e895f84600ad9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18850 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17531 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18180 "10 flakes 169 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17267 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17630 "2 new passes 2 flakes 2 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14803 "4 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19666 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14869 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15494 "1 flakes 9 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22199 "5 flakes 124 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15869 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15661 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20016 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16251 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13781 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->