### PR TITLE
Handle NaN in the Audio delay curves

### DIFF
--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010, Google Inc. All rights reserved.
+ * Copyright (C) 2010-2016 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,7 +121,12 @@ void DelayDSPKernel::processARate(const float* source, float* destination, size_
     copyToCircularBuffer(buffer, m_writeIndex, bufferLength, source, framesToProcess);
 
     for (unsigned i = 0; i < framesToProcess; ++i) {
-        double delayTime = std::clamp<double>(m_delayTimes[i], 0.0, maxDelayTime());
+        double delayTime = m_delayTimes[i];
+        if (std::isnan(delayTime))
+            delayTime = maxDelayTime();
+        else
+            delayTime = std::clamp<double>(delayTime, 0.0, maxDelayTime());
+
         double desiredDelayFrames = delayTime * sampleRate();
 
         double readPosition = m_writeIndex + bufferLength - desiredDelayFrames;


### PR DESCRIPTION
#### 138a64742ac6865e3a147dc63205f53673bdc97c
<pre>
Handle NaN in the Audio delay curves

<a href="https://bugs.webkit.org/show_bug.cgi?id=261066">https://bugs.webkit.org/show_bug.cgi?id=261066</a>

Reviewed by Chris Dumez.

Cherry-Pick: <a href="https://chromium.googlesource.com/chromium/src.git/+/f6e3d4665d9261e4fef2b5931e4c75ecb5e032bf">https://chromium.googlesource.com/chromium/src.git/+/f6e3d4665d9261e4fef2b5931e4c75ecb5e032bf</a>

This PR updates to handle &apos;NaN&apos; in &apos;delay to interpret as &apos;maxDelayTime&apos;.

* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
(DelayDSPKernel::processARate):

Canonical link: <a href="https://commits.webkit.org/267589@main">https://commits.webkit.org/267589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1ff54674b9dde46bdaf0681fb36298e1bdb0d99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18192 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19680 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22210 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20027 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15421 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->