### PR TITLE
WebRTC remote video codec factories should check video format strings in a case insensitive way

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
@@ -7,6 +7,7 @@ PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecogn
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecognized codec with dataview description
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Audio codec
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Codec with MIME type
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future H264 codec string
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
@@ -16,6 +17,7 @@ PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized cod
 PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized codec with dataview description
 PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
@@ -59,6 +59,10 @@ const validButUnsupportedConfigs = [
     config: {codec: 'vp9'},
   },
   {
+    comment: 'Codec with bad casing',
+    config: {codec: 'Vp09.00.10.08'},
+  },
+  {
     comment: 'Codec with MIME type',
     config: {codec: 'video/webm; codecs="vp8"'},
   },

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
@@ -7,6 +7,7 @@ PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecogn
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Unrecognized codec with dataview description
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Audio codec
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Codec with MIME type
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future H264 codec string
 PASS Test that VideoDecoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
@@ -16,6 +17,7 @@ PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized cod
 PASS Test that VideoDecoder.configure() doesn't support config: Unrecognized codec with dataview description
 PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -13,6 +13,7 @@ PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 
 PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
 FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
@@ -25,6 +26,9 @@ FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalabil
           codec.configure(entry.config);
         }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
 FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
@@ -90,6 +90,14 @@ const validButUnsupportedConfigs = [
     },
   },
   {
+    comment: 'Codec with bad casing',
+    config: {
+      codec: 'vP8',
+      width: 640,
+      height: 480,
+    },
+  },
+  {
     comment: 'Width is too large',
     config: {
       codec: 'vp8',

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -13,6 +13,7 @@ PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 
 PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
 FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
@@ -25,6 +26,9 @@ FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalabil
           codec.configure(entry.config);
         }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
 FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1836,6 +1836,8 @@ webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 
+webkit.org/b/261099 webrtc/video-lowercase-media-subtype.html [ Skip ]
+
 # DataChannel GstWebRTC implementation incomplete, missing stats support.
 webkit.org/b/235885 webrtc/datachannel/datachannel-stats.html [ Skip ]
 webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [ Skip ]

--- a/LayoutTests/webrtc/video-lowercase-media-subtype-expected.txt
+++ b/LayoutTests/webrtc/video-lowercase-media-subtype-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Video exchange with lower case h264 on encoding side
+PASS Video exchange with lower case h264 on decoding side
+

--- a/LayoutTests/webrtc/video-lowercase-media-subtype.html
+++ b/LayoutTests/webrtc/video-lowercase-media-subtype.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Lowercase media subtype name in SDP</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video1" playsinline autoplay=""></video>
+        <video id="video2" playsinline autoplay=""></video>
+        <script>
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video:true });
+
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    pc2.addTrack(localStream.getVideoTracks()[0], localStream);
+    pc1.addTransceiver("video", {direction:"recvonly"});
+
+    const codecs = RTCRtpSender.getCapabilities("video").codecs;
+    const h264Codec = codecs.filter(codec => { return codec.mimeType === "video/H264"; })[0];
+    pc1.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([h264Codec]); });
+
+    pc1.onicecandidate = (e) => pc2.addIceCandidate(e.candidate);
+    pc2.onicecandidate = (e) => pc1.addIceCandidate(e.candidate);
+
+    await pc1.setLocalDescription();
+    let desc = pc1.localDescription;
+
+    const regex = /H264/i;
+    desc.sdp = desc.sdp.replace(regex, "h264");
+    await pc2.setRemoteDescription(desc);
+
+    const answer = await pc2.createAnswer();
+    await pc1.setRemoteDescription(answer);
+
+    answer.sdp = answer.sdp.replace(regex, "h264");
+    await pc2.setLocalDescription(answer);
+
+    video1.srcObject = new MediaStream([pc1.getReceivers()[0].track]);
+    await video1.play();
+}, "Video exchange with lower case h264 on encoding side");
+
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video:true });
+
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    pc1.addTrack(localStream.getVideoTracks()[0], localStream);
+    const remoteStreamPromise = new Promise((resolve, reject) => {
+        pc2.ontrack = (e) => resolve(e.streams[0]);
+        setTimeout(() => reject("no remote track"), 5000);
+    });
+
+    const codecs = RTCRtpSender.getCapabilities("video").codecs;
+    const h264Codec = codecs.filter(codec => { return codec.mimeType === "video/H264"; })[0];
+    pc1.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([h264Codec]); });
+
+    pc1.onicecandidate = (e) => pc2.addIceCandidate(e.candidate);
+    pc2.onicecandidate = (e) => pc1.addIceCandidate(e.candidate);
+
+    await pc1.setLocalDescription();
+    let desc = pc1.localDescription;
+
+    const regex = /H264/i;
+    desc.sdp = desc.sdp.replace(regex, "h264");
+    await pc2.setRemoteDescription(desc);
+
+    const answer = await pc2.createAnswer();
+    await pc1.setRemoteDescription(answer);
+
+    answer.sdp = answer.sdp.replace(regex, "h264");
+    await pc2.setLocalDescription(answer);
+
+    video2.srcObject = await remoteStreamPromise;
+    await video2.play();
+}, "Video exchange with lower case h264 on decoding side");
+        </script>
+    </body>
+</html>

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -65,16 +65,18 @@ using namespace WebCore;
 static webrtc::WebKitVideoDecoder createVideoDecoder(const webrtc::SdpVideoFormat& format)
 {
     auto& codecs = WebProcess::singleton().libWebRTCCodecs();
-    if (format.name == "H264")
+    auto codecString = String::fromUTF8(format.name.data(), format.name.length());
+
+    if (equalIgnoringASCIICase(codecString, "H264"_s))
         return { codecs.createDecoder(VideoCodecType::H264), false };
 
-    if (format.name == "H265")
+    if (equalIgnoringASCIICase(codecString, "H265"_s))
         return { codecs.createDecoder(VideoCodecType::H265), false };
 
-    if (format.name == "VP9" && codecs.supportVP9VTB())
+    if (equalIgnoringASCIICase(codecString, "VP9"_s) && codecs.supportVP9VTB())
         return { codecs.createDecoder(VideoCodecType::VP9), false };
 
-    if (format.name == "AV1") {
+    if (equalIgnoringASCIICase(codecString, "AV1"_s)) {
         auto av1Decoder = createLibWebRTCDav1dDecoder().moveToUniquePtr();
         return { av1Decoder.release(), true };
     }
@@ -124,10 +126,10 @@ static int32_t registerDecodeCompleteCallback(webrtc::WebKitVideoDecoder::Value 
 
 static webrtc::WebKitVideoEncoder createVideoEncoder(const webrtc::SdpVideoFormat& format)
 {
-    if (format.name == "H264")
+    if (format.name == "H264" || format.name == "h264")
         return WebProcess::singleton().libWebRTCCodecs().createEncoder(VideoCodecType::H264, format.parameters);
 
-    if (format.name == "H265")
+    if (format.name == "H265" || format.name == "h265")
         return WebProcess::singleton().libWebRTCCodecs().createEncoder(VideoCodecType::H265, format.parameters);
 
     return nullptr;


### PR DESCRIPTION
#### 758b9fa876abfee20303553bcdb17de2b92746e1
<pre>
WebRTC remote video codec factories should check video format strings in a case insensitive way
<a href="https://bugs.webkit.org/show_bug.cgi?id=261099">https://bugs.webkit.org/show_bug.cgi?id=261099</a>
rdar://114839348

Reviewed by Jean-Yves Avenard.

Make WebRTC codec checks case insensitive, which follows what other browsers are doing.
Add a WebRTC test case to cover this case.

Keep doing case sensitive checks for WebCodecs and beef up WPT webcodecs tests accordingly.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* LayoutTests/webrtc/video-lowercase-media-subtype-expected.txt: Added.
* LayoutTests/webrtc/video-lowercase-media-subtype.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::createVideoDecoder):
(WebKit::createVideoEncoder):

Canonical link: <a href="https://commits.webkit.org/267637@main">https://commits.webkit.org/267637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638a6ff7314e5d401f47834587a4fc87a0790eb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19777 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22290 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20108 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13877 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4120 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->