### PR TITLE
Fix test-webkitpy on Python 3.6

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/executive_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/executive_unittest.py
@@ -149,25 +149,26 @@ class ExecutiveTest(unittest.TestCase):
 
         executive = Executive()
 
-        output = executive.run_command(command_line('cat'), input=unicode_tor_input)
+        output = executive.run_command(command_line('cat'), input=unicode_tor_input, return_stderr=False)
         self.assertEqual(output, unicode_tor_output)
 
-        output = executive.run_command(command_line('echo', unicode_tor_input))
+        output = executive.run_command(command_line('echo', unicode_tor_input), return_stderr=False)
         self.assertEqual(output, unicode_tor_output)
 
-        output = executive.run_command(command_line('echo', unicode_tor_input), decode_output=False)
+        output = executive.run_command(command_line('echo', unicode_tor_input), decode_output=False, return_stderr=False)
         self.assertEqual(output, encoded_tor)
 
         # Make sure that str() input also works.
-        output = executive.run_command(command_line('cat'), input=encoded_tor, decode_output=False)
+        output = executive.run_command(command_line('cat'), input=encoded_tor, decode_output=False, return_stderr=False)
         self.assertEqual(output, encoded_tor)
 
         # FIXME: We should only have one run* method to test
+        # These use assertIn as run_and_throw_if_fail always redirects stderr to stdout
         output = executive.run_and_throw_if_fail(command_line('echo', unicode_tor_input), quiet=True)
-        self.assertEqual(output, unicode_tor_output)
+        self.assertIn(unicode_tor_output, output)
 
         output = executive.run_and_throw_if_fail(command_line('echo', unicode_tor_input), quiet=True, decode_output=False)
-        self.assertEqual(output, encoded_tor)
+        self.assertIn(encoded_tor, output)
 
     def serial_test_kill_process(self):
         executive = Executive()

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -137,7 +137,7 @@ class ConfigTest(unittest.TestCase):
         expected = 'Debug'
 
         args = [sys.executable, script, '--mock', expected]
-        actual = e.run_command(args).rstrip()
+        actual = e.run_command(args, return_stderr=False).rstrip()
         self.assertEqual(actual, expected)
 
     def test_default_configuration__no_perl(self):


### PR DESCRIPTION
#### 09fd8864fcaaf359aa1737833ea6027c99b2c8ae
<pre>
Fix test-webkitpy on Python 3.6
<a href="https://bugs.webkit.org/show_bug.cgi?id=261115">https://bugs.webkit.org/show_bug.cgi?id=261115</a>

Reviewed by Jonathan Bedard.

All of these failures are caused by the `sys.stderr.write` in
`webkitpy.__init__`. As such, when we run subprocesses in our tests, ignore
what&apos;s written to stderr.

* Tools/Scripts/webkitpy/common/system/executive_unittest.py:
(ExecutiveTest.test_run_command_with_unicode):
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest.test_default_configuration__standalone):

Canonical link: <a href="https://commits.webkit.org/267686@main">https://commits.webkit.org/267686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/012e018154d93947cf1e005d7762a249db42ffeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16068 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18264 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19773 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17307 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22287 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19877 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2125 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->