### PR TITLE
Correct URL encoding of CSS

### DIFF
--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-expected.webarchive
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-expected.webarchive
@@ -87,7 +87,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<key>MIMEType</key>
 				<string>image/gif</string>
 				<key>URL</key>
-				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%88%9F</string>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%CB%86%C5%B8</string>
 				<key>allHeaderFields</key>
 				<dict>
 					<key>Accept-Ranges</key>
@@ -111,7 +111,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<integer>200</integer>
 			</dict>
 			<key>WebResourceURL</key>
-			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%88%9F</string>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%CB%86%C5%B8</string>
 		</dict>
 		<dict>
 			<key>WebResourceData</key>
@@ -162,7 +162,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<key>MIMEType</key>
 				<string>image/gif</string>
 				<key>URL</key>
-				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%88%9F</string>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
 				<key>allHeaderFields</key>
 				<dict>
 					<key>Accept-Ranges</key>
@@ -186,7 +186,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<integer>200</integer>
 			</dict>
 			<key>WebResourceURL</key>
-			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%88%9F</string>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
 		</dict>
 		<dict>
 			<key>WebResourceData</key>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis-expected.webarchive
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis-expected.webarchive
@@ -89,7 +89,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<key>MIMEType</key>
 				<string>image/gif</string>
 				<key>URL</key>
-				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%88%9F</string>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%E4%BA%9C</string>
 				<key>allHeaderFields</key>
 				<dict>
 					<key>Accept-Ranges</key>
@@ -113,7 +113,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<integer>200</integer>
 			</dict>
 			<key>WebResourceURL</key>
-			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%88%9F</string>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%E4%BA%9C</string>
 		</dict>
 		<dict>
 			<key>WebResourceData</key>
@@ -164,7 +164,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<key>MIMEType</key>
 				<string>image/gif</string>
 				<key>URL</key>
-				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%88%9F</string>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
 				<key>allHeaderFields</key>
 				<dict>
 					<key>Accept-Ranges</key>
@@ -188,7 +188,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<integer>200</integer>
 			</dict>
 			<key>WebResourceURL</key>
-			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%88%9F</string>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
 		</dict>
 		<dict>
 			<key>WebResourceData</key>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8-expected.webarchive
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8-expected.webarchive
@@ -164,7 +164,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<key>MIMEType</key>
 				<string>image/gif</string>
 				<key>URL</key>
-				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%88%9F</string>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
 				<key>allHeaderFields</key>
 				<dict>
 					<key>Accept-Ranges</key>
@@ -188,7 +188,7 @@ Webarchive fails to save images referenced in CSS&lt;/a&gt;
 				<integer>200</integer>
 			</dict>
 			<key>WebResourceURL</key>
-			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%88%9F</string>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
 		</dict>
 		<dict>
 			<key>WebResourceData</key>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=css-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=css-expected.txt
@@ -1,23 +1,23 @@
 
 PASS CSS <link> (utf-8) #<id> { background-image:<url> }
-FAIL CSS <link> (windows-1252) #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id> { background-image:<url> }
 PASS CSS <style> #<id> { background-image:<url> }
 PASS CSS <link> (utf-8) #<id> { border-image-source:<url> }
-FAIL CSS <link> (windows-1252) #<id> { border-image-source:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id> { border-image-source:<url> }
 PASS CSS <style> #<id> { border-image-source:<url> }
 PASS CSS <link> (utf-8) #<id>::before { content:<url> }
-FAIL CSS <link> (windows-1252) #<id>::before { content:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id>::before { content:<url> }
 PASS CSS <style> #<id>::before { content:<url> }
 PASS CSS <link> (utf-8) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
-FAIL CSS <link> (windows-1252) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
 PASS CSS <style> @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
 PASS CSS <link> (utf-8) #<id> { display:list-item; list-style-image:<url> }
-FAIL CSS <link> (windows-1252) #<id> { display:list-item; list-style-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id> { display:list-item; list-style-image:<url> }
 PASS CSS <style> #<id> { display:list-item; list-style-image:<url> }
 PASS CSS <link> (utf-8) @import <url>;
 PASS CSS <link> (windows-1252) @import <url>;
 PASS CSS <style> @import <url>;
 PASS CSS <link> (utf-8) #<id> { cursor:<url>, pointer }
-FAIL CSS <link> (windows-1252) #<id> { cursor:<url>, pointer } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id> { cursor:<url>, pointer }
 PASS CSS <style> #<id> { cursor:<url>, pointer }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=css-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=css-expected.txt
@@ -1,23 +1,23 @@
 
-FAIL CSS <link> (windows-1251) #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <link> (windows-1251) #<id> { background-image:<url> }
 PASS CSS <link> (utf-8) #<id> { background-image:<url> }
-FAIL CSS <style> #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
-FAIL CSS <link> (windows-1251) #<id> { border-image-source:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <style> #<id> { background-image:<url> }
+PASS CSS <link> (windows-1251) #<id> { border-image-source:<url> }
 PASS CSS <link> (utf-8) #<id> { border-image-source:<url> }
-FAIL CSS <style> #<id> { border-image-source:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
-FAIL CSS <link> (windows-1251) #<id>::before { content:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <style> #<id> { border-image-source:<url> }
+PASS CSS <link> (windows-1251) #<id>::before { content:<url> }
 PASS CSS <link> (utf-8) #<id>::before { content:<url> }
-FAIL CSS <style> #<id>::before { content:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
-FAIL CSS <link> (windows-1251) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <style> #<id>::before { content:<url> }
+PASS CSS <link> (windows-1251) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
 PASS CSS <link> (utf-8) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
-FAIL CSS <style> @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
-FAIL CSS <link> (windows-1251) #<id> { display:list-item; list-style-image:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <style> @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
+PASS CSS <link> (windows-1251) #<id> { display:list-item; list-style-image:<url> }
 PASS CSS <link> (utf-8) #<id> { display:list-item; list-style-image:<url> }
-FAIL CSS <style> #<id> { display:list-item; list-style-image:<url> } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <style> #<id> { display:list-item; list-style-image:<url> }
 PASS CSS <link> (windows-1251) @import <url>;
 PASS CSS <link> (utf-8) @import <url>;
 PASS CSS <style> @import <url>;
-FAIL CSS <link> (windows-1251) #<id> { cursor:<url>, pointer } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <link> (windows-1251) #<id> { cursor:<url>, pointer }
 PASS CSS <link> (utf-8) #<id> { cursor:<url>, pointer }
-FAIL CSS <style> #<id> { cursor:<url>, pointer } assert_equals: expected "%C3%A5" but got "%26%23229%3B"
+PASS CSS <style> #<id> { cursor:<url>, pointer }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=css-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=css-expected.txt
@@ -1,23 +1,23 @@
 
-FAIL CSS <link> (windows-1252) #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id> { background-image:<url> }
 PASS CSS <link> (utf-8) #<id> { background-image:<url> }
-FAIL CSS <style> #<id> { background-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
-FAIL CSS <link> (windows-1252) #<id> { border-image-source:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <style> #<id> { background-image:<url> }
+PASS CSS <link> (windows-1252) #<id> { border-image-source:<url> }
 PASS CSS <link> (utf-8) #<id> { border-image-source:<url> }
-FAIL CSS <style> #<id> { border-image-source:<url> } assert_equals: expected "%C3%A5" but got "%E5"
-FAIL CSS <link> (windows-1252) #<id>::before { content:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <style> #<id> { border-image-source:<url> }
+PASS CSS <link> (windows-1252) #<id>::before { content:<url> }
 PASS CSS <link> (utf-8) #<id>::before { content:<url> }
-FAIL CSS <style> #<id>::before { content:<url> } assert_equals: expected "%C3%A5" but got "%E5"
-FAIL CSS <link> (windows-1252) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <style> #<id>::before { content:<url> }
+PASS CSS <link> (windows-1252) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
 PASS CSS <link> (utf-8) @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
-FAIL CSS <style> @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> } assert_equals: expected "%C3%A5" but got "%E5"
-FAIL CSS <link> (windows-1252) #<id> { display:list-item; list-style-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <style> @font-face { font-family:<id>; src:<url> } #<id> { font-family:<id> }
+PASS CSS <link> (windows-1252) #<id> { display:list-item; list-style-image:<url> }
 PASS CSS <link> (utf-8) #<id> { display:list-item; list-style-image:<url> }
-FAIL CSS <style> #<id> { display:list-item; list-style-image:<url> } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <style> #<id> { display:list-item; list-style-image:<url> }
 PASS CSS <link> (windows-1252) @import <url>;
 PASS CSS <link> (utf-8) @import <url>;
 PASS CSS <style> @import <url>;
-FAIL CSS <link> (windows-1252) #<id> { cursor:<url>, pointer } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <link> (windows-1252) #<id> { cursor:<url>, pointer }
 PASS CSS <link> (utf-8) #<id> { cursor:<url>, pointer }
-FAIL CSS <style> #<id> { cursor:<url>, pointer } assert_equals: expected "%C3%A5" but got "%E5"
+PASS CSS <style> #<id> { cursor:<url>, pointer }
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -147,17 +147,14 @@ void add(Hasher& hasher, const CSSParserContext& context)
 ResolvedURL CSSParserContext::completeURL(const String& string) const
 {
     auto result = [&] () -> ResolvedURL {
-        // See also Document::completeURL(const String&)
+        // See also Document::completeURL(const String&), but note that CSS always uses UTF-8 for URLs
         if (string.isNull())
             return { };
 
         if (CSSValue::isCSSLocalURL(string))
             return { string, URL { string } };
 
-        if (charset.isEmpty())
-            return { string, { baseURL, string } };
-        auto encodingForURLParsing = PAL::TextEncoding { charset }.encodingForFormSubmissionOrURLParsing();
-        return { string, { baseURL, string, encodingForURLParsing == PAL::UTF8Encoding() ? nullptr : &encodingForURLParsing } };
+        return { string, { baseURL, string } };
     }();
 
     if (mode == WebVTTMode && !result.resolvedURL.protocolIsData())


### PR DESCRIPTION
#### c195704a1cc8afc565fb5bd694d06fd329321267
<pre>
Correct URL encoding of CSS
<a href="https://bugs.webkit.org/show_bug.cgi?id=261079">https://bugs.webkit.org/show_bug.cgi?id=261079</a>
<a href="https://rdar.apple.com/114889625">rdar://114889625</a>

Reviewed by Tim Nguyen.

CSS invokes the URL parser normally and therefore always uses UTF-8 as
its URL encoding: <a href="https://drafts.csswg.org/css-values/#url-processing.">https://drafts.csswg.org/css-values/#url-processing.</a>

This aligns us with the standard and Gecko.

* LayoutTests/http/tests/webarchive/test-css-url-encoding-expected.webarchive:
* LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis-expected.webarchive:
* LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8-expected.webarchive:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=css-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=css-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=css-expected.txt:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::completeURL const):

Canonical link: <a href="https://commits.webkit.org/270169@main">https://commits.webkit.org/270169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f5bd704893fa52f77884e474ecfd147cc1319c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/727 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27446 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28454 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26264 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3277 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5926 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->