### PR TITLE
[Curl] Support multipart response

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -32,13 +32,35 @@
 
 #include "CurlMultipartHandleClient.h"
 #include "CurlResponse.h"
-#include "HTTPHeaderNames.h"
 #include "HTTPParsers.h"
-#include "ResourceResponse.h"
+#include "ParsedContentType.h"
 #include "SharedBuffer.h"
 #include <wtf/StringExtras.h>
 
 namespace WebCore {
+
+static std::optional<CString> extractBoundary(const CurlResponse& response)
+{
+    static const auto contentTypeLength = strlen("content-type:");
+
+    for (auto header : response.headers) {
+        if (!header.startsWithIgnoringASCIICase("content-type:"_s))
+            continue;
+
+        auto contentType = ParsedContentType::create(header.substring(contentTypeLength));
+
+        if (!equalLettersIgnoringASCIICase(contentType->mimeType(), "multipart/x-mixed-replace"_s))
+            return std::nullopt;
+
+        auto boundary = contentType->parameterValueForName("boundary"_s);
+        if (boundary.isEmpty())
+            return std::nullopt;
+
+        return makeString("--", boundary).latin1();
+    }
+
+    return std::nullopt;
+}
 
 std::unique_ptr<CurlMultipartHandle> CurlMultipartHandle::createIfNeeded(CurlMultipartHandleClient& client, const CurlResponse& response)
 {
@@ -46,82 +68,18 @@ std::unique_ptr<CurlMultipartHandle> CurlMultipartHandle::createIfNeeded(CurlMul
     if (!boundary)
         return nullptr;
 
-    return makeUnique<CurlMultipartHandle>(client, *boundary);
+    return makeUnique<CurlMultipartHandle>(client, WTFMove(*boundary));
 }
 
-std::optional<String> CurlMultipartHandle::extractBoundary(const CurlResponse& response)
-{
-    for (auto header : response.headers) {
-        auto splitPosition = header.find(':');
-        if (splitPosition == notFound)
-            continue;
-
-        auto key = header.left(splitPosition).trim(deprecatedIsSpaceOrNewline);
-        if (!equalIgnoringASCIICase(key, "Content-Type"_s))
-            continue;
-
-        auto contentType = header.substring(splitPosition + 1).trim(deprecatedIsSpaceOrNewline);
-        auto mimeType = extractMIMETypeFromMediaType(contentType);
-        if (!equalLettersIgnoringASCIICase(mimeType, "multipart/x-mixed-replace"_s))
-            continue;
-
-        auto boundary = extractBoundaryFromContentType(contentType);
-        if (!boundary)
-            continue;
-
-        return String("--" + *boundary);
-    }
-
-    return std::nullopt;
-}
-
-std::optional<String> CurlMultipartHandle::extractBoundaryFromContentType(const String& contentType)
-{
-    static const size_t length = strlen("boundary=");
-
-    auto boundaryStart = contentType.findIgnoringASCIICase("boundary="_s);
-    if (boundaryStart == notFound)
-        return std::nullopt;
-
-    boundaryStart += length;
-    size_t boundaryEnd = 0;
-
-    if (contentType[boundaryStart] == '"') {
-        // Boundary value starts with a " quote. Search for the closing one.
-        ++boundaryStart;
-        boundaryEnd = contentType.find('"', boundaryStart);
-        if (boundaryEnd == notFound)
-            return std::nullopt;
-    } else if (contentType[boundaryStart] == '\'') {
-        // Boundary value starts with a ' quote. Search for the closing one.
-        ++boundaryStart;
-        boundaryEnd = contentType.find('\'', boundaryStart);
-        if (boundaryEnd == notFound)
-            return std::nullopt;
-    } else {
-        // Check for the end of the boundary. That can be a semicolon or a newline.
-        boundaryEnd = contentType.find(';', boundaryStart);
-        if (boundaryEnd == notFound)
-            boundaryEnd = contentType.length();
-    }
-
-    // The boundary end should not be before the start
-    if (boundaryEnd <= boundaryStart)
-        return std::nullopt;
-
-    return contentType.substring(boundaryStart, boundaryEnd - boundaryStart);
-}
-
-CurlMultipartHandle::CurlMultipartHandle(CurlMultipartHandleClient& client, const String& boundary)
+CurlMultipartHandle::CurlMultipartHandle(CurlMultipartHandleClient& client, CString&& boundary)
     : m_client(client)
-    , m_boundary(boundary)
+    , m_boundary(WTFMove(boundary))
 {
-
 }
 
-void CurlMultipartHandle::didReceiveData(const SharedBuffer& buffer)
+void CurlMultipartHandle::didReceiveMessage(const SharedBuffer& buffer)
 {
-    if (m_state == State::End)
+    if (m_state == State::WaitingForTerminate || m_state == State::End || m_didCompleteMessage)
         return; // The handler is closed down so ignore everything.
 
     m_buffer.append(buffer.data(), buffer.size());
@@ -129,230 +87,227 @@ void CurlMultipartHandle::didReceiveData(const SharedBuffer& buffer)
     while (processContent()) { }
 }
 
-void CurlMultipartHandle::didComplete()
+void CurlMultipartHandle::completeHeaderProcessing()
 {
-    // Process the leftover data.
+    if (m_state == State::WaitingForTerminate || m_state == State::End)
+        return; // The handler is closed down so ignore everything.
+
+    RELEASE_ASSERT(m_state == State::WaitingForHeaderProcessing);
+
+    m_state = State::InBody;
+
     while (processContent()) { }
+}
 
-    if (m_state != State::End) {
-        // It seems we are still not at the end of the processing.
-        // Push out the remaining data.
-        m_client.didReceiveDataFromMultipart(SharedBuffer::create(WTFMove(m_buffer)));
-        m_state = State::End;
-    }
+void CurlMultipartHandle::didCompleteMessage()
+{
+    if (m_state == State::End)
+        return; // The handler is closed down so ignore everything.
 
-    m_buffer.clear();
+    m_didCompleteMessage = true;
+
+    if (m_state == State::WaitingForTerminate)
+        m_state = State::Terminating;
+
+    while (processContent()) { }
 }
 
 bool CurlMultipartHandle::processContent()
 {
-/*
-    The allowed transitions between the states:
-         Check Boundary
-               |
-      /-- In Boundary <----\
-     |         |            |
-     |     In Header        |
-     |         |            |
-     |     In Content       |
-     |         |            |
-     |    End Boundary ----/
-     |         |
-      \-----> End
-
-*/
     switch (m_state) {
-    case State::CheckBoundary: {
-        if (m_buffer.size() < m_boundary.length()) {
-            // We don't have enough data, so just skip.
-            return false;
-        }
-
-        // Check for the boundary string.
-        size_t boundaryStart;
-        size_t lastPartialMatch;
-
-        if (!checkForBoundary(boundaryStart, lastPartialMatch) && boundaryStart == notFound) {
-            // Did not find the boundary start in this chunk.
-            // Skip ahead to the last valid looking boundary character and start again.
-            m_buffer.remove(0, lastPartialMatch);
-            return false;
-        }
-
-        // Found the boundary start.
-        // Consume everything before that and also the boundary
-        m_buffer.remove(0, boundaryStart + m_boundary.length());
-        m_state = State::InBoundary;
-    }
-    // Fallthrough.
-    case State::InBoundary: {
-        // Now the first two characters should be: \r\n
-        if (m_buffer.size() < 2)
-            return false;
-
-        auto* content = m_buffer.data();
-        // By default we'll remove 2 characters at the end.
-        // The \r and \n as stated in the multipart RFC.
-        size_t removeCount = 2;
-
-        if (content[0] != '\r' || content[1] != '\n') {
-            // There should be a \r and a \n but it seems that's not the case.
-            // So we'll check for a simple \n. Not really RFC compatible but servers do tricky things.
-            if (content[0] != '\n') {
-                // Also no \n so just go to the end.
-                m_state = State::End;
-                return false;
-            }
-
-            // Found a simple \n so remove just that.
-            removeCount = 1;
-        }
-
-        // Consume the characters.
-        m_buffer.remove(0, removeCount);
-        m_headers.clear();
-        m_state = State::InHeader;
-    }
-    // Fallthrough.
-    case State::InHeader: {
-        // Process the headers.
-        if (!parseHeadersIfPossible()) {
-            // Parsing of headers failed, try again later.
-            return false;
-        }
-
-        m_client.didReceiveHeaderFromMultipart(m_headers);
-        m_state = State::InContent;
-    }
-    // Fallthrough.
-    case State::InContent: {
-        if (m_buffer.isEmpty())
-            return false;
-
-        size_t boundaryStart;
-        size_t lastPartialMatch;
-
-        if (!checkForBoundary(boundaryStart, lastPartialMatch) && boundaryStart == notFound) {
-            // Did not find the boundary start, all data up to the lastPartialMatch is ok.
-            m_client.didReceiveDataFromMultipart(SharedBuffer::create(m_buffer.data(), lastPartialMatch));
-            m_buffer.remove(0, lastPartialMatch);
-            return false;
-        }
-
-        // There was a boundary start (or end we'll check that later), push out part of the data.
-        m_client.didReceiveDataFromMultipart(SharedBuffer::create(m_buffer.data(), boundaryStart));
-        m_buffer.remove(0, boundaryStart + m_boundary.length());
-        m_state = State::EndBoundary;
-    }
-    // Fallthrough.
-    case State::EndBoundary: {
-        if (m_buffer.size() < 2)
-            return false; // Not enough data to check. Return later when there is more data.
-
-        // We'll decide if this is a closing boundary or an opening one.
-        auto* content = m_buffer.data();
-
-        if (content[0] == '-' && content[1] == '-') {
-            // This is a closing boundary. Close down the handler.
+    case State::FindBoundaryStart:
+        FALLTHROUGH;
+    case State::InBody: {
+        auto result = findBoundary();
+        if (result.isSyntaxError) {
+            m_hasError = true;
             m_state = State::End;
             return false;
         }
 
-        // This was a simple content separator not a closing one.
-        // Go to before the content processing.
-        m_state = State::InBoundary;
-        break;
-    }
-    case State::End:
-        // We are done. Nothing to do anymore.
-        return false;
-    default:
-        ASSERT_NOT_REACHED();
-        return false;
-    }
+        if (m_state == State::InBody && result.dataEnd)
+            m_client->didReceiveDataFromMultipart(SharedBuffer::create(m_buffer.data(), result.dataEnd));
 
-    return true; // There are still things to process, so go for it.
-}
+        if (result.processed)
+            m_buffer.remove(0, result.processed);
 
-bool CurlMultipartHandle::checkForBoundary(size_t& boundaryStartPosition, size_t& lastPartialMatchPosition)
-{
-    auto contentLength = m_buffer.size();
+        if (!result.hasBoundary || result.hasCloseDelimiter) {
+            if (m_didCompleteMessage) {
+                m_state = State::Terminating;
+                return true;
+            }
 
-    boundaryStartPosition = notFound;
-    lastPartialMatchPosition = contentLength;
+            if (result.hasCloseDelimiter)
+                m_state = State::WaitingForTerminate;
 
-    if (contentLength < m_boundary.length())
-        return false;
-
-    const auto content = m_buffer.data();
-
-    for (size_t i = 0; i < contentLength - m_boundary.length(); ++i) {
-        auto length = matchedLength(content + i);
-        if (length == m_boundary.length()) {
-            boundaryStartPosition = i;
-            return true;
+            return false;
         }
 
-        if (length)
-            lastPartialMatchPosition = i;
+        m_headers.clear();
+        m_state = State::InHeader;
+        return true;
+    }
+
+    case State::InHeader: {
+        switch (parseHeadersIfPossible()) {
+        case ParseHeadersResult::Success:
+            m_client->didReceiveHeaderFromMultipart(WTFMove(m_headers));
+            m_state = State::WaitingForHeaderProcessing;
+            return true;
+
+        case ParseHeadersResult::NeedMoreData:
+            if (m_didCompleteMessage) {
+                m_state = State::Terminating;
+                return true;
+            }
+            return false;
+
+        case ParseHeadersResult::HeaderSizeTooLarge:
+            m_hasError = true;
+            m_state = State::End;
+            return false;
+        }
+
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    case State::WaitingForHeaderProcessing: {
+        // Wait until completeHeaderProcessing() is called
+        return false;
+    }
+
+    case State::WaitingForTerminate: {
+        // Wait until didCompleteMessage() is called
+        return false;
+    }
+
+    case State::Terminating: {
+        m_client->didCompleteFromMultipart();
+        m_state = State::End;
+        return false;
+    }
+
+    case State::End:
+        return false;
     }
 
     return false;
 }
 
-size_t CurlMultipartHandle::matchedLength(const uint8_t* data)
+CurlMultipartHandle::FindBoundaryResult CurlMultipartHandle::findBoundary()
 {
-    auto length = m_boundary.length();
-    for (size_t i = 0; i < length; ++i) {
-        if (data[i] != m_boundary[i])
-            return i;
+    FindBoundaryResult result;
+
+    auto contentLength = m_buffer.size();
+    const auto contentStartPtr = m_buffer.data();
+    const auto contentEndPtr = contentStartPtr + contentLength;
+
+    auto boundaryLength = m_boundary.length();
+    auto boundaryStartPtr = m_boundary.data();
+
+    auto matchedStartPtr = static_cast<const uint8_t*>(memmem(contentStartPtr, contentLength, boundaryStartPtr, boundaryLength));
+    if (!matchedStartPtr) {
+        if (!m_didCompleteMessage) {
+            // Not enough data to check the boundary (Temporarily retain "Initial CRLF + (boundary - 1)" bytes for the next search.)
+            result.dataEnd = std::max(int(contentLength) - int(boundaryLength) + 1 - 2, 0);
+        } else
+            result.dataEnd = contentLength;
+
+        result.processed = result.dataEnd;
+        return result;
     }
 
-    return length;
+    auto matchedEndPtr = matchedStartPtr + boundaryLength;
+
+    // The initial CRLF is considered to be attached to the boundary delimiter line rather than
+    // part of the preceding part. (See RFC2046 [5.1.1. Common Syntax])
+    if (matchedStartPtr - contentStartPtr >= 2 && !memcmp(matchedStartPtr - 2, "\r\n", 2))
+        matchedStartPtr -= 2;
+    else if (matchedStartPtr - contentStartPtr >= 1 && !memcmp(matchedStartPtr - 1, "\n", 1))
+        matchedStartPtr--;
+
+    result.dataEnd = matchedStartPtr - contentStartPtr;
+    result.processed = result.dataEnd;
+
+    // Check the Close Delimiter
+    if (contentEndPtr - matchedEndPtr < 2) {
+        if (!m_didCompleteMessage) {
+            // Not enough data to check the Close Delimiter.
+            return result;
+        }
+    } else if (!memcmp(matchedEndPtr, "--", 2)) {
+        result.hasBoundary = true;
+        result.hasCloseDelimiter = true;
+        result.processed = matchedEndPtr + 2 - contentStartPtr;
+        return result;
+    }
+
+    // Skip transport-padding
+    for (; matchedEndPtr < contentEndPtr && isTabOrSpace(*matchedEndPtr); ++matchedEndPtr) { }
+
+    // There should be a \r and a \n but it seems that's not the case.
+    // So we'll check for a simple \n. Not really RFC compatible but servers do tricky things.
+    if (contentEndPtr - matchedEndPtr >= 2  && !memcmp(matchedEndPtr, "\r\n", 2))
+        matchedEndPtr += 2;
+    else if (contentEndPtr - matchedEndPtr >= 1 && !memcmp(matchedEndPtr, "\n", 1))
+        matchedEndPtr++;
+    else if (matchedEndPtr >= contentEndPtr) {
+        // Not enough data to check the boundary
+        return result;
+    } else {
+        result.isSyntaxError = true;
+        return result;
+    }
+
+    result.hasBoundary = true;
+    result.processed = matchedEndPtr - contentStartPtr;
+    return result;
 }
 
-bool CurlMultipartHandle::parseHeadersIfPossible()
+CurlMultipartHandle::ParseHeadersResult CurlMultipartHandle::parseHeadersIfPossible()
 {
+    static const auto maxHeaderSize = 300 * 1024;
+
     auto contentLength = m_buffer.size();
-
-    if (!contentLength)
-        return false;
-
-    auto* content = m_buffer.data();
+    const auto contentStartPtr = m_buffer.data();
 
     // Check if we have the header closing strings.
-    if (!memmem(content, contentLength, "\r\n\r\n", 4)) {
-        // Some servers closes the headers with only \n-s.
-        if (!memmem(content, contentLength, "\n\n", 2)) {
-            // Don't have the header closing string. Wait for more data.
-            return false;
-        }
+    const uint8_t* end = nullptr;
+    if ((end = static_cast<const uint8_t*>(memmem(contentStartPtr, contentLength, "\r\n\r\n", 4))))
+        end += 4;
+    else if ((end = static_cast<const uint8_t*>(memmem(contentStartPtr, contentLength, "\n\n", 2))))
+        end += 2;
+    else if (contentLength > maxHeaderSize)
+        return ParseHeadersResult::HeaderSizeTooLarge;
+    else {
+        // Don't have the header closing string. Wait for more data.
+        return ParseHeadersResult::NeedMoreData;
     }
 
+    if (end - contentStartPtr > maxHeaderSize)
+        return ParseHeadersResult::HeaderSizeTooLarge;
+
     // Parse the HTTP headers.
-    String value;
+    String failureReason;
     StringView name;
-    auto p = content;
-    const auto end = content + contentLength;
-    size_t totalConsumedLength = 0;
-    for (; p < end; ++p) {
-        String failureReason;
+    String value;
+
+    for (auto p = contentStartPtr; p < end; ++p) {
         size_t consumedLength = parseHTTPHeader(p, end - p, failureReason, name, value, false);
         if (!consumedLength)
             break; // No more header to parse.
 
         p += consumedLength;
-        totalConsumedLength += consumedLength;
 
         // The name should not be empty, but the value could be empty.
         if (name.isEmpty())
             break;
 
-        m_headers.append(name.toString() + ": " + value + "\r\n");
+        m_headers.append(makeString(name, ": ", value, "\r\n"));
     }
 
-    m_buffer.remove(0, totalConsumedLength + 1);
-    return true;
+    m_buffer.remove(0, end - contentStartPtr);
+    return ParseHeadersResult::Success;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.h
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,39 +40,57 @@ class SharedBuffer;
 class CurlMultipartHandle {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<CurlMultipartHandle> createIfNeeded(CurlMultipartHandleClient&, const CurlResponse&);
+    WEBCORE_EXPORT static std::unique_ptr<CurlMultipartHandle> createIfNeeded(CurlMultipartHandleClient&, const CurlResponse&);
 
-    CurlMultipartHandle(CurlMultipartHandleClient&, const String&);
+    CurlMultipartHandle(CurlMultipartHandleClient&, CString&&);
     ~CurlMultipartHandle() { }
 
-    void didReceiveData(const SharedBuffer&);
-    void didComplete();
+    WEBCORE_EXPORT void didReceiveMessage(const SharedBuffer&);
+    WEBCORE_EXPORT void didCompleteMessage();
+
+    WEBCORE_EXPORT void completeHeaderProcessing();
+
+    bool completed() { return m_didCompleteMessage; }
+    bool hasError() const { return m_hasError; }
 
 private:
     enum class State {
-        CheckBoundary,
-        InBoundary,
+        FindBoundaryStart,
         InHeader,
-        InContent,
-        EndBoundary,
+        WaitingForHeaderProcessing,
+        InBody,
+        WaitingForTerminate,
+        Terminating,
         End
     };
 
-    static std::optional<String> extractBoundary(const CurlResponse&);
-    static std::optional<String> extractBoundaryFromContentType(const String&);
+    enum class ParseHeadersResult {
+        Success,
+        NeedMoreData,
+        HeaderSizeTooLarge
+    };
+
+    struct FindBoundaryResult {
+        bool isSyntaxError { false };
+        bool hasBoundary { false };
+        bool hasCloseDelimiter { false };
+        size_t processed { 0 };
+        size_t dataEnd { 0 };
+    };
 
     bool processContent();
-    bool checkForBoundary(size_t& boundaryStartPosition, size_t& lastPartialMatchPosition);
-    size_t matchedLength(const uint8_t* data);
-    bool parseHeadersIfPossible();
+    FindBoundaryResult findBoundary();
+    ParseHeadersResult parseHeadersIfPossible();
 
-    CurlMultipartHandleClient& m_client;
+    CheckedRef<CurlMultipartHandleClient> m_client;
 
-    String m_boundary;
+    CString m_boundary;
     Vector<uint8_t> m_buffer;
     Vector<String> m_headers;
 
-    State m_state { State::CheckBoundary };
+    State m_state { State::FindBoundaryStart };
+    bool m_didCompleteMessage { false };
+    bool m_hasError { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
@@ -25,15 +25,15 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
+
 namespace WebCore {
 
-class CurlResponse;
-class FragmentedSharedBuffer;
-
-class CurlMultipartHandleClient {
+class CurlMultipartHandleClient : public CanMakeCheckedPtr {
 public:
-    virtual void didReceiveHeaderFromMultipart(const Vector<String>&) = 0;
-    virtual void didReceiveDataFromMultipart(const SharedBuffer&) = 0;
+    virtual void didReceiveHeaderFromMultipart(Vector<String>&&) = 0;
+    virtual void didReceiveDataFromMultipart(Ref<SharedBuffer>&&) = 0;
+    virtual void didCompleteFromMultipart() = 0;
 
 protected:
     ~CurlMultipartHandleClient() { }

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -41,10 +41,9 @@
 
 namespace WebCore {
 
-CurlRequest::CurlRequest(const ResourceRequest&request, CurlRequestClient* client, EnableMultipart enableMultipart, CaptureNetworkLoadMetrics captureExtraMetrics)
+CurlRequest::CurlRequest(const ResourceRequest&request, CurlRequestClient* client, CaptureNetworkLoadMetrics captureExtraMetrics)
     : m_client(client)
     , m_request(request.isolatedCopy())
-    , m_enableMultipart(enableMultipart == EnableMultipart::Yes)
     , m_formDataStream(m_request.httpBody())
     , m_captureExtraMetrics(captureExtraMetrics == CaptureNetworkLoadMetrics::Extended)
 {
@@ -337,8 +336,7 @@ size_t CurlRequest::didReceiveHeader(String&& header)
 
     m_response.networkLoadMetrics = networkLoadMetrics();
 
-    if (m_enableMultipart)
-        m_multipartHandle = CurlMultipartHandle::createIfNeeded(*this, m_response);
+    m_multipartHandle = CurlMultipartHandle::createIfNeeded(*this, m_response);
 
     // Response will send at didReceiveData() or didCompleteTransfer()
     // to receive continueDidRceiveResponse() for asynchronously.
@@ -372,9 +370,11 @@ size_t CurlRequest::didReceiveData(const SharedBuffer& buffer)
     m_totalReceivedSize += receiveBytes;
 
     if (receiveBytes) {
-        if (m_multipartHandle)
-            m_multipartHandle->didReceiveData(buffer);
-        else {
+        if (m_multipartHandle) {
+            m_multipartHandle->didReceiveMessage(buffer);
+            if (m_multipartHandle->hasError())
+                return CURL_WRITEFUNC_ERROR;
+        } else {
             callClient([buffer = Ref { buffer }](CurlRequest& request, CurlRequestClient& client) {
                 client.curlDidReceiveData(request, buffer);
             });
@@ -384,7 +384,7 @@ size_t CurlRequest::didReceiveData(const SharedBuffer& buffer)
     return receiveBytes;
 }
 
-void CurlRequest::didReceiveHeaderFromMultipart(const Vector<String>& headers)
+void CurlRequest::didReceiveHeaderFromMultipart(Vector<String>&& headers)
 {
     if (isCompletedOrCancelled())
         return;
@@ -393,24 +393,40 @@ void CurlRequest::didReceiveHeaderFromMultipart(const Vector<String>& headers)
     response.expectedContentLength = 0;
     response.headers.clear();
 
-    for (auto header : headers)
-        response.headers.append(header);
+    for (auto& header : headers)
+        response.headers.append(WTFMove(header));
 
-    invokeDidReceiveResponse(response);
+    invokeDidReceiveResponse(response, [this] {
+        runOnWorkerThreadIfRequired([this, protectedThis = Ref { *this }]() {
+            if (isCompletedOrCancelled() || !m_multipartHandle)
+                return;
+
+            m_multipartHandle->completeHeaderProcessing();
+        });
+    });
 }
 
-void CurlRequest::didReceiveDataFromMultipart(const SharedBuffer& buffer)
+void CurlRequest::didReceiveDataFromMultipart(Ref<SharedBuffer>&& buffer)
 {
     if (isCompletedOrCancelled())
         return;
 
-    auto receiveBytes = buffer.size();
+    auto receiveBytes = buffer->size();
 
     if (receiveBytes) {
-        callClient([buffer = Ref { buffer }](CurlRequest& request, CurlRequestClient& client) {
-            client.curlDidReceiveData(request, buffer);
+        callClient([buffer = WTFMove(buffer)](CurlRequest& request, CurlRequestClient& client) {
+            client.curlDidReceiveData(request, buffer.get());
         });
     }
+}
+
+void CurlRequest::didCompleteFromMultipart()
+{
+    ASSERT(m_multipartHandle && m_multipartHandle->completed());
+
+    runOnWorkerThreadIfRequired([this, protectedThis = Ref { *this }]() {
+        didCompleteTransfer(CURLE_OK);
+    });
 }
 
 void CurlRequest::didCompleteTransfer(CURLcode result)
@@ -434,8 +450,10 @@ void CurlRequest::didCompleteTransfer(CURLcode result)
     }
 
     if (result == CURLE_OK) {
-        if (m_multipartHandle)
-            m_multipartHandle->didComplete();
+        if (m_multipartHandle && !m_multipartHandle->completed()) {
+            m_multipartHandle->didCompleteMessage();
+            return;
+        }
 
         auto metrics = networkLoadMetrics();
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -46,19 +46,14 @@ class CurlRequest : public ThreadSafeRefCounted<CurlRequest>, public CurlRequest
     WTF_MAKE_NONCOPYABLE(CurlRequest);
 
 public:
-    enum class EnableMultipart : bool {
-        No = false,
-        Yes = true
-    };
-
     enum class CaptureNetworkLoadMetrics : uint8_t {
         Basic,
         Extended
     };
 
-    static Ref<CurlRequest> create(const ResourceRequest& request, CurlRequestClient& client, EnableMultipart enableMultipart = EnableMultipart::No, CaptureNetworkLoadMetrics captureMetrics = CaptureNetworkLoadMetrics::Basic)
+    static Ref<CurlRequest> create(const ResourceRequest& request, CurlRequestClient& client, CaptureNetworkLoadMetrics captureMetrics = CaptureNetworkLoadMetrics::Basic)
     {
-        return adoptRef(*new CurlRequest(request, &client, enableMultipart, captureMetrics));
+        return adoptRef(*new CurlRequest(request, &client, captureMetrics));
     }
 
     virtual ~CurlRequest();
@@ -84,7 +79,7 @@ public:
     WEBCORE_EXPORT void completeDidReceiveResponse();
 
 private:
-    WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, EnableMultipart, CaptureNetworkLoadMetrics);
+    WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, CaptureNetworkLoadMetrics);
 
     void retain() override { ref(); }
     void release() override { deref(); }
@@ -102,8 +97,9 @@ private:
     size_t willSendData(char*, size_t, size_t);
     size_t didReceiveHeader(String&&);
     size_t didReceiveData(const SharedBuffer&);
-    void didReceiveHeaderFromMultipart(const Vector<String>&) override;
-    void didReceiveDataFromMultipart(const SharedBuffer&) override;
+    void didReceiveHeaderFromMultipart(Vector<String>&&) override;
+    void didReceiveDataFromMultipart(Ref<SharedBuffer>&&) override;
+    void didCompleteFromMultipart() override;
     void didCompleteTransfer(CURLcode) override;
     void didCancelTransfer() override;
     void finalizeTransfer();
@@ -140,7 +136,6 @@ private:
     String m_password;
     unsigned long m_authType { CURLAUTH_ANY };
     bool m_shouldDisableServerTrustEvaluation { false };
-    bool m_enableMultipart { false };
 
     std::unique_ptr<CurlHandle> m_curlHandle;
     CurlFormDataStream m_formDataStream;

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -141,7 +141,7 @@ Ref<CurlRequest> NetworkDataTaskCurl::createCurlRequest(ResourceRequest&& reques
     // Creates a CurlRequest in suspended state.
     // Then, NetworkDataTaskCurl::resume() will be called and communication resumes.
     const auto captureMetrics = shouldCaptureExtraNetworkLoadMetrics() ? CurlRequest::CaptureNetworkLoadMetrics::Extended : CurlRequest::CaptureNetworkLoadMetrics::Basic;
-    return CurlRequest::create(request, *this, CurlRequest::EnableMultipart::No, captureMetrics);
+    return CurlRequest::create(request, *this, captureMetrics);
 }
 
 void NetworkDataTaskCurl::curlDidSendData(CurlRequest&, unsigned long long totalBytesSent, unsigned long long totalBytesExpectedToSend)

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -16,6 +16,7 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/CryptoDigest.cpp
 
     Tests/WebCore/curl/Cookies.cpp
+    Tests/WebCore/curl/CurlMultipartHandleTests.cpp
     Tests/WebCore/curl/OpenSSLHelperTests.cpp
 
     Tests/WebCore/win/BitmapImage.cpp

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -1,0 +1,797 @@
+/*
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if USE(CURL)
+
+#include <WebCore/CurlMultipartHandle.h>
+#include <WebCore/CurlMultipartHandleClient.h>
+#include <WebCore/CurlResponse.h>
+#include <WebCore/SharedBuffer.h>
+
+namespace TestWebKitAPI {
+
+namespace Curl {
+
+using namespace WebCore;
+
+static CurlResponse createCurlResponse(std::optional<String> contentType = "multipart/x-mixed-replace"_s, std::optional<String> boundary = "boundary"_s)
+{
+    CurlResponse response;
+
+    response.headers.append("x-dummy-pre-header: dummy\r\n"_s);
+
+    if (contentType && boundary)
+        response.headers.append(makeString("Content-type: ", *contentType, "; boundary=\"", *boundary, "\"", "\r\n"));
+    else if (contentType)
+        response.headers.append(makeString("Content-type: ", *contentType, ";\r\n"));
+
+    response.headers.append("x-dummy-post-header: dummy\r\n"_s);
+
+    return response;
+}
+
+class MultipartHandleClient : public CurlMultipartHandleClient {
+public:
+    void setMultipartHandle();
+
+    void didReceiveHeaderFromMultipart(Vector<String>&& headers) final
+    {
+        for (auto header : headers)
+            m_headers.append(WTFMove(header));
+    }
+
+    void didReceiveDataFromMultipart(Ref<SharedBuffer>&& buffer) final
+    {
+        m_data.append(buffer->data(), buffer->size());
+    }
+
+    void didCompleteFromMultipart() final
+    {
+        m_didComplete = true;
+    }
+
+    void clear()
+    {
+        m_headers.clear();
+        m_data.clear();
+        m_didComplete = false;
+    }
+
+    const Vector<String>& headers() { return m_headers; }
+    const Vector<uint8_t>& data() { return m_data; }
+    bool complete() { return m_didComplete; }
+
+private:
+    Vector<String> m_headers;
+    Vector<uint8_t> m_data;
+    bool m_didComplete { false };
+};
+
+class CurlMultipartHandleTests : public testing::Test {
+public:
+    CurlMultipartHandleTests() { }
+};
+
+TEST(CurlMultipartHandleTests, CreateCurlMultipartHandle)
+{
+    MultipartHandleClient client;
+
+    // Content-Type header is missing
+    auto curlResponse = createCurlResponse(std::nullopt, std::nullopt);
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+    EXPECT_FALSE(handle);
+
+    // Not multipart/x-mixed-replace
+    curlResponse = createCurlResponse("text/html"_s, std::nullopt);
+    handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+    EXPECT_FALSE(handle);
+
+    curlResponse = createCurlResponse("multipart/mixed"_s, "boundary"_s);
+    handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+    EXPECT_FALSE(handle);
+
+    // boundary is not set for multipart/x-mixed-replace
+    curlResponse = createCurlResponse("multipart/x-mixed-replace"_s, std::nullopt);
+    handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+    EXPECT_FALSE(handle);
+
+    // Normal case
+    curlResponse = createCurlResponse();
+    handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+    EXPECT_TRUE(handle);
+}
+
+TEST(CurlMultipartHandleTests, SimpleMessage)
+{
+    auto data =
+        " This is the preamble.--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n This is the epilogue."_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, NoHeader)
+{
+    auto data =
+        "--boundary\r\n\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 0);
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, NoBody)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "\r\n--boundary  \r\nContent-type: text/html\r\n\r\n"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_EQ(client.data().size(), 0);
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_EQ(client.data().size(), 0);
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, TransportPadding)
+{
+    auto data =
+        " This is the preamble.--boundary     \r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary  \r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n This is the epilogue."_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, NoEndOfBoundary)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    // Retain "Initial CRLF + (boundary - 1)" bytes.
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<h", 2));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, NoEndOfBoundaryAfterCompleted)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, NoCloseDelimiter)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    // Retain "Initial CRLF + (boundary - 1)" bytes
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<h", 2));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, NoCloseDelimiterAfterCompleted)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, CloseDelimiter)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)
+{
+    auto data =
+        "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideFirstDelimiter)
+{
+    auto data = "--bound"_s;
+
+    auto nextData = "ary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 0);
+
+    handle->didReceiveMessage(SharedBuffer::create(nextData, strlen(nextData)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideSecondDelimiter)
+{
+    auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--b"_s;
+
+    auto nextData = "oundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_EQ(client.headers().size(), 0);
+
+    handle->didReceiveMessage(SharedBuffer::create(nextData, strlen(nextData)));
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideLastDelimiter)
+{
+    auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundar"_s;
+
+    auto nextData = "y--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    // Retain "Initial CRLF + (boundary - 1)" bytes
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<h", 2));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didReceiveMessage(SharedBuffer::create(nextData, strlen(nextData)));
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideCloseDelimiter)
+{
+    auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary"_s;
+
+    auto nextData = "--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    // Retain "Initial CRLF + (boundary - 1)" bytes
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<h", 2));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didReceiveMessage(SharedBuffer::create(nextData, strlen(nextData)));
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideTransportPadding)
+{
+    auto data = "--boundary  \r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary      "_s;
+
+    auto nextData =
+        "  \r\nContent-type: text/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--        \r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_EQ(client.headers().size(), 0);
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+
+    handle->didReceiveMessage(SharedBuffer::create(nextData, strlen(nextData)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideHeader)
+{
+    auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABCDEF"
+        "\r\n--boundary\r\nContent-type: t"_s;
+
+    auto nextData = "ext/html\r\n\r\n"
+        "<html></html>"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 0);
+
+    handle->didReceiveMessage(SharedBuffer::create(nextData, strlen(nextData)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, DivideBody)
+{
+    auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABC"_s;
+
+    auto secondData = "DEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<h"_s;
+
+    auto lastData = "tml></html>"
+        "\r\n--boundary--\r\n"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_EQ(client.data().size(), 0);
+
+    handle->didReceiveMessage(SharedBuffer::create(secondData, strlen(secondData)));
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_EQ(client.data().size(), 0);
+
+    handle->didReceiveMessage(SharedBuffer::create(lastData, strlen(lastData)));
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(!client.complete());
+
+    handle->didCompleteMessage();
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)
+{
+    auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
+        "ABC"_s;
+
+    auto secondData = "DEF"
+        "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
+        "<h"_s;
+
+    auto lastData = "tml></html>"_s;
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data, strlen(data)));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
+    EXPECT_EQ(client.data().size(), 0);
+    client.clear();
+
+    handle->didReceiveMessage(SharedBuffer::create(secondData, strlen(secondData)));
+    EXPECT_EQ(client.headers().size(), 0);
+    EXPECT_EQ(client.data().size(), 0);
+
+    handle->didReceiveMessage(SharedBuffer::create(lastData, strlen(lastData)));
+    EXPECT_EQ(client.headers().size(), 0);
+    EXPECT_EQ(client.data().size(), 0);
+
+    handle->didCompleteMessage();
+    EXPECT_EQ(client.headers().size(), 0);
+    EXPECT_EQ(client.data().size(), 0);
+    EXPECT_TRUE(!client.complete());
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
+    EXPECT_EQ(client.headers().size(), 1);
+    EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
+    EXPECT_TRUE(!client.complete());
+    client.clear();
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
+    EXPECT_TRUE(client.complete());
+}
+
+TEST(CurlMultipartHandleTests, MaxHeaderSize)
+{
+    Vector<uint8_t> data;
+    data.append("--boundary\r\n", 12);
+
+    for (auto i = 0; i < 300 * 1024 - 4; i++)
+        data.append("a", 1);
+
+    data.append("\r\n\r\n", 4);
+    data.append("\r\n--boundary\r\n", 14);
+
+    for (auto i = 0; i < 300 * 1024 - 3; i++)
+        data.append("a", 1);
+
+    data.append("\r\n\r\n", 4);
+
+    MultipartHandleClient client;
+
+    auto curlResponse = createCurlResponse();
+    auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
+
+    handle->didReceiveMessage(SharedBuffer::create(data.data(), data.size()));
+    handle->didCompleteMessage();
+    EXPECT_FALSE(handle->hasError());
+
+    handle->completeHeaderProcessing();
+    EXPECT_TRUE(handle->hasError());
+}
+
+}
+
+}
+
+#endif // USE(CURL)


### PR DESCRIPTION
#### a3b8bd468c68ab1305db67c5e6f8c39b066b7042
<pre>
[Curl] Support multipart response
<a href="https://bugs.webkit.org/show_bug.cgi?id=261104">https://bugs.webkit.org/show_bug.cgi?id=261104</a>

Reviewed by Fujii Hironori.

WinCairo WK2 (curl port) does not support multipart response. So we add
support for multipart response in WinCairo WK2.

* Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp:
(WebCore::extractBoundary):
(WebCore::CurlMultipartHandle::createIfNeeded):
(WebCore::CurlMultipartHandle::CurlMultipartHandle):
(WebCore::CurlMultipartHandle::didReceiveMessage):
(WebCore::CurlMultipartHandle::completeHeaderProcessing):
(WebCore::CurlMultipartHandle::didCompleteMessage):
(WebCore::CurlMultipartHandle::processContent):
(WebCore::CurlMultipartHandle::findBoundary):
(WebCore::CurlMultipartHandle::parseHeadersIfPossible):
(WebCore::CurlMultipartHandle::extractBoundary): Deleted.
(WebCore::CurlMultipartHandle::extractBoundaryFromContentType): Deleted.
(WebCore::CurlMultipartHandle::didReceiveData): Deleted.
(WebCore::CurlMultipartHandle::didComplete): Deleted.
(WebCore::CurlMultipartHandle::checkForBoundary): Deleted.
(WebCore::CurlMultipartHandle::matchedLength): Deleted.
* Source/WebCore/platform/network/curl/CurlMultipartHandle.h:
(WebCore::CurlMultipartHandle::completed):
(WebCore::CurlMultipartHandle::hasError const):
* Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h:
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::CurlRequest):
(WebCore::CurlRequest::didReceiveHeader):
(WebCore::CurlRequest::didReceiveData):
(WebCore::CurlRequest::didReceiveHeaderFromMultipart):
(WebCore::CurlRequest::didReceiveDataFromMultipart):
(WebCore::CurlRequest::didCompleteFromMultipart):
(WebCore::CurlRequest::didCompleteTransfer):
* Source/WebCore/platform/network/curl/CurlRequest.h:
(WebCore::CurlRequest::create):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::createCurlRequest):
* Tools/TestWebKitAPI/PlatformWin.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp: Added.
(TestWebKitAPI::Curl::createCurlResponse):
(TestWebKitAPI::Curl::MultipartHandleClient::clear):
(TestWebKitAPI::Curl::MultipartHandleClient::headers):
(TestWebKitAPI::Curl::MultipartHandleClient::data):
(TestWebKitAPI::Curl::MultipartHandleClient::complete):
(TestWebKitAPI::Curl::CurlMultipartHandleTests::CurlMultipartHandleTests):
(TestWebKitAPI::Curl::TEST):

Canonical link: <a href="https://commits.webkit.org/268180@main">https://commits.webkit.org/268180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c43894ab2eecbeb8c72bfb7c847a0f80c58216dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19409 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19167 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21694 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18012 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17093 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21453 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2314 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->