### PR TITLE
[GStreamer][WebCodecs] Build video encoder active configuration from source pad caps

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h
@@ -35,7 +35,7 @@ class GStreamerVideoEncoder : public VideoEncoder {
 public:
     static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    GStreamerVideoEncoder(const String& codecName, OutputCallback&&, PostTaskCallback&&);
+    GStreamerVideoEncoder(const String& codecName, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
     ~GStreamerVideoEncoder();
 
 private:


### PR DESCRIPTION
#### 0717ba7dec18b44a84043c0b7a83db6f7ae97a62
<pre>
[GStreamer][WebCodecs] Build video encoder active configuration from source pad caps
<a href="https://bugs.webkit.org/show_bug.cgi?id=261084">https://bugs.webkit.org/show_bug.cgi?id=261084</a>

Reviewed by Xabier Rodriguez-Calvar.

The active configuration should now have a valid header buffer and colorspace, filled from the caps
of the underlying GStreamer encoder source pad. Some encoders store the header in
`streamheaders` (vp8, vp9) and some use a `codec_data` field (x264), so both cases need to be
handled.

Drive-by: Weaken the link between the GStreamerInternalVideoEncoder and its GStreamerElementHarness
in order to avoid memory leaks.

* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::GStreamerVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::encode):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/267606@main">https://commits.webkit.org/267606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791e50baa0f2c1cae13ed705a8946d8aa6ffb0a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18253 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19761 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22275 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20093 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15498 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4095 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->