### PR TITLE
Change --logJIT to dump its header line on a single line.

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -94,11 +94,10 @@ LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithDisassemblyImp
         out.vprintf(format, argList);
 
     va_end(argList);
-    out.printf(":\n");
 
     uint8_t* executableAddress = result.code().untaggedPtr<uint8_t*>();
-    out.printf("    Code at [%p, %p)%s\n", executableAddress, executableAddress + result.size(), justDumpingHeader ? "." : ":");
-    
+    out.printf(": [%p, %p) %zu bytes%s\n", executableAddress, executableAddress + result.size(), result.size(), justDumpingHeader ? "." : ":");
+
     CString header = out.toCString();
     
     if (justDumpingHeader) {

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,15 +157,18 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
 
     MonotonicTime before;
     CString codeBlockName;
-    if (UNLIKELY(computeCompileTimes()))
+
+    bool computeCompileTimes = this->computeCompileTimes();
+    if (UNLIKELY(computeCompileTimes)) {
         before = MonotonicTime::now();
-    if (UNLIKELY(reportCompileTimes()))
-        codeBlockName = toCString(*m_codeBlock);
+        if (reportCompileTimes())
+            codeBlockName = toCString(*m_codeBlock);
+    }
 
     CompilationScope compilationScope;
 
 #if ENABLE(DFG_JIT)
-    if (DFG::logCompilationChanges(m_mode) || Options::logPhaseTimes())
+    if (UNLIKELY(DFG::logCompilationChanges(m_mode) || Options::logPhaseTimes()))
         dataLog("DFG(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
 #endif // ENABLE(DFG_JIT)
 
@@ -173,21 +176,22 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
 
     RELEASE_ASSERT((path == CancelPath) == (m_stage == JITPlanStage::Canceled));
 
-    MonotonicTime after;
-    if (UNLIKELY(computeCompileTimes())) {
-        after = MonotonicTime::now();
+    if (LIKELY(!computeCompileTimes))
+        return;
 
-        if (Options::reportTotalCompileTimes()) {
-            if (isFTL()) {
-                totalFTLCompileTime += after - before;
-                totalFTLDFGCompileTime += m_timeBeforeFTL - before;
-                totalFTLB3CompileTime += after - m_timeBeforeFTL;
-            } else if (mode() == JITCompilationMode::Baseline)
-                totalBaselineCompileTime += after - before;
-            else
-                totalDFGCompileTime += after - before;
-        }
+    MonotonicTime after = MonotonicTime::now();
+
+    if (Options::reportTotalCompileTimes()) {
+        if (isFTL()) {
+            totalFTLCompileTime += after - before;
+            totalFTLDFGCompileTime += m_timeBeforeFTL - before;
+            totalFTLB3CompileTime += after - m_timeBeforeFTL;
+        } else if (mode() == JITCompilationMode::Baseline)
+            totalBaselineCompileTime += after - before;
+        else
+            totalDFGCompileTime += after - before;
     }
+
     const char* pathName = nullptr;
     switch (path) {
     case FailPath:

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -558,7 +558,6 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
     v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
-    v(Bool, dumpCompilerConstructionSite, false, Normal, nullptr) \
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \


### PR DESCRIPTION
#### aaec31beee6cfb4e90729eb3814609a04b776fe2
<pre>
Change --logJIT to dump its header line on a single line.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261096">https://bugs.webkit.org/show_bug.cgi?id=261096</a>
rdar://114916585

Reviewed by Alexey Shvayka.

It currently dumps one &quot;Generated JIT code for ...&quot; line and a second line indicating the bounds
of the JIT code.  This patch makes the 2 into 1 line, and adds JITCode size in bytes to the
dump.  This makes the dump easier to filter out / grep for info about certain JIT code
generation.

Other miscellaneous changes:
1. Removed unused --dumpCompilerConstructionSite option.
2. Changed JITPlan::compileInThread to cache the result of computeCompileTimes(), and to return
   early if it is false.  The rest of the function after the call to compileInThreadImpl() are
   all to do dumps.  Those dumps are gated on conditions which will cause computeCompileTimes()
   to return true if the dump is needed.  Hence, there&apos;s no need to do extra work if
   computeCompileTimes() is false.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::finalizeCodeWithDisassemblyImpl):
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::compileInThread):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/267639@main">https://commits.webkit.org/267639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ab8155ceb00eda327b28905e7ad01a6957b2747

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18921 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18231 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19737 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22255 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14794 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20072 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16356 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13843 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18698 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15475 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4351 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19842 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19923 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2111 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16152 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4212 "Passed tests") | 
<!--EWS-Status-Bubble-End-->