### PR TITLE
RemoteImageBufferProxy::ensureBackendCreated can wait for a message that isn't pending.

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -269,7 +269,8 @@ void RemoteImageBufferProxy::clearBackend()
 {
     m_needsFlush = false;
     m_pendingFlush = nullptr;
-    prepareForBackingStoreChange();
+    if (m_backend)
+        prepareForBackingStoreChange();
     m_backend = nullptr;
 }
 


### PR DESCRIPTION
#### df7a74a8f788e5e1ea909d9e843a674d0e1e50a8
<pre>
RemoteImageBufferProxy::ensureBackendCreated can wait for a message that isn&apos;t pending.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261091">https://bugs.webkit.org/show_bug.cgi?id=261091</a>
&lt;rdar://114795818&gt;

Reviewed by Kimmo Kinnunen.

Currently, we clear the backend in response to a GPUP clear, which calls prepareForBackingStoreChange.
That can trigger ensureBackendCreated if we didn&apos;t yet have a backend, which will wait for the original backend (from the crashed process),
but does so by forcing creation of the new GPUP. This message never arrives.

clearBackend doesn&apos;t need to call prepareForBackingStoreChange if we didn&apos;t have a backend yet.

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::clearBackend):

Canonical link: <a href="https://commits.webkit.org/267619@main">https://commits.webkit.org/267619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b169307256aeb5de6bbf76a4ba71525497e778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16016 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19720 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14910 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22236 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20053 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15459 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4104 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->