### PR TITLE
Let the compiler generate more comparison operators in WebCore

### DIFF
--- a/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
+++ b/Source/WebCore/platform/graphics/ColorInterpolationMethod.h
@@ -72,46 +72,61 @@ struct ColorInterpolationMethod {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::HSL;
         using ColorType = WebCore::HSLA<float>;
         HueInterpolationMethod hueInterpolationMethod = HueInterpolationMethod::Shorter;
+
+        friend constexpr bool operator==(const HSL&, const HSL&) = default;
     };
     struct HWB {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::HWB;
         using ColorType = WebCore::HWBA<float>;
         HueInterpolationMethod hueInterpolationMethod = HueInterpolationMethod::Shorter;
+
+        friend constexpr bool operator==(const HWB&, const HWB&) = default;
     };
     struct LCH {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::LCH;
         using ColorType = WebCore::LCHA<float>;
         HueInterpolationMethod hueInterpolationMethod = HueInterpolationMethod::Shorter;
+
+        friend constexpr bool operator==(const LCH&, const LCH&) = default;
     };
     struct Lab {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::Lab;
         using ColorType = WebCore::Lab<float>;
+        friend constexpr bool operator==(const Lab&, const Lab&) = default;
     };
     struct OKLCH {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::OKLCH;
         using ColorType = WebCore::OKLCHA<float>;
         HueInterpolationMethod hueInterpolationMethod = HueInterpolationMethod::Shorter;
+        friend constexpr bool operator==(const OKLCH&, const OKLCH&) = default;
     };
     struct OKLab {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::OKLab;
         using ColorType = WebCore::OKLab<float>;
+        friend constexpr bool operator==(const OKLab&, const OKLab&) = default;
     };
     struct SRGB {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::SRGB;
         using ColorType = WebCore::ExtendedSRGBA<float>;
+        friend constexpr bool operator==(const SRGB&, const SRGB&) = default;
     };
     struct SRGBLinear {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::SRGBLinear;
         using ColorType = WebCore::ExtendedLinearSRGBA<float>;
+        friend constexpr bool operator==(const SRGBLinear&, const SRGBLinear&) = default;
     };
     struct XYZD50 {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::XYZD50;
         using ColorType = WebCore::XYZA<float, WhitePoint::D50>;
+        friend constexpr bool operator==(const XYZD50&, const XYZD50&) = default;
     };
     struct XYZD65 {
         static constexpr auto interpolationColorSpace = ColorInterpolationColorSpace::XYZD65;
         using ColorType = WebCore::XYZA<float, WhitePoint::D65>;
+        friend constexpr bool operator==(const XYZD65&, const XYZD65&) = default;
     };
+
+    friend constexpr bool operator==(const ColorInterpolationMethod&, const ColorInterpolationMethod&) = default;
 
     std::variant<HSL, HWB, LCH, Lab, OKLCH, OKLab, SRGB, SRGBLinear, XYZD50, XYZD65> colorSpace;
     AlphaPremultiplication alphaPremultiplication;
@@ -128,61 +143,6 @@ inline void add(Hasher& hasher, const ColorInterpolationMethod& colorInterpolati
             }
         }
     );
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::HSL& a, const ColorInterpolationMethod::HSL& b)
-{
-    return a.hueInterpolationMethod == b.hueInterpolationMethod;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::HWB& a, const ColorInterpolationMethod::HWB& b)
-{
-    return a.hueInterpolationMethod == b.hueInterpolationMethod;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::LCH& a, const ColorInterpolationMethod::LCH& b)
-{
-    return a.hueInterpolationMethod == b.hueInterpolationMethod;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::OKLCH& a, const ColorInterpolationMethod::OKLCH& b)
-{
-    return a.hueInterpolationMethod == b.hueInterpolationMethod;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::Lab&, const ColorInterpolationMethod::Lab&)
-{
-    return true;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::OKLab&, const ColorInterpolationMethod::OKLab&)
-{
-    return true;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::SRGB&, const ColorInterpolationMethod::SRGB&)
-{
-    return true;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::SRGBLinear&, const ColorInterpolationMethod::SRGBLinear&)
-{
-    return true;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::XYZD50&, const ColorInterpolationMethod::XYZD50&)
-{
-    return true;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod::XYZD65&, const ColorInterpolationMethod::XYZD65&)
-{
-    return true;
-}
-
-inline constexpr bool operator==(const ColorInterpolationMethod& a, const ColorInterpolationMethod& b)
-{
-    return a.alphaPremultiplication == b.alphaPremultiplication && a.colorSpace == b.colorSpace;
 }
 
 void serializationForCSS(StringBuilder&, const ColorInterpolationMethod&);

--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -50,21 +50,11 @@ public:
         return m_matrix[(row * ColumnCount) + column];
     }
 
+    friend bool operator==(const ColorMatrix&, const ColorMatrix&) = default;
+
 private:
     std::array<float, RowCount * ColumnCount> m_matrix;
 };
-
-template<size_t ColumnCount, size_t RowCount>
-constexpr bool operator==(const ColorMatrix<ColumnCount, RowCount>& a, const ColorMatrix<ColumnCount, RowCount>& b)
-{
-    for (size_t row = 0; row < RowCount; ++row) {
-        for (size_t column = 0; column < ColumnCount; ++column) {
-            if (a.at(row, column) != b.at(row, column))
-                return false;
-        }
-    }
-    return true;
-}
 
 constexpr ColorMatrix<3, 3> brightnessColorMatrix(float amount)
 {

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -44,10 +44,7 @@ public:
     {
     }
 
-    bool operator==(const DecodingOptions& other) const
-    {
-        return m_decodingMode == other.m_decodingMode && m_sizeForDrawing == other.m_sizeForDrawing;
-    }
+    friend bool operator==(const DecodingOptions&, const DecodingOptions&) = default;
 
     DecodingMode decodingMode() const { return m_decodingMode; }
     bool isAuto() const { return m_decodingMode == DecodingMode::Auto; }

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -196,6 +196,8 @@ public:
     WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
+    friend bool operator==(const FloatPoint&, const FloatPoint&) = default;
+
 private:
     float m_x { 0 };
     float m_y { 0 };
@@ -243,11 +245,6 @@ inline FloatPoint operator-(const FloatPoint& a, const FloatSize& b)
 inline FloatPoint operator-(const FloatPoint& a)
 {
     return FloatPoint(-a.x(), -a.y());
-}
-
-inline bool operator==(const FloatPoint& a, const FloatPoint& b)
-{
-    return a.x() == b.x() && a.y() == b.y();
 }
 
 inline float operator*(const FloatPoint& a, const FloatPoint& b)

--- a/Source/WebCore/platform/graphics/FloatPoint3D.h
+++ b/Source/WebCore/platform/graphics/FloatPoint3D.h
@@ -119,6 +119,8 @@ public:
     
     float distanceTo(const FloatPoint3D& a) const;
 
+    friend bool operator==(const FloatPoint3D&, const FloatPoint3D&) = default;
+
 private:
     float m_x { 0 };
     float m_y { 0 };
@@ -167,11 +169,6 @@ inline FloatPoint3D operator-(const FloatPoint3D& a, const FloatPoint3D& b)
 inline FloatPoint3D operator-(const FloatPoint3D& a, const FloatPoint& b)
 {
     return FloatPoint3D(a.x() - b.x(), a.y() - b.y(), a.z());
-}
-
-inline bool operator==(const FloatPoint3D& a, const FloatPoint3D& b)
-{
-    return a.x() == b.x() && a.y() == b.y() && a.z() == b.z();
 }
 
 inline float operator*(const FloatPoint3D& a, const FloatPoint3D& b)

--- a/Source/WebCore/platform/graphics/FloatQuad.h
+++ b/Source/WebCore/platform/graphics/FloatQuad.h
@@ -150,6 +150,8 @@ public:
     // Note that output is undefined when all points are colinear.
     bool isCounterclockwise() const;
 
+    friend bool operator==(const FloatQuad&, const FloatQuad&) = default;
+
 private:
     FloatPoint m_p1;
     FloatPoint m_p2;
@@ -167,11 +169,6 @@ inline FloatQuad& operator-=(FloatQuad& a, const FloatSize& b)
 {
     a.move(-b.width(), -b.height());
     return a;
-}
-
-inline bool operator==(const FloatQuad& a, const FloatQuad& b)
-{
-    return a.p1() == b.p1() && a.p2() == b.p2() && a.p3() == b.p3() && a.p4() == b.p4();
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatQuad&);

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -240,6 +240,8 @@ public:
     WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
+    friend bool operator==(const FloatRect&, const FloatRect&) = default;
+
 private:
     FloatPoint m_location;
     FloatSize m_size;
@@ -279,11 +281,6 @@ inline FloatRect operator+(const FloatRect& a, const FloatRect& b)
     FloatRect c = a;
     c += b;
     return c;
-}
-
-inline bool operator==(const FloatRect& a, const FloatRect& b)
-{
-    return a.location() == b.location() && a.size() == b.size();
 }
 
 inline bool areEssentiallyEqual(const FloatRect& a, const FloatRect& b)

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.h
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.h
@@ -95,6 +95,8 @@ public:
         void shrink(float topWidth, float bottomWidth, float leftWidth, float rightWidth) { expand(-topWidth, -bottomWidth, -leftWidth, -rightWidth); }
         void shrink(float size) { shrink(size, size, size, size); }
 
+        friend bool operator==(const Radii&, const Radii&) = default;
+
     private:
         FloatSize m_topLeft;
         FloatSize m_topRight;
@@ -145,20 +147,12 @@ public:
 
     bool intersectionIsRectangular(const FloatRect&) const;
 
+    friend bool operator==(const FloatRoundedRect&, const FloatRoundedRect&) = default;
+
 private:
     FloatRect m_rect;
     Radii m_radii;
 };
-
-inline bool operator==(const FloatRoundedRect::Radii& a, const FloatRoundedRect::Radii& b)
-{
-    return a.topLeft() == b.topLeft() && a.topRight() == b.topRight() && a.bottomLeft() == b.bottomLeft() && a.bottomRight() == b.bottomRight();
-}
-
-inline bool operator==(const FloatRoundedRect& a, const FloatRoundedRect& b)
-{
-    return a.rect() == b.rect() && a.radii() == b.radii();
-}
 
 inline float calcBorderRadiiConstraintScaleFor(const FloatRect& rect, const FloatRoundedRect::Radii& radii)
 {

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -156,6 +156,8 @@ public:
     WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
+    friend bool operator==(const FloatSize&, const FloatSize&) = default;
+
 private:
     float m_width { 0 };
     float m_height { 0 };
@@ -218,11 +220,6 @@ constexpr FloatSize operator/(const FloatSize& a, float b)
 constexpr FloatSize operator/(float a, const FloatSize& b)
 {
     return FloatSize(a / b.width(), a / b.height());
-}
-
-inline bool operator==(const FloatSize& a, const FloatSize& b)
-{
-    return a.width() == b.width() && a.height() == b.height();
 }
 
 inline bool areEssentiallyEqual(const FloatSize& a, const FloatSize& b)

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -57,18 +57,13 @@ struct FontPlatformDataCacheKey {
     FontDescriptionKey descriptionKey;
     FontFamilyName family;
     FontCreationContext fontCreationContext;
+
+    friend bool operator==(const FontPlatformDataCacheKey&, const FontPlatformDataCacheKey&) = default;
 };
 
 inline void add(Hasher& hasher, const FontPlatformDataCacheKey& key)
 {
     add(hasher, key.descriptionKey, key.family, key.fontCreationContext);
-}
-
-static bool operator==(const FontPlatformDataCacheKey& a, const FontPlatformDataCacheKey& b)
-{
-    return a.descriptionKey == b.descriptionKey
-        && a.family == b.family
-        && a.fontCreationContext == b.fontCreationContext;
 }
 
 struct FontPlatformDataCacheKeyHash {

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -59,14 +59,6 @@ bool operator==(const FontFamilyName& a, const FontFamilyName& b)
     return (a.string().isNull() || b.string().isNull()) ? a.string() == b.string() : FontCascadeDescription::familyNamesAreEqual(a.string(), b.string());
 }
 
-bool operator==(const FontCascadeCacheKey& a, const FontCascadeCacheKey& b)
-{
-    return a.fontDescriptionKey == b.fontDescriptionKey
-        && a.fontSelectorId == b.fontSelectorId
-        && a.fontSelectorVersion == b.fontSelectorVersion
-        && a.families == b.families;
-}
-
 FontCascadeCache& FontCascadeCache::forCurrentThread()
 {
     return FontCache::forCurrentThread().fontCascadeCache();

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -228,14 +228,14 @@ struct FontCascadeCacheKey {
     Vector<FontFamilyName, 3> families;
     unsigned fontSelectorId;
     unsigned fontSelectorVersion;
+
+    friend bool operator==(const FontCascadeCacheKey&, const FontCascadeCacheKey&) = default;
 };
 
 inline void add(Hasher& hasher, const FontCascadeCacheKey& key)
 {
     add(hasher, key.fontDescriptionKey, key.families, key.fontSelectorId, key.fontSelectorVersion);
 }
-
-bool operator==(const FontCascadeCacheKey&, const FontCascadeCacheKey&);
 
 struct FontCascadeCacheEntry {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -160,7 +160,7 @@ private:
 
 inline bool FontCascadeDescription::operator==(const FontCascadeDescription& other) const
 {
-    return FontDescription::operator==(other)
+    return static_cast<const FontDescription&>(*this) == static_cast<const FontDescription&>(other)
         && m_families.get() == other.m_families.get()
         && m_specifiedSize == other.m_specifiedSize
         && m_isAbsoluteSize == other.m_isAbsoluteSize

--- a/Source/WebCore/platform/graphics/FontCreationContext.h
+++ b/Source/WebCore/platform/graphics/FontCreationContext.h
@@ -134,7 +134,7 @@ inline void add(Hasher& hasher, const FontCreationContext& fontCreationContext)
 {
     if (fontCreationContext.fontFaceFeatures())
         add(hasher, *fontCreationContext.fontFaceFeatures());
-    add(hasher, fontCreationContext.fontFaceCapabilities().tied());
+    add(hasher, fontCreationContext.fontFaceCapabilities());
     if (fontCreationContext.fontPaletteValues())
         add(hasher, *fontCreationContext.fontPaletteValues());
     if (fontCreationContext.fontFeatureValues())

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -42,7 +42,7 @@ class FontDescription {
 public:
     WEBCORE_EXPORT FontDescription();
 
-    bool operator==(const FontDescription&) const;
+    friend bool operator==(const FontDescription&, const FontDescription&) = default;
 
     float computedSize() const { return m_computedSize; }
     // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
@@ -201,46 +201,6 @@ private:
     unsigned m_shouldAllowUserInstalledFonts : 1; // AllowUserInstalledFonts: If this description is allowed to match a user-installed font
     unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
 };
-
-inline bool FontDescription::operator==(const FontDescription& other) const
-{
-    return m_computedSize == other.m_computedSize
-        && m_fontSelectionRequest == other.m_fontSelectionRequest
-        && m_textRendering == other.m_textRendering
-        && m_orientation == other.m_orientation
-        && m_nonCJKGlyphOrientation == other.m_nonCJKGlyphOrientation
-        && m_widthVariant == other.m_widthVariant
-        && m_specifiedLocale == other.m_specifiedLocale
-        && m_featureSettings == other.m_featureSettings
-        && m_variationSettings == other.m_variationSettings
-        && m_fontSynthesisWeight == other.m_fontSynthesisWeight
-        && m_fontSynthesisStyle == other.m_fontSynthesisStyle
-        && m_fontSynthesisCaps == other.m_fontSynthesisCaps
-        && m_variantCommonLigatures == other.m_variantCommonLigatures
-        && m_variantDiscretionaryLigatures == other.m_variantDiscretionaryLigatures
-        && m_variantHistoricalLigatures == other.m_variantHistoricalLigatures
-        && m_variantContextualAlternates == other.m_variantContextualAlternates
-        && m_variantPosition == other.m_variantPosition
-        && m_variantCaps == other.m_variantCaps
-        && m_variantNumericFigure == other.m_variantNumericFigure
-        && m_variantNumericSpacing == other.m_variantNumericSpacing
-        && m_variantNumericFraction == other.m_variantNumericFraction
-        && m_variantNumericOrdinal == other.m_variantNumericOrdinal
-        && m_variantNumericSlashedZero == other.m_variantNumericSlashedZero
-        && m_variantAlternates == other.m_variantAlternates
-        && m_variantEastAsianVariant == other.m_variantEastAsianVariant
-        && m_variantEastAsianWidth == other.m_variantEastAsianWidth
-        && m_variantEastAsianRuby == other.m_variantEastAsianRuby
-        && m_variantEmoji == other.m_variantEmoji
-        && m_opticalSizing == other.m_opticalSizing
-        && m_fontStyleAxis == other.m_fontStyleAxis
-        && m_shouldAllowUserInstalledFonts == other.m_shouldAllowUserInstalledFonts
-        && m_shouldDisableLigaturesForSpacing == other.m_shouldDisableLigaturesForSpacing
-        && m_fontPalette == other.m_fontPalette
-        && m_sizeAdjust == other.m_sizeAdjust
-        && m_textSpacingTrim == other.m_textSpacingTrim
-        && m_textAutospace == other.m_textAutospace;
-}
 
 template<class Encoder>
 void FontDescription::encode(Encoder& encoder) const

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
@@ -71,6 +71,8 @@ public:
     template<class Decoder>
     static std::optional<FontSelectionValue> decode(Decoder&);
 
+    friend constexpr bool operator==(FontSelectionValue, FontSelectionValue) = default;
+
 private:
     enum class RawTag { RawTag };
     constexpr FontSelectionValue(int, RawTag);
@@ -158,11 +160,6 @@ constexpr FontSelectionValue operator/(FontSelectionValue a, FontSelectionValue 
 constexpr FontSelectionValue operator-(FontSelectionValue value)
 {
     return { -value.m_backing, FontSelectionValue::RawTag::RawTag };
-}
-
-constexpr bool operator==(FontSelectionValue a, FontSelectionValue b)
-{
-    return a.rawValue() == b.rawValue();
 }
 
 constexpr bool operator<(FontSelectionValue a, FontSelectionValue b)
@@ -306,10 +303,7 @@ struct FontSelectionRange {
     {
     }
 
-    constexpr bool operator==(const FontSelectionRange& other) const
-    {
-        return WTF::tie(minimum, maximum) == WTF::tie(other.minimum, other.maximum);
-    }
+    friend constexpr bool operator==(const FontSelectionRange&, const FontSelectionRange&) = default;
 
     constexpr bool isValid() const
     {
@@ -385,10 +379,7 @@ struct FontSelectionRequest {
     // "oblique" font style. See webkit.org/b/187774.
     std::optional<Value> slope;
 
-    std::tuple<Value, Value, std::optional<Value>> tied() const
-    {
-        return WTF::tie(weight, width, slope);
-    }
+    friend bool operator==(const FontSelectionRequest&, const FontSelectionRequest&) = default;
 };
 
 inline TextStream& operator<<(TextStream& ts, const FontSelectionValue& fontSelectionValue)
@@ -403,23 +394,15 @@ inline TextStream& operator<<(TextStream& ts, const std::optional<FontSelectionV
     return ts;
 }
 
-inline bool operator==(const FontSelectionRequest& a, const FontSelectionRequest& b)
-{
-    return a.tied() == b.tied();
-}
-
 inline void add(Hasher& hasher, const FontSelectionRequest& request)
 {
-    add(hasher, request.tied());
+    add(hasher, request.weight, request.width, request.slope);
 }
 
 struct FontSelectionCapabilities {
     using Range = FontSelectionRange;
 
-    constexpr std::tuple<Range, Range, Range> tied() const
-    {
-        return WTF::tie(weight, width, slope);
-    }
+    friend constexpr bool operator==(const FontSelectionCapabilities&, const FontSelectionCapabilities&) = default;
 
     void expand(const FontSelectionCapabilities& capabilities)
     {
@@ -433,11 +416,6 @@ struct FontSelectionCapabilities {
     Range slope { normalItalicValue() };
 };
 
-constexpr bool operator==(const FontSelectionCapabilities& a, const FontSelectionCapabilities& b)
-{
-    return a.tied() == b.tied();
-}
-
 struct FontSelectionSpecifiedCapabilities {
     using Capabilities = FontSelectionCapabilities;
     using Range = FontSelectionRange;
@@ -448,19 +426,13 @@ struct FontSelectionSpecifiedCapabilities {
         return { computeWeight(), computeWidth(), computeSlope() };
     }
 
-    constexpr std::tuple<OptionalRange&, OptionalRange&, OptionalRange&> tied()
-    {
-        return WTF::tie(weight, width, slope);
-    }
-
-    constexpr std::tuple<const OptionalRange&, const OptionalRange&, const OptionalRange&> tied() const
-    {
-        return WTF::tie(weight, width, slope);
-    }
+    friend constexpr bool operator==(const FontSelectionSpecifiedCapabilities&, const FontSelectionSpecifiedCapabilities&) = default;
 
     FontSelectionSpecifiedCapabilities& operator=(const Capabilities& other)
     {
-        tied() = other.tied();
+        weight = other.weight;
+        width = other.width;
+        slope = other.slope;
         return *this;
     }
 
@@ -490,6 +462,11 @@ struct FontSelectionSpecifiedCapabilities {
     OptionalRange slope;
 };
 
+inline void add(Hasher& hasher, const FontSelectionSpecifiedCapabilities& capabilities)
+{
+    add(hasher, capabilities.weight, capabilities.width, capabilities.slope);
+}
+
 template<class Encoder>
 void FontSelectionSpecifiedCapabilities::encode(Encoder& encoder) const
 {
@@ -517,11 +494,6 @@ std::optional<FontSelectionSpecifiedCapabilities> FontSelectionSpecifiedCapabili
         return std::nullopt;
 
     return {{ *weight, *width, *slope }};
-}
-
-constexpr bool operator==(const FontSelectionSpecifiedCapabilities& a, const FontSelectionSpecifiedCapabilities& b)
-{
-    return a.tied() == b.tied();
 }
 
 class FontSelectionAlgorithm {

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -44,11 +44,7 @@ struct FloatMarkableTraits {
 };
 
 struct FontSizeAdjust {
-    bool operator==(const FontSizeAdjust& other) const
-    {
-        return metric == other.metric && value == other.value
-            && isFromFont == other.isFromFont;
-    }
+    friend bool operator==(const FontSizeAdjust&, const FontSizeAdjust&) = default;
 
     enum class Metric : uint8_t {
         ExHeight,

--- a/Source/WebCore/platform/graphics/FontTaggedSettings.h
+++ b/Source/WebCore/platform/graphics/FontTaggedSettings.h
@@ -69,7 +69,7 @@ public:
     FontTaggedSetting() = delete;
     FontTaggedSetting(FontTag, T value);
 
-    bool operator==(const FontTaggedSetting<T>& other) const;
+    friend bool operator==(const FontTaggedSetting&, const FontTaggedSetting&) = default;
     bool operator<(const FontTaggedSetting<T>& other) const;
 
     FontTag tag() const { return m_tag; }
@@ -89,12 +89,6 @@ FontTaggedSetting<T>::FontTaggedSetting(FontTag tag, T value)
     : m_tag(tag)
     , m_value(value)
 {
-}
-
-template <typename T>
-bool FontTaggedSetting<T>::operator==(const FontTaggedSetting<T>& other) const
-{
-    return m_tag == other.m_tag && m_value == other.m_value;
 }
 
 template <typename T>
@@ -156,7 +150,7 @@ public:
     using Setting = FontTaggedSetting<T>;
 
     void insert(FontTaggedSetting<T>&&);
-    bool operator==(const FontTaggedSettings<T>& other) const { return m_list == other.m_list; }
+    friend bool operator==(const FontTaggedSettings&, const FontTaggedSettings&) = default;
 
     bool isEmpty() const { return !size(); }
     size_t size() const { return m_list.size(); }

--- a/Source/WebCore/platform/graphics/FourCC.h
+++ b/Source/WebCore/platform/graphics/FourCC.h
@@ -35,11 +35,10 @@ struct FourCC {
     constexpr FourCC(const char (&nullTerminatedString)[5]);
     constexpr std::array<char, 5> string() const;
     static std::optional<FourCC> fromString(StringView);
+    friend constexpr bool operator==(FourCC, FourCC) = default;
 
     uint32_t value { 0 };
 };
-
-constexpr bool operator==(FourCC, FourCC);
 
 constexpr FourCC::FourCC(const char (&data)[5])
     : value(data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3])
@@ -61,8 +60,6 @@ constexpr std::array<char, 5> FourCC::string() const
         '\0'
     };
 }
-
-constexpr bool operator==(FourCC a, FourCC b) { return a.value == b.value; }
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -64,26 +64,19 @@ inline bool operator==(const GraphicsDropShadow& a, const GraphicsDropShadow& b)
 struct GraphicsGaussianBlur {
     FloatSize radius;
 
+    friend bool operator==(const GraphicsGaussianBlur&, const GraphicsGaussianBlur&) = default;
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<GraphicsGaussianBlur> decode(Decoder&);
 };
 
-inline bool operator==(const GraphicsGaussianBlur& a, const GraphicsGaussianBlur& b)
-{
-    return a.radius == b.radius;
-}
-
 struct GraphicsColorMatrix {
     std::array<float, 20> values;
+
+    friend bool operator==(const GraphicsColorMatrix&, const GraphicsColorMatrix&) = default;
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<GraphicsColorMatrix> decode(Decoder&);
 };
-
-inline bool operator==(const GraphicsColorMatrix& a, const GraphicsColorMatrix& b)
-{
-    return a.values == b.values;
-}
 
 using GraphicsStyle = std::variant<
     GraphicsDropShadow,

--- a/Source/WebCore/platform/graphics/GraphicsTypes.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.h
@@ -79,12 +79,9 @@ enum class BlendMode : uint8_t {
 struct CompositeMode {
     CompositeOperator operation;
     BlendMode blendMode;
-};
 
-inline bool operator==(const CompositeMode& a, const CompositeMode& b)
-{
-    return a.operation == b.operation && a.blendMode == b.blendMode;
-}
+    friend bool operator==(const CompositeMode&, const CompositeMode&) = default;
+};
 
 enum class DocumentMarkerLineStyleMode : uint8_t {
     TextCheckingDictationPhraseWithAlternatives,

--- a/Source/WebCore/platform/graphics/ImageOrientation.h
+++ b/Source/WebCore/platform/graphics/ImageOrientation.h
@@ -75,8 +75,7 @@ struct ImageOrientation {
     }
 
     constexpr operator int() const { return static_cast<int>(m_orientation); }
-    friend constexpr bool operator==(const ImageOrientation& lhs, const ImageOrientation& rhs) { return lhs.m_orientation == rhs.m_orientation; }
-    friend constexpr bool operator==(const ImageOrientation& lhs, const Orientation& rhs) { return lhs.m_orientation == rhs; }
+    friend constexpr bool operator==(const ImageOrientation&, const ImageOrientation&) = default;
 
     constexpr Orientation orientation() const { return m_orientation; }
     

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -190,10 +190,7 @@ private:
         size_t index;
         SubsamplingLevel subsamplingLevel;
         DecodingOptions decodingOptions;
-        bool operator==(const ImageFrameRequest& other) const
-        {
-            return index == other.index && subsamplingLevel == other.subsamplingLevel && decodingOptions == other.decodingOptions;
-        }
+        friend bool operator==(const ImageFrameRequest&, const ImageFrameRequest&) = default;
     };
     using FrameRequestQueue = SynchronizedFixedQueue<ImageFrameRequest, BufferSize>;
     using FrameCommitQueue = Deque<ImageFrameRequest, BufferSize>;

--- a/Source/WebCore/platform/graphics/IntPoint.h
+++ b/Source/WebCore/platform/graphics/IntPoint.h
@@ -118,6 +118,8 @@ public:
         return IntPoint(m_y, m_x);
     }
 
+    friend bool operator==(const IntPoint&, const IntPoint&) = default;
+
 #if USE(CG)
     WEBCORE_EXPORT explicit IntPoint(const CGPoint&); // don't do this implicitly since it's lossy
     WEBCORE_EXPORT operator CGPoint() const;
@@ -176,11 +178,6 @@ inline IntPoint operator-(const IntPoint& a, const IntSize& b)
 inline IntPoint operator-(const IntPoint& point)
 {
     return IntPoint(-point.x(), -point.y());
-}
-
-inline bool operator==(const IntPoint& a, const IntPoint& b)
-{
-    return a.x() == b.x() && a.y() == b.y();
 }
 
 inline IntSize toIntSize(const IntPoint& a)

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -190,6 +190,8 @@ public:
     // Return false if x + width or y + height overflows.
     WEBCORE_EXPORT bool isValid() const;
 
+    friend bool operator==(const IntRect&, const IntRect&) = default;
+
 #if PLATFORM(WIN)
     WEBCORE_EXPORT IntRect(const RECT&);
     WEBCORE_EXPORT operator RECT() const;
@@ -225,11 +227,6 @@ inline IntRect unionRect(const IntRect& a, const IntRect& b)
     IntRect c = a;
     c.unite(b);
     return c;
-}
-
-inline bool operator==(const IntRect& a, const IntRect& b)
-{
-    return a.location() == b.location() && a.size() == b.size();
 }
 
 inline IntRect& operator-=(IntRect& r, const IntPoint& offset)

--- a/Source/WebCore/platform/graphics/IntSize.h
+++ b/Source/WebCore/platform/graphics/IntSize.h
@@ -152,6 +152,8 @@ public:
         return IntSize(m_height, m_width);
     }
 
+    friend constexpr bool operator==(const IntSize&, const IntSize&) = default;
+
 #if USE(CG)
     WEBCORE_EXPORT explicit IntSize(const CGSize&); // don't do this implicitly since it's lossy
     WEBCORE_EXPORT operator CGSize() const;
@@ -202,11 +204,6 @@ constexpr IntSize operator-(const IntSize& a, const IntSize& b)
 constexpr IntSize operator-(const IntSize& size)
 {
     return IntSize(-size.width(), -size.height());
-}
-
-constexpr bool operator==(const IntSize& a, const IntSize& b)
-{
-    return a.width() == b.width() && a.height() == b.height();
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const IntSize&);

--- a/Source/WebCore/platform/graphics/LayoutPoint.h
+++ b/Source/WebCore/platform/graphics/LayoutPoint.h
@@ -56,6 +56,8 @@ public:
     void moveBy(const LayoutPoint& offset) { move(offset.x(), offset.y()); }
     template<typename T, typename U> void move(T dx, U dy) { m_x += dx; m_y += dy; }
     
+    friend bool operator==(const LayoutPoint&, const LayoutPoint&) = default;
+
     void scale(float s)
     {
         m_x *= s;
@@ -146,11 +148,6 @@ inline LayoutPoint operator-(const LayoutPoint& a, const LayoutSize& b)
 inline LayoutPoint operator-(const LayoutPoint& point)
 {
     return LayoutPoint(-point.x(), -point.y());
-}
-
-inline bool operator==(const LayoutPoint& a, const LayoutPoint& b)
-{
-    return a.x() == b.x() && a.y() == b.y();
 }
 
 inline LayoutPoint toLayoutPoint(const LayoutSize& size)

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -204,6 +204,8 @@ public:
 
     operator FloatRect() const { return FloatRect(m_location, m_size); }
 
+    friend bool operator==(const LayoutRect&, const LayoutRect&) = default;
+
 private:
     friend struct IPC::ArgumentCoder<WebCore::LayoutRect, void>;
     void setLocationAndSizeFromEdges(LayoutUnit left, LayoutUnit top, LayoutUnit right, LayoutUnit bottom);
@@ -227,11 +229,6 @@ inline LayoutRect unionRect(const LayoutRect& a, const LayoutRect& b)
 }
 
 LayoutRect unionRect(const Vector<LayoutRect>&);
-
-inline bool operator==(const LayoutRect& a, const LayoutRect& b)
-{
-    return a.location() == b.location() && a.size() == b.size();
-}
 
 inline bool LayoutRect::isInfinite() const
 {

--- a/Source/WebCore/platform/graphics/LayoutSize.h
+++ b/Source/WebCore/platform/graphics/LayoutSize.h
@@ -144,6 +144,7 @@ public:
         return m_width.mightBeSaturated() || m_height.mightBeSaturated();
     }
 
+    friend bool operator==(const LayoutSize&, const LayoutSize&) = default;
 private:
     LayoutUnit m_width;
     LayoutUnit m_height;
@@ -176,11 +177,6 @@ inline LayoutSize operator-(const LayoutSize& a, const LayoutSize& b)
 inline LayoutSize operator-(const LayoutSize& size)
 {
     return LayoutSize(-size.width(), -size.height());
-}
-
-inline bool operator==(const LayoutSize& a, const LayoutSize& b)
-{
-    return a.width() == b.width() && a.height() == b.height();
 }
 
 inline IntSize flooredIntSize(const LayoutSize& s)

--- a/Source/WebCore/platform/graphics/MediaUsageInfo.h
+++ b/Source/WebCore/platform/graphics/MediaUsageInfo.h
@@ -67,44 +67,7 @@ struct MediaUsageInfo {
     bool isInViewport { false };
 #endif
 
-    bool operator==(const MediaUsageInfo& other) const
-    {
-        return mediaURL == other.mediaURL
-            && hasSource == other.hasSource
-            && isPlaying == other.isPlaying
-            && canShowControlsManager == other.canShowControlsManager
-            && canShowNowPlayingControls == other.canShowNowPlayingControls
-            && isSuspended == other.isSuspended
-            && isInActiveDocument == other.isInActiveDocument
-            && isFullscreen == other.isFullscreen
-            && isMuted == other.isMuted
-            && isMediaDocumentInMainFrame == other.isMediaDocumentInMainFrame
-            && isVideo == other.isVideo
-            && isAudio == other.isAudio
-            && hasAudio == other.hasAudio
-            && hasVideo == other.hasVideo
-            && hasRenderer == other.hasRenderer
-            && audioElementWithUserGesture == other.audioElementWithUserGesture
-            && userHasPlayedAudioBefore == other.userHasPlayedAudioBefore
-            && isElementRectMostlyInMainFrame == other.isElementRectMostlyInMainFrame
-            && playbackPermitted == other.playbackPermitted
-            && pageMediaPlaybackSuspended == other.pageMediaPlaybackSuspended
-            && isMediaDocumentAndNotOwnerElement == other.isMediaDocumentAndNotOwnerElement
-            && pageExplicitlyAllowsElementToAutoplayInline == other.pageExplicitlyAllowsElementToAutoplayInline
-            && requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted == other.requiresFullscreenForVideoPlaybackAndFullscreenNotPermitted
-            && isVideoAndRequiresUserGestureForVideoRateChange == other.isVideoAndRequiresUserGestureForVideoRateChange
-            && isAudioAndRequiresUserGestureForAudioRateChange == other.isAudioAndRequiresUserGestureForAudioRateChange
-            && isVideoAndRequiresUserGestureForVideoDueToLowPowerMode == other.isVideoAndRequiresUserGestureForVideoDueToLowPowerMode
-            && noUserGestureRequired == other.noUserGestureRequired
-            && requiresPlaybackAndIsNotPlaying == other.requiresPlaybackAndIsNotPlaying
-            && hasEverNotifiedAboutPlaying == other.hasEverNotifiedAboutPlaying
-            && outsideOfFullscreen == other.outsideOfFullscreen
-            && isLargeEnoughForMainContent == other.isLargeEnoughForMainContent
-#if PLATFORM(COCOA) && !HAVE(CGS_FIX_FOR_RADAR_97530095)
-            && isInViewport == other.isInViewport
-#endif
-            ;
-    }
+    friend bool operator==(const MediaUsageInfo&, const MediaUsageInfo&) = default;
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<MediaUsageInfo> decode(Decoder&);

--- a/Source/WebCore/platform/graphics/PathTraversalState.cpp
+++ b/Source/WebCore/platform/graphics/PathTraversalState.cpp
@@ -43,12 +43,7 @@ struct QuadraticBezier {
     {
     }
 
-    bool operator==(const QuadraticBezier& rhs) const
-    {
-        return start == rhs.start
-            && control == rhs.control
-            && end == rhs.end;
-    }
+    friend bool operator==(const QuadraticBezier&, const QuadraticBezier&) = default;
     
     float approximateDistance() const
     {
@@ -85,13 +80,7 @@ struct CubicBezier {
     {
     }
 
-    bool operator==(const CubicBezier& rhs) const
-    {
-        return start == rhs.start
-            && control1 == rhs.control1
-            && control2 == rhs.control2
-            && end == rhs.end;
-    }
+    friend bool operator==(const CubicBezier&, const CubicBezier&) = default;
 
     float approximateDistance() const
     {

--- a/Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h
@@ -35,15 +35,9 @@ struct PlatformAudioTrackConfiguration : PlatformTrackConfiguration {
     uint32_t sampleRate { 0 };
     uint32_t numberOfChannels { 0 };
     uint64_t bitrate { 0 };
-};
 
-inline bool operator==(const PlatformAudioTrackConfiguration& a, const PlatformAudioTrackConfiguration& b)
-{
-    return a.codec == b.codec
-        && a.sampleRate == b.sampleRate
-        && a.numberOfChannels == b.numberOfChannels
-        && a.bitrate == b.bitrate;
-}
+    friend bool operator==(const PlatformAudioTrackConfiguration&, const PlatformAudioTrackConfiguration&) = default;
+};
 
 }
 

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -360,11 +360,6 @@ String PlatformTimeRanges::toString() const
     return result.toString();
 }
 
-bool PlatformTimeRanges::operator==(const PlatformTimeRanges& other) const
-{
-    return m_ranges == other.m_ranges;
-}
-
 size_t PlatformTimeRanges::findLastRangeIndexBefore(const MediaTime& start, const MediaTime& end) const
 {
     ASSERT(start <= end);

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -123,10 +123,10 @@ public:
             return range.start >= end;
         }
 
-        inline bool operator==(const Range& other) const { return start == other.start && end == other.end; }
+        friend bool operator==(const Range&, const Range&) = default;
     };
 
-    bool operator==(const PlatformTimeRanges& other) const;
+    friend bool operator==(const PlatformTimeRanges&, const PlatformTimeRanges&) = default;
 
 private:
     friend struct IPC::ArgumentCoder<PlatformTimeRanges, void>;

--- a/Source/WebCore/platform/graphics/PlatformTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformTrackConfiguration.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 struct PlatformTrackConfiguration {
     String codec;
+    friend bool operator==(const PlatformTrackConfiguration&, const PlatformTrackConfiguration&) = default;
 };
 
 }

--- a/Source/WebCore/platform/graphics/PlatformVideoColorSpace.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoColorSpace.h
@@ -39,15 +39,8 @@ struct PlatformVideoColorSpace {
     std::optional<PlatformVideoTransferCharacteristics> transfer;
     std::optional<PlatformVideoMatrixCoefficients> matrix;
     std::optional<bool> fullRange;
+
+    friend bool operator==(const PlatformVideoColorSpace&, const PlatformVideoColorSpace&) = default;
 };
-
-inline bool operator==(const PlatformVideoColorSpace& a, const PlatformVideoColorSpace& b)
-{
-    return a.primaries == b.primaries
-        && a.transfer == b.transfer
-        && a.matrix == b.matrix
-        && a.fullRange == b.fullRange;
-}
-
 
 }

--- a/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h
@@ -38,17 +38,9 @@ struct PlatformVideoTrackConfiguration : PlatformTrackConfiguration {
     PlatformVideoColorSpace colorSpace;
     double framerate { 0 };
     uint64_t bitrate { 0 };
-};
 
-inline bool operator==(const PlatformVideoTrackConfiguration& a, const PlatformVideoTrackConfiguration& b)
-{
-    return a.codec == b.codec
-        && a.width == b.width
-        && a.height == b.height
-        && a.colorSpace == b.colorSpace
-        && a.framerate == b.framerate
-        && a.bitrate == b.bitrate;
-}
+    friend bool operator==(const PlatformVideoTrackConfiguration&, const PlatformVideoTrackConfiguration&) = default;
+};
 
 }
 

--- a/Source/WebCore/platform/graphics/Region.h
+++ b/Source/WebCore/platform/graphics/Region.h
@@ -79,6 +79,8 @@ public:
     struct Span {
         int y { 0 };
         size_t segmentIndex { 0 };
+
+        friend bool operator==(const Span&, const Span&) = default;
     };
 
     class Shape {
@@ -116,6 +118,8 @@ public:
         void dump() const;
 #endif
 
+        friend bool operator==(const Shape&, const Shape&) = default;
+
     private:
         friend struct IPC::ArgumentCoder<WebCore::Region::Shape, void>;
         WEBCORE_EXPORT Shape(Vector<int, 32>&&, Vector<Span, 16>&&);
@@ -135,8 +139,6 @@ public:
 
         Vector<int, 32> m_segments;
         Vector<Span, 16> m_spans;
-
-        friend bool operator==(const Shape&, const Shape&);
     };
 
 private:
@@ -151,8 +153,6 @@ private:
     std::unique_ptr<Shape> m_shape;
 
     friend bool operator==(const Region&, const Region&);
-    friend bool operator==(const Shape&, const Shape&);
-    friend bool operator==(const Span&, const Span&);
 };
 
 static inline Region intersect(const Region& a, const Region& b)
@@ -182,16 +182,6 @@ static inline Region translate(const Region& region, const IntSize& offset)
 inline bool operator==(const Region& a, const Region& b)
 {
     return a.m_bounds == b.m_bounds && arePointingToEqualData(a.m_shape, b.m_shape);
-}
-
-inline bool operator==(const Region::Shape& a, const Region::Shape& b)
-{
-    return a.m_spans == b.m_spans && a.m_segments == b.m_segments;
-}
-
-inline bool operator==(const Region::Span& a, const Region::Span& b)
-{
-    return a.y == b.y && a.segmentIndex == b.segmentIndex;
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Region&);

--- a/Source/WebCore/platform/graphics/RoundedRect.h
+++ b/Source/WebCore/platform/graphics/RoundedRect.h
@@ -70,6 +70,8 @@ public:
     LayoutUnit minimumRadius() const { return std::min({ m_topLeft.minDimension(), m_topRight.minDimension(), m_bottomLeft.minDimension(), m_bottomRight.minDimension() }); }
     LayoutUnit maximumRadius() const { return std::max({ m_topLeft.minDimension(), m_topRight.minDimension(), m_bottomLeft.minDimension(), m_bottomRight.minDimension() }); }
 
+    friend bool operator==(const RoundedRectRadii&, const RoundedRectRadii&) = default;
+
 private:
     LayoutSize m_topLeft;
     LayoutSize m_topRight;
@@ -115,20 +117,12 @@ public:
 
     RoundedRect transposedRect() const { return RoundedRect(m_rect.transposedRect(), m_radii.transposedRadii()); }
 
+    friend bool operator==(const RoundedRect&, const RoundedRect&) = default;
+
 private:
     LayoutRect m_rect;
     Radii m_radii;
 };
-
-inline bool operator==(const RoundedRect::Radii& a, const RoundedRect::Radii& b)
-{
-    return a.topLeft() == b.topLeft() && a.topRight() == b.topRight() && a.bottomLeft() == b.bottomLeft() && a.bottomRight() == b.bottomRight();
-}
-
-inline bool operator==(const RoundedRect& a, const RoundedRect& b)
-{
-    return a.rect() == b.rect() && a.radii() == b.radii();
-}
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RoundedRect&);
 

--- a/Source/WebCore/platform/graphics/ScreenDataOverrides.h
+++ b/Source/WebCore/platform/graphics/ScreenDataOverrides.h
@@ -31,11 +31,8 @@ struct ScreenDataOverrides {
     double width { 0 };
     double height { 0 };
     double scale { 1 };
-};
 
-inline bool operator==(const ScreenDataOverrides& a, const ScreenDataOverrides& b)
-{
-    return a.width == b.width && a.height == b.height && a.scale == b.scale;
-}
+    friend bool operator==(const ScreenDataOverrides&, const ScreenDataOverrides&) = default;
+};
 
 }

--- a/Source/WebCore/platform/graphics/SourceBrush.h
+++ b/Source/WebCore/platform/graphics/SourceBrush.h
@@ -38,9 +38,13 @@ public:
             std::variant<Ref<Gradient>, RenderingResourceIdentifier> gradient;
             AffineTransform spaceTransform;
 
+            friend bool operator==(const LogicalGradient&, const LogicalGradient&);
+
             template<typename Encoder> void encode(Encoder&) const;
             template<typename Decoder> static std::optional<LogicalGradient> decode(Decoder&);
         };
+
+        friend bool operator==(const Brush&, const Brush&);
 
         using Variant = std::variant<LogicalGradient, Ref<Pattern>>;
         Variant brush;
@@ -64,6 +68,8 @@ public:
 
     bool isInlineColor() const { return !m_brush && m_color.tryGetAsSRGBABytes(); }
     bool isVisible() const { return m_brush || m_color.isVisible(); }
+
+    friend bool operator==(const SourceBrush&, const SourceBrush&) = default;
 
 private:
     Color m_color { Color::black };
@@ -103,11 +109,6 @@ inline bool operator==(const SourceBrush::Brush& a, const SourceBrush::Brush& b)
             return false;
         }
     );
-}
-
-inline bool operator==(const SourceBrush& a, const SourceBrush& b)
-{
-    return a.color() == b.color() && a.brush() == b.brush();
 }
 
 template<class Encoder>

--- a/Source/WebCore/platform/graphics/TabSize.h
+++ b/Source/WebCore/platform/graphics/TabSize.h
@@ -60,13 +60,10 @@ struct TabSize {
 
     operator bool() const { return value(); }
 
+    friend bool operator==(const TabSize&, const TabSize&) = default;
+
     float m_value;
     bool m_isSpaces;
 };
-
-inline bool operator==(const TabSize& a, const TabSize& b)
-{
-    return (a.m_value == b.m_value) && (a.m_isSpaces == b.m_isSpaces);
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/TextBoxIterator.h
+++ b/Source/WebCore/platform/graphics/TextBoxIterator.h
@@ -45,10 +45,7 @@ public:
     UChar current() const { return (*m_textRun)[m_offset]; }
     UCharDirection direction() const { return atEnd() ? U_OTHER_NEUTRAL : u_charDirection(current()); }
 
-    bool operator==(const TextBoxIterator& other) const
-    {
-        return m_offset == other.m_offset && m_textRun == other.m_textRun;
-    }
+    friend bool operator==(const TextBoxIterator&, const TextBoxIterator&) = default;
 
 private:
     const TextRun* m_textRun { nullptr };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -185,7 +185,7 @@ public:
     struct Request {
         AtomString initType;
         Vector<RetainPtr<AVContentKeyRequest>> requests;
-        bool operator==(const Request& other) const { return initType == other.initType && requests == other.requests; }
+        friend bool operator==(const Request&, const Request&) = default;
     };
 
     bool hasRequest(AVContentKeyRequest*) const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h
@@ -64,10 +64,7 @@ private:
         MediaTime m_duration;
         String m_title;
 
-        constexpr bool operator==(const ChapterData& other) const
-        {
-            return m_startTime == other.m_startTime && m_duration == other.m_duration && m_title == other.m_title;
-        }
+        friend bool operator==(const ChapterData&, const ChapterData&) = default;
     };
 
     Vector<ChapterData> m_processedChapters;

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.h
@@ -61,16 +61,7 @@ public:
             return fontName.isHashTableDeletedValue();
         }
 
-        bool operator==(const CascadeListParameters& other) const
-        {
-            return fontName == other.fontName
-                && locale == other.locale
-                && weight == other.weight
-                && width == other.width
-                && size == other.size
-                && allowUserInstalledFonts == other.allowUserInstalledFonts
-                && italic == other.italic;
-        }
+        friend bool operator==(const CascadeListParameters&, const CascadeListParameters&) = default;
 
         struct Hash {
             static unsigned hash(const CascadeListParameters&);

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
@@ -446,18 +446,6 @@ static const GLfloat* YCbCrToRGBMatrixForRangeAndTransferFunction(PixelRange ran
     return iterator->second;
 }
 
-inline bool GraphicsContextGLCVCocoa::TextureContent::operator==(const TextureContent& other) const
-{
-    return surface == other.surface
-        && surfaceSeed == other.surfaceSeed
-        && level == other.level
-        && internalFormat == other.internalFormat
-        && format == other.format
-        && type == other.type
-        && unpackFlipY == other.unpackFlipY
-        && orientation == other.orientation;
-}
-
 std::unique_ptr<GraphicsContextGLCVCocoa> GraphicsContextGLCVCocoa::create(GraphicsContextGLCocoa& context)
 {
     std::unique_ptr<GraphicsContextGLCVCocoa> cv { new GraphicsContextGLCVCocoa(context) };

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
@@ -80,7 +80,7 @@ private:
         FlipY unpackFlipY { FlipY::No };
         ImageOrientation orientation;
 
-        bool operator==(const TextureContent&) const;
+        friend bool operator==(const TextureContent&, const TextureContent&) = default;
     };
     using TextureContentMap = HashMap<GCGLuint, TextureContent, IntHash<GCGLuint>, WTF::UnsignedWithZeroKeyHashTraits<GCGLuint>>;
     TextureContentMap m_knownContent;

--- a/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h
@@ -44,6 +44,7 @@ public:
         bool flipY { false };
         unsigned angle { 0 };
 
+        friend bool operator==(const RotationProperties&, const RotationProperties&) = default;
         bool isIdentity() const { return !flipX && !flipY && !angle; }
     };
 
@@ -75,10 +76,5 @@ private:
     RetainPtr<CVPixelBufferPoolRef> m_rotationPool;
     bool m_shouldUseIOSurface { true };
 };
-
-inline bool operator==(const ImageRotationSessionVT::RotationProperties& rotation1, const ImageRotationSessionVT::RotationProperties& rotation2)
-{
-    return rotation1.flipX == rotation2.flipX && rotation1.flipY == rotation2.flipY && rotation1.angle == rotation2.angle;
-}
 
 }

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -163,15 +163,7 @@ public:
             && WTF::areEssentiallyEqual(narrowPrecisionToFloat(m_transform[5]), narrowPrecisionToFloat(m2.m_transform[5]));
     }
 
-    bool operator==(const AffineTransform& m2) const
-    {
-        return (m_transform[0] == m2.m_transform[0]
-            && m_transform[1] == m2.m_transform[1]
-            && m_transform[2] == m2.m_transform[2]
-            && m_transform[3] == m2.m_transform[3]
-            && m_transform[4] == m2.m_transform[4]
-            && m_transform[5] == m2.m_transform[5]);
-    }
+    friend bool operator==(const AffineTransform&, const AffineTransform&) = default;
 
     // *this = *this * t (i.e., a multRight)
     AffineTransform& operator*=(const AffineTransform& t)

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -314,13 +314,7 @@ public:
         double angle;
         double m11, m12, m21, m22;
         
-        bool operator==(const Decomposed2Type& other) const
-        {
-            return scaleX == other.scaleX && scaleY == other.scaleY
-                && translateX == other.translateX && translateY == other.translateY
-                && angle == other.angle
-                && m11 == other.m11 && m12 == other.m12 && m21 == other.m21 && m22 == other.m22;
-        }
+        friend bool operator==(const Decomposed2Type&, const Decomposed2Type&) = default;
     };
 
     struct Decomposed4Type {
@@ -330,14 +324,7 @@ public:
         double translateX, translateY, translateZ;
         double perspectiveX, perspectiveY, perspectiveZ, perspectiveW;
 
-        bool operator==(const Decomposed4Type& other) const
-        {
-            return scaleX == other.scaleX && scaleY == other.scaleY && scaleZ == other.scaleZ
-                && skewXY == other.skewXY && skewXZ == other.skewXZ && skewYZ == other.skewYZ
-                && quaternion == other.quaternion
-                && translateX == other.translateX && translateY == other.translateY && translateZ == other.translateZ
-                && perspectiveX == other.perspectiveX && perspectiveY == other.perspectiveY && perspectiveZ == other.perspectiveZ && perspectiveW == other.perspectiveW;
-        }
+        friend bool operator==(const Decomposed4Type&, const Decomposed4Type&) = default;
     };
     
     bool decompose2(Decomposed2Type&) const WARN_UNUSED_RETURN;

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -73,22 +73,13 @@ struct FormDataElement {
             return { filename.isolatedCopy(), fileStart, fileLength, expectedFileModificationTime };
         }
         
-        bool operator==(const EncodedFileData& other) const
-        {
-            return filename == other.filename
-                && fileStart == other.fileStart
-                && fileLength == other.fileLength
-                && expectedFileModificationTime == other.expectedFileModificationTime;
-        }
+        friend bool operator==(const EncodedFileData&, const EncodedFileData&) = default;
     };
 
     struct EncodedBlobData {
         URL url;
 
-        bool operator==(const EncodedBlobData& other) const
-        {
-            return url == other.url;
-        }
+        friend bool operator==(const EncodedBlobData&, const EncodedBlobData&) = default;
     };
     
     bool operator==(const FormDataElement& other) const

--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -43,7 +43,7 @@ public:
         CommonHeader isolatedCopy() const & { return { key , value.isolatedCopy() }; }
         CommonHeader isolatedCopy() && { return { key , WTFMove(value).isolatedCopy() }; }
 
-        bool operator==(const CommonHeader& other) const { return key == other.key && value == other.value; }
+        friend bool operator==(const CommonHeader&, const CommonHeader&) = default;
     };
 
     struct UncommonHeader {
@@ -53,7 +53,7 @@ public:
         UncommonHeader isolatedCopy() const & { return { key.isolatedCopy() , value.isolatedCopy() }; }
         UncommonHeader isolatedCopy() && { return { WTFMove(key).isolatedCopy() , WTFMove(value).isolatedCopy() }; }
 
-        bool operator==(const UncommonHeader& other) const { return key == other.key && value == other.value; }
+        friend bool operator==(const UncommonHeader&, const UncommonHeader&) = default;
     };
 
     typedef Vector<CommonHeader, 0, CrashOnOverflow, 6> CommonHeadersVector;

--- a/Source/WebCore/platform/network/cf/CertificateInfo.h
+++ b/Source/WebCore/platform/network/cf/CertificateInfo.h
@@ -60,10 +60,7 @@ public:
         return !m_trust;
     }
 
-    bool operator==(const CertificateInfo& other) const
-    {
-        return trust() == other.trust();
-    }
+    friend bool operator==(const CertificateInfo&, const CertificateInfo&) = default;
 
     WEBCORE_EXPORT static RetainPtr<CFArrayRef> certificateChainFromSecTrust(SecTrustRef);
     WEBCORE_EXPORT static RetainPtr<SecTrustRef> secTrustFromCertificateChain(CFArrayRef);

--- a/Source/WebCore/platform/text/StringWithDirection.h
+++ b/Source/WebCore/platform/text/StringWithDirection.h
@@ -48,12 +48,9 @@ namespace WebCore {
 struct StringWithDirection {
     String string;
     TextDirection direction { TextDirection::LTR };
-};
 
-inline bool operator==(const StringWithDirection& a, const StringWithDirection& b)
-{
-    return a.string == b.string && a.direction == b.direction;
-}
+    friend bool operator==(const StringWithDirection&, const StringWithDirection&) = default;
+};
 
 inline StringWithDirection truncateFromEnd(const StringWithDirection& string, unsigned maxLength)
 {

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -87,10 +87,7 @@ struct ExpansionBehavior {
     {
     }
 
-    bool operator==(const ExpansionBehavior& other) const
-    {
-        return left == other.left && right == other.right;
-    }
+    friend bool operator==(const ExpansionBehavior&, const ExpansionBehavior&) = default;
 
     static ExpansionBehavior defaultBehavior()
     {
@@ -169,16 +166,7 @@ enum class FontVariantNumericOrdinal : bool { Normal, Yes };
 enum class FontVariantNumericSlashedZero : bool { Normal, Yes };
 
 struct FontVariantAlternatesValues {
-    bool operator==(const FontVariantAlternatesValues& other) const
-    {
-        return stylistic == other.stylistic
-            && styleset == other.styleset
-            && characterVariant == other.characterVariant
-            && swash == other.swash
-            && ornaments == other.ornaments
-            && annotation == other.annotation
-            && historicalForms == other.historicalForms;
-    }
+    friend bool operator==(const FontVariantAlternatesValues&, const FontVariantAlternatesValues&) = default;
 
     String stylistic;
     Vector<String> styleset;
@@ -213,10 +201,7 @@ class FontVariantAlternates {
     using Values = FontVariantAlternatesValues;
 
 public:
-    bool operator==(const FontVariantAlternates& other) const
-    {
-        return m_values == other.m_values;
-    }
+    friend bool operator==(const FontVariantAlternates&, const FontVariantAlternates&) = default;
 
     bool isNormal() const
     {
@@ -361,25 +346,7 @@ struct FontVariantSettings {
             && emoji == FontVariantEmoji::Normal;
     }
 
-    bool operator==(const FontVariantSettings& other) const
-    {
-        return commonLigatures == other.commonLigatures
-            && discretionaryLigatures == other.discretionaryLigatures
-            && historicalLigatures == other.historicalLigatures
-            && contextualAlternates == other.contextualAlternates
-            && position == other.position
-            && caps == other.caps
-            && numericFigure == other.numericFigure
-            && numericSpacing == other.numericSpacing
-            && numericFraction == other.numericFraction
-            && numericOrdinal == other.numericOrdinal
-            && numericSlashedZero == other.numericSlashedZero
-            && alternates == other.alternates
-            && eastAsianVariant == other.eastAsianVariant
-            && eastAsianWidth == other.eastAsianWidth
-            && eastAsianRuby == other.eastAsianRuby
-            && emoji == other.emoji;
-    }
+    friend bool operator==(const FontVariantSettings&, const FontVariantSettings&) = default;
 
     FontVariantLigatures commonLigatures;
     FontVariantLigatures discretionaryLigatures;

--- a/Source/WebCore/platform/text/TextSpacing.h
+++ b/Source/WebCore/platform/text/TextSpacing.h
@@ -30,19 +30,15 @@
 namespace WebCore {
 
 struct TextSpacingTrim {
+    enum class TrimType : bool {
+        Auto = 0,
+        SpaceAll // equivalent to None in text-spacing shorthand
+    };
 
-enum class TrimType: uint8_t {
-    Auto = 0,
-    SpaceAll // equivalent to None in text-spacing shorthand
-};
-
-bool isAuto() const { return m_trim == TrimType::Auto; }
-bool isSpaceAll() const { return m_trim == TrimType::SpaceAll; }
-bool operator==(const TextSpacingTrim& other) const
-{
-    return m_trim == other.m_trim;
-}
-TrimType m_trim { TrimType::SpaceAll };
+    bool isAuto() const { return m_trim == TrimType::Auto; }
+    bool isSpaceAll() const { return m_trim == TrimType::SpaceAll; }
+    friend bool operator==(const TextSpacingTrim&, const TextSpacingTrim&) = default;
+    TrimType m_trim { TrimType::SpaceAll };
 };
 
 inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextSpacingTrim& value)
@@ -58,18 +54,15 @@ inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextSpacingTrim& v
 }
 
 struct TextAutospace {
-enum class TextAutospaceType: uint8_t {
-    Auto = 0,
-    NoAutospace // equivalent to None in text-spacing shorthand
-};
+    enum class TextAutospaceType : bool {
+        Auto = 0,
+        NoAutospace // equivalent to None in text-spacing shorthand
+    };
 
-bool isAuto() const { return m_autoSpace == TextAutospaceType::Auto; }
-bool isNoAutospace() const { return m_autoSpace == TextAutospaceType::NoAutospace; }
-bool operator==(const TextAutospace& other) const
-{
-    return m_autoSpace == other.m_autoSpace;
-}
-TextAutospaceType m_autoSpace { TextAutospaceType::NoAutospace };
+    bool isAuto() const { return m_autoSpace == TextAutospaceType::Auto; }
+    bool isNoAutospace() const { return m_autoSpace == TextAutospaceType::NoAutospace; }
+    friend bool operator==(const TextAutospace&, const TextAutospace&) = default;
+    TextAutospaceType m_autoSpace { TextAutospaceType::NoAutospace };
 };
 
 inline WTF::TextStream& operator<<(WTF::TextStream& ts, const TextAutospace& value)

--- a/Source/WebCore/plugins/PluginData.h
+++ b/Source/WebCore/plugins/PluginData.h
@@ -53,12 +53,9 @@ struct MimeClassInfo {
     AtomString type;
     String desc;
     Vector<String> extensions;
-};
 
-inline bool operator==(const MimeClassInfo& a, const MimeClassInfo& b)
-{
-    return a.type == b.type && a.desc == b.desc && a.extensions == b.extensions;
-}
+    friend bool operator==(const MimeClassInfo&, const MimeClassInfo&) = default;
+};
 
 struct PluginInfo {
     String name;
@@ -73,16 +70,9 @@ struct PluginInfo {
 #if PLATFORM(MAC)
     String versionString;
 #endif
-};
 
-inline bool operator==(PluginInfo& a, PluginInfo& b)
-{
-    bool result = a.name == b.name && a.file == b.file && a.desc == b.desc && a.mimes == b.mimes && a.isApplicationPlugin == b.isApplicationPlugin && a.clientLoadPolicy == b.clientLoadPolicy && a.bundleIdentifier == b.bundleIdentifier;
-#if PLATFORM(MAC)
-    result = result && a.versionString == b.versionString;
-#endif
-    return result;
-}
+    friend bool operator==(const PluginInfo&, const PluginInfo&) = default;
+};
 
 struct SupportedPluginIdentifier {
     String matchingDomain;


### PR DESCRIPTION
#### f1d8394cd5374197cb332d34d5fe9e46f80a7e1c
<pre>
Let the compiler generate more comparison operators in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=261076">https://bugs.webkit.org/show_bug.cgi?id=261076</a>

Reviewed by Darin Adler.

Let the compiler generate more comparison operators in WebCore now that we
support C++20.

* Source/WebCore/platform/graphics/ColorInterpolationMethod.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::operator== const): Deleted.
* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FloatPoint3D.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FloatQuad.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FloatRoundedRect.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::operator== const):
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FontDescription::operator== const): Deleted.
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.h:
(WebCore::operator==): Deleted.
(WebCore::FontSelectionRange::operator== const): Deleted.
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::FontSizeAdjust::operator== const): Deleted.
* Source/WebCore/platform/graphics/FontTaggedSettings.h:
(WebCore::= const): Deleted.
(WebCore::FontTaggedSettings::operator== const): Deleted.
* Source/WebCore/platform/graphics/FourCC.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/GraphicsStyle.h:
* Source/WebCore/platform/graphics/GraphicsTypes.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/ImageOrientation.h:
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/platform/graphics/IntPoint.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/IntRect.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/IntSize.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/LayoutPoint.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/LayoutRect.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/LayoutSize.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/MediaUsageInfo.h:
(WebCore::MediaUsageInfo::operator== const): Deleted.
* Source/WebCore/platform/graphics/PathTraversalState.cpp:
(WebCore::QuadraticBezier::operator== const): Deleted.
(WebCore::CubicBezier::operator== const): Deleted.
* Source/WebCore/platform/graphics/PlatformAudioTrackConfiguration.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::operator== const): Deleted.
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/PlatformTrackConfiguration.h:
* Source/WebCore/platform/graphics/PlatformVideoColorSpace.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/PlatformVideoTrackConfiguration.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/Region.h:
* Source/WebCore/platform/graphics/RoundedRect.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/ScreenDataOverrides.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/SourceBrush.h:
* Source/WebCore/platform/graphics/TabSize.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/TextBoxIterator.h:
(WebCore::TextBoxIterator::operator== const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.h:
(WebCore::InbandChapterTrackPrivateAVFObjC::ChapterData::operator== const): Deleted.
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.h:
(WebCore::SystemFontDatabaseCoreText::CascadeListParameters::operator== const): Deleted.
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp:
(WebCore::GraphicsContextGLCVCocoa::TextureContent::operator== const): Deleted.
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h:
* Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/graphics/transforms/AffineTransform.h:
(WebCore::AffineTransform::operator== const): Deleted.
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
(WebCore::TransformationMatrix::Decomposed2Type::operator== const): Deleted.
(WebCore::TransformationMatrix::Decomposed4Type::operator== const): Deleted.
* Source/WebCore/platform/network/FormData.h:
(WebCore::FormDataElement::EncodedFileData::operator== const): Deleted.
(WebCore::FormDataElement::EncodedBlobData::operator== const): Deleted.
* Source/WebCore/platform/network/HTTPHeaderMap.h:
(WebCore::HTTPHeaderMap::CommonHeader::operator== const): Deleted.
(WebCore::HTTPHeaderMap::UncommonHeader::operator== const): Deleted.
* Source/WebCore/platform/network/cf/CertificateInfo.h:
(WebCore::CertificateInfo::operator== const): Deleted.
* Source/WebCore/platform/text/StringWithDirection.h:
(WebCore::operator==): Deleted.
* Source/WebCore/platform/text/TextFlags.h:
(WebCore::ExpansionBehavior::operator== const): Deleted.
(WebCore::FontVariantAlternatesValues::operator== const): Deleted.
(WebCore::FontVariantAlternates::operator== const): Deleted.
(WebCore::FontVariantSettings::operator== const): Deleted.
* Source/WebCore/platform/text/TextSpacing.h:
(WebCore::TextSpacingTrim::isAuto const):
(WebCore::TextSpacingTrim::isSpaceAll const):
(WebCore::TextAutospace::isAuto const):
(WebCore::TextAutospace::isNoAutospace const):
(WebCore::TextSpacingTrim::operator== const): Deleted.
(WebCore::TextAutospace::operator== const): Deleted.
* Source/WebCore/plugins/PluginData.h:
(WebCore::operator==): Deleted.

Canonical link: <a href="https://commits.webkit.org/267597@main">https://commits.webkit.org/267597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a65099517d5213c8072d5276e2d3062a0e9caed8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18906 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17587 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19722 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15548 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16306 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15461 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4086 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->