### PR TITLE
Fixed selectionEnd for `textarea` with text end in newline

### DIFF
--- a/LayoutTests/fast/forms/textarea/textarea-selection-selectAll-expected.txt
+++ b/LayoutTests/fast/forms/textarea/textarea-selection-selectAll-expected.txt
@@ -1,0 +1,3 @@
+
+PASS textarea selection index is correct when text ends in newline
+

--- a/LayoutTests/fast/forms/textarea/textarea-selection-selectAll.html
+++ b/LayoutTests/fast/forms/textarea/textarea-selection-selectAll.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>This test selectAll in textarea.</title>
+<link rel="author" title="yu.han" href="mailto:yuzhehan@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-textarea/input-setselectionrange">
+<script src=../../../resources/testharness.js></script>
+<script src=../../../resources/testharnessreport.js></script>
+<div id=log></div>
+<form id="form"><textarea id="form-textarea"></textarea></form>
+<script>
+test(function() {
+    var textarea = document.getElementById('form-textarea');
+    textarea.value = 'a\n';
+    textarea.focus();
+    document.execCommand('selectAll');
+    assert_equals(textarea.selectionStart, 0, 'textarea.selectionStart');
+    assert_equals(textarea.selectionEnd, 2, 'textarea.selectionEnd');
+}, 'textarea selection index is correct when text ends in newline');
+</script>

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -4,7 +4,7 @@
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
- * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2019 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -710,7 +710,8 @@ unsigned HTMLTextFormControlElement::indexForPosition(const Position& passedPosi
                 index += std::min<unsigned>(length, passedPosition.offsetInContainerNode());
             else
                 index += length;
-        } else if (is<HTMLBRElement>(*node))
+            // Disregard the last auto added placeholder <br> tag.
+        } else if (is<HTMLBRElement>(*node) && node != innerText->lastChild())
             ++index;
     }
 


### PR DESCRIPTION
<pre>
Fixed selectionEnd for `textarea` with text end in newline
<a href="https://bugs.webkit.org/show_bug.cgi?id=261092">https://bugs.webkit.org/show_bug.cgi?id=261092</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/a5a503556d3fdec80c655ac0830018e9cca4c091">https://chromium.googlesource.com/chromium/src.git/+/a5a503556d3fdec80c655ac0830018e9cca4c091</a>

Previous to this patch, hitting CTRL-A inside a `textarea`
containing text that ends with a newline would cause the
selectionEnd property to be incorrect. selectionEnd returns
a number that's 1 pass the end of text.

This is because TextControl automatically inserts an `BR` Element
at the end when the last child is a carriage return. And the
inserted node is taken into consideration when calculating the
selection range.

The fix is to ignore this last child if it's a `BR` Element.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(HTMLTextFormControlElement::indexForPosition):
* LayoutTests/fast/forms/textarea/textarea-selection-selectAll.html: Add Test Case
* LayoutTests/fast/forms/textarea/textarea-selection-selectAll-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8603325763cb5ba38aac2a0a0e8301a7b4f55fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16019 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18217 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19723 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22238 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20055 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13853 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15389 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->