### PR TITLE
[motion-path] Use border radius for coord-box

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5284,9 +5284,6 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-011.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-014.html [ ImageOnlyFailure ]
 
-# CSS motion path tests for missing <coord-box> support with border-radius.
-imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-001.html [ ImageOnlyFailure ]
-
 # CSS motion path tests <basic-shape> misc bugs.
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-001.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Motion Path test: &lt;coord-box&gt; &lt;border-box&gt;</title>
-<meta name=fuzzy content="0-20;0-200">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-450" />
 <link rel="author" title="Daniil Sakhapov" href="sakhapov@google.com">
 <link rel="match" href="offset-path-coord-box-001-ref.html">
 <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-coord-box">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-006-expected.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; circle() path with border radius on container</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  position: relative;
+  transform: translate(300px, 200px) translate(50px, -50px);
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="inner">
+    <div id="box"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-006.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; circle() path with border radius on container</title>
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-500" />
+<link rel="match" href="offset-path-shape-circle-006-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+  border-radius: 50%;
+}
+#box {
+  background-color: green;
+  position: relative;
+  offset-path: circle(100px);
+  offset-position: normal;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FloatRoundedRect.h"
 #include "RenderLayerModelObject.h"
 
 namespace WebCore {
@@ -35,7 +36,7 @@ class PathOperation;
 class RayPathOperation;
 
 struct MotionPathData {
-    FloatRect containingBlockBoundingRect;
+    FloatRoundedRect containingBlockBoundingRect;
     FloatPoint offsetFromContainingBlock;
     FloatPoint usedStartingPosition;
 };

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -148,7 +148,7 @@ public:
     const std::optional<Path> getPath(const TransformOperationData& data) const final
     {
         if (data.motionPathData())
-            return pathForReferenceRect(data.motionPathData()->containingBlockBoundingRect);
+            return pathForReferenceRect(data.motionPathData()->containingBlockBoundingRect.rect());
         return pathForReferenceRect(data.boundingBox());
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2681,7 +2681,7 @@ header: <WebCore/RenderStyleConstants.h>
 
 header: <WebCore/MotionPath.h>
 [CustomHeader] struct WebCore::MotionPathData {
-    WebCore::FloatRect containingBlockBoundingRect;
+    WebCore::FloatRoundedRect containingBlockBoundingRect;
     WebCore::FloatPoint offsetFromContainingBlock;
     WebCore::FloatPoint usedStartingPosition;
 };


### PR DESCRIPTION
#### 2f9a2a0138750b5ab4bd34fc487766a4adfb4c66
<pre>
[motion-path] Use border radius for coord-box
<a href="https://bugs.webkit.org/show_bug.cgi?id=261074">https://bugs.webkit.org/show_bug.cgi?id=261074</a>
rdar://114883507

Reviewed by Tim Nguyen.

Change containingBlockBoundingRect to FloatRoundedRect to take into account the border-radius
property.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-coord-box-001.html:
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::motionPathDataForRenderer):
(WebCore::MotionPath::lengthForRayPath):
(WebCore::MotionPath::computePathForRay):
(WebCore::MotionPath::computePathForBox):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/PathOperation.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/267613@main">https://commits.webkit.org/267613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afadbe94a3b6339f7d94d05f4d7959d0fb263364

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16086 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17655 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19792 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14974 "1 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15617 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16375 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4099 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->