### PR TITLE
Check for NaN when creating a DelayNode for WebAudio

### DIFF
--- a/LayoutTests/webaudio/delaynode-maxdelaylimit-expected.txt
+++ b/LayoutTests/webaudio/delaynode-maxdelaylimit-expected.txt
@@ -5,6 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS context.createDelay(180) threw exception NotSupportedError: maxDelayTime should be less than 180.
 PASS context.createDelay(0) threw exception NotSupportedError: maxDelayTime should be a positive value.
 PASS context.createDelay(-1) threw exception NotSupportedError: maxDelayTime should be a positive value.
+PASS context.createDelay(NaN) threw exception TypeError: The provided value is non-finite.
 PASS delay.delayTime.value === 0.5 is true
 PASS Test signal was correctly delayed by 0.5 sec.
 PASS successfullyParsed is true

--- a/LayoutTests/webaudio/delaynode-maxdelaylimit.html
+++ b/LayoutTests/webaudio/delaynode-maxdelaylimit.html
@@ -29,6 +29,7 @@ function runTest() {
     shouldThrow("context.createDelay(180)");
     shouldThrow("context.createDelay(0)");
     shouldThrow("context.createDelay(-1)");
+    shouldThrow("context.createDelay(NaN)");
 
     var delay = context.createDelay(179);
     delay.delayTime.value = delayTimeSeconds;

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -72,8 +72,8 @@ DelayDSPKernel::DelayDSPKernel(DelayProcessor* processor)
         return;
 
     m_maxDelayTime = processor->maxDelayTime();
-    ASSERT(m_maxDelayTime >= 0);
-    if (m_maxDelayTime < 0)
+    ASSERT(m_maxDelayTime >= 0 && !std::isnan(m_maxDelayTime));
+    if (m_maxDelayTime < 0 || std::isnan(m_maxDelayTime))
         return;
 
     m_buffer.resize(bufferLengthForDelay(m_maxDelayTime, processor->sampleRate()));

--- a/Source/WebCore/Modules/webaudio/DelayNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010, Google Inc. All rights reserved.
+ * Copyright (C) 2010-2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,7 +52,7 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
     if (options.maxDelayTime <= 0)
         return Exception { NotSupportedError, "maxDelayTime should be a positive value"_s };
 
-    if (options.maxDelayTime >= maximumAllowedDelayTime)
+    if (options.maxDelayTime >= maximumAllowedDelayTime || std::isnan(options.maxDelayTime))
         return Exception { NotSupportedError, makeString("maxDelayTime should be less than ", maximumAllowedDelayTime) };
 
     auto delayNode = adoptRef(*new DelayNode(context, options.maxDelayTime));


### PR DESCRIPTION
#### 5736f9dd89eab88f61ab2755cc11ea8bdcd08af3
<pre>
Check for NaN when creating a DelayNode for WebAudio

<a href="https://bugs.webkit.org/show_bug.cgi?id=261067">https://bugs.webkit.org/show_bug.cgi?id=261067</a>

Reviewed by Chris Dumez.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/c8c4a710be6292a220177fef0c3f1c7c7853d062">https://chromium.googlesource.com/chromium/src.git/+/c8c4a710be6292a220177fef0c3f1c7c7853d062</a>

In createDelay(), throw an exception if the specified delay is NaN.
Check a few other places for NaN where we are creating a buffer based
on that value.

Update a layout test to check that createDelay(NaN) throws an
exception.

* Source/WebCore/Modules/webaudio/DelayNode.cpp:
(DelayNode::create):
* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
(DelayDSPKernel::DelayDSPKernel):
* LayoutTests/webaudio/delaynode-maxdelaylimit.html: Rebaselined
* LayoutTests/webaudio/delaynode-maxdelaylimit-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/267650@main">https://commits.webkit.org/267650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2d3ed6383eab3c15e5042f62e5a825550037b50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19688 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22217 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20034 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13802 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4131 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19794 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->