### PR TITLE
Fix `test-webkitpy webkitflaskpy`

### DIFF
--- a/Tools/Scripts/webkitpy/test/finder.py
+++ b/Tools/Scripts/webkitpy/test/finder.py
@@ -40,11 +40,8 @@ class _DirectoryTree(object):
     def __init__(self, filesystem, top_directory, starting_subdirectory):
         self.filesystem = filesystem
         self.top_directory = filesystem.realpath(top_directory)
-        self.search_directory = self.top_directory
-        self.top_package = ''
-        if starting_subdirectory:
-            self.top_package = starting_subdirectory.replace(filesystem.sep, '.') + '.'
-            self.search_directory = filesystem.join(self.top_directory, starting_subdirectory)
+        self.top_package = starting_subdirectory.replace(filesystem.sep, '.') + '.'
+        self.search_directory = filesystem.join(self.top_directory, starting_subdirectory)
 
     def find_modules(self, suffixes, sub_directory=None):
         if sub_directory:
@@ -64,7 +61,9 @@ class _DirectoryTree(object):
     def subpath(self, path):
         """Returns the relative path from the top of the tree to the path, or None if the path is not under the top of the tree."""
         realpath = self.filesystem.realpath(self.filesystem.join(self.top_directory, path))
-        if realpath.startswith(self.top_directory + self.filesystem.sep):
+        if realpath == self.search_directory:
+            return self.top_package
+        if realpath.startswith(self.search_directory + self.filesystem.sep):
             return realpath.replace(self.top_directory + self.filesystem.sep, '')
         return None
 
@@ -89,7 +88,7 @@ class Finder(object):
         self.trees = []
         self._names_to_skip = []
 
-    def add_tree(self, top_directory, starting_subdirectory=None):
+    def add_tree(self, top_directory, starting_subdirectory):
         self.trees.append(_DirectoryTree(self.filesystem, top_directory, starting_subdirectory))
 
     def skip(self, names, reason, bugid):

--- a/Tools/Scripts/webkitpy/test/finder_unittest.py
+++ b/Tools/Scripts/webkitpy/test/finder_unittest.py
@@ -34,6 +34,8 @@ class FinderTest(unittest.TestCase):
         files = {
           '/foo/bar/baz.py': '',
           '/foo/bar/baz_unittest.py': '',
+          '/foo/libraries/corelib/baz.py': '',
+          '/foo/libraries/corelib/baz_unittest.py': '',
           '/foo2/bar2/baz2.py': '',
           '/foo2/bar2/baz2.pyc': '',
           '/foo2/bar2/baz2_integrationtest.py': '',
@@ -43,7 +45,8 @@ class FinderTest(unittest.TestCase):
         self.fs = MockFileSystem(files)
         self.finder = Finder(self.fs)
         self.finder.add_tree('/foo', 'bar')
-        self.finder.add_tree('/foo2')
+        self.finder.add_tree('/foo2', 'bar2')
+        self.finder.add_tree('/foo/libraries', 'corelib')
 
         # Here we have to jump through a hoop to make sure test-webkitpy doesn't log
         # any messages from these tests :(.
@@ -60,7 +63,7 @@ class FinderTest(unittest.TestCase):
 
     def test_additional_system_paths(self):
         self.assertEqual(self.finder.additional_paths(['/usr']),
-                          ['/foo', '/foo2'])
+                         ['/foo', '/foo2', '/foo/libraries'])
 
     def test_is_module(self):
         self.assertTrue(self.finder.is_module('bar.baz'))
@@ -84,8 +87,8 @@ class FinderTest(unittest.TestCase):
         self.assertEqual(self.finder.find_names(names, find_all), expected_names)
 
     def test_default_names(self):
-        self.check_names([], ['bar.baz_unittest', 'bar2.baz2_integrationtest'], find_all=True)
-        self.check_names([], ['bar.baz_unittest', 'bar2.baz2_integrationtest'], find_all=False)
+        self.check_names([], ['bar.baz_unittest', 'bar2.baz2_integrationtest', 'corelib.baz_unittest'], find_all=True)
+        self.check_names([], ['bar.baz_unittest', 'bar2.baz2_integrationtest', 'corelib.baz_unittest'], find_all=False)
 
         # Should return the names given it, even if they don't exist.
         self.check_names(['foobar'], ['foobar'], find_all=False)
@@ -101,6 +104,7 @@ class FinderTest(unittest.TestCase):
         self.fs.chdir('/')
         self.check_names(['bar'], ['bar.baz_unittest'])
         self.check_names(['/foo/bar/'], ['bar.baz_unittest'])
+        self.check_names(['corelib'], ['corelib.baz_unittest'])
 
         # This works 'by accident' since it maps onto a package.
         self.check_names(['bar/'], ['bar.baz_unittest'])

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -135,7 +135,7 @@ class Tester(object):
         self._options = None
         self.upload_style = 'release'
 
-    def add_tree(self, top_directory, starting_subdirectory=None):
+    def add_tree(self, top_directory, starting_subdirectory):
         self.finder.add_tree(top_directory, starting_subdirectory)
 
     def skip(self, names, reason, bugid):


### PR DESCRIPTION
#### 375f0a128550381f809ffad568989797289dda60
<pre>
Fix `test-webkitpy webkitflaskpy`
<a href="https://bugs.webkit.org/show_bug.cgi?id=261108">https://bugs.webkit.org/show_bug.cgi?id=261108</a>

Reviewed by Jonathan Bedard.

webkitpy.test.finder.DirectoryTree.subpath used to consider everything except
for absolute paths as subpaths, and as such everything was always found as a
subtree of the first tree. This is clearly incorrect. Instead, require it
actually start with the name of the package described by the tree.

While we&apos;re at it, make `starting_directory` required everywhere: the only place
where it was previously None was in finder_unittest, which isn&apos;t helpful.

* Tools/Scripts/webkitpy/test/finder.py:
(_DirectoryTree.__init__):
(_DirectoryTree.subpath):
(Finder.add_tree):
* Tools/Scripts/webkitpy/test/finder_unittest.py:
(FinderTest.setUp):
(FinderTest.test_additional_system_paths):
(FinderTest.test_default_names):
(FinderTest.test_paths):
* Tools/Scripts/webkitpy/test/main.py:
(Tester.add_tree):

Canonical link: <a href="https://commits.webkit.org/267685@main">https://commits.webkit.org/267685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/582fb8b4f85cc9f385c0e0809170cadc48c7fed5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18291 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19802 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17335 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22311 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13901 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19906 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2126 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->