### PR TITLE
prepare-commit-msg hook doesn't generate a changed file list with Windows Git

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -106,7 +106,7 @@ def parseChanges(command, commit_message):
 
 def message(source=None, sha=None):
     commit_message = []
-    command = ['perl', os.path.join(SCRIPTS, 'prepare-ChangeLog'), '--no-write', '--only-files', '--delimiters', '--git-index']
+    command = [{{ perl }}, os.path.join(SCRIPTS, 'prepare-ChangeLog'), '--no-write', '--only-files', '--delimiters', '--git-index']
 
     if sha:
         commit_message.append('Amend changes:')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -23,6 +23,7 @@
 import os
 import re
 import sys
+import shutil
 
 from .command import Command
 from webkitbugspy import radar
@@ -181,6 +182,9 @@ class InstallHooks(Command):
 
         trailers_to_strip = ['Identifier'] + ([identifier_template.split(':', 1)[0]] if identifier_template else [])
         source_remotes = repository.source_remotes() or ['origin']
+        perl = 'perl'
+        if sys.version_info >= (3, 3):
+            perl = shutil.which('perl')
 
         installed_hooks = 0
         for hook in hook_names:
@@ -197,6 +201,7 @@ class InstallHooks(Command):
                 from jinja2 import Template
                 contents = Template(f.read()).render(
                     location=os.path.relpath(source_path, repository.root_path),
+                    perl=repr(perl),
                     python=os.path.basename(sys.executable),
                     prefer_radar=bool(radar.Tracker.radarclient()),
                     default_pre_push_mode="'{}'".format(getattr(args, 'mode', cls.MODES[0])),


### PR DESCRIPTION
#### 662e3790e0b6902fe02cd8594c47052a8bb935c9
<pre>
prepare-commit-msg hook doesn&apos;t generate a changed file list with Windows Git
<a href="https://bugs.webkit.org/show_bug.cgi?id=261097">https://bugs.webkit.org/show_bug.cgi?id=261097</a>

Reviewed by Jonathan Bedard.

prepare-ChangeLog reproted &quot;Can&apos;t locate VCSUtils.pm in @INC&quot; error if
it was executed from prepare-commit-msg hook of Windows Git. It failed
to set a library path to &apos;Tools/Scripts&apos; directory.

Windows Git includes msys perl. prepare-commit-msg hook unexpectedly
executed it. It should execute Windows Perl.

Use shutil.which to get perl&apos;s absolute path. But, it&apos;s available for
Python 3.3 or newer. Windows port developers have been switched to
Python 3. Use the original relative command name &apos;perl&apos; for older
Python.

* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
* (InstallHooks.main): Added a new template variable &apos;perl&apos; to set
perl&apos;s absolute path.

Canonical link: <a href="https://commits.webkit.org/267649@main">https://commits.webkit.org/267649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc3b7cf5e809a106acc3e30d34897718d3bd557

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18240 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19746 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17281 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22259 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16330 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13852 "1 failures") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/17007 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15484 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4129 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->