### PR TITLE
Introduce OptionSet to updateLayout

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -334,6 +334,11 @@ enum class DimensionsCheck : uint8_t {
     All = 1 << 2, // FIXME: This is probably meant to be Width | Height instead.
 };
 
+enum class LayoutOptions : uint8_t {
+    RunPostLayoutTasksSynchronously = 1 << 0,
+    IgnorePendingStylesheets = 1 << 1,
+};
+
 enum class HttpEquivPolicy {
     Enabled,
     DisabledBySettings,
@@ -666,12 +671,11 @@ public:
     bool needsStyleRecalc() const;
     unsigned lastStyleUpdateSizeForTesting() const { return m_lastStyleUpdateSizeForTesting; }
 
-    WEBCORE_EXPORT void updateLayout();
+    WEBCORE_EXPORT void updateLayout(OptionSet<LayoutOptions> = { });
     
     // updateLayoutIgnorePendingStylesheets() forces layout even if we are waiting for pending stylesheet loads,
     // so calling this may cause a flash of unstyled content (FOUC).
-    enum class RunPostLayoutTasks : bool { Asynchronously, Synchronously };
-    WEBCORE_EXPORT void updateLayoutIgnorePendingStylesheets(RunPostLayoutTasks = RunPostLayoutTasks::Asynchronously);
+    void updateLayoutIgnorePendingStylesheets(OptionSet<LayoutOptions> = { });
 
     std::unique_ptr<RenderStyle> styleForElementIgnoringPendingStylesheets(Element&, const RenderStyle* parentStyle, PseudoId = PseudoId::None);
 

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -130,7 +130,7 @@ RenderWidget* HTMLPlugInElement::renderWidgetLoadingPlugin() const
         // Needs to load the plugin immediatedly because this function is called
         // when JavaScript code accesses the plugin.
         // FIXME: <rdar://16893708> Check if dispatching events here is safe.
-        document().updateLayoutIgnorePendingStylesheets(Document::RunPostLayoutTasks::Synchronously);
+        document().updateLayout({ LayoutOptions::IgnorePendingStylesheets, LayoutOptions::RunPostLayoutTasksSynchronously });
     }
     return renderWidget(); // This will return nullptr if the renderer is not a RenderWidget.
 }

--- a/Source/WebCore/page/VisualViewport.cpp
+++ b/Source/WebCore/page/VisualViewport.cpp
@@ -71,7 +71,7 @@ bool VisualViewport::addEventListener(const AtomString& eventType, Ref<EventList
 void VisualViewport::updateFrameLayout() const
 {
     ASSERT(frame());
-    frame()->document()->updateLayoutIgnorePendingStylesheets(Document::RunPostLayoutTasks::Synchronously);
+    frame()->document()->updateLayout({ LayoutOptions::IgnorePendingStylesheets, LayoutOptions::RunPostLayoutTasksSynchronously });
 }
 
 double VisualViewport::offsetLeft() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1824,7 +1824,7 @@ ExceptionOr<Ref<DOMRect>> Internals::absoluteLineRectFromPoint(int x, int y)
 
     auto& frame = *document.frame();
     auto& view = *document.view();
-    document.updateLayoutIgnorePendingStylesheets();
+    document.updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     auto position = frame.visiblePositionForPoint(view.rootViewToContents(IntPoint { x, y }));
     return DOMRect::create(position.absoluteSelectionBoundsForLine());
@@ -1850,7 +1850,7 @@ ExceptionOr<bool> Internals::isCaretBlinkingSuspended()
 
 Ref<DOMRect> Internals::boundingBox(Element& element)
 {
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto renderer = element.renderer();
     if (!renderer)
         return DOMRect::create();
@@ -1907,7 +1907,7 @@ ExceptionOr<unsigned> Internals::markerCountForNode(Node& node, const String& ma
 
 ExceptionOr<RenderedDocumentMarker*> Internals::markerAt(Node& node, const String& markerType, unsigned index)
 {
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     OptionSet<DocumentMarker::MarkerType> markerTypes;
     if (!markerTypesFrom(markerType, markerTypes))
@@ -2090,7 +2090,7 @@ ExceptionOr<Ref<DOMRect>> Internals::layoutViewportRect()
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     auto& frameView = *document->view();
     return DOMRect::create(frameView.layoutViewportRect());
@@ -2102,7 +2102,7 @@ ExceptionOr<Ref<DOMRect>> Internals::visualViewportRect()
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     auto& frameView = *document->view();
     return DOMRect::create(frameView.visualViewportRect());
@@ -2178,7 +2178,7 @@ ExceptionOr<uint64_t> Internals::lineIndexAfterPageBreak(Element& element)
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!element.renderer() || !is<RenderBlockFlow>(element.renderer()))
         return Exception { NotFoundError };
@@ -2302,7 +2302,7 @@ Vector<String> Internals::recentSearches(const HTMLInputElement& element)
     if (!element.isSearchField())
         return { };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = element.renderer();
     if (!is<RenderSearchField>(renderer))
         return { };
@@ -2566,7 +2566,7 @@ ExceptionOr<RefPtr<NodeList>> Internals::nodesFromRect(Document& document, int c
     if (!renderView)
         return nullptr;
 
-    document.updateLayoutIgnorePendingStylesheets();
+    document.updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     float zoomFactor = frame->pageZoomFactor();
     LayoutPoint point(centerX * zoomFactor + frameView->scrollX(), centerY * zoomFactor + frameView->scrollY());
@@ -3129,7 +3129,7 @@ ExceptionOr<uint64_t> Internals::layerIDForElement(Element& element)
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!element.renderer() || !element.renderer()->hasLayer())
         return Exception { NotFoundError };
@@ -3194,7 +3194,7 @@ ExceptionOr<ScrollableArea*> Internals::scrollableAreaForNode(Node* node) const
         return Exception { InvalidAccessError };
 
     Ref nodeRef { *node };
-    nodeRef->document().updateLayoutIgnorePendingStylesheets();
+    nodeRef->document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     ScrollableArea* scrollableArea = nullptr;
     if (is<Document>(nodeRef)) {
@@ -3289,7 +3289,7 @@ ExceptionOr<String> Internals::scrollingStateTreeAsText() const
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     Page* page = document->page();
     if (!page)
@@ -3304,7 +3304,7 @@ ExceptionOr<String> Internals::scrollingTreeAsText() const
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     auto page = document->page();
     if (!page)
@@ -3324,7 +3324,7 @@ ExceptionOr<bool> Internals::haveScrollingTree() const
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     auto page = document->page();
     if (!page)
@@ -3369,7 +3369,7 @@ ExceptionOr<void> Internals::setElementUsesDisplayListDrawing(Element& element, 
     if (!document || !document->renderView())
         return Exception { InvalidAccessError };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!element.renderer())
         return Exception { InvalidAccessError };
@@ -3391,7 +3391,7 @@ ExceptionOr<void> Internals::setElementTracksDisplayListReplay(Element& element,
     if (!document || !document->renderView())
         return Exception { InvalidAccessError };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!element.renderer())
         return Exception { InvalidAccessError };
@@ -3423,7 +3423,7 @@ ExceptionOr<String> Internals::displayListForElement(Element& element, unsigned 
     if (!document || !document->renderView())
         return Exception { InvalidAccessError };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!element.renderer())
         return Exception { InvalidAccessError };
@@ -3444,7 +3444,7 @@ ExceptionOr<String> Internals::replayDisplayListForElement(Element& element, uns
     if (!document || !document->renderView())
         return Exception { InvalidAccessError };
 
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!element.renderer())
         return Exception { InvalidAccessError };
@@ -3478,7 +3478,7 @@ ExceptionOr<String> Internals::cachedGlyphDisplayListsForTextNode(Node& node, un
     if (!is<Text>(node))
         return Exception { InvalidAccessError };
 
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     if (!node.renderer())
         return Exception { InvalidAccessError };
@@ -4005,7 +4005,7 @@ ExceptionOr<void> Internals::updateLayoutIgnorePendingStylesheetsAndRunPostLayou
     else
         return Exception { TypeError };
 
-    document->updateLayoutIgnorePendingStylesheets(Document::RunPostLayoutTasks::Synchronously);
+    document->updateLayout({ LayoutOptions::IgnorePendingStylesheets, LayoutOptions::RunPostLayoutTasksSynchronously });
     document->flushDeferredAXObjectCacheUpdate();
 
     return { };
@@ -4325,7 +4325,7 @@ ExceptionOr<void> Internals::setOverridePreferredDynamicRangeMode(HTMLMediaEleme
 
 bool Internals::isSelectPopupVisible(HTMLSelectElement& element)
 {
-    element.document().updateLayoutIgnorePendingStylesheets();
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     auto* renderer = element.renderer();
     if (!is<RenderMenuList>(renderer))
@@ -5013,7 +5013,7 @@ ExceptionOr<String> Internals::pageOverlayLayerTreeAsText(unsigned short flags) 
     if (!document || !document->page())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     return MockPageOverlayClient::singleton().layerTreeAsText(*document->page(), toLayerTreeAsTextOptions(flags));
 }

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -124,7 +124,7 @@ ExceptionOr<RefPtr<Range>> Internals::rangeForDictionaryLookupAtLocation(int x, 
     if (!document || !document->frame())
         return Exception { InvalidAccessError };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
     

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -113,7 +113,7 @@
 
 - (NSArray *)textRects
 {
-    _impl->document().updateLayoutIgnorePendingStylesheets();
+    _impl->document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     if (!_impl->renderer())
         return nil;
     return createNSArray(WebCore::RenderObject::absoluteTextRects(WebCore::makeRangeSelectingNodeContents(*_impl))).autorelease();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -130,7 +130,7 @@
 - (NSArray *)textRects
 {
     auto range = makeSimpleRange(*_impl);
-    range.start.document().updateLayoutIgnorePendingStylesheets();
+    range.start.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     return createNSArray(WebCore::RenderObject::absoluteTextRects(range)).autorelease();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -163,7 +163,7 @@ std::optional<std::pair<double, double>> ViewGestureGeometryCollector::computeTe
     if (!document)
         return std::nullopt;
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     HashSet<Ref<Node>> allTextNodes;
     HashMap<unsigned, unsigned> fontSizeToCountMap;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1366,7 +1366,7 @@ void WebPage::setForceAlwaysUserScalable(bool userScalable)
 
 static IntRect elementBoundsInFrame(const LocalFrame& frame, const Element& focusedElement)
 {
-    frame.document()->updateLayoutIgnorePendingStylesheets();
+    frame.document()->updateLayout(LayoutOptions::IgnorePendingStylesheets);
     
     if (focusedElement.hasTagName(HTMLNames::textareaTag) || focusedElement.hasTagName(HTMLNames::inputTag) || focusedElement.hasTagName(HTMLNames::selectTag))
         return WebPage::absoluteInteractionBounds(focusedElement);
@@ -4848,7 +4848,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest reques
     }
 
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
-    RefPtr { frame->document() }->updateLayoutIgnorePendingStylesheets();
+    RefPtr { frame->document() }->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     VisibleSelection selection = frame->selection().selection();
 
@@ -5096,7 +5096,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
     ASSERT(target->document().frame());
     Ref targetFrame = *target->document().frame();
 
-    targetFrame->document()->updateLayoutIgnorePendingStylesheets();
+    targetFrame->document()->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     // Performing layout could have could torn down the element's renderer. Check that we still
     // have one. Otherwise, bail out as this function only focuses elements that have a visual

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -68,7 +68,7 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
     if (!document->hasLivingRenderTree() || document->activeDOMObjectsAreStopped())
         return { };
 
-    document->updateLayoutIgnorePendingStylesheets();
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = element.renderer();
     if (!renderer)
         return { };

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -300,7 +300,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 #endif
 {
     auto& node = *core(self);
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer)
 #if PLATFORM(IOS_FAMILY)
@@ -327,7 +327,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (WKQuad)absoluteQuadAndInsideFixedPosition:(BOOL *)insideFixed
 {
     auto& node = *core(self);
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer) {
         if (insideFixed)
@@ -352,7 +352,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (CGRect)boundingBoxUsingTransforms
 {
     auto& node = *core(self);
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer)
         return CGRectZero;
@@ -363,7 +363,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSArray *)lineBoxQuads
 {
     auto& node = *core(self);
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     WebCore::RenderObject *renderer = node.renderer();
     if (!renderer)
         return nil;
@@ -432,7 +432,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (WKQuad)innerFrameQuad // takes transforms into account
 {
     auto& node = *core(self);
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer)
         return zeroQuad();
@@ -494,7 +494,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSArray *)textRects
 {
     auto& node = *core(self);
-    node.document().updateLayoutIgnorePendingStylesheets();
+    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     if (!node.renderer())
         return nil;
     return createNSArray(RenderObject::absoluteTextRects(makeRangeSelectingNodeContents(node))).autorelease();
@@ -571,7 +571,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 #endif
 {
     auto range = makeSimpleRange(*core(self));
-    range.start.document().updateLayoutIgnorePendingStylesheets();
+    range.start.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     return unionRect(RenderObject::absoluteTextRects(range));
 }
 
@@ -601,7 +601,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSArray *)textRects
 {
     auto range = makeSimpleRange(*core(self));
-    range.start.document().updateLayoutIgnorePendingStylesheets();
+    range.start.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
     return createNSArray(RenderObject::absoluteTextRects(range)).autorelease();
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1891,7 +1891,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
                 continue;
             auto *document = localFrame->document();
             if (document)
-                document->updateLayoutIgnorePendingStylesheets();
+                document->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
         }
     });
 }


### PR DESCRIPTION
#### 9ed0cc30d357eb9673342ff8bd1d8143485034c8
<pre>
Introduce OptionSet to updateLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=261105">https://bugs.webkit.org/show_bug.cgi?id=261105</a>

Reviewed by Tim Nguyen.

Introduce OptionSet to updateLayout to be able to specify its
behaviour, i.e. whether to run post lasyout tasks and/or ignore stylesheets.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayoutIgnorePendingStylesheets):
(WebCore::Document::updateLayout):
* Source/WebCore/dom/Document.h:
(WebCore::Document::updateLayout):
(WebCore::Document::updateLayoutIgnorePendingStylesheets):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::renderWidgetLoadingPlugin const):
* Source/WebCore/page/VisualViewport.cpp:
(WebCore::VisualViewport::updateFrameLayout const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::absoluteLineRectFromPoint):
(WebCore::Internals::boundingBox):
(WebCore::Internals::layoutViewportRect):
(WebCore::Internals::visualViewportRect):
(WebCore::Internals::lineIndexAfterPageBreak):
(WebCore::Internals::recentSearches):
(WebCore::Internals::nodesFromRect const):
(WebCore::Internals::layerIDForElement):
(WebCore:: const):
(WebCore::Internals::scrollingStateTreeAsText const):
(WebCore::Internals::scrollingTreeAsText const):
(WebCore::Internals::haveScrollingTree const):
(WebCore::Internals::setElementUsesDisplayListDrawing):
(WebCore::Internals::setElementTracksDisplayListReplay):
(WebCore::Internals::displayListForElement):
(WebCore::Internals::replayDisplayListForElement):
(WebCore::Internals::cachedGlyphDisplayListsForTextNode):
(WebCore::Internals::updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks):
(WebCore::Internals::isSelectPopupVisible):
(WebCore::Internals::pageOverlayLayerTreeAsText const):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::rangeForDictionaryLookupAtLocation):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
(-[WKDOMNode textRects]):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm:
(-[WKDOMRange textRects]):
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
(WebKit::ViewGestureGeometryCollector::computeTextLegibilityScales):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::elementBoundsInFrame):
(WebKit::WebPage::requestDocumentEditingContext):
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::inlineVideoFrame):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMNode boundingBox]):
(-[DOMNode absoluteQuadAndInsideFixedPosition:]):
(-[DOMNode boundingBoxUsingTransforms]):
(-[DOMNode lineBoxQuads]):
(-[DOMNode innerFrameQuad]):
(-[DOMNode textRects]):
(-[DOMRange boundingBox]):
(-[DOMRange textRects]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView updateLayoutIgnorePendingStyleSheets]):

Canonical link: <a href="https://commits.webkit.org/268241@main">https://commits.webkit.org/268241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2375f4782bacd7e4440b7fec907ed986e77acdab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18413 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19961 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22457 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20284 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15683 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4557 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->