### PR TITLE
Add using WTF::TrailingZerosPolicy to WTFString

### DIFF
--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -478,7 +478,7 @@ JSC_DEFINE_HOST_FUNCTION(numberProtoFuncToPrecision, (JSGlobalObject* globalObje
     if (significantFigures < 1 || significantFigures > 100)
         return throwVMRangeError(globalObject, scope, "toPrecision() argument must be between 1 and 100"_s);
 
-    return JSValue::encode(jsString(vm, String::numberToStringFixedPrecision(x, significantFigures, WTF::TrailingZerosPolicy::Keep)));
+    return JSValue::encode(jsString(vm, String::numberToStringFixedPrecision(x, significantFigures, TrailingZerosPolicy::Keep)));
 }
 
 JSString* NumericStrings::addJSString(VM& vm, int i)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -573,6 +573,7 @@ inline String operator"" _str(const UChar* characters, size_t length)
 
 } // namespace WTF
 
+using WTF::TrailingZerosPolicy;
 using WTF::String;
 using WTF::charactersToDouble;
 using WTF::charactersToFloat;

--- a/Source/WebCore/accessibility/AccessibilityObjectInterface.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
@@ -1712,7 +1712,7 @@ inline AXCoreObject::AXValue AXCoreObject::value()
 
     if (isColorWell()) {
         auto color = convertColor<SRGBA<float>>(colorValue()).resolved();
-        return makeString("rgb ", String::numberToStringFixedPrecision(color.red, 6, WTF::TrailingZerosPolicy::Keep), " ", String::numberToStringFixedPrecision(color.green, 6, WTF::TrailingZerosPolicy::Keep), " ", String::numberToStringFixedPrecision(color.blue, 6, WTF::TrailingZerosPolicy::Keep), " 1");
+        return makeString("rgb ", String::numberToStringFixedPrecision(color.red, 6, TrailingZerosPolicy::Keep), " ", String::numberToStringFixedPrecision(color.green, 6, TrailingZerosPolicy::Keep), " ", String::numberToStringFixedPrecision(color.blue, 6, TrailingZerosPolicy::Keep), " 1");
     }
 
     return stringValue();

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -462,7 +462,7 @@ void ResourceUsageOverlay::platformDraw(CGContextRef context)
     CGContextClearRect(context, viewBounds);
 
     static NeverDestroyed<RetainPtr<CGColorRef>> colorForLabels = createColor(0.9, 0.9, 0.9, 1);
-    showText(context, 10, 20, colorForLabels.get().get(), makeString("        CPU: ", FormattedNumber::fixedPrecision(data.cpu.last(), 6, WTF::TrailingZerosPolicy::Keep)));
+    showText(context, 10, 20, colorForLabels.get().get(), makeString("        CPU: ", FormattedNumber::fixedPrecision(data.cpu.last(), 6, TrailingZerosPolicy::Keep)));
     showText(context, 10, 30, colorForLabels.get().get(), "  Footprint: " + formatByteNumber(memoryFootprint()));
     showText(context, 10, 40, colorForLabels.get().get(), "   External: " + formatByteNumber(data.totalExternalSize.last()));
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
@@ -145,31 +145,31 @@ TEST(WTF, StringConcatenate_Double)
 TEST(WTF, StringConcatenate_FormattedDoubleFixedPrecision)
 {
     EXPECT_STREQ("hello 17890 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0) , " world").utf8().data());
-    EXPECT_STREQ("hello 17890.0 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 6, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello 1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 3, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello 17890.000 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 8, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 17890.0 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 6, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 3, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 17890.000 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 8, TrailingZerosPolicy::Keep) , " world").utf8().data());
     EXPECT_STREQ("hello 17890 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.0, 8) , " world").utf8().data());
 
     EXPECT_STREQ("hello 17890.5 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.5) , " world").utf8().data());
-    EXPECT_STREQ("hello 1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.5, 3, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello 17890.500 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.5, 8, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.5, 3, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 17890.500 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.5, 8, TrailingZerosPolicy::Keep) , " world").utf8().data());
     EXPECT_STREQ("hello 17890.5 world", makeString("hello ", FormattedNumber::fixedPrecision(17890.5, 8) , " world").utf8().data());
 
     EXPECT_STREQ("hello -17890 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0) , " world").utf8().data());
-    EXPECT_STREQ("hello -17890.0 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 6, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello -1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 3, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello -17890.000 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 8, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello -17890.0 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 6, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello -1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 3, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello -17890.000 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 8, TrailingZerosPolicy::Keep) , " world").utf8().data());
     EXPECT_STREQ("hello -17890 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.0, 8) , " world").utf8().data());
 
     EXPECT_STREQ("hello -17890.5 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.5) , " world").utf8().data());
-    EXPECT_STREQ("hello -1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.5, 3, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello -17890.500 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.5, 8, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello -1.79e+4 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.5, 3, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello -17890.500 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.5, 8, TrailingZerosPolicy::Keep) , " world").utf8().data());
     EXPECT_STREQ("hello -17890.5 world", makeString("hello ", FormattedNumber::fixedPrecision(-17890.5, 8) , " world").utf8().data());
 
     EXPECT_STREQ("hello 0 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0) , " world").utf8().data());
-    EXPECT_STREQ("hello 0.00000 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 6, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello 0.00 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 3, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
-    EXPECT_STREQ("hello 0.0000000 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 8, WTF::TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 0.00000 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 6, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 0.00 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 3, TrailingZerosPolicy::Keep) , " world").utf8().data());
+    EXPECT_STREQ("hello 0.0000000 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 8, TrailingZerosPolicy::Keep) , " world").utf8().data());
     EXPECT_STREQ("hello 0 world", makeString("hello ", FormattedNumber::fixedPrecision(0.0, 8) , " world").utf8().data());
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -282,12 +282,12 @@ static String attributesOfElement(AccessibilityUIElement& element)
 
     builder.append("AXChildren: ", element.childrenCount(), '\n');
 
-    builder.append("AXPosition:  { ", FormattedNumber::fixedPrecision(element.x(), 6, WTF::TrailingZerosPolicy::Keep));
-    builder.append(", ", FormattedNumber::fixedPrecision(element.y(), 6, WTF::TrailingZerosPolicy::Keep));
+    builder.append("AXPosition:  { ", FormattedNumber::fixedPrecision(element.x(), 6, TrailingZerosPolicy::Keep));
+    builder.append(", ", FormattedNumber::fixedPrecision(element.y(), 6, TrailingZerosPolicy::Keep));
     builder.append(" }\n");
 
-    builder.append("AXSize: { ", FormattedNumber::fixedPrecision(element.width(), 6, WTF::TrailingZerosPolicy::Keep));
-    builder.append(", ", FormattedNumber::fixedPrecision(element.height(), 6, WTF::TrailingZerosPolicy::Keep));
+    builder.append("AXSize: { ", FormattedNumber::fixedPrecision(element.width(), 6, TrailingZerosPolicy::Keep));
+    builder.append(", ", FormattedNumber::fixedPrecision(element.height(), 6, TrailingZerosPolicy::Keep));
     builder.append(" }\n");
 
     String title = element.title()->string();


### PR DESCRIPTION
#### 5b24c7862343ef0a6df9bcc649b0f6a14d69e00c
<pre>
Add using WTF::TrailingZerosPolicy to WTFString
<a href="https://bugs.webkit.org/show_bug.cgi?id=261063">https://bugs.webkit.org/show_bug.cgi?id=261063</a>
rdar://114869245

Reviewed by Chris Dumez.

I incorrectly dropped this in 267447@main when converting this to an
enum.

* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/accessibility/AccessibilityObjectInterface.h:
(WebCore::AXCoreObject::value):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::ResourceUsageOverlay::platformDraw):
* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::TEST):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::attributesOfElement):

Canonical link: <a href="https://commits.webkit.org/267586@main">https://commits.webkit.org/267586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dfb7f6b28b1016bdd0878bd4f3f1a01bd8ccf75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18184 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19672 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22202 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14729 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20019 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13787 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18633 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15414 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19778 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19858 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16089 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4199 "Passed tests") | 
<!--EWS-Status-Bubble-End-->