### PR TITLE
Cleanup convertingToLengthHasRequiredConversionData after 267590@main

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1769,4 +1769,27 @@ void CSSPrimitiveValue::collectComputedStyleDependencies(ComputedStyleDependenci
     }
 }
 
+bool CSSPrimitiveValue::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
+{
+    // FIXME: We should probably make CSSPrimitiveValue::computeLengthDouble and
+    // CSSPrimitiveValue::computeNonCalcLengthDouble (which has the style assertion)
+    // return std::optional<double> instead of having this check here.
+
+    bool isFixedNumberConversion = lengthConversion & (FixedIntegerConversion | FixedFloatConversion);
+    auto dependencies = computedStyleDependencies();
+    if (!dependencies.rootProperties.isEmpty() && !conversionData.rootStyle())
+        return !isFixedNumberConversion;
+
+    if (!dependencies.properties.isEmpty() && !conversionData.style())
+        return !isFixedNumberConversion;
+
+    if (dependencies.containerDimensions && !conversionData.elementForContainerUnitResolution())
+        return !isFixedNumberConversion;
+
+    if (dependencies.viewportDimensions && conversionData.defaultViewportFactor().isEmpty())
+        return !isFixedNumberConversion;
+
+    return true;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1953,32 +1953,6 @@ enum LengthConversion {
     CalculatedConversion = 1 << 4
 };
 
-inline bool CSSPrimitiveValue::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
-{
-    // FIXME: We should probably make CSSPrimitiveValue::computeLengthDouble and
-    // CSSPrimitiveValue::computeNonCalcLengthDouble (which has the style assertion)
-    // return std::optional<double> instead of having this check here.
-
-    bool isFixedNumberConversion = lengthConversion & (FixedIntegerConversion | FixedFloatConversion);
-    auto dependencies = computedStyleDependencies();
-    if (!dependencies.rootProperties.isEmpty() && !conversionData.rootStyle())
-        return !isFixedNumberConversion;
-
-    if (!dependencies.properties.isEmpty() && !conversionData.style())
-        return !isFixedNumberConversion;
-
-    if (dependencies.containerDimensions && !conversionData.elementForContainerUnitResolution())
-        return !isFixedNumberConversion;
-
-    if (isViewportPercentageLength() && conversionData.defaultViewportFactor().isEmpty())
-        return !isFixedNumberConversion;
-
-    if (primitiveUnitType() == CSSUnitType::CSS_CALC)
-        return m_value.calc->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
-
-    return true;
-}
-
 template<int supported> Length CSSPrimitiveValue::convertToLength(const CSSToLengthConversionData& conversionData) const
 {
     if (!convertingToLengthHasRequiredConversionData(supported, conversionData))

--- a/Source/WebCore/css/calc/CSSCalcExpressionNode.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNode.h
@@ -61,7 +61,6 @@ public:
     virtual CSSUnitType primitiveType() const = 0;
 
     virtual void collectComputedStyleDependencies(ComputedStyleDependencies&) const = 0;
-    virtual bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const = 0;
 
     CalculationCategory category() const { return m_category; }
 

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.h
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.h
@@ -57,7 +57,6 @@ private:
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }
 
     void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const final { m_child->collectComputedStyleDependencies(dependencies); }
-    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const final { return m_child->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData); }
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.h
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.h
@@ -57,7 +57,6 @@ private:
     CSSUnitType primitiveType() const final { return m_child->primitiveType(); }
 
     void collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const final { m_child->collectComputedStyleDependencies(dependencies); }
-    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const final { return m_child->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData); }
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1062,13 +1062,6 @@ void CSSCalcOperationNode::collectComputedStyleDependencies(ComputedStyleDepende
         child->collectComputedStyleDependencies(dependencies);
 }
 
-bool CSSCalcOperationNode::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
-{
-    return WTF::anyOf(m_children, [lengthConversion, &conversionData] (auto& child) {
-        return child->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
-    });
-}
-
 void CSSCalcOperationNode::buildCSSText(const CSSCalcExpressionNode& node, StringBuilder& builder)
 {
     auto shouldOutputEnclosingCalc = [](const CSSCalcExpressionNode& rootNode) {

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -128,7 +128,6 @@ private:
     double computeLengthPx(const CSSToLengthConversionData&) const final;
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
-    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const final;
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -208,11 +208,6 @@ void CSSCalcPrimitiveValueNode::collectComputedStyleDependencies(ComputedStyleDe
     m_value->collectComputedStyleDependencies(dependencies);
 }
 
-bool CSSCalcPrimitiveValueNode::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
-{
-    return m_value->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
-}
-
 bool CSSCalcPrimitiveValueNode::isZero() const
 {
     return !m_value->doubleValue();

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -74,7 +74,6 @@ private:
 
     double computeLengthPx(const CSSToLengthConversionData&) const final;
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const final;
-    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const final;
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -357,11 +357,6 @@ double CSSCalcValue::computeLengthPx(const CSSToLengthConversionData& conversion
     return clampToPermittedRange(m_expression->computeLengthPx(conversionData));
 }
 
-bool CSSCalcValue::convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData& conversionData) const
-{
-    return m_expression->convertingToLengthHasRequiredConversionData(lengthConversion, conversionData);
-}
-
 bool CSSCalcValue::isCalcFunction(CSSValueID functionId)
 {
     switch (functionId) {

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -74,8 +74,6 @@ public:
 
     void dump(TextStream&) const;
 
-    bool convertingToLengthHasRequiredConversionData(int lengthConversion, const CSSToLengthConversionData&) const;
-
     const CSSCalcExpressionNode& expressionNode() const { return m_expression; }
 
 private:


### PR DESCRIPTION
#### 6044332a1ccc67d068dd7f7abb645d9972f36a6e
<pre>
Cleanup convertingToLengthHasRequiredConversionData after 267590@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=261088">https://bugs.webkit.org/show_bug.cgi?id=261088</a>
rdar://114906119

Reviewed by Cameron McCormack.

Now that computedStyleDependencies collects viewport units dependencies, we can clean up convertingToLengthHasRequiredConversionData and stop traversing recursively in the calc() case (since computedStyleDependencies already does so).

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::convertingToLengthHasRequiredConversionData const):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::CSSPrimitiveValue::convertingToLengthHasRequiredConversionData const): Deleted.
* Source/WebCore/css/calc/CSSCalcExpressionNode.h:
* Source/WebCore/css/calc/CSSCalcInvertNode.h:
* Source/WebCore/css/calc/CSSCalcNegateNode.h:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::convertingToLengthHasRequiredConversionData const): Deleted.
* Source/WebCore/css/calc/CSSCalcOperationNode.h:
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
(WebCore::CSSCalcPrimitiveValueNode::convertingToLengthHasRequiredConversionData const): Deleted.
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::convertingToLengthHasRequiredConversionData const): Deleted.
* Source/WebCore/css/calc/CSSCalcValue.h:

Canonical link: <a href="https://commits.webkit.org/267601@main">https://commits.webkit.org/267601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d666e06bce0fd5f805c1a30b5db91caa0faaa287

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18220 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22241 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13832 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15464 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4088 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->