### PR TITLE
Invalidate :has() with nested positional pseudo-class selectors correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/child-indexed-pseudo-classes-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/child-indexed-pseudo-classes-in-has-expected.txt
@@ -11,56 +11,56 @@ PASS Prepend #div1.green: #last_child
 PASS Prepend #div1.green: #nth_child_3n_1
 PASS Prepend #div1.green: #nth_child_3n_2
 PASS Prepend #div1.green: #nth_child_3n
-FAIL Prepend #div2.yellow: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS Prepend #div2.yellow: #only_child
 PASS Prepend #div2.yellow: #first_child
 PASS Prepend #div2.yellow: #last_child
 PASS Prepend #div2.yellow: #nth_child_3n_1
-FAIL Prepend #div2.yellow: #nth_child_3n_2 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS Prepend #div2.yellow: #nth_child_3n_2
 PASS Prepend #div2.yellow: #nth_child_3n
-FAIL Prepend #div3.orange: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS Prepend #div3.orange: #only_child
 PASS Prepend #div3.orange: #first_child
 PASS Prepend #div3.orange: #last_child
 PASS Prepend #div3.orange: #nth_child_3n_1
-FAIL Prepend #div3.orange: #nth_child_3n_2 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div3.orange: #nth_child_3n assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div4: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Prepend #div4: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend #div3.orange: #nth_child_3n_2
+PASS Prepend #div3.orange: #nth_child_3n
+PASS Prepend #div4: #only_child
+PASS Prepend #div4: #first_child
 PASS Prepend #div4: #last_child
-FAIL Prepend #div4: #nth_child_3n_1 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 165, 0)"
-FAIL Prepend #div4: #nth_child_3n_2 assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div4: #nth_child_3n assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div5: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Prepend #div5: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend #div4: #nth_child_3n_1
+PASS Prepend #div4: #nth_child_3n_2
+PASS Prepend #div4: #nth_child_3n
+PASS Prepend #div5: #only_child
+PASS Prepend #div5: #first_child
 PASS Prepend #div5: #last_child
-FAIL Prepend #div5: #nth_child_3n_1 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(255, 165, 0)"
-FAIL Prepend #div5: #nth_child_3n_2 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div5: #nth_child_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Remove #div1: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Remove #div1: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend #div5: #nth_child_3n_1
+PASS Prepend #div5: #nth_child_3n_2
+PASS Prepend #div5: #nth_child_3n
+PASS Remove #div1: #only_child
+PASS Remove #div1: #first_child
 PASS Remove #div1: #last_child
-FAIL Remove #div1: #nth_child_3n_1 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(255, 165, 0)"
+PASS Remove #div1: #nth_child_3n_1
 PASS Remove #div1: #nth_child_3n_2
-FAIL Remove #div1: #nth_child_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Remove #div2: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Remove #div2: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div1: #nth_child_3n
+PASS Remove #div2: #only_child
+PASS Remove #div2: #first_child
 PASS Remove #div2: #last_child
 PASS Remove #div2: #nth_child_3n_1
 PASS Remove #div2: #nth_child_3n_2
-FAIL Remove #div2: #nth_child_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Remove #div3: #only_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Remove #div3: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div2: #nth_child_3n
+PASS Remove #div3: #only_child
+PASS Remove #div3: #first_child
 PASS Remove #div3: #last_child
 PASS Remove #div3: #nth_child_3n_1
 PASS Remove #div3: #nth_child_3n_2
 PASS Remove #div3: #nth_child_3n
 PASS Remove #div4: #only_child
-FAIL Remove #div4: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div4: #first_child
 PASS Remove #div4: #last_child
 PASS Remove #div4: #nth_child_3n_1
 PASS Remove #div4: #nth_child_3n_2
 PASS Remove #div4: #nth_child_3n
 PASS Remove #div5: #only_child
-FAIL Remove #div5: #first_child assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div5: #first_child
 PASS Remove #div5: #last_child
 PASS Remove #div5: #nth_child_3n_1
 PASS Remove #div5: #nth_child_3n_2

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/typed-child-indexed-pseudo-classes-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/typed-child-indexed-pseudo-classes-in-has-expected.txt
@@ -23,80 +23,80 @@ PASS Prepend span (2): #last_of_type
 PASS Prepend span (2): #nth_of_type_3n_1
 PASS Prepend span (2): #nth_of_type_3n_2
 PASS Prepend span (2): #nth_of_type_3n
-FAIL Prepend #div2.yellow: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS Prepend #div2.yellow: #only_of_type
 PASS Prepend #div2.yellow: #first_of_type
 PASS Prepend #div2.yellow: #last_of_type
 PASS Prepend #div2.yellow: #nth_of_type_3n_1
-FAIL Prepend #div2.yellow: #nth_of_type_3n_2 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS Prepend #div2.yellow: #nth_of_type_3n_2
 PASS Prepend #div2.yellow: #nth_of_type_3n
-FAIL Prepend span (3): #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS Prepend span (3): #only_of_type
 PASS Prepend span (3): #first_of_type
 PASS Prepend span (3): #last_of_type
 PASS Prepend span (3): #nth_of_type_3n_1
-FAIL Prepend span (3): #nth_of_type_3n_2 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS Prepend span (3): #nth_of_type_3n_2
 PASS Prepend span (3): #nth_of_type_3n
-FAIL Prepend #div3.orange: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS Prepend #div3.orange: #only_of_type
 PASS Prepend #div3.orange: #first_of_type
 PASS Prepend #div3.orange: #last_of_type
 PASS Prepend #div3.orange: #nth_of_type_3n_1
-FAIL Prepend #div3.orange: #nth_of_type_3n_2 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div3.orange: #nth_of_type_3n assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend span (4): #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
+PASS Prepend #div3.orange: #nth_of_type_3n_2
+PASS Prepend #div3.orange: #nth_of_type_3n
+PASS Prepend span (4): #only_of_type
 PASS Prepend span (4): #first_of_type
 PASS Prepend span (4): #last_of_type
 PASS Prepend span (4): #nth_of_type_3n_1
-FAIL Prepend span (4): #nth_of_type_3n_2 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend span (4): #nth_of_type_3n assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div4: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Prepend #div4: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend span (4): #nth_of_type_3n_2
+PASS Prepend span (4): #nth_of_type_3n
+PASS Prepend #div4: #only_of_type
+PASS Prepend #div4: #first_of_type
 PASS Prepend #div4: #last_of_type
-FAIL Prepend #div4: #nth_of_type_3n_1 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 165, 0)"
-FAIL Prepend #div4: #nth_of_type_3n_2 assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div4: #nth_of_type_3n assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend span (5): #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Prepend span (5): #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend #div4: #nth_of_type_3n_1
+PASS Prepend #div4: #nth_of_type_3n_2
+PASS Prepend #div4: #nth_of_type_3n
+PASS Prepend span (5): #only_of_type
+PASS Prepend span (5): #first_of_type
 PASS Prepend span (5): #last_of_type
-FAIL Prepend span (5): #nth_of_type_3n_1 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 165, 0)"
-FAIL Prepend span (5): #nth_of_type_3n_2 assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend span (5): #nth_of_type_3n assert_equals: expected "rgb(255, 255, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div5: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Prepend #div5: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend span (5): #nth_of_type_3n_1
+PASS Prepend span (5): #nth_of_type_3n_2
+PASS Prepend span (5): #nth_of_type_3n
+PASS Prepend #div5: #only_of_type
+PASS Prepend #div5: #first_of_type
 PASS Prepend #div5: #last_of_type
-FAIL Prepend #div5: #nth_of_type_3n_1 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(255, 165, 0)"
-FAIL Prepend #div5: #nth_of_type_3n_2 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend #div5: #nth_of_type_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend span (6): #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Prepend span (6): #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend #div5: #nth_of_type_3n_1
+PASS Prepend #div5: #nth_of_type_3n_2
+PASS Prepend #div5: #nth_of_type_3n
+PASS Prepend span (6): #only_of_type
+PASS Prepend span (6): #first_of_type
 PASS Prepend span (6): #last_of_type
-FAIL Prepend span (6): #nth_of_type_3n_1 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(255, 165, 0)"
-FAIL Prepend span (6): #nth_of_type_3n_2 assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
-FAIL Prepend span (6): #nth_of_type_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Remove #div1: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Remove #div1: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Prepend span (6): #nth_of_type_3n_1
+PASS Prepend span (6): #nth_of_type_3n_2
+PASS Prepend span (6): #nth_of_type_3n
+PASS Remove #div1: #only_of_type
+PASS Remove #div1: #first_of_type
 PASS Remove #div1: #last_of_type
-FAIL Remove #div1: #nth_of_type_3n_1 assert_equals: expected "rgb(255, 255, 0)" but got "rgb(255, 165, 0)"
+PASS Remove #div1: #nth_of_type_3n_1
 PASS Remove #div1: #nth_of_type_3n_2
-FAIL Remove #div1: #nth_of_type_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Remove #div2: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Remove #div2: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div1: #nth_of_type_3n
+PASS Remove #div2: #only_of_type
+PASS Remove #div2: #first_of_type
 PASS Remove #div2: #last_of_type
 PASS Remove #div2: #nth_of_type_3n_1
 PASS Remove #div2: #nth_of_type_3n_2
-FAIL Remove #div2: #nth_of_type_3n assert_equals: expected "rgb(255, 165, 0)" but got "rgb(128, 128, 128)"
-FAIL Remove #div3: #only_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 0, 0)"
-FAIL Remove #div3: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div2: #nth_of_type_3n
+PASS Remove #div3: #only_of_type
+PASS Remove #div3: #first_of_type
 PASS Remove #div3: #last_of_type
 PASS Remove #div3: #nth_of_type_3n_1
 PASS Remove #div3: #nth_of_type_3n_2
 PASS Remove #div3: #nth_of_type_3n
 PASS Remove #div4: #only_of_type
-FAIL Remove #div4: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div4: #first_of_type
 PASS Remove #div4: #last_of_type
 PASS Remove #div4: #nth_of_type_3n_1
 PASS Remove #div4: #nth_of_type_3n_2
 PASS Remove #div4: #nth_of_type_3n
 PASS Remove #div5: #only_of_type
-FAIL Remove #div5: #first_of_type assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 165, 0)"
+PASS Remove #div5: #first_of_type
 PASS Remove #div5: #last_of_type
 PASS Remove #div5: #nth_of_type_3n_1
 PASS Remove #div5: #nth_of_type_3n_2

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1418,6 +1418,34 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     if (cache)
         cache->add(Style::makeHasPseudoClassCacheKey(element, hasSelector), matchTypeForCache());
 
+    auto relationNeededForHasInvalidation = [](Style::Relation::Type type) {
+        switch (type) {
+        case Style::Relation::ChildrenAffectedByForwardPositionalRules:
+        case Style::Relation::ChildrenAffectedByBackwardPositionalRules:
+        case Style::Relation::ChildrenAffectedByFirstChildRules:
+        case Style::Relation::ChildrenAffectedByLastChildRules:
+            return true;
+        case Style::Relation::AffectedByEmpty:
+        case Style::Relation::AffectedByPreviousSibling:
+        case Style::Relation::DescendantsAffectedByPreviousSibling:
+        case Style::Relation::AffectsNextSibling:
+        case Style::Relation::DescendantsAffectedByForwardPositionalRules:
+        case Style::Relation::DescendantsAffectedByBackwardPositionalRules:
+        case Style::Relation::FirstChild:
+        case Style::Relation::LastChild:
+        case Style::Relation::NthChildIndex:
+        case Style::Relation::Unique:
+            return false;
+        }
+        ASSERT_NOT_REACHED();
+        return false;
+    };
+
+    for (auto& relation : hasCheckingContext.styleRelations) {
+        if (relationNeededForHasInvalidation(relation.type))
+            checkingContext.styleRelations.append(relation);
+    }
+
     return result;
 }
 

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -46,10 +46,12 @@ private:
     void invalidateAfterChange();
     void checkForSiblingStyleChanges();
     using MatchingHasSelectors = HashSet<const CSSSelector*>;
-    void invalidateForChangedElement(Element&, MatchingHasSelectors&);
+    enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
+    void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
 
     template<typename Function> void traverseRemovedElements(Function&&);
     template<typename Function> void traverseAddedElements(Function&&);
+    template<typename Function> void traverseRemainingExistingSiblings(Function&&);
 
     Element& parentElement() { return *m_parentElement; }
 


### PR DESCRIPTION
#### 630e5323e6dcbd3c95adb5b8caedb9d8038b445b
<pre>
Invalidate :has() with nested positional pseudo-class selectors correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=253943">https://bugs.webkit.org/show_bug.cgi?id=253943</a>
rdar://106768224

Reviewed by Antti Koivisto.

ChildChangeInvalidation currently handles :has() invalidation by
traversing the newly inserted or removed subtree and checking whether
there are any :has() rules whose nested selector could match the elements
in the subtree. This is not sufficient to invalidate rules like:

:has(:first-child)
:has(:nth-child(2n+1))
:has(:nth-child(n2+1 of .foo))

When the parent of the changed subtree has any of these flags:

ChildrenAffectedByFirstChildRules
ChildrenAffectedByLastChildRules
ChildrenAffectedByForwardPositionalRules
ChildrenAffectedByBackwardPositionalRules

we must invalidate some siblings of the subtree, to determine if the
:has() selector might have changed.

The &quot;check the existing sibling&quot; optimization that
ChildChangeInvalidation::invalidateForChangedElement does is not valid
if it&apos;s called with a sibling of the changed subtree, so we pass in
a ChangedElementRelation value to control whether to skip it.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/child-indexed-pseudo-classes-in-has-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/typed-child-indexed-pseudo-classes-in-has-expected.txt:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasPseudoClass const):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):
(WebCore::Style::ChildChangeInvalidation::traverseRemovedElements):
(WebCore::Style::ChildChangeInvalidation::traverseAddedElements):
(WebCore::Style::ChildChangeInvalidation::traverseRemainingExistingSiblings):
* Source/WebCore/style/ChildChangeInvalidation.h:

Canonical link: <a href="https://commits.webkit.org/267771@main">https://commits.webkit.org/267771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0387482caef1269ed66ac5110e5ed34e3b45c655

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18136 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18170 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20332 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16081 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20525 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16826 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15942 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4202 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->