### PR TITLE
WIP: Move background-image document element painting to RenderView

### DIFF
--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -67,7 +67,6 @@ BackgroundPainter::BackgroundPainter(RenderBoxModelObject& renderer, const Paint
 void BackgroundPainter::paintBackground(const LayoutRect& paintRect, BackgroundBleedAvoidance bleedAvoidance)
 {
     if (m_renderer.isDocumentElementRenderer()) {
-        paintRootBoxFillLayers();
         return;
     }
 

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -71,8 +71,8 @@ public:
     static void clipRoundedInnerRect(GraphicsContext&, const FloatRect&, const FloatRoundedRect& clipRect);
     static bool boxShadowShouldBeAppliedToBackground(const RenderBoxModelObject&, const LayoutPoint& paintOffset, BackgroundBleedAvoidance, const InlineIterator::InlineBoxIterator&);
 
-private:
     void paintRootBoxFillLayers();
+private:
 
     RoundedRect backgroundRoundedRectAdjustedForBleedAvoidance(const LayoutRect& borderRect, BackgroundBleedAvoidance, const InlineIterator::InlineBoxIterator&, bool includeLogicalLeftEdge, bool includeLogicalRightEdge) const;
     RoundedRect backgroundRoundedRect(const LayoutRect& borderRect, const InlineIterator::InlineBoxIterator&, bool includeLogicalLeftEdge, bool includeLogicalRightEdge) const;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -895,7 +895,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
     bool newStyleSlowScroll = false;
     if (newStyle.hasAnyFixedBackground() && !settings().fixedBackgroundsPaintRelativeToDocument()) {
         newStyleSlowScroll = true;
-        bool drawsRootBackground = isDocumentElementRenderer() || (isBody() && !rendererHasBackground(document().documentElement()->renderer()));
+        bool drawsRootBackground = isRenderView() || (isBody() && !rendererHasBackground(document().documentElement()->renderer()));
         if (drawsRootBackground && newStyle.hasEntirelyFixedBackground() && view().compositor().supportsFixedRootBackgroundCompositing())
             newStyleSlowScroll = false;
     }
@@ -906,7 +906,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
     } else if (newStyleSlowScroll)
         view().frameView().addSlowRepaintObject(*this);
 
-    if (isDocumentElementRenderer() || isBody())
+    if (isRenderView() || isBody())
         view().frameView().updateExtendBackgroundIfNecessary();
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2710,7 +2710,7 @@ static inline bool hasPerspectiveOrPreserves3D(const RenderStyle& style)
 Color RenderLayerBacking::rendererBackgroundColor() const
 {
     RenderElement* backgroundRenderer = nullptr;
-    if (renderer().isDocumentElementRenderer())
+    if (renderer().isRenderView())
         backgroundRenderer = renderer().view().rendererForRootBackground();
     
     if (!backgroundRenderer)


### PR DESCRIPTION
#### 0d63d1eca4990de45301c67cbe60ff4d86ec1eb5
<pre>
WIP: Move background-image document element painting to RenderView
<a href="https://bugs.webkit.org/show_bug.cgi?id=245032">https://bugs.webkit.org/show_bug.cgi?id=245032</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBackground):
(WebCore::BackgroundPainter::paintRootBoxFillLayers):
(WebCore::BackgroundPainter::paintFillLayer):
(WebCore::BackgroundPainter::calculateBackgroundImageGeometry):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::rendererBackgroundColor const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::paintBoxDecorations):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d63d1eca4990de45301c67cbe60ff4d86ec1eb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17660 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18285 "14 flakes 145 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17396 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17738 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19797 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14978 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15621 "9 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22306 "7 flakes 109 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15977 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15788 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20124 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16380 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13896 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->