### PR TITLE
Remove CSSValueInternalVariableValue

### DIFF
--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -71,11 +71,6 @@ public:
         return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { std::in_place_type<Ref<CSSVariableReferenceValue>>, WTFMove(value) }));
     }
 
-    static Ref<CSSCustomPropertyValue> createUnresolved(const AtomString& name, CSSValueID value)
-    {
-        return adoptRef(*new CSSCustomPropertyValue(name, { value }));
-    }
-
     static Ref<CSSCustomPropertyValue> createWithID(const AtomString& name, CSSValueID);
 
     static Ref<CSSCustomPropertyValue> createSyntaxAll(const AtomString& name, Ref<CSSVariableData>&& value)

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -957,7 +957,6 @@ exclude
 // Variables Implementation
 //
 var
--internal-variable-value
 
 //
 // Environment Variables

--- a/Source/WebCore/css/parser/CSSParserIdioms.cpp
+++ b/Source/WebCore/css/parser/CSSParserIdioms.cpp
@@ -47,7 +47,6 @@ bool isValueAllowedInMode(unsigned short id, CSSParserMode mode)
 #endif
     case CSSValueInternalDocumentTextColor:
     case CSSValueInternalThCenter:
-    case CSSValueInternalVariableValue:
         return isUASheetBehavior(mode);
     default:
         return true;

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -139,27 +139,31 @@ bool isValidConstantReference(CSSParserTokenRange range, const CSSParserContext&
     return classifyBlock(range, hasReferences, parserContext);
 }
 
-static CSSValueID classifyVariableRange(CSSParserTokenRange range, bool& hasReferences, const CSSParserContext& parserContext)
-{
-    hasReferences = false;
+struct VariableType {
+    std::optional<CSSValueID> cssWideKeyword { };
+    bool hasReferences { false };
+};
 
+static std::optional<VariableType> classifyVariableRange(CSSParserTokenRange range, const CSSParserContext& parserContext)
+{
     range.consumeWhitespace();
     if (range.peek().type() == IdentToken) {
         CSSValueID id = range.consumeIncludingWhitespace().id();
         if (range.atEnd() && isCSSWideKeyword(id))
-            return id;
+            return VariableType { id };
     }
 
-    if (classifyBlock(range, hasReferences, parserContext))
-        return CSSValueInternalVariableValue;
-    return CSSValueInvalid;
+    VariableType type;
+    if (!classifyBlock(range, type.hasReferences, parserContext))
+        return { };
+
+    return type;
 }
 
 bool CSSVariableParser::containsValidVariableReferences(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
-    bool hasReferences;
-    CSSValueID type = classifyVariableRange(range, hasReferences, parserContext);
-    return type == CSSValueInternalVariableValue && hasReferences;
+    auto type = classifyVariableRange(range, parserContext);
+    return type && type->hasReferences;
 }
 
 RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext)
@@ -167,14 +171,15 @@ RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const At
     if (range.atEnd())
         return nullptr;
 
-    bool hasReferences;
-    CSSValueID type = classifyVariableRange(range, hasReferences, parserContext);
+    auto type = classifyVariableRange(range, parserContext);
 
-    if (type == CSSValueInvalid)
+    if (!type)
         return nullptr;
-    if (type == CSSValueInternalVariableValue)
-        return CSSCustomPropertyValue::createUnresolved(variableName, CSSVariableReferenceValue::create(range, parserContext));
-    return CSSCustomPropertyValue::createUnresolved(variableName, type);
+
+    if (type->cssWideKeyword)
+        return CSSCustomPropertyValue::createWithID(variableName, *type->cssWideKeyword);
+
+    return CSSCustomPropertyValue::createUnresolved(variableName, CSSVariableReferenceValue::create(range, parserContext));
 }
 
 RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseInitialValueForUniversalSyntax(const AtomString& variableName, CSSParserTokenRange range)
@@ -182,12 +187,9 @@ RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseInitialValueForUniversalS
     if (range.atEnd())
         return nullptr;
 
-    bool hasReferences;
-    CSSValueID valueID = classifyVariableRange(range, hasReferences, strictCSSParserContext());
+    auto type = classifyVariableRange(range, strictCSSParserContext());
 
-    if (hasReferences)
-        return nullptr;
-    if (valueID != CSSValueInternalVariableValue)
+    if (!type || type->cssWideKeyword || type->hasReferences)
         return nullptr;
 
     return CSSCustomPropertyValue::createSyntaxAll(variableName, CSSVariableData::create(range));

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1992,7 +1992,7 @@ inline void BuilderCustom::applyInitialCustomProperty(BuilderState& builderState
         return;
     }
 
-    auto invalid = CSSCustomPropertyValue::createUnresolved(name, CSSValueInvalid);
+    auto invalid = CSSCustomPropertyValue::createWithID(name, CSSValueInvalid);
     applyValueCustomProperty(builderState, registered, invalid.get());
 }
 


### PR DESCRIPTION
#### daefe5b35709bc997ea5e5624f815834e1d13740
<pre>
Remove CSSValueInternalVariableValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=261112">https://bugs.webkit.org/show_bug.cgi?id=261112</a>
rdar://114935023

Reviewed by Alan Baradlay.

It is not used for anything meaningful.

* Source/WebCore/css/CSSCustomPropertyValue.h:

Also remove the unnecessary and confusing createUnresolved constructor function.

* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserIdioms.cpp:
(WebCore::isValueAllowedInMode):
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::classifyVariableRange):

Return a simple struct instead of relying on CSSValueInternalVariableValue/CSSValueInvalid and a separate bool.

(WebCore::CSSVariableParser::containsValidVariableReferences):
(WebCore::CSSVariableParser::parseDeclarationValue):
(WebCore::CSSVariableParser::parseInitialValueForUniversalSyntax):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyInitialCustomProperty):

Canonical link: <a href="https://commits.webkit.org/267610@main">https://commits.webkit.org/267610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ceb6eef0784b0d995fb9cfc759225e135f8309

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18262 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19769 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22284 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13872 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15506 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->