### PR TITLE
Let the compiler generate more comparison operators in WebCore

### DIFF
--- a/Source/WebCore/rendering/CSSValueKey.h
+++ b/Source/WebCore/rendering/CSSValueKey.h
@@ -30,18 +30,14 @@
 namespace WebCore {
 
 struct CSSValueKey {
-
     unsigned hash() const;
+
+    friend bool operator==(const CSSValueKey&, const CSSValueKey&) = default;
 
     unsigned cssValueID;
     bool useDarkAppearance;
     bool useElevatedUserInterfaceLevel;
 };
-
-inline bool operator==(const CSSValueKey& a, const CSSValueKey& b)
-{
-    return a.cssValueID == b.cssValueID && a.useDarkAppearance == b.useDarkAppearance && a.useElevatedUserInterfaceLevel == b.useElevatedUserInterfaceLevel;
-}
 
 inline unsigned CSSValueKey::hash() const
 {

--- a/Source/WebCore/rendering/ClipRect.h
+++ b/Source/WebCore/rendering/ClipRect.h
@@ -51,8 +51,7 @@ public:
     bool affectedByRadius() const { return m_affectedByRadius; }
     void setAffectedByRadius(bool affectedByRadius) { m_affectedByRadius = affectedByRadius; }
     
-    bool operator==(const ClipRect& other) const { return rect() == other.rect() && affectedByRadius() == other.affectedByRadius(); }
-    bool operator==(const LayoutRect& otherRect) const { return rect() == otherRect; }
+    friend bool operator==(const ClipRect&, const ClipRect&) = default;
     
     void intersect(const LayoutRect& other);
     void intersect(const ClipRect& other);

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -344,33 +344,6 @@ EventRegion::EventRegion(Region&& region
 {
 }
 
-bool EventRegion::operator==(const EventRegion& other) const
-{
-#if ENABLE(TOUCH_ACTION_REGIONS)
-    if (m_touchActionRegions != other.m_touchActionRegions)
-        return false;
-#endif
-
-#if ENABLE(WHEEL_EVENT_REGIONS)
-    if (m_wheelEventListenerRegion != other.m_wheelEventListenerRegion)
-        return false;
-    if (m_nonPassiveWheelEventListenerRegion != other.m_nonPassiveWheelEventListenerRegion)
-        return false;
-#endif
-
-#if ENABLE(EDITABLE_REGION)
-    if (m_editableRegion != other.m_editableRegion)
-        return false;
-#endif
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (m_interactionRegions != other.m_interactionRegions)
-        return false;
-#endif
-
-    return m_region == other.m_region;
-}
-
 void EventRegion::unite(const Region& region, const RenderStyle& style, bool overrideUserModifyIsEditable)
 {
     if (style.effectivePointerEvents() == PointerEvents::None)

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -98,7 +98,7 @@ public:
 
     bool isEmpty() const { return m_region.isEmpty(); }
 
-    WEBCORE_EXPORT bool operator==(const EventRegion&) const;
+    friend bool operator==(const EventRegion&, const EventRegion&) = default;
 
     void unite(const Region&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
     void translate(const IntSize&);

--- a/Source/WebCore/rendering/GapRects.h
+++ b/Source/WebCore/rendering/GapRects.h
@@ -44,10 +44,7 @@ namespace WebCore {
             return result;
         }
 
-        bool operator==(const GapRects& other) const
-        {
-            return m_left == other.left() && m_center == other.center() && m_right == other.right();
-        }
+        friend bool operator==(const GapRects&, const GapRects&) = default;
 
     private:
         LayoutRect m_left;

--- a/Source/WebCore/rendering/HighlightData.h
+++ b/Source/WebCore/rendering/HighlightData.h
@@ -56,10 +56,7 @@ public:
     unsigned startOffset() const { return m_startOffset; }
     unsigned endOffset() const { return m_endOffset; }
 
-    bool operator==(const RenderRange& other) const
-    {
-        return m_start == other.m_start && m_end == other.m_end && m_startOffset == other.m_startOffset && m_endOffset == other.m_endOffset;
-    }
+    friend bool operator==(const RenderRange&, const RenderRange&) = default;
 
 private:
     WeakPtr<RenderObject> m_start;

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -47,12 +47,7 @@ struct CompositedClipData {
     {
     }
 
-    bool operator==(const CompositedClipData& other) const
-    {
-        return clippingLayer == other.clippingLayer
-            && clipRect == other.clipRect
-            && isOverflowScroll == other.isOverflowScroll;
-    }
+    friend bool operator==(const CompositedClipData&, const CompositedClipData&) = default;
     
     WeakPtr<RenderLayer> clippingLayer; // For scroller entries, the scrolling layer. For other entries, the most-descendant layer that has a clip.
     RoundedRect clipRect; // In the coordinate system of the RenderLayer that owns the stack.

--- a/Source/WebCore/rendering/Pagination.h
+++ b/Source/WebCore/rendering/Pagination.h
@@ -34,10 +34,7 @@ enum PaginationMode : uint8_t { Unpaginated, LeftToRightPaginated, RightToLeftPa
 struct Pagination {
     using Mode = PaginationMode;
 
-    bool operator==(const Pagination& other) const
-    {
-        return mode == other.mode && behavesLikeColumns == other.behavesLikeColumns && pageLength == other.pageLength && gap == other.gap;
-    }
+    friend bool operator==(const Pagination&, const Pagination&) = default;
 
     Mode mode { Unpaginated };
     bool behavesLikeColumns { false };

--- a/Source/WebCore/rendering/shapes/ShapeInterval.h
+++ b/Source/WebCore/rendering/shapes/ShapeInterval.h
@@ -90,7 +90,7 @@ public:
             set(std::min<T>(x1(), interval.x1()), std::max<T>(x2(), interval.x2()));
     }
 
-    bool operator==(const ShapeInterval<T>& other) const { return x1() == other.x1() && x2() == other.x2(); }
+    friend bool operator==(const ShapeInterval<T>&, const ShapeInterval<T>&) = default;
 
 private:
     T m_x1;

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -63,10 +63,7 @@ void BasicShapeCenterCoordinate::updateComputedLength()
 }
 
 struct SVGPathTransformedByteStream {
-    bool operator==(const SVGPathTransformedByteStream& other) const 
-    { 
-        return other.offset == offset && other.zoom == zoom && other.rawStream == rawStream;
-    }
+    friend bool operator==(const SVGPathTransformedByteStream&, const SVGPathTransformedByteStream&) = default;
     bool isEmpty() const { return rawStream.isEmpty(); }
 
     Path path() const

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -37,6 +37,8 @@ struct BorderDataRadii {
     LengthSize topRight { LengthType::Fixed, LengthType::Fixed };
     LengthSize bottomLeft { LengthType::Fixed, LengthType::Fixed };
     LengthSize bottomRight { LengthType::Fixed, LengthType::Fixed };
+
+    friend bool operator==(const BorderDataRadii&, const BorderDataRadii&) = default;
 };
 
 class BorderData {
@@ -110,11 +112,7 @@ public:
 
     bool isEquivalentForPainting(const BorderData& other, bool currentColorDiffers) const;
 
-    bool operator==(const BorderData& o) const
-    {
-        return m_left == o.m_left && m_right == o.m_right && m_top == o.m_top && m_bottom == o.m_bottom && m_image == o.m_image
-            && m_radii.topLeft == o.m_radii.topLeft && m_radii.topRight == o.m_radii.topRight && m_radii.bottomLeft == o.m_radii.bottomLeft && m_radii.bottomRight == o.m_radii.bottomRight;
-    }
+    friend bool operator==(const BorderData&, const BorderData&) = default;
 
     const BorderValue& left() const { return m_left; }
     const BorderValue& right() const { return m_right; }

--- a/Source/WebCore/rendering/style/BorderValue.h
+++ b/Source/WebCore/rendering/style/BorderValue.h
@@ -45,10 +45,7 @@ public:
 
     bool isVisible() const;
 
-    bool operator==(const BorderValue& o) const
-    {
-        return m_width == o.m_width && m_style == o.m_style && m_color == o.m_color;
-    }
+    friend bool operator==(const BorderValue&, const BorderValue&) = default;
 
     void setColor(const StyleColor& color)
     {

--- a/Source/WebCore/rendering/style/CounterContent.h
+++ b/Source/WebCore/rendering/style/CounterContent.h
@@ -45,17 +45,12 @@ public:
     ListStyleType listStyleType() const { return m_listStyle; }
     const AtomString& separator() const { return m_separator; }
 
+    friend bool operator==(const CounterContent&, const CounterContent&) = default;
+
 private:
     AtomString m_identifier;
     ListStyleType m_listStyle;
     AtomString m_separator;
 };
-
-static inline bool operator==(const CounterContent& a, const CounterContent& b)
-{
-    return a.identifier() == b.identifier()
-        && a.listStyleType() == b.listStyleType()
-        && a.separator() == b.separator();
-}
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/CounterDirectives.h
+++ b/Source/WebCore/rendering/style/CounterDirectives.h
@@ -29,12 +29,9 @@ struct CounterDirectives {
     std::optional<int> resetValue;
     std::optional<int> incrementValue;
     std::optional<int> setValue;
-};
 
-constexpr bool operator==(const CounterDirectives& a, const CounterDirectives& b)
-{
-    return a.incrementValue == b.incrementValue && a.resetValue == b.resetValue && a.setValue == b.setValue;
-}
+    friend constexpr bool operator==(const CounterDirectives&, const CounterDirectives&) = default;
+};
 
 struct CounterDirectiveMap {
     HashMap<AtomString, CounterDirectives> map;

--- a/Source/WebCore/rendering/style/CursorData.h
+++ b/Source/WebCore/rendering/style/CursorData.h
@@ -37,10 +37,7 @@ public:
     {
     }
 
-    bool operator==(const CursorData& o) const
-    {
-        return m_hotSpot == o.m_hotSpot && m_image == o.m_image;
-    }
+    friend bool operator==(const CursorData&, const CursorData&) = default;
 
     StyleImage* image() const { return m_image.get(); }    
     void setImage(RefPtr<StyleImage>&& image) { m_image = WTFMove(image); }

--- a/Source/WebCore/rendering/style/FillLayer.h
+++ b/Source/WebCore/rendering/style/FillLayer.h
@@ -46,6 +46,8 @@ struct FillSize {
     {
     }
 
+    friend bool operator==(const FillSize&, const FillSize&) = default;
+
     FillSizeType type;
     LengthSize size;
 };
@@ -54,13 +56,8 @@ struct FillRepeatXY {
     FillRepeat x { FillRepeat::Repeat };
     FillRepeat y { FillRepeat::Repeat };
     
-    bool operator==(const FillRepeatXY& other) const { return x == other.x && y == other.y; }
+    friend bool operator==(const FillRepeatXY&, const FillRepeatXY&) = default;
 };
-
-inline bool operator==(const FillSize& a, const FillSize& b)
-{
-    return a.type == b.type && a.size == b.size;
-}
 
 class FillLayer : public RefCounted<FillLayer> {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/rendering/style/GapLength.h
+++ b/Source/WebCore/rendering/style/GapLength.h
@@ -56,10 +56,7 @@ public:
     bool isNormal() const { return m_isNormal; }
     const Length& length() const { ASSERT(!m_isNormal); return m_length; }
 
-    bool operator==(const GapLength& other) const
-    {
-        return m_isNormal == other.m_isNormal && m_length == other.m_length;
-    }
+    friend bool operator==(const GapLength&, const GapLength&) = default;
 
 private:
     bool m_isNormal;

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -63,10 +63,7 @@ public:
         return GridSpan(0, 1, TranslatedDefinite);
     }
 
-    bool operator==(const GridSpan& o) const
-    {
-        return m_type == o.m_type && m_startLine == o.m_startLine && m_endLine == o.m_endLine;
-    }
+    friend bool operator==(const GridSpan&, const GridSpan&) = default;
 
     unsigned integerSpan() const
     {
@@ -206,8 +203,6 @@ private:
     int m_startLine;
     int m_endLine;
     GridSpanType m_type;
-
-
 };
 
 // This represents a grid area that spans in both rows' and columns' direction.
@@ -238,7 +233,8 @@ public:
 
 struct NamedGridAreaMap {
     HashMap<String, GridArea> map;
+
+    friend bool operator==(const NamedGridAreaMap&, const NamedGridAreaMap&) = default;
 };
-inline bool operator==(const NamedGridAreaMap& a, const NamedGridAreaMap& b) { return a.map == b.map; }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/GridLength.h
+++ b/Source/WebCore/rendering/style/GridLength.h
@@ -63,10 +63,7 @@ public:
 
     bool isPercentage() const { return m_type == LengthType && m_length.isPercentOrCalculated(); }
 
-    bool operator==(const GridLength& o) const
-    {
-        return m_type == o.m_type && m_flex == o.m_flex && m_length == o.m_length;
-    }
+    friend bool operator==(const GridLength&, const GridLength&) = default;
 
     bool isContentSized() const { return m_type == LengthType && (m_length.isAuto() || m_length.isMinContent() || m_length.isMaxContent()); }
     bool isAuto() const { return m_type == LengthType && m_length.isAuto(); }

--- a/Source/WebCore/rendering/style/GridPosition.cpp
+++ b/Source/WebCore/rendering/style/GridPosition.cpp
@@ -95,11 +95,6 @@ int GridPosition::min()
     return -max();
 }
 
-bool GridPosition::operator==(const GridPosition& other) const
-{
-    return m_type == other.m_type && m_integerPosition == other.m_integerPosition && m_namedGridLine == other.m_namedGridLine;
-}
-
 void GridPosition::setMaxPositionForTesting(unsigned maxPosition)
 {
     gMaxPositionForTesting = static_cast<int>(maxPosition);

--- a/Source/WebCore/rendering/style/GridPosition.h
+++ b/Source/WebCore/rendering/style/GridPosition.h
@@ -73,7 +73,7 @@ public:
     String namedGridLine() const;
     WEBCORE_EXPORT int spanPosition() const;
 
-    bool operator==(const GridPosition& other) const;
+    friend bool operator==(const GridPosition&, const GridPosition&) = default;
 
     bool shouldBeResolvedAgainstOppositePosition() const { return isAuto() || isSpan(); }
 

--- a/Source/WebCore/rendering/style/LineClampValue.h
+++ b/Source/WebCore/rendering/style/LineClampValue.h
@@ -48,10 +48,7 @@ public:
 
     constexpr bool isNone() const { return m_value == -1; }
 
-    constexpr bool operator==(const LineClampValue& o) const
-    {
-        return value() == o.value() && isPercentage() == o.isPercentage();
-    }
+    friend constexpr bool operator==(const LineClampValue&, const LineClampValue&) = default;
     
 private:
     LineClamp m_type;

--- a/Source/WebCore/rendering/style/ListStyleType.h
+++ b/Source/WebCore/rendering/style/ListStyleType.h
@@ -44,7 +44,7 @@ struct ListStyleType {
     bool isDisc() const;
     bool isDisclosureClosed() const;
 
-    bool operator==(const ListStyleType& other) const { return type == other.type && identifier == other.identifier; }
+    friend bool operator==(const ListStyleType&, const ListStyleType&) = default;
 
     Type type { Type::None };
     // The identifier is the string when the type is String and is the @counter-style name when the type is CounterStyle.

--- a/Source/WebCore/rendering/style/NinePieceImage.h
+++ b/Source/WebCore/rendering/style/NinePieceImage.h
@@ -114,7 +114,7 @@ public:
     NinePieceImage(Type = Type::Normal);
     NinePieceImage(RefPtr<StyleImage>&&, LengthBox imageSlices, bool fill, LengthBox borderSlices, bool overridesBorderWidths, LengthBox outset, NinePieceImageRule horizontalRule, NinePieceImageRule verticalRule);
 
-    bool operator==(const NinePieceImage& other) const { return m_data == other.m_data; }
+    friend bool operator==(const NinePieceImage&, const NinePieceImage&) = default;
 
     bool hasImage() const { return m_data->image; }
     StyleImage* image() const { return m_data->image.get(); }

--- a/Source/WebCore/rendering/style/OffsetRotation.cpp
+++ b/Source/WebCore/rendering/style/OffsetRotation.cpp
@@ -31,11 +31,6 @@
 
 namespace WebCore {
 
-bool OffsetRotation::operator==(const OffsetRotation& o) const
-{
-    return m_hasAuto == o.m_hasAuto && m_angle == o.m_angle;
-}
-
 bool OffsetRotation::canBlend(const OffsetRotation& to) const
 {
     return m_hasAuto == to.hasAuto();

--- a/Source/WebCore/rendering/style/OffsetRotation.h
+++ b/Source/WebCore/rendering/style/OffsetRotation.h
@@ -41,7 +41,7 @@ public:
     bool canBlend(const OffsetRotation&) const;
     WEBCORE_EXPORT OffsetRotation blend(const OffsetRotation&, const BlendingContext&) const;
 
-    bool operator==(const OffsetRotation&) const;
+    friend bool operator==(const OffsetRotation&, const OffsetRotation&) = default;
 
 private:
     float m_angle { 0 };

--- a/Source/WebCore/rendering/style/OutlineValue.h
+++ b/Source/WebCore/rendering/style/OutlineValue.h
@@ -31,10 +31,7 @@ namespace WebCore {
 class OutlineValue : public BorderValue {
 friend class RenderStyle;
 public:
-    bool operator==(const OutlineValue& o) const
-    {
-        return m_width == o.m_width && m_style == o.m_style && m_color == o.m_color && m_offset == o.m_offset && m_isAuto == o.m_isAuto;
-    }
+    friend bool operator==(const OutlineValue&, const OutlineValue&) = default;
     
     float offset() const { return m_offset; }
     OutlineIsAuto isAuto() const { return static_cast<OutlineIsAuto>(m_isAuto); }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2134,7 +2134,7 @@ public:
 
 private:
     struct NonInheritedFlags {
-        bool operator==(const NonInheritedFlags&) const;
+        friend bool operator==(const NonInheritedFlags&, const NonInheritedFlags&) = default;
 
         inline void copyNonInheritedFrom(const NonInheritedFlags&);
 
@@ -2178,7 +2178,7 @@ private:
     };
 
     struct InheritedFlags {
-        bool operator==(const InheritedFlags&) const;
+        friend bool operator==(const InheritedFlags&, const InheritedFlags&) = default;
 
         unsigned emptyCells : 1; // EmptyCell
         unsigned captionSide : 2; // CaptionSide

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -787,65 +787,6 @@ inline TextSizeAdjustment RenderStyle::textSizeAdjust() const { return m_rareInh
 inline StyleColor RenderStyle::tapHighlightColor() const { return m_rareInheritedData->tapHighlightColor; }
 #endif
 
-inline bool RenderStyle::InheritedFlags::operator==(const InheritedFlags& other) const
-{
-    return emptyCells == other.emptyCells
-        && captionSide == other.captionSide
-        && listStylePosition == other.listStylePosition
-        && visibility == other.visibility
-        && textAlign == other.textAlign
-        && textTransform == other.textTransform
-        && textDecorationLines == other.textDecorationLines
-        && cursor == other.cursor
-#if ENABLE(CURSOR_VISIBILITY)
-        && cursorVisibility == other.cursorVisibility
-#endif
-        && direction == other.direction
-        && whiteSpaceCollapse == other.whiteSpaceCollapse
-        && textWrap == other.textWrap
-        && borderCollapse == other.borderCollapse
-        && boxDirection == other.boxDirection
-        && rtlOrdering == other.rtlOrdering
-        && printColorAdjust == other.printColorAdjust
-        && pointerEvents == other.pointerEvents
-        && insideLink == other.insideLink
-        && insideDefaultButton == other.insideDefaultButton
-        && writingMode == other.writingMode
-        && hasExplicitlySetColor == other.hasExplicitlySetColor;
-}
-
-inline bool RenderStyle::NonInheritedFlags::operator==(const NonInheritedFlags& other) const
-{
-    return effectiveDisplay == other.effectiveDisplay
-        && originalDisplay == other.originalDisplay
-        && overflowX == other.overflowX
-        && overflowY == other.overflowY
-        && verticalAlign == other.verticalAlign
-        && clear == other.clear
-        && position == other.position
-        && unicodeBidi == other.unicodeBidi
-        && floating == other.floating
-        && tableLayout == other.tableLayout
-        && textDecorationLine == other.textDecorationLine
-        && hasExplicitlySetDirection == other.hasExplicitlySetDirection
-        && hasExplicitlySetWritingMode == other.hasExplicitlySetWritingMode
-#if ENABLE(DARK_MODE_CSS)
-        && hasExplicitlySetColorScheme == other.hasExplicitlySetColorScheme
-#endif
-        && usesViewportUnits == other.usesViewportUnits
-        && usesContainerUnits == other.usesContainerUnits
-        && hasExplicitlyInheritedProperties == other.hasExplicitlyInheritedProperties
-        && disallowsFastPathInheritance == other.disallowsFastPathInheritance
-        && hasContentNone == other.hasContentNone
-        && isUnique == other.isUnique
-        && emptyState == other.emptyState
-        && firstChildState == other.firstChildState
-        && lastChildState == other.lastChildState
-        && isLink == other.isLink
-        && styleType == other.styleType
-        && pseudoBits == other.pseudoBits;
-}
-
 inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) const
 {
     ASSERT(pseudo > PseudoId::None);

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -192,7 +192,7 @@ private:
     void setBitDefaults();
 
     struct InheritedFlags {
-        bool operator==(const InheritedFlags&) const;
+        friend bool operator==(const InheritedFlags&, const InheritedFlags&) = default;
 
         unsigned shapeRendering : 2; // ShapeRendering
         unsigned clipRule : 1; // WindRule
@@ -472,18 +472,6 @@ inline void SVGRenderStyle::setBitDefaults()
     m_nonInheritedFlags.flagBits.vectorEffect = static_cast<unsigned>(initialVectorEffect());
     m_nonInheritedFlags.flagBits.bufferedRendering = static_cast<unsigned>(initialBufferedRendering());
     m_nonInheritedFlags.flagBits.maskType = static_cast<unsigned>(initialMaskType());
-}
-
-inline bool SVGRenderStyle::InheritedFlags::operator==(const InheritedFlags& other) const
-{
-    return shapeRendering == other.shapeRendering
-        && clipRule == other.clipRule
-        && fillRule == other.fillRule
-        && textAnchor == other.textAnchor
-        && colorInterpolation == other.colorInterpolation
-        && colorInterpolationFilters == other.colorInterpolationFilters
-        && glyphOrientationHorizontal == other.glyphOrientationHorizontal
-        && glyphOrientationVertical == other.glyphOrientationVertical;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleColorScheme.h
+++ b/Source/WebCore/rendering/style/StyleColorScheme.h
@@ -41,10 +41,7 @@ public:
         , m_allowsTransformations(allowsTransformations)
     { }
 
-    constexpr bool operator==(const StyleColorScheme& other) const
-    {
-        return m_colorScheme == other.m_colorScheme && m_allowsTransformations == other.m_allowsTransformations;
-    }
+    friend constexpr bool operator==(const StyleColorScheme&, const StyleColorScheme&) = default;
 
     constexpr bool isNormal() const { return m_colorScheme.isEmpty() && m_allowsTransformations; }
     constexpr bool isOnly() const { return m_colorScheme.isEmpty() && !m_allowsTransformations; }

--- a/Source/WebCore/rendering/style/StyleContentAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleContentAlignmentData.h
@@ -54,10 +54,7 @@ public:
     ContentDistribution distribution() const { return static_cast<ContentDistribution>(m_distribution); }
     OverflowAlignment overflow() const { return static_cast<OverflowAlignment>(m_overflow); }
 
-    bool operator==(const StyleContentAlignmentData& o) const
-    {
-        return m_position == o.m_position && m_distribution == o.m_distribution && m_overflow == o.m_overflow;
-    }
+    friend bool operator==(const StyleContentAlignmentData&, const StyleContentAlignmentData&) = default;
 
 private:
     uint16_t m_position : 4 { 0 }; // ContentPosition

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -49,46 +49,6 @@ static inline bool operator==(const StyleGradientImageStop& a, const StyleGradie
         && compareCSSValuePtr(a.position, b.position);
 }
 
-static inline bool operator==(const StyleGradientImage::LinearData& a, const StyleGradientImage::LinearData& b)
-{
-    return a.repeating == b.repeating
-        && a.data == b.data;
-}
-
-static inline bool operator==(const StyleGradientImage::PrefixedLinearData& a, const StyleGradientImage::PrefixedLinearData& b)
-{
-    return a.repeating == b.repeating
-        && a.data == b.data;
-}
-
-static inline bool operator==(const StyleGradientImage::DeprecatedLinearData& a, const StyleGradientImage::DeprecatedLinearData& b)
-{
-    return a.data == b.data;
-}
-
-static inline bool operator==(const StyleGradientImage::RadialData& a, const StyleGradientImage::RadialData& b)
-{
-    return a.repeating == b.repeating
-        && a.data == b.data;
-}
-
-static inline bool operator==(const StyleGradientImage::PrefixedRadialData& a, const StyleGradientImage::PrefixedRadialData& b)
-{
-    return a.repeating == b.repeating
-        && a.data == b.data;
-}
-
-static inline bool operator==(const StyleGradientImage::DeprecatedRadialData& a, const StyleGradientImage::DeprecatedRadialData& b)
-{
-    return a.data == b.data;
-}
-
-static inline bool operator==(const StyleGradientImage::ConicData& a, const StyleGradientImage::ConicData& b)
-{
-    return a.repeating == b.repeating
-        && a.data == b.data;
-}
-
 static bool stopsAreCacheable(const Vector<StyleGradientImage::Stop>& stops)
 {
     for (auto& stop : stops) {

--- a/Source/WebCore/rendering/style/StyleGradientImage.h
+++ b/Source/WebCore/rendering/style/StyleGradientImage.h
@@ -45,28 +45,42 @@ public:
     struct LinearData {
         CSSLinearGradientValue::Data data;
         CSSGradientRepeat repeating;
+
+        friend bool operator==(const LinearData&, const LinearData&) = default;
     };
     struct PrefixedLinearData {
         CSSPrefixedLinearGradientValue::Data data;
         CSSGradientRepeat repeating;
+
+        friend bool operator==(const PrefixedLinearData&, const PrefixedLinearData&) = default;
     };
     struct DeprecatedLinearData {
         CSSDeprecatedLinearGradientValue::Data data;
+
+        friend bool operator==(const DeprecatedLinearData&, const DeprecatedLinearData&) = default;
     };
     struct RadialData {
         CSSRadialGradientValue::Data data;
         CSSGradientRepeat repeating;
+
+        friend bool operator==(const RadialData&, const RadialData&) = default;
     };
     struct PrefixedRadialData {
         CSSPrefixedRadialGradientValue::Data data;
         CSSGradientRepeat repeating;
+
+        friend bool operator==(const PrefixedRadialData&, const PrefixedRadialData&) = default;
     };
     struct DeprecatedRadialData {
         CSSDeprecatedRadialGradientValue::Data data;
+
+        friend bool operator==(const DeprecatedRadialData&, const DeprecatedRadialData&) = default;
     };
     struct ConicData {
         CSSConicGradientValue::Data data;
         CSSGradientRepeat repeating;
+
+        friend bool operator==(const ConicData&, const ConicData&) = default;
     };
 
     using Data = std::variant<LinearData, DeprecatedLinearData, PrefixedLinearData, RadialData, DeprecatedRadialData, PrefixedRadialData, ConicData>;

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -40,10 +40,9 @@ namespace WebCore {
 
 struct NamedGridLinesMap {
     HashMap<String, Vector<unsigned>> map;
-};
 
-inline bool operator==(const NamedGridLinesMap& a, const NamedGridLinesMap& b) { return a.map == b.map; }
-inline bool operator!=(const NamedGridLinesMap& a, const NamedGridLinesMap& b) { return a.map != b.map; }
+    friend bool operator==(const NamedGridLinesMap&, const NamedGridLinesMap&) = default;
+};
 
 struct OrderedNamedGridLinesMap {
     HashMap<unsigned, Vector<String>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> map;
@@ -53,44 +52,29 @@ typedef std::variant<GridTrackSize, Vector<String>> RepeatEntry;
 typedef Vector<RepeatEntry> RepeatTrackList;
 
 struct GridTrackEntrySubgrid {
-    bool operator==(const GridTrackEntrySubgrid&) const
-    {
-        return true;
-    }
+    friend bool operator==(const GridTrackEntrySubgrid&, const GridTrackEntrySubgrid&) = default;
 };
 
 struct GridTrackEntryMasonry {
-    bool operator==(const GridTrackEntryMasonry&) const
-    {
-        return true;
-    }
+    friend bool operator==(const GridTrackEntryMasonry&, const GridTrackEntryMasonry&) = default;
 };
 
 struct GridTrackEntryRepeat {
-    bool operator==(const GridTrackEntryRepeat& other) const
-    {
-        return repeats == other.repeats && list == other.list;
-    }
+    friend bool operator==(const GridTrackEntryRepeat&, const GridTrackEntryRepeat&) = default;
 
     unsigned repeats;
     RepeatTrackList list;
 };
 
 struct GridTrackEntryAutoRepeat {
-    bool operator==(const GridTrackEntryAutoRepeat& other) const
-    {
-        return type == other.type && list == other.list;
-    }
+    friend bool operator==(const GridTrackEntryAutoRepeat&, const GridTrackEntryAutoRepeat&) = default;
 
     AutoRepeatType type;
     RepeatTrackList list;
 };
 
 struct MasonryAutoFlow {
-    bool operator==(const MasonryAutoFlow& other) const
-    { 
-        return placementAlgorithm == other.placementAlgorithm && placementOrder == other.placementOrder;
-    }
+    friend bool operator==(const MasonryAutoFlow&, const MasonryAutoFlow&) = default;
 
     MasonryAutoFlowPlacementAlgorithm placementAlgorithm;
     MasonryAutoFlowPlacementOrder placementOrder;
@@ -99,8 +83,8 @@ struct MasonryAutoFlow {
 typedef std::variant<GridTrackSize, Vector<String>, GridTrackEntryRepeat, GridTrackEntryAutoRepeat, GridTrackEntrySubgrid, GridTrackEntryMasonry> GridTrackEntry;
 struct GridTrackList {
     Vector<GridTrackEntry> list;
+    friend bool operator==(const GridTrackList&, const GridTrackList&) = default;
 };
-inline bool operator==(const GridTrackList& a, const GridTrackList& b) { return a.list == b.list; }
 inline WTF::TextStream& operator<<(WTF::TextStream& stream, const GridTrackList& list) { return stream << list.list; }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RepeatEntry&);
@@ -115,7 +99,7 @@ public:
 
     bool operator==(const StyleGridData& o) const
     {
-        return m_columns.list == o.m_columns.list && m_rows.list == o.m_rows.list && implicitNamedGridColumnLines.map == o.implicitNamedGridColumnLines.map && implicitNamedGridRowLines.map == o.implicitNamedGridRowLines.map && gridAutoFlow == o.gridAutoFlow && gridAutoRows == o.gridAutoRows && gridAutoColumns == o.gridAutoColumns && namedGridArea.map == o.namedGridArea.map && namedGridAreaRowCount == o.namedGridAreaRowCount && namedGridAreaColumnCount == o.namedGridAreaColumnCount && m_masonryRows == o.m_masonryRows && m_masonryColumns == o.m_masonryColumns && masonryAutoFlow == o.masonryAutoFlow && alignTracks == o.alignTracks && justifyTracks == o.justifyTracks;
+        return m_columns == o.m_columns && m_rows == o.m_rows && implicitNamedGridColumnLines == o.implicitNamedGridColumnLines && implicitNamedGridRowLines == o.implicitNamedGridRowLines && gridAutoFlow == o.gridAutoFlow && gridAutoRows == o.gridAutoRows && gridAutoColumns == o.gridAutoColumns && namedGridArea == o.namedGridArea && namedGridAreaRowCount == o.namedGridAreaRowCount && namedGridAreaColumnCount == o.namedGridAreaColumnCount && m_masonryRows == o.m_masonryRows && m_masonryColumns == o.m_masonryColumns && masonryAutoFlow == o.masonryAutoFlow && alignTracks == o.alignTracks && justifyTracks == o.justifyTracks;
     }
 
     void setRows(const GridTrackList&);

--- a/Source/WebCore/rendering/style/StyleScrollSnapPoints.h
+++ b/Source/WebCore/rendering/style/StyleScrollSnapPoints.h
@@ -36,21 +36,15 @@ namespace WebCore {
 struct ScrollSnapType {
     ScrollSnapAxis axis { ScrollSnapAxis::Both };
     ScrollSnapStrictness strictness { ScrollSnapStrictness::None };
-};
 
-inline bool operator==(const ScrollSnapType& a, const ScrollSnapType& b)
-{
-    return a.axis == b.axis && a.strictness == b.strictness;
-}
+    friend bool operator==(const ScrollSnapType&, const ScrollSnapType&) = default;
+};
 
 struct ScrollSnapAlign {
     ScrollSnapAxisAlignType blockAlign { ScrollSnapAxisAlignType::None };
     ScrollSnapAxisAlignType inlineAlign { ScrollSnapAxisAlignType::None };
-};
 
-inline bool operator==(const ScrollSnapAlign& a, const ScrollSnapAlign& b)
-{
-    return a.blockAlign == b.blockAlign && a.inlineAlign == b.inlineAlign;
-}
+    friend bool operator==(const ScrollSnapAlign&, const ScrollSnapAlign&) = default;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -54,10 +54,7 @@ public:
     ItemPositionType positionType() const { return static_cast<ItemPositionType>(m_positionType); }
     OverflowAlignment overflow() const { return static_cast<OverflowAlignment>(m_overflow); }
 
-    bool operator==(const StyleSelfAlignmentData& o) const
-    {
-        return m_position == o.m_position && m_positionType == o.m_positionType && m_overflow == o.m_overflow;
-    }
+    friend bool operator==(const StyleSelfAlignmentData&, const StyleSelfAlignmentData&) = default;
 
 private:
     uint8_t m_position : 4 { 0 }; // ItemPosition

--- a/Source/WebCore/rendering/style/StyleTextBoxEdge.h
+++ b/Source/WebCore/rendering/style/StyleTextBoxEdge.h
@@ -32,11 +32,8 @@ namespace WebCore {
 struct TextBoxEdge {
     TextBoxEdgeType over { TextBoxEdgeType::Leading };
     TextBoxEdgeType under { TextBoxEdgeType::Leading };
-};
 
-inline bool operator==(const TextBoxEdge& a, const TextBoxEdge& b)
-{
-    return a.over == b.over && a.under == b.under;
-}
+    friend bool operator==(const TextBoxEdge&, const TextBoxEdge&) = default;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/TextSizeAdjustment.h
+++ b/Source/WebCore/rendering/style/TextSizeAdjustment.h
@@ -42,7 +42,7 @@ public:
     constexpr bool isNone() const { return m_value == NoTextSizeAdjustment; }
     constexpr bool isPercentage() const { return m_value >= 0; }
 
-    constexpr bool operator==(const TextSizeAdjustment& anAdjustment) const { return m_value == anAdjustment.m_value; }
+    friend constexpr bool operator==(TextSizeAdjustment, TextSizeAdjustment) = default;
 
 private:
     float m_value;
@@ -64,7 +64,7 @@ public:
 
     constexpr bool contains(Fields) const;
 
-    constexpr bool operator==(const AutosizeStatus& other) const { return fields() == other.fields(); }
+    friend constexpr bool operator==(AutosizeStatus, AutosizeStatus) = default;
 
     static float idempotentTextSize(float specifiedSize, float pageScale);
     static AutosizeStatus computeStatus(const RenderStyle&);

--- a/Source/WebCore/rendering/style/TextUnderlineOffset.h
+++ b/Source/WebCore/rendering/style/TextUnderlineOffset.h
@@ -69,10 +69,7 @@ public:
         return m_length.value_or(defaultValue);
     }
 
-    constexpr bool operator==(const TextUnderlineOffset& other) const
-    {
-        return m_length == other.m_length;
-    }
+    friend constexpr bool operator==(TextUnderlineOffset, TextUnderlineOffset) = default;
 
 private:
     constexpr TextUnderlineOffset(std::optional<float> length)

--- a/Source/WebCore/rendering/style/WillChangeData.h
+++ b/Source/WebCore/rendering/style/WillChangeData.h
@@ -112,10 +112,7 @@ private:
             }
         }
         
-        bool operator==(const AnimatableFeature& other) const
-        {
-            return m_feature == other.m_feature && m_cssPropertyID == other.m_cssPropertyID;
-        }
+        friend bool operator==(const AnimatableFeature&, const AnimatableFeature&) = default;
     };
 
     Vector<AnimatableFeature, 1> m_animatableFeatures;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -35,10 +35,7 @@ struct GradientData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     struct Inputs {
-        bool operator==(const Inputs& other) const
-        {
-            return std::tie(objectBoundingBox, textPaintingScale) == std::tie(other.objectBoundingBox, other.textPaintingScale);
-        }
+        friend bool operator==(const Inputs&, const Inputs&) = default;
 
         std::optional<FloatRect> objectBoundingBox;
         float textPaintingScale = 1;

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -57,16 +57,9 @@ struct MatchResult {
     Vector<MatchedProperties> authorDeclarations;
 
     bool isEmpty() const { return userAgentDeclarations.isEmpty() && userDeclarations.isEmpty() && authorDeclarations.isEmpty(); }
-};
 
-inline bool operator==(const MatchResult& a, const MatchResult& b)
-{
-    return a.isForLink == b.isForLink
-        && a.isCacheable == b.isCacheable
-        && a.userAgentDeclarations == b.userAgentDeclarations
-        && a.userDeclarations == b.userDeclarations
-        && a.authorDeclarations == b.authorDeclarations;
-}
+    friend bool operator==(const MatchResult&, const MatchResult&) = default;
+};
 
 inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
 {

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -95,16 +95,13 @@ public:
 
     ExceptionOr<void> convertToSpecifiedUnits(const SVGLengthContext&, SVGLengthType);
 
+    friend bool operator==(SVGLengthValue, SVGLengthValue) = default;
+
 private:
     float m_valueInSpecifiedUnits { 0 };
     SVGLengthType m_lengthType { SVGLengthType::Number };
     SVGLengthMode m_lengthMode { SVGLengthMode::Other };
 };
-
-inline bool operator==(const SVGLengthValue& a, const SVGLengthValue& b)
-{
-    return a.valueInSpecifiedUnits() == b.valueInSpecifiedUnits() && a.lengthType() == b.lengthType() && a.lengthMode() == b.lengthMode();
-}
 
 WTF::TextStream& operator<<(WTF::TextStream&, const SVGLengthValue&);
 

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -70,7 +70,7 @@ public:
         return *this;
     }
 
-    bool operator==(const SVGPathByteStream& other) const { return m_data == other.m_data; }
+    friend bool operator==(const SVGPathByteStream&, const SVGPathByteStream&) = default;
 
     std::unique_ptr<SVGPathByteStream> copy() const
     {

--- a/Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h
@@ -35,16 +35,13 @@ struct ServiceWorkerJobDataIdentifier {
     SWServerConnectionIdentifier connectionIdentifier;
     ServiceWorkerJobIdentifier jobIdentifier;
 
+    friend bool operator==(const ServiceWorkerJobDataIdentifier&, const ServiceWorkerJobDataIdentifier&) = default;
+
     String loggingString() const
     {
         return connectionIdentifier.loggingString() + "-" + jobIdentifier.loggingString();
     }
 };
-
-inline bool operator==(const ServiceWorkerJobDataIdentifier& a, const ServiceWorkerJobDataIdentifier& b)
-{
-    return a.connectionIdentifier == b.connectionIdentifier && a.jobIdentifier == b.jobIdentifier;
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.cpp
@@ -48,11 +48,6 @@ ServiceWorkerRegistrationKey ServiceWorkerRegistrationKey::emptyKey()
     return { };
 }
 
-bool ServiceWorkerRegistrationKey::operator==(const ServiceWorkerRegistrationKey& other) const
-{
-    return m_topOrigin == other.m_topOrigin && m_scope == other.m_scope;
-}
-
 ServiceWorkerRegistrationKey ServiceWorkerRegistrationKey::isolatedCopy() const &
 {
     return { m_topOrigin.isolatedCopy(), m_scope.isolatedCopy() };

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
@@ -43,7 +43,7 @@ public:
 
     WEBCORE_EXPORT static ServiceWorkerRegistrationKey emptyKey();
 
-    WEBCORE_EXPORT bool operator==(const ServiceWorkerRegistrationKey&) const;
+    friend bool operator==(const ServiceWorkerRegistrationKey&, const ServiceWorkerRegistrationKey&) = default;
     bool isEmpty() const { return *this == emptyKey(); }
     WEBCORE_EXPORT bool isMatching(const SecurityOriginData& topOrigin, const URL& clientURL) const;
     bool originIsMatching(const SecurityOriginData& topOrigin, const URL& clientURL) const;

--- a/Source/WebCore/workers/shared/SharedWorkerKey.h
+++ b/Source/WebCore/workers/shared/SharedWorkerKey.h
@@ -33,16 +33,13 @@ struct SharedWorkerKey {
     ClientOrigin origin;
     URL url;
     String name;
+
+    friend bool operator==(const SharedWorkerKey&, const SharedWorkerKey&) = default;
 };
 
 inline void add(Hasher& hasher, const SharedWorkerKey& key)
 {
     add(hasher, key.origin, key.url, key.name);
-}
-
-inline bool operator==(const SharedWorkerKey& a, const SharedWorkerKey& b)
-{
-    return a.origin == b.origin && a.url == b.url && a.name == b.name;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### c14146dd49a0b019dccb408d52339caa77594558
<pre>
Let the compiler generate more comparison operators in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=261095">https://bugs.webkit.org/show_bug.cgi?id=261095</a>

Reviewed by Darin Adler.

Let the compiler generate more comparison operators in WebCore now
that we support c++20.

* Source/WebCore/rendering/CSSValueKey.h:
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/ClipRect.h:
(WebCore::ClipRect::operator== const): Deleted.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::operator== const): Deleted.
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/GapRects.h:
(WebCore::GapRects::operator== const): Deleted.
* Source/WebCore/rendering/HighlightData.h:
(WebCore::RenderRange::operator== const): Deleted.
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
(WebCore::CompositedClipData::operator== const): Deleted.
* Source/WebCore/rendering/Pagination.h:
(WebCore::Pagination::operator== const): Deleted.
* Source/WebCore/rendering/shapes/ShapeInterval.h:
(WebCore::ShapeInterval::operator== const): Deleted.
* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::SVGPathTransformedByteStream::operator== const): Deleted.
* Source/WebCore/rendering/style/BorderData.h:
(WebCore::BorderData::operator== const): Deleted.
* Source/WebCore/rendering/style/BorderValue.h:
(WebCore::BorderValue::operator== const): Deleted.
* Source/WebCore/rendering/style/CounterContent.h:
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/style/CounterDirectives.h:
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/style/CursorData.h:
(WebCore::CursorData::operator== const): Deleted.
* Source/WebCore/rendering/style/FillLayer.h:
(WebCore::FillRepeatXY::operator== const): Deleted.
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/style/GapLength.h:
(WebCore::GapLength::operator== const): Deleted.
* Source/WebCore/rendering/style/GridArea.h:
(WebCore::GridSpan::operator== const): Deleted.
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/style/GridLength.h:
(WebCore::GridLength::operator== const): Deleted.
* Source/WebCore/rendering/style/GridPosition.cpp:
(WebCore::GridPosition::operator== const): Deleted.
* Source/WebCore/rendering/style/GridPosition.h:
* Source/WebCore/rendering/style/LineClampValue.h:
(WebCore::LineClampValue::operator== const): Deleted.
* Source/WebCore/rendering/style/ListStyleType.h:
(WebCore::ListStyleType::operator== const): Deleted.
* Source/WebCore/rendering/style/NinePieceImage.h:
(WebCore::NinePieceImage::operator== const): Deleted.
* Source/WebCore/rendering/style/OffsetRotation.cpp:
(WebCore::OffsetRotation::operator== const): Deleted.
* Source/WebCore/rendering/style/OffsetRotation.h:
* Source/WebCore/rendering/style/OutlineValue.h:
(WebCore::OutlineValue::operator== const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::InheritedFlags::operator== const): Deleted.
(WebCore::RenderStyle::NonInheritedFlags::operator== const): Deleted.
* Source/WebCore/rendering/style/SVGRenderStyle.h:
(WebCore::SVGRenderStyle::InheritedFlags::operator== const): Deleted.
* Source/WebCore/rendering/style/StyleColorScheme.h:
(WebCore::StyleColorScheme::operator== const): Deleted.
* Source/WebCore/rendering/style/StyleContentAlignmentData.h:
(WebCore::StyleContentAlignmentData::operator== const): Deleted.
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
* Source/WebCore/rendering/style/StyleGradientImage.h:
* Source/WebCore/rendering/style/StyleGridData.h:
(WebCore::StyleGridData::operator== const):
(WebCore::operator==): Deleted.
(WebCore::GridTrackEntrySubgrid::operator== const): Deleted.
(WebCore::GridTrackEntryMasonry::operator== const): Deleted.
(WebCore::GridTrackEntryRepeat::operator== const): Deleted.
(WebCore::GridTrackEntryAutoRepeat::operator== const): Deleted.
(WebCore::MasonryAutoFlow::operator== const): Deleted.
* Source/WebCore/rendering/style/StyleScrollSnapPoints.h:
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
(WebCore::StyleSelfAlignmentData::operator== const): Deleted.
* Source/WebCore/rendering/style/StyleTextBoxEdge.h:
(WebCore::operator==): Deleted.
* Source/WebCore/rendering/style/TextSizeAdjustment.h:
(WebCore::TextSizeAdjustment::operator== const): Deleted.
(WebCore::AutosizeStatus::operator== const): Deleted.
* Source/WebCore/rendering/style/TextUnderlineOffset.h:
(WebCore::TextUnderlineOffset::operator== const): Deleted.
* Source/WebCore/rendering/style/WillChangeData.h:
(WebCore::WillChangeData::AnimatableFeature::operator== const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
(WebCore::GradientData::Inputs::operator== const): Deleted.
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::MatchResult::isEmpty const):
* Source/WebCore/svg/SVGLengthValue.h:
(WebCore::operator==): Deleted.
* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::operator== const): Deleted.
* Source/WebCore/workers/service/ServiceWorkerJobDataIdentifier.h:
(WebCore::operator==): Deleted.
* Source/WebCore/workers/service/ServiceWorkerRegistrationKey.cpp:
(WebCore::ServiceWorkerRegistrationKey::operator== const): Deleted.
* Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h:
* Source/WebCore/workers/shared/SharedWorkerKey.h:
(WebCore::operator==): Deleted.

Canonical link: <a href="https://commits.webkit.org/267612@main">https://commits.webkit.org/267612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a58a335d81849c9198dc35d7c2b9872e294dc40a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16080 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19786 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22297 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15523 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4098 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->