### PR TITLE
Handle OnErrorEventHandler in JSEventListener

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext-expected.txt
@@ -1,7 +1,7 @@
 
 PASS non-error event handler
 PASS error event handler not on body
-FAIL error event handler on disconnected body assert_equals: expected "function onerror(event, source, lineno, colno, error) {\nfoo\n}" but got "function onerror(event) {\nfoo\n}"
-FAIL error event handler on disconnected frameset assert_equals: expected "function onerror(event, source, lineno, colno, error) {\nfoo\n}" but got "function onerror(event) {\nfoo\n}"
-FAIL error event handler on connected body, reflected to Window assert_equals: expected "function onerror(event, source, lineno, colno, error) {\nfoo\n}" but got "function onerror(event) {\nfoo\n}"
+PASS error event handler on disconnected body
+PASS error event handler on disconnected frameset
+PASS error event handler on connected body, reflected to Window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/onerroreventhandler-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/onerroreventhandler-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL onerror + ErrorEvent + Window assert_equals: expected 5 but got 1
-FAIL onerror + !ErrorEvent + Window assert_equals: expected 5 but got 1
+PASS onerror + ErrorEvent + Window
+PASS onerror + !ErrorEvent + Window
 PASS onerror + Document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: SyntaxError: Unexpected token ')'
 
-FAIL <body onerror> - compile error in <script src=data:...> assert_equals: first arg expected "string" but got "object"
-FAIL <body onerror> - compile error in <script src=data:...> (column) assert_equals: fourth arg expected "number" but got "undefined"
+PASS <body onerror> - compile error in <script src=data:...>
+PASS <body onerror> - compile error in <script src=data:...> (column)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: SyntaxError: Unexpected token ')'
 
-FAIL <body onerror> - compile error in <script> assert_equals: first arg expected "string" but got "object"
-FAIL <body onerror> - compile error in <script> (column) assert_equals: fourth arg expected "number" but got "undefined"
+PASS <body onerror> - compile error in <script>
+PASS <body onerror> - compile error in <script> (column)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-runtime-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-runtime-error-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: ReferenceError: Can't find variable: undefined_variable
 
-FAIL <body onerror> - runtime error in <script> assert_equals: first arg expected "string" but got "object"
-FAIL <body onerror> - runtime error in <script> (column) assert_equals: fourth arg expected "number" but got "undefined"
+PASS <body onerror> - runtime error in <script>
+PASS <body onerror> - runtime error in <script> (column)
 

--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 using namespace JSC;
 
 inline JSErrorHandler::JSErrorHandler(JSObject& listener, JSObject& wrapper, bool isAttribute, DOMWrapperWorld& world)
-    : JSEventListener(&listener, &wrapper, isAttribute, CreatedFromMarkup::No, world)
+    : JSEventListener(&listener, &wrapper, isAttribute, CreatedFromMarkup::No, world, true)
 {
 }
 

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -65,6 +65,8 @@ public:
         return is<JSEventListener>(listener) && downcast<JSEventListener>(listener).wasCreatedFromMarkup();
     }
 
+    bool isWindowOnError() const { return m_isWindowOnError; }
+
 private:
     virtual JSC::JSObject* initializeJSFunction(ScriptExecutionContext&) const;
 
@@ -79,13 +81,14 @@ private:
 protected:
     enum class CreatedFromMarkup : bool { No, Yes };
 
-    JSEventListener(JSC::JSObject* function, JSC::JSObject* wrapper, bool isAttribute, CreatedFromMarkup, DOMWrapperWorld&);
+    JSEventListener(JSC::JSObject* function, JSC::JSObject* wrapper, bool isAttribute, CreatedFromMarkup, DOMWrapperWorld&, bool isWindowOnError);
     void handleEvent(ScriptExecutionContext&, Event&) override;
     void setWrapperWhenInitializingJSFunction(JSC::VM&, JSC::JSObject* wrapper) const { m_wrapper = JSC::Weak<JSC::JSObject>(wrapper); }
 
 private:
     bool m_isAttribute : 1;
     bool m_wasCreatedFromMarkup : 1;
+    const bool m_isWindowOnError;
 
     mutable bool m_isInitialized : 1;
     mutable JSC::Weak<JSC::JSObject> m_jsFunction;


### PR DESCRIPTION
#### 41a75d510e692b33297c0d13fdd719c019564b5e
<pre>
Handle OnErrorEventHandler in JSEventListener
<a href="https://bugs.webkit.org/show_bug.cgi?id=211597">https://bugs.webkit.org/show_bug.cgi?id=211597</a>

Reviewed by NOBODY (OOPS!).

When an onerror event handler is added via `attributeChanged`, the
event listener is always initialized via `JSLazyEventListener` so
the callback always handle with a single parameter, `event`. To fix
the issue, we can add a boolean flag in `JSEventListener` to add more
args to the callback when the flag is true.

* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-sourcetext-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/onerroreventhandler-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/body-onerror-runtime-error-expected.txt:
* Source/WebCore/bindings/js/JSErrorHandler.cpp:
(WebCore::JSErrorHandler::JSErrorHandler):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::JSEventListener):
(WebCore::JSEventListener::handleEvent):
* Source/WebCore/bindings/js/JSEventListener.h:
(WebCore::JSEventListener::isWindowOnError const):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::JSLazyEventListener):
(WebCore::JSLazyEventListener::initializeJSFunction const):
(WebCore::JSLazyEventListener::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a75d510e692b33297c0d13fdd719c019564b5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18257 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17363 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17707 "4 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19763 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22277 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20095 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13866 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->