### PR TITLE
Correct URL encoding of SVG <image> elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=svg-expected.txt
@@ -1,6 +1,6 @@
 
 PASS SVG <a>
 TIMEOUT SVG <feImage> Test timed out
-FAIL SVG <image> assert_equals: expected "%26%23229%3B" but got "%C3%A5"
+PASS SVG <image>
 PASS SVG <use>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=svg-expected.txt
@@ -1,6 +1,6 @@
 
 PASS SVG <a>
 TIMEOUT SVG <feImage> Test timed out
-FAIL SVG <image> assert_equals: expected "%E5" but got "%C3%A5"
+PASS SVG <image>
 PASS SVG <use>
 

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -72,12 +72,6 @@ void HTMLImageLoader::dispatchLoadEvent()
     element().dispatchEvent(Event::create(errorOccurred ? eventNames().errorEvent : eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-String HTMLImageLoader::sourceURI(const AtomString& attr) const
-{
-    // FIXME: trimming whitespace is probably redundant with the URL parser
-    return attr.string().trim(isASCIIWhitespace);
-}
-
 void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& metrics)
 {
     ASSERT(image());

--- a/Source/WebCore/html/HTMLImageLoader.h
+++ b/Source/WebCore/html/HTMLImageLoader.h
@@ -32,7 +32,6 @@ public:
     virtual ~HTMLImageLoader();
 
     void dispatchLoadEvent() override;
-    String sourceURI(const AtomString&) const override;
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
 };

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -174,7 +174,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 
     AtomString attr = element().imageSourceURL();
 
-    LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement, current URI is " << sourceURI(attr));
+    LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement, current URL is " << attr);
 
     // Avoid loading a URL we already failed to load.
     if (!m_failedLoadURL.isEmpty() && attr == m_failedLoadURL)
@@ -205,7 +205,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         if (m_image && attr == m_pendingURL)
             imageURL = m_image->url();
         else {
-            imageURL = document.completeURL(sourceURI(attr));
+            imageURL = document.completeURL(attr);
             m_pendingURL = attr;
         }
         ResourceRequest resourceRequest(imageURL);

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -94,7 +94,6 @@ private:
     void resetLazyImageLoading(Document&);
 
     virtual void dispatchLoadEvent() = 0;
-    virtual String sourceURI(const AtomString&) const = 0;
 
     void updatedHasPendingEvent();
     void didUpdateCachedImage(RelevantMutation, CachedResourceHandle<CachedImage>&&);

--- a/Source/WebCore/svg/SVGImageLoader.cpp
+++ b/Source/WebCore/svg/SVGImageLoader.cpp
@@ -44,12 +44,4 @@ void SVGImageLoader::dispatchLoadEvent()
         downcast<SVGImageElement>(ImageLoader::element()).sendLoadEventIfPossible();
 }
 
-String SVGImageLoader::sourceURI(const AtomString& attribute) const
-{
-    URL base = element().baseURI();
-    if (base != aboutBlankURL())
-        return URL(base, attribute).string();
-    return element().document().completeURL(attribute).string();
-}
-
 }

--- a/Source/WebCore/svg/SVGImageLoader.h
+++ b/Source/WebCore/svg/SVGImageLoader.h
@@ -32,7 +32,6 @@ public:
 
 private:
     void dispatchLoadEvent() override;
-    String sourceURI(const AtomString&) const override;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### bfad000ee7c8b2b89733b2f243d1db130940ad8e
<pre>
Correct URL encoding of SVG &lt;image&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=261065">https://bugs.webkit.org/show_bug.cgi?id=261065</a>
rdar://114873373

Reviewed by Chris Dumez.

SVGImageLoader&apos;s sourceURI and HTMLImageLoader&apos;s sourceURI did some
wildly different processing and neither was necessary given that the
return value is passed to completeURL in ImageLoader, which does the
correct thing for both HTML &lt;img&gt; and SVG &lt;image&gt;.

(Perhaps the SVGImageLoader implementation was relevant at a point
where xml:base support was imagined, but xml:base will not return.)

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=svg-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=svg-expected.txt:
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::sourceURI const): Deleted.
* Source/WebCore/html/HTMLImageLoader.h:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/svg/SVGImageLoader.cpp:
(WebCore::SVGImageLoader::sourceURI const): Deleted.
* Source/WebCore/svg/SVGImageLoader.h:

Canonical link: <a href="https://commits.webkit.org/267593@main">https://commits.webkit.org/267593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b054bedba648b04eab189d70c27ebf1d3921299

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18191 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19679 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22209 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13794 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15420 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4082 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->