### PR TITLE
Split out :has(:host-context()) invalidation tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Before adding 'a' to #host_parent: Check #subject1 color
+PASS Before adding 'a' to #host_parent: Check #subject2 color
+FAIL After adding 'a' to #host_parent: Check #subject1 color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL After adding 'a' to #host_parent: Check #subject2 color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS After removing 'a' from #host_parent: Check #subject1 color
+PASS After removing 'a' from #host_parent: Check #subject2 color
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>CSS Test: Invalidation for :host() inside :has()</title>
+<title>CSS Test: Invalidation for :host-context() inside :has()</title>
 <link rel="author" title="Byungwoo" href="mailto:blee@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/selectors/#relational">
 <script src="/resources/testharness.js"></script>
@@ -13,8 +13,8 @@
       .subject {
         color: red;
       }
-      .subject:has(:is(:host(.a) > .foo .bar)) { color: green }
-      .subject:has(:is(:host(.a) .bar)) { color: blue }
+      .subject:has(:is(:host-context(.a) > .foo .bar)) { color: green }
+      .subject:has(:is(:host-context(.a) .bar)) { color: blue }
     </style>
     <div class="foo">
       <div id="subject1" class="subject">
@@ -41,11 +41,16 @@
     }, test_name + ": Check #" + subject_id + " color");
   }
 
-  checkColor("Before adding 'a' to #host", "subject1", red);
-  checkColor("Before adding 'a' to #host", "subject2", red);
+  checkColor("Before adding 'a' to #host_parent", "subject1", red);
+  checkColor("Before adding 'a' to #host_parent", "subject2", red);
 
-  host.classList.add('a');
+  host_parent.classList.add('a');
 
-  checkColor("After adding 'a' to #host", "subject1", green);
-  checkColor("After adding 'a' to #host", "subject2", blue);
+  checkColor("After adding 'a' to #host_parent", "subject1", green);
+  checkColor("After adding 'a' to #host_parent", "subject2", blue);
+
+  host_parent.classList.remove('a');
+
+  checkColor("After removing 'a' from #host_parent", "subject1", red);
+  checkColor("After removing 'a' from #host_parent", "subject2", red);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt
@@ -1,10 +1,6 @@
 
-PASS Before adding 'a' to #host_parent: Check #subject1 color
-PASS Before adding 'a' to #host_parent: Check #subject2 color
-FAIL After adding 'a' to #host_parent: Check #subject1 color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL After adding 'a' to #host_parent: Check #subject2 color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
-PASS After removing 'a' from #host_parent: Check #subject1 color
-PASS After removing 'a' from #host_parent: Check #subject2 color
-FAIL After adding 'a' to #host: Check #subject1 color assert_equals: expected "rgb(154, 205, 50)" but got "rgb(255, 0, 0)"
-FAIL After adding 'a' to #host: Check #subject2 color assert_equals: expected "rgb(135, 206, 235)" but got "rgb(255, 0, 0)"
+PASS Before adding 'a' to #host: Check #subject1 color
+PASS Before adding 'a' to #host: Check #subject2 color
+FAIL After adding 'a' to #host: Check #subject1 color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL After adding 'a' to #host: Check #subject2 color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
 


### PR DESCRIPTION
#### 68e96f24aae90f5a0a5e0c56c932c93616766cc7
<pre>
Split out :has(:host-context()) invalidation tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=261098">https://bugs.webkit.org/show_bug.cgi?id=261098</a>
rdar://114918695

Reviewed by Cameron McCormack.

We intentionally don&apos;t implement :host-context().

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-context-pseudo-class-in-has.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has.html.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-pseudo-class-in-has.html:

Canonical link: <a href="https://commits.webkit.org/267603@main">https://commits.webkit.org/267603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b3fcf66a119f07f1eb2eef3c6d250fa5d67d771

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17695 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19747 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14935 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15934 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20078 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16331 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15485 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/15414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19852 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2105 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->