### PR TITLE
Don't treat an empty value attribute as null on image input types

### DIFF
--- a/LayoutTests/fast/forms/input-image-button-with-empty-value-expected.html
+++ b/LayoutTests/fast/forms/input-image-button-with-empty-value-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<p>crbug.com/625604: Don't display fallback content when value attribute is empty rather than null.</p>

--- a/LayoutTests/fast/forms/input-image-button-with-empty-value.html
+++ b/LayoutTests/fast/forms/input-image-button-with-empty-value.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>crbug.com/625604: Don't display fallback content when value attribute is empty rather than null.</p>
+<input value="" type="image" style="background-image: url('data:image/gif;base64,R0lGODdhAgACAIABAAAAAP///ywAAAAAAgACAAACA0QCBQA7'); display: block;">
+<input value="" type="image" style="display: block;">
+

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -938,7 +938,7 @@ String HTMLInputElement::altText() const
         alt = attributeWithoutSynchronization(titleAttr);
     if (alt.isNull())
         alt = attributeWithoutSynchronization(valueAttr);
-    if (alt.isEmpty())
+    if (alt.isNull())
         alt = inputElementAltText();
     return alt;
 }


### PR DESCRIPTION
#### e5ac3b8b98d2b58ab6406bd72eae9d27225746ea
<pre>
Don&apos;t treat an empty value attribute as null on image input types

<a href="https://bugs.webkit.org/show_bug.cgi?id=261072">https://bugs.webkit.org/show_bug.cgi?id=261072</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/350b1fecbdea7310b122e3e83c67929fa282d754">https://chromium.googlesource.com/chromium/src.git/+/350b1fecbdea7310b122e3e83c67929fa282d754</a>

If value=&quot;&quot; is specified on an image-type form control then use &quot;&quot; as the alt-text
for the control if one is required. This matches Firefox and Edge, also IE11.

* Source/WebCore/html/HTMLInputElement.cpp:
(HTMLInputElement::altText):
* LayoutTests/fast/forms/input-image-button-with-empty-value.html: Add Test Case
* LayoutTests/fast/forms/input-image-button-with-empty-value-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/267592@main">https://commits.webkit.org/267592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48f7c06136d0570bf8da18dc7c7d6906db5b1df0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18873 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18200 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19689 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22218 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20035 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15359 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->