### PR TITLE
Add support for the “details” element’s “name” attribute

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -6601,6 +6601,7 @@
         "web-platform-tests/html/semantics/grouping-content/the-pre-element/grouping-pre-reftest-001-ref.html",
         "web-platform-tests/html/semantics/grouping-content/the-pre-element/pre-newline-bidi-ref.html",
         "web-platform-tests/html/semantics/interactive-elements/the-details-element/details-add-summary-ref.html",
+        "web-platform-tests/html/semantics/interactive-elements/the-details-element/support/empty-html-document.html",
         "web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-descendant-selector-ref.html",
         "web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-does-not-inherit-ref.html",
         "web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-dynamic-display-none-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/name-content-attribute-and-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/name-content-attribute-and-property-expected.txt
@@ -16,6 +16,7 @@ PASS param element's name property reflects its content attribute
 PASS select element's name property reflects its content attribute
 PASS slot element's name property reflects its content attribute
 PASS textarea element's name property reflects its content attribute
+PASS details element's name property reflects its content attribute
 PASS abbr element's name property does not reflect its content attribute
 PASS address element's name property does not reflect its content attribute
 PASS area element's name property does not reflect its content attribute
@@ -39,7 +40,6 @@ PASS data element's name property does not reflect its content attribute
 PASS datalist element's name property does not reflect its content attribute
 PASS dd element's name property does not reflect its content attribute
 PASS del element's name property does not reflect its content attribute
-PASS details element's name property does not reflect its content attribute
 PASS dfn element's name property does not reflect its content attribute
 PASS dialog element's name property does not reflect its content attribute
 PASS div element's name property does not reflect its content attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/name-content-attribute-and-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/name-content-attribute-and-property.html
@@ -26,7 +26,20 @@
     "iframe", "img", "input", "map", "meta", "object", "output",
     "param", "select", "slot", "textarea",
   ];
+
+  // Optionally add "details" to reflectingTagNames since Chromium is
+  // prototyping the proposal at
+  // https://open-ui.org/components/accordion.explainer that adds this
+  // reflection to "details" as well.
+  // TODO(https://crbug.com/1444057): This runtime check should eventually be
+  // removed, and depending on the outcome of the proposal details should
+  // possibly be added to reflectingTagNames unconditionally.
+  if ("name" in HTMLDetailsElement.prototype) {
+    reflectingTagNames.push("details");
+  }
+
   const old_and_new_elements = [...HTML5_ELEMENTS, ...HTML5_DEPRECATED_ELEMENTS];
+
   const nonReflectingTagNames = old_and_new_elements.filter(x => !reflectingTagNames.includes(x));
 
   reflectingTagNames.forEach(function(tagName) {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative-expected.txt
@@ -1,0 +1,16 @@
+
+PASS basic handling of mutually exclusive details
+PASS more complex handling of mutually exclusive details
+PASS mutually exclusive details across multiple names and multiple tree scopes
+PASS mutation event and toggle event order matches tree order
+PASS interaction of open attribute changes with mutation events
+PASS empty and missing name attributes do not create groups
+PASS exclusivity enforcement with attachment scenario connected
+PASS exclusivity enforcement with attachment scenario disconnected
+PASS exclusivity enforcement with attachment scenario shadow
+PASS exclusivity enforcement with attachment scenario shadow-in-disconnected
+PASS exclusivity enforcement with attachment scenario template-in-disconnected
+PASS exclusivity enforcement with attachment scenario connected-in-xhr-response
+PASS exclusivity enforcement with attachment scenario connected-in-implementation-create-document
+PASS exclusivity enforcement with attachment scenario connected-in-template
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative.html
@@ -1,0 +1,329 @@
+<!DOCTYPE HTML>
+<meta charset=UTF-8>
+<title>Test for the name attribute creating exclusive accordions from details elements</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-details-element">
+<link rel="help" href="https://open-ui.org/components/accordion.explainer">
+<link rel="help" href="https://github.com/openui/open-ui/issues/725">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1444057">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="container">
+</div>
+
+<script>
+
+function assert_element_states(elements, expectations, description) {
+  assert_array_equals(elements.map(e => Number(e.open)), expectations, description);
+}
+
+let container = document.getElementById("container");
+
+promise_test(async t => {
+  container.innerHTML = `
+    <details name="a">
+      <summary>1</summary>
+      This is the first item.
+    </details>
+
+    <details name="a">
+      <summary>2</summary>
+      This is the second item.
+    </details>
+  `;
+  let first = container.firstElementChild;
+  let second = first.nextElementSibling;
+  assert_false(first.open);
+  assert_false(second.open);
+  first.open = true;
+  assert_true(first.open);
+  assert_false(second.open);
+  second.open = true;
+  assert_false(first.open);
+  assert_true(second.open);
+  second.open = true;
+  assert_false(first.open);
+  assert_true(second.open);
+  second.open = false;
+  assert_false(first.open);
+  assert_false(second.open);
+}, "basic handling of mutually exclusive details");
+
+promise_test(async t => {
+  container.innerHTML = `
+    <details name="a" open>
+      <summary>1</summary>
+      This is the first item.
+    </details>
+
+    <details name="a">
+      <summary>2</summary>
+      This is the second item.
+    </details>
+
+    <details name="a" open>
+      <summary>3</summary>
+      This is the third item.
+    </details>
+  `;
+  let first = container.firstElementChild;
+  let second = first.nextElementSibling;
+  let third = second.nextElementSibling;
+  function assert_states(expected_first, expected_second, expected_third, description) {
+    assert_array_equals([first.open, second.open, third.open], [expected_first, expected_second, expected_third], description);
+  }
+
+  assert_states(true, false, true, "initial states from open attribute");
+  first.open = true;
+  assert_states(true, false, true, "non-mutation doesn't change state");
+  second.open = true;
+  assert_states(false, true, false, "mutation closes multiple open elements");
+  third.setAttribute("open", "");
+  assert_states(false, false, true, "setAttribute closes other open element");
+}, "more complex handling of mutually exclusive details");
+
+promise_test(async t => {
+  let details_elements_string = `
+    <details name="a"></details>
+    <details name="a" open></details>
+    <details name="b"></details>
+    <details name="b"></details>
+  `;
+  container.innerHTML = `
+    ${details_elements_string}
+    <div id="shadow_host"></div>
+  `;
+  let shadow_root = document.getElementById("shadow_host").attachShadow({ mode: "open" });
+  shadow_root.innerHTML = details_elements_string;
+  let elements = Array.from(container.querySelectorAll("details")).concat(Array.from(shadow_root.querySelectorAll("details")));
+
+  assert_element_states(elements, [0, 1, 0, 0, 0, 1, 0, 0], "initial states from open attribute");
+  elements[4].open = true;
+  assert_element_states(elements, [0, 1, 0, 0, 1, 0, 0, 0], "after mutation in shadow tree");
+  for (let i = 0; i < 8; ++i) {
+    elements[i].open = true;
+  }
+  assert_element_states(elements, [0, 1, 0, 1, 0, 1, 0, 1], "after setting all elements open");
+  elements[0].open = true;
+  assert_element_states(elements, [1, 0, 0, 1, 0, 1, 0, 1], "after final mutation");
+}, "mutually exclusive details across multiple names and multiple tree scopes");
+
+promise_test(async t => {
+  container.innerHTML = `
+    <details name="a" id="e0" open></details>
+    <details name="a" id="e1"></details>
+    <details name="a" id="e3" open></details>
+  `;
+  let e2 = document.createElement("details");
+  e2.id = "e2";
+  e2.name = "a";
+  e2.open = true;
+  let elements = [ document.getElementById("e0"),
+                   document.getElementById("e1"),
+                   e2,
+                   document.getElementById("e3") ];
+  container.insertBefore(e2, elements[3]);
+
+  let mutation_event_received_ids = [];
+  let mutation_listener = event => {
+    assert_equals(event.type, "DOMSubtreeModified");
+    assert_equals(event.target.nodeType, Node.ELEMENT_NODE);
+    let element = event.target;
+    assert_equals(element.localName, "details");
+    mutation_event_received_ids.push(element.id);
+  };
+  let toggle_event_received_ids = [];
+  let toggle_event_promises = [];
+  for (let element of elements) {
+    element.addEventListener("DOMSubtreeModified", mutation_listener);
+    toggle_event_promises.push(new Promise((resolve, reject) => {
+      element.addEventListener("toggle", event => {
+        assert_equals(event.type, "toggle");
+        assert_equals(event.target, element);
+        toggle_event_received_ids.push(element.id);
+        resolve(undefined);
+      });
+    }));
+  }
+  assert_array_equals(mutation_event_received_ids, []);
+  assert_element_states(elements, [1, 0, 1, 1], "states before mutation");
+  elements[1].open = true;
+  if (mutation_event_received_ids.length == 0) {
+    // ok if mutation events are not supported
+  } else {
+    assert_array_equals(mutation_event_received_ids, ["e0", "e2", "e3", "e1"],
+                        "removal events received in tree order, followed by addition event");
+  }
+  assert_element_states(elements, [0, 1, 0, 0], "states after mutation");
+  assert_array_equals(toggle_event_received_ids, [], "toggle events received before awaiting promises");
+  await Promise.all(toggle_event_promises);
+  assert_array_equals(toggle_event_received_ids, ["e1", "e0", "e2", "e3"], "toggle events received after awaiting promises");
+}, "mutation event and toggle event order matches tree order");
+
+// This function is used to guard tests that test behavior that is
+// relevant only because of Mutation Events.  If mutation events (for
+// attribute addition/removal) are removed from the web, the tests using
+// this function can be removed.
+function mutation_events_for_attribute_removal_supported() {
+  if (!("MutationEvent" in window)) {
+    return false;
+  }
+  container.innerHTML = `<div id="event-removal-test"></div>`;
+  let element = container.firstChild;
+  let event_fired = false;
+  element.addEventListener("DOMSubtreeModified", event => event_fired = true);
+  element.removeAttribute("id");
+  return event_fired;
+}
+
+promise_test(async t => {
+  if (!mutation_events_for_attribute_removal_supported()) {
+    return;
+  }
+  container.innerHTML = `
+    <details name="a" id="e0" open></details>
+    <details name="a" id="e1"></details>
+    <details name="a" id="e2" open></details>
+  `;
+  let elements = [ document.getElementById("e0"),
+                   document.getElementById("e1"),
+                   document.getElementById("e2") ];
+
+  let received_ids = [];
+  let listener = event => {
+    received_ids.push(event.target.id);
+    let i = 0;
+    for (let element of elements) {
+      element.setAttribute("name", `b${i++}`);
+    }
+  };
+  for (let element of elements) {
+    element.addEventListener("DOMSubtreeModified", listener);
+  }
+  assert_array_equals(received_ids, []);
+  assert_element_states(elements, [1, 0, 1], "states before mutation");
+  elements[1].open = true;
+  assert_array_equals(received_ids, ["e0", "e2", "e1"],
+                      "removal events received in tree order, followed by addition event, despite changes to name during mutation event");
+  assert_element_states(elements, [0, 1, 0], "states after mutation");
+}, "interaction of open attribute changes with mutation events");
+
+promise_test(async t => {
+  container.innerHTML = `
+    <details></details>
+    <details></details>
+    <details name></details>
+    <details name></details>
+    <details name=""></details>
+    <details name=""></details>
+  `;
+  let elements = Array.from(container.querySelectorAll("details"));
+
+  assert_element_states(elements, [0, 0, 0, 0, 0, 0], "initial states from open attribute");
+  for (let i = 0; i < 6; ++i) {
+    elements[i].open = true;
+  }
+  assert_element_states(elements, [1, 1, 1, 1, 1, 1], "after setting all elements open");
+}, "empty and missing name attributes do not create groups");
+
+const connected_scenarios = {
+  "connected": {
+    "create": data => container,
+    "cleanup": data => {},
+  },
+  "disconnected": {
+    "create": data => document.createElement("div"),
+    "cleanup": data => {},
+  },
+  "shadow": {
+    "create": data => {
+      let e = document.createElement("div");
+      container.appendChild(e);
+      data.wrapper = e;
+      let shadowRoot = e.attachShadow({ mode: "open" });
+      let d = document.createElement("div");
+      shadowRoot.appendChild(d);
+      return d;
+    },
+    "cleanup": data => { data.wrapper.remove(); },
+  },
+  "shadow-in-disconnected": {
+    "create": data => {
+      let e = document.createElement("div");
+      let shadowRoot = e.attachShadow({ mode: "open" });
+      let d = document.createElement("div");
+      shadowRoot.appendChild(d);
+      return d;
+    },
+    "cleanup": data => {},
+  },
+  "template-in-disconnected": {
+    "create": data => {
+      let e = document.createElement("div");
+      e.innerHTML = `
+        <template>
+          <div></div>
+        </template>
+      `;
+      return e.firstElementChild.content.firstElementChild;
+    },
+    "cleanup": data => {},
+  },
+  "connected-in-xhr-response": {
+    "create": data => new Promise((resolve, reject) => {
+      let xhr = new XMLHttpRequest();
+      xhr.open("GET", "support/empty-html-document.html");
+      xhr.responseType = "document";
+      xhr.send();
+      xhr.addEventListener("load", event => { resolve(xhr.response.body); });
+      let reject_with_type =
+        event => { reject(`${event.type} event received`); }
+      xhr.addEventListener("error", reject_with_type);
+      xhr.addEventListener("abort", reject_with_type);
+    }),
+    "cleanup": data => {},
+  },
+  "connected-in-implementation-create-document": {
+    "create": data => {
+      let doc = document.implementation.createHTMLDocument("impl-created");
+      return doc.body;
+    },
+    "cleanup": data => {},
+  },
+  "connected-in-template": {
+    "create": data => {
+      container.innerHTML = `
+        <template>
+          <div></div>
+        </template>
+      `;
+      return container.firstElementChild.content.firstElementChild;
+    },
+    "cleanup": data => { container.innerHTML = ""; },
+  },
+};
+
+for (const [scenario, scenario_callbacks] of Object.entries(connected_scenarios)) {
+  promise_test(async t => {
+    let data = {};
+    let container = await scenario_callbacks.create(data);
+    t.add_cleanup(async () => await scenario_callbacks.cleanup(data));
+    assert_true(container instanceof HTMLDivElement ||
+                  container instanceof HTMLBodyElement,
+                "error in test setup");
+
+    container.innerHTML = `
+      <details name="scenariotest" open></details>
+      <details name="scenariotest"></details>
+    `;
+
+    let elements = Array.from(container.querySelectorAll("details[name='scenariotest']"));
+    assert_element_states(elements, [1, 0], "state before toggle");
+    elements[1].open = true;
+    assert_element_states(elements, [0, 1], "state after toggle enforces exclusivity");
+  }, `exclusivity enforcement with attachment scenario ${scenario}`);
+}
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/empty-html-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/empty-html-document.html
@@ -1,0 +1,2 @@
+<!DOCTYPE HTML>
+<title>Empty HTML Document</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/empty-html-document.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/w3c-import.log
@@ -26,6 +26,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/display-table-with-rt-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/modified-details-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/nested-details-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/nested-top-layer-elements-in-details-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2205,6 +2205,20 @@ DeprecationReportingEnabled:
     WebCore:
       default: false
 
+DetailsNameAttributeEnabled:
+  type: bool
+  status: preview
+  category: html
+  humanReadableName: "HTML <details name> attribute"
+  humanReadableDescription: "Enable HTML <details name> attribute"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DeveloperExtrasEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -159,6 +159,15 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
             if (m_isOpen) {
                 root->appendChild(*m_defaultSlot);
                 queueDetailsToggleEventTask(DetailsState::Closed, DetailsState::Open);
+                if (auto& name = attributeWithoutSynchronization(nameAttr); document().settings().detailsNameAttributeEnabled() && !name.isEmpty()) {
+                    Vector<RefPtr<HTMLDetailsElement>> otherElementsInNameGroup;
+                    for (auto& detailsElement : descendantsOfType<HTMLDetailsElement>(rootNode())) {
+                        if (&detailsElement != this && detailsElement.attributeWithoutSynchronization(nameAttr) == name)
+                            otherElementsInNameGroup.append(&detailsElement);
+                    }
+                    for (RefPtr otherDetailsElement : otherElementsInNameGroup)
+                        otherDetailsElement->removeAttribute(openAttr);
+                }
             } else {
                 root->removeChild(*m_defaultSlot);
                 queueDetailsToggleEventTask(DetailsState::Open, DetailsState::Closed);

--- a/Source/WebCore/html/HTMLDetailsElement.idl
+++ b/Source/WebCore/html/HTMLDetailsElement.idl
@@ -20,6 +20,7 @@
 [
     Exposed=Window
 ] interface HTMLDetailsElement : HTMLElement {
+    [CEReactions=NotNeeded, EnabledBySetting=DetailsNameAttributeEnabled, Reflect] attribute DOMString name;
     [CEReactions=NotNeeded, Reflect] attribute boolean open;
 };
 


### PR DESCRIPTION
#### d4b4fa5cfed7b41046a9e62017e7a6e787d9d8ba
<pre>
Add support for the “details” element’s “name” attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=260893">https://bugs.webkit.org/show_bug.cgi?id=260893</a>

Reviewed by Tim Nguyen.

This changes adds support for the “name” attribute for the “details”
element, which allows grouping together a set of “details” elements such
that opening one “details” element in a group causes all other “details”
elements in the group to close.

<a href="https://github.com/whatwg/html/pull/9400">https://github.com/whatwg/html/pull/9400</a>

This change also introduces the DetailsNameAttributeEnabled preference
(enabled by default), for controlling whether the “name” attribute
actually causes the grouping/closing behavior described above.

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/name-content-attribute-and-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/name-content-attribute-and-property.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/name-attribute.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/empty-html-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/support/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/w3c-import.log:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt: Renamed from LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::attributeChanged):
* Source/WebCore/html/HTMLDetailsElement.idl:

Canonical link: <a href="https://commits.webkit.org/267756@main">https://commits.webkit.org/267756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f3b03a13802b8f4257e6c93bbb2c83952b2de64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18085 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18126 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20267 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16035 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15220 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20490 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16820 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14209 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/19186 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15876 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4192 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/20419 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16621 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4295 "Passed tests") | 
<!--EWS-Status-Bubble-End-->