### PR TITLE
Invalidate :has(:is(:host(...) ...)) correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Before adding 'a' to #host: Check #subject1 color
 PASS Before adding 'a' to #host: Check #subject2 color
-FAIL After adding 'a' to #host: Check #subject1 color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL After adding 'a' to #host: Check #subject2 color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS After adding 'a' to #host: Check #subject1 color
+PASS After adding 'a' to #host: Check #subject2 color
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -75,11 +75,23 @@ static unsigned rulesCountForName(const RuleSet::AtomRuleMap& map, const AtomStr
 
 static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
 {
+    auto isHostSelectorMatchingInShadowTreeInSelectorList = [](const CSSSelectorList* selectorList) {
+        if (!selectorList || selectorList->isEmpty())
+            return false;
+        for (auto* selector = selectorList->first(); selector; selector = CSSSelectorList::next(selector)) {
+            if (isHostSelectorMatchingInShadowTree(*selector))
+                return true;
+        }
+        return false;
+    };
+
     bool hasOnlyOneCompound = true;
     bool hasHostInLastCompound = false;
     for (auto* selector = &startSelector; selector; selector = selector->tagHistory()) {
         if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassType::Host)
             hasHostInLastCompound = true;
+        if (isHostSelectorMatchingInShadowTreeInSelectorList(selector->selectorList()))
+            return true;
         if (selector->tagHistory() && selector->relation() != CSSSelector::RelationType::Subselector) {
             hasOnlyOneCompound = false;
             hasHostInLastCompound = false;


### PR DESCRIPTION
#### 12307bbe8a5a1eb20864ff71890f87469666c7d9
<pre>
Invalidate :has(:is(:host(...) ...)) correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=253945">https://bugs.webkit.org/show_bug.cgi?id=253945</a>
rdar://106768205

Reviewed by Antti Koivisto.

RuleSet records whether it contains any :host() rules that could
possibly match correctly in a shadow tree -- it checks that the :host()
only appears in the leftmost compound. Invalidation uses this state to
determine whether we need to traverse into a shadow tree, when a class
changes on a host element.

But this is not sufficient to invalidate rules like:

:has(:is(:host(...) div))

This is a properly used :host() selector, since it appears in the
leftmost position. So we adjust isHostSelectorMatchingInShadowTree to
look into nested selector list arguments like those found in :has().

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::isHostSelectorMatchingInShadowTree):

Canonical link: <a href="https://commits.webkit.org/267773@main">https://commits.webkit.org/267773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47797c4152c9f451edf9e2df11ab7a729af17d02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18133 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18166 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20328 "Failed to checkout and rebase branch from PR 17398") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16080 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/20328 "Failed to checkout and rebase branch from PR 17398") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16410 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/20328 "Failed to checkout and rebase branch from PR 17398") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16823 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15939 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4203 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->