### PR TITLE
REGRESSION(266896@main): html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html is flaky

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6666,5 +6666,3 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/im
 [ Debug ] imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html [ Pass Failure ]
 
 webkit.org/b/260823 http/tests/workers/service/self_registration.html [ Pass Failure ]
-
-webkit.org/b/260929 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html
@@ -14,14 +14,16 @@
       var e = document.createElement(tagName);
       e.src = src;
       assert_equals(e.currentSrc, '');
-      t.step_timeout(function() {
-        if (src == '') {
-          assert_equals(e.currentSrc, '');
-        } else {
-          assert_equals(e.currentSrc, e.src);
-        }
-        t.done();
-      }, 0);
+      e.addEventListener('loadstart', function () {
+        t.step_timeout(function () {
+          if (src == '') {
+            assert_equals(e.currentSrc, '');
+          } else {
+            assert_equals(e.currentSrc, e.src);
+          }
+          t.done();
+        }, 0);
+      })
     }, tagName + '.currentSrc after setting src attribute "' + src + '"');
 
     async_test(function(t) {
@@ -30,14 +32,16 @@
       s.src = src;
       e.appendChild(s);
       assert_equals(e.currentSrc, '');
-      t.step_timeout(function() {
-        if (src == '') {
-          assert_equals(e.currentSrc, '');
-        } else {
-          assert_equals(e.currentSrc, s.src);
-        }
-        t.done();
-      }, 0);
+      e.addEventListener('loadstart', function() {
+        t.step_timeout(function () {
+          if (src == '') {
+            assert_equals(e.currentSrc, '');
+          } else {
+            assert_equals(e.currentSrc, s.src);
+          }
+          t.done();
+        }, 0);
+      });
     }, tagName + '.currentSrc after adding source element with src attribute "' + src + '"');
   });
 });


### PR DESCRIPTION
#### 68e39d4247937c0adf6f60ae15d2124254b5126d
<pre>
REGRESSION(266896@main): html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=260929">https://bugs.webkit.org/show_bug.cgi?id=260929</a>

Reviewed by Alan Baradlay.

The flakiness was caused by the 0s timer sometimes firing before the media task had a chance to run til completion.
To avoid this non-determinism, wait for loadstart event before scheduling the 0s timer.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html:

Canonical link: <a href="https://commits.webkit.org/267591@main">https://commits.webkit.org/267591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aef7e60368cd637aa0951020236e3fd75d6bc6c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15984 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19686 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15517 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20033 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13801 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15357 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19792 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2102 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->