### PR TITLE
Let the compiler generate more comparison operators in JSC

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -435,7 +435,7 @@ public:
             masm->invalidateAllTempRegisters();
         }
 
-        bool operator==(const Label& other) const { return m_label == other.m_label; }
+        friend bool operator==(Label, Label) = default;
 
         bool isSet() const { return m_label.isSet(); }
     private:

--- a/Source/JavaScriptCore/b3/B3Effects.cpp
+++ b/Source/JavaScriptCore/b3/B3Effects.cpp
@@ -85,20 +85,6 @@ bool Effects::interferes(const Effects& other) const
         || (fence && other.fence);
 }
 
-bool Effects::operator==(const Effects& other) const
-{
-    return terminal == other.terminal
-        && exitsSideways == other.exitsSideways
-        && controlDependent == other.controlDependent
-        && writesLocalState == other.writesLocalState
-        && readsLocalState == other.readsLocalState
-        && writesPinned == other.writesPinned
-        && readsPinned == other.readsPinned
-        && writes == other.writes
-        && reads == other.reads
-        && fence == other.fence;
-}
-
 void Effects::dump(PrintStream& out) const
 {
     CommaPrinter comma("|");

--- a/Source/JavaScriptCore/b3/B3Effects.h
+++ b/Source/JavaScriptCore/b3/B3Effects.h
@@ -118,7 +118,7 @@ struct Effects {
     // behavior in an observable way.
     bool interferes(const Effects&) const;
     
-    JS_EXPORT_PRIVATE bool operator==(const Effects&) const;
+    friend bool operator==(const Effects&, const Effects&) = default;
 
     JS_EXPORT_PRIVATE void dump(PrintStream& out) const;
 };

--- a/Source/JavaScriptCore/b3/B3GenericFrequentedBlock.h
+++ b/Source/JavaScriptCore/b3/B3GenericFrequentedBlock.h
@@ -45,11 +45,7 @@ public:
     {
     }
 
-    bool operator==(const GenericFrequentedBlock& other) const
-    {
-        return m_block == other.m_block
-            && m_frequency == other.m_frequency;
-    }
+    friend bool operator==(const GenericFrequentedBlock&, const GenericFrequentedBlock&) = default;
 
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/b3/B3Kind.h
+++ b/Source/JavaScriptCore/b3/B3Kind.h
@@ -207,14 +207,7 @@ public:
     // - Try not to increase the size of Kind too much. But it wouldn't be the end of the
     //   world if it bloated to 64 bits.
     
-    bool operator==(const Kind& other) const
-    {
-        return m_opcode == other.m_opcode
-            && m_isChill == other.m_isChill
-            && m_traps == other.m_traps
-            && m_isSensitiveToNaN == other.m_isSensitiveToNaN
-            && m_cloningForbidden == other.m_cloningForbidden;
-    }
+    friend bool operator==(const Kind&, const Kind&) = default;
     
     void dump(PrintStream&) const;
     

--- a/Source/JavaScriptCore/b3/B3Origin.h
+++ b/Source/JavaScriptCore/b3/B3Origin.h
@@ -46,7 +46,7 @@ public:
 
     const void* data() const { return m_data; }
 
-    bool operator==(const Origin& other) const { return m_data == other.m_data; }
+    friend bool operator==(Origin, Origin) = default;
 
     // You should avoid using this. Use OriginDump instead.
     void dump(PrintStream&) const;

--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -75,8 +75,7 @@ public:
     inline bool isTuple() const;
     inline bool isVector() const;
 
-    bool operator==(const TypeKind& otherKind) const { return kind() == otherKind; }
-    bool operator==(const Type& type) const { return m_kind == type.m_kind; }
+    friend bool operator==(Type, Type) = default;
 
 private:
     TypeKind m_kind { Void };

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -1444,10 +1444,7 @@ public:
         Tmp operator*() const { return TmpMapper::tmpFromAbsoluteIndex(*m_indexIterator); }
         IndexToTmpIteratorAdaptor& operator++() { ++m_indexIterator; return *this; }
 
-        bool operator==(const IndexToTmpIteratorAdaptor& other) const
-        {
-            return m_indexIterator == other.m_indexIterator;
-        }
+        friend bool operator==(const IndexToTmpIteratorAdaptor&, const IndexToTmpIteratorAdaptor&) = default;
 
     private:
         IndexIterator m_indexIterator;

--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -316,12 +316,7 @@ private:
         {
         }
 
-        bool operator==(const CoalescableMove& other) const
-        {
-            return src == other.src
-                && dst == other.dst
-                && frequency == other.frequency;
-        }
+        friend bool operator==(const CoalescableMove&, const CoalescableMove&) = default;
 
         explicit operator bool() const
         {

--- a/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
@@ -355,11 +355,7 @@ private:
             return !!reg;
         }
         
-        bool operator==(const RegConst& other) const
-        {
-            return reg == other.reg
-                && constant == other.constant;
-        }
+        friend bool operator==(const RegConst&, const RegConst&) = default;
 
         bool operator<(const RegConst& other) const
         {
@@ -398,12 +394,7 @@ private:
             return slot && reg;
         }
         
-        bool operator==(const RegSlot& other) const
-        {
-            return slot == other.slot
-                && reg == other.reg
-                && mode == other.mode;
-        }
+        friend bool operator==(const RegSlot&, const RegSlot&) = default;
 
         bool operator<(const RegSlot& other) const
         {
@@ -448,11 +439,7 @@ private:
             return slot;
         }
         
-        bool operator==(const SlotConst& other) const
-        {
-            return slot == other.slot
-                && constant == other.constant;
-        }
+        friend bool operator==(const SlotConst&, const SlotConst&) = default;
 
         bool operator<(const SlotConst& other) const
         {

--- a/Source/JavaScriptCore/b3/air/AirKind.h
+++ b/Source/JavaScriptCore/b3/air/AirKind.h
@@ -50,12 +50,7 @@ struct Kind {
     {
     }
     
-    bool operator==(const Kind& other) const
-    {
-        return opcode == other.opcode
-            && effects == other.effects
-            && spill == other.spill;
-    }
+    friend bool operator==(const Kind&, const Kind&) = default;
     
     unsigned hash() const
     {

--- a/Source/JavaScriptCore/b3/air/AirTmp.h
+++ b/Source/JavaScriptCore/b3/air/AirTmp.h
@@ -185,10 +185,7 @@ public:
         return !!*this;
     }
 
-    bool operator==(const Tmp& other) const
-    {
-        return m_value == other.m_value;
-    }
+    friend bool operator==(Tmp, Tmp) = default;
 
     void dump(PrintStream& out) const;
 

--- a/Source/JavaScriptCore/b3/air/AirTmpSet.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpSet.h
@@ -98,11 +98,7 @@ public:
             return *this;
         }
         
-        bool operator==(const iterator& other) const
-        {
-            return m_gpIter == other.m_gpIter
-                && m_fpIter == other.m_fpIter;
-        }
+        friend bool operator==(const iterator&, const iterator&) = default;
         
     private:
         BitVector::iterator m_gpIter;

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -424,17 +424,7 @@ public:
 
             bool isHashTableDeletedValue() const { return m_wrapped == bitwise_cast<PolymorphicAccessJITStubRoutine*>(static_cast<uintptr_t>(1)); }
 
-            friend bool operator==(const Key& a, const Key& b)
-            {
-                return a.m_wrapped == b.m_wrapped
-                    && a.m_baseGPR == b.m_baseGPR
-                    && a.m_valueGPR == b.m_valueGPR
-                    && a.m_extraGPR == b.m_extraGPR
-                    && a.m_extra2GPR == b.m_extra2GPR
-                    && a.m_stubInfoGPR == b.m_stubInfoGPR
-                    && a.m_arrayProfileGPR == b.m_arrayProfileGPR
-                    && a.m_usedRegisters == b.m_usedRegisters;
-            }
+            friend bool operator==(const Key&, const Key&) = default;
 
             PolymorphicAccessJITStubRoutine* m_wrapped { nullptr };
             GPRReg m_baseGPR;

--- a/Source/JavaScriptCore/bytecode/ArithProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArithProfile.h
@@ -53,7 +53,7 @@ struct ObservedType {
     constexpr ObservedType withNonNumber() const { return ObservedType(m_bits | TypeNonNumber); }
     constexpr ObservedType withoutNonNumber() const { return ObservedType(m_bits & ~TypeNonNumber); }
 
-    constexpr bool operator==(const ObservedType& other) const { return m_bits == other.m_bits; }
+    friend constexpr bool operator==(ObservedType, ObservedType) = default;
 
     static constexpr uint8_t TypeEmpty = 0x0;
     static constexpr uint8_t TypeInt32 = 0x1;

--- a/Source/JavaScriptCore/bytecode/BytecodeRewriter.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeRewriter.h
@@ -111,10 +111,7 @@ public:
             return bytecodeOffset < other.bytecodeOffset;
         }
 
-        bool operator==(const InsertionPoint& other) const
-        {
-            return bytecodeOffset == other.bytecodeOffset && position == other.position;
-        }
+        friend bool operator==(const InsertionPoint&, const InsertionPoint&) = default;
     };
 
 private:

--- a/Source/JavaScriptCore/bytecode/CallVariant.h
+++ b/Source/JavaScriptCore/bytecode/CallVariant.h
@@ -146,10 +146,7 @@ public:
         return m_callee == deletedToken();
     }
     
-    bool operator==(const CallVariant& other) const
-    {
-        return m_callee == other.m_callee;
-    }
+    friend bool operator==(CallVariant, CallVariant) = default;
     
     bool operator<(const CallVariant& other) const
     {

--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.h
@@ -64,7 +64,7 @@ public:
     void dump(PrintStream&) const;
     
     // Comparison methods useful for bisection.
-    bool operator==(const CodeBlockHash& other) const { return hash() == other.hash(); }
+    friend bool operator==(CodeBlockHash, CodeBlockHash) = default;
     bool operator<(const CodeBlockHash& other) const { return hash() < other.hash(); }
     bool operator>(const CodeBlockHash& other) const { return hash() > other.hash(); }
     bool operator<=(const CodeBlockHash& other) const { return hash() <= other.hash(); }

--- a/Source/JavaScriptCore/bytecode/DFGExitProfile.h
+++ b/Source/JavaScriptCore/bytecode/DFGExitProfile.h
@@ -86,13 +86,7 @@ public:
         return m_kind == ExitKindUnset;
     }
     
-    bool operator==(const FrequentExitSite& other) const
-    {
-        return m_bytecodeIndex == other.m_bytecodeIndex
-            && m_kind == other.m_kind
-            && m_jitType == other.m_jitType
-            && m_inlineKind == other.m_inlineKind;
-    }
+    friend bool operator==(const FrequentExitSite&, const FrequentExitSite&) = default;
     
     bool subsumes(const FrequentExitSite& other) const
     {

--- a/Source/JavaScriptCore/bytecode/LazyOperandValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/LazyOperandValueProfile.h
@@ -62,11 +62,7 @@ public:
         return !m_operand.isValid();
     }
     
-    bool operator==(const LazyOperandValueProfileKey& other) const
-    {
-        return m_bytecodeIndex == other.m_bytecodeIndex
-            && m_operand == other.m_operand;
-    }
+    friend bool operator==(const LazyOperandValueProfileKey&, const LazyOperandValueProfileKey&) = default;
     
     unsigned hash() const
     {

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h
@@ -204,11 +204,7 @@ public:
         return WTF::PtrHash<JSObject*>::hash(m_object) ^ m_condition.hash();
     }
     
-    bool operator==(const ObjectPropertyCondition& other) const
-    {
-        return m_object == other.m_object
-            && m_condition == other.m_condition;
-    }
+    friend bool operator==(const ObjectPropertyCondition&, const ObjectPropertyCondition&) = default;
     
     bool isHashTableDeletedValue() const
     {

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -341,10 +341,7 @@ private:
             return hash;
         }
 
-        friend bool operator==(const BufferedStructure& a, const BufferedStructure& b)
-        {
-            return a.m_structure == b.m_structure && a.m_byValId == b.m_byValId;
-        }
+        friend bool operator==(const BufferedStructure&, const BufferedStructure&) = default;
 
         struct Hash {
             static unsigned hash(const BufferedStructure& key)

--- a/Source/JavaScriptCore/bytecode/VirtualRegister.h
+++ b/Source/JavaScriptCore/bytecode/VirtualRegister.h
@@ -78,7 +78,7 @@ public:
     int offset() const { return m_virtualRegister; }
     int offsetInBytes() const { return m_virtualRegister * sizeof(Register); }
 
-    bool operator==(VirtualRegister other) const { return m_virtualRegister == other.m_virtualRegister; }
+    friend bool operator==(VirtualRegister, VirtualRegister) = default;
     bool operator<(VirtualRegister other) const { return m_virtualRegister < other.m_virtualRegister; }
     bool operator>(VirtualRegister other) const { return m_virtualRegister > other.m_virtualRegister; }
     bool operator<=(VirtualRegister other) const { return m_virtualRegister <= other.m_virtualRegister; }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -138,16 +138,7 @@ namespace JSC {
 
         void dump(PrintStream&) const;
 
-        bool operator==(const Variable& other) const
-        {
-            return m_ident == other.m_ident
-                && m_offset == other.m_offset
-                && m_local == other.m_local
-                && m_attributes == other.m_attributes
-                && m_kind == other.m_kind
-                && m_symbolTableConstantIndex == other.m_symbolTableConstantIndex
-                && m_isLexicallyScoped == other.m_isLexicallyScoped;
-        }
+        friend bool operator==(const Variable&, const Variable&) = default;
 
     private:
         Identifier m_ident;

--- a/Source/JavaScriptCore/debugger/DebuggerScope.h
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.h
@@ -70,7 +70,7 @@ public:
         iterator& operator++() { m_node = m_node->next(); return *this; }
         // postfix ++ intentionally omitted
 
-        bool operator==(const iterator& other) const { return m_node == other.m_node; }
+        friend bool operator==(iterator, iterator) = default;
 
     private:
         DebuggerScope* m_node;

--- a/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
@@ -153,11 +153,7 @@ public:
             return static_cast<int32_t>(value());
         }
         
-        bool operator==(const Payload& other) const
-        {
-            return m_isTop == other.m_isTop
-                && m_value == other.m_value;
-        }
+        friend bool operator==(const Payload&, const Payload&) = default;
         
         bool operator<(const Payload& other) const
         {
@@ -286,10 +282,7 @@ public:
         return WTF::IntHash<int64_t>::hash(m_value);
     }
     
-    bool operator==(const AbstractHeap& other) const
-    {
-        return m_value == other.m_value;
-    }
+    friend bool operator==(AbstractHeap, AbstractHeap) = default;
     
     bool operator<(const AbstractHeap& other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGAbstractValueClobberEpoch.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValueClobberEpoch.h
@@ -64,10 +64,7 @@ public:
         m_value |= watchedFlag;
     }
     
-    bool operator==(const AbstractValueClobberEpoch& other) const
-    {
-        return m_value == other.m_value;
-    }
+    friend bool operator==(AbstractValueClobberEpoch, AbstractValueClobberEpoch) = default;
     
     StructureClobberState structureClobberState() const
     {

--- a/Source/JavaScriptCore/dfg/DFGAvailability.h
+++ b/Source/JavaScriptCore/dfg/DFGAvailability.h
@@ -118,11 +118,7 @@ public:
     
     bool operator!() const { return nodeIsUnavailable() && flushedAt().format() == ConflictingFlush; }
 
-    bool operator==(const Availability& other) const
-    {
-        return m_node == other.m_node
-            && m_flushedAt == other.m_flushedAt;
-    }
+    friend bool operator==(const Availability&, const Availability&) = default;
     
     Availability merge(const Availability& other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp
@@ -86,12 +86,6 @@ void AvailabilityMap::dump(PrintStream& out) const
     out.print("{locals = ", m_locals, "; heap = ", mapDump(m_heap), "}");
 }
 
-bool AvailabilityMap::operator==(const AvailabilityMap& other) const
-{
-    return m_locals == other.m_locals
-        && m_heap == other.m_heap;
-}
-
 void AvailabilityMap::merge(const AvailabilityMap& other)
 {
     for (unsigned i = other.m_locals.size(); i--;)

--- a/Source/JavaScriptCore/dfg/DFGAvailabilityMap.h
+++ b/Source/JavaScriptCore/dfg/DFGAvailabilityMap.h
@@ -39,7 +39,7 @@ struct AvailabilityMap {
     
     void dump(PrintStream& out) const;
     
-    bool operator==(const AvailabilityMap& other) const;
+    friend bool operator==(const AvailabilityMap&, const AvailabilityMap&) = default;
     
     void merge(const AvailabilityMap& other);
     

--- a/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperty.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperty.h
@@ -56,10 +56,7 @@ public:
     JSGlobalObject* globalObject() const { return m_globalObject; }
     unsigned identifierNumber() const { return m_identifierNumber; }
 
-    bool operator==(const DesiredGlobalProperty& other) const
-    {
-        return m_globalObject == other.m_globalObject && m_identifierNumber == other.m_identifierNumber;
-    }
+    friend bool operator==(const DesiredGlobalProperty&, const DesiredGlobalProperty&) = default;
 
     bool isHashTableDeletedValue() const
     {

--- a/Source/JavaScriptCore/dfg/DFGEdge.h
+++ b/Source/JavaScriptCore/dfg/DFGEdge.h
@@ -160,14 +160,7 @@ public:
     bool operator!() const { return !isSet(); }
     explicit operator bool() const { return isSet(); }
     
-    bool operator==(Edge other) const
-    {
-#if USE(JSVALUE64)
-        return m_encodedWord == other.m_encodedWord;
-#else
-        return m_node == other.m_node && m_encodedWord == other.m_encodedWord;
-#endif
-    }
+    friend bool operator==(Edge, Edge) = default;
 
     void dump(PrintStream&) const;
     

--- a/Source/JavaScriptCore/dfg/DFGEpoch.h
+++ b/Source/JavaScriptCore/dfg/DFGEpoch.h
@@ -81,10 +81,7 @@ public:
         *this = next();
     }
     
-    bool operator==(const Epoch& other) const
-    {
-        return m_epoch == other.m_epoch;
-    }
+    friend bool operator==(Epoch, Epoch) = default;
     
     bool operator<(const Epoch& other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGFlushedAt.h
+++ b/Source/JavaScriptCore/dfg/DFGFlushedAt.h
@@ -58,11 +58,7 @@ public:
     FlushFormat format() const { return m_format; }
     VirtualRegister virtualRegister() const { return m_virtualRegister; }
     
-    bool operator==(const FlushedAt& other) const
-    {
-        return m_format == other.m_format
-            && m_virtualRegister == other.m_virtualRegister;
-    }
+    friend bool operator==(const FlushedAt&, const FlushedAt&) = default;
     
     FlushedAt merge(const FlushedAt& other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -132,14 +132,7 @@ public:
         return m_kind + m_heap.hash() + m_index.hash() + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_base)) + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_descriptor));
     }
     
-    bool operator==(const HeapLocation& other) const
-    {
-        return m_kind == other.m_kind
-            && m_heap == other.m_heap
-            && m_base == other.m_base
-            && m_index == other.m_index
-            && m_descriptor == other.m_descriptor;
-    }
+    friend bool operator==(const HeapLocation&, const HeapLocation&) = default;
     
     bool isHashTableDeletedValue() const
     {

--- a/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
@@ -83,12 +83,7 @@ public:
             return m_kind + m_source.hash() + PtrHash<Node*>::hash(m_key);
         }
         
-        bool operator==(const RangeKey& other) const
-        {
-            return m_kind == other.m_kind
-                && m_source == other.m_source
-                && m_key == other.m_key;
-        }
+        friend bool operator==(const RangeKey&, const RangeKey&) = default;
         
         void dump(PrintStream& out) const
         {

--- a/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h
@@ -72,10 +72,7 @@ public:
         return m_word;
     }
     
-    bool operator==(NodeFlowProjection other) const
-    {
-        return m_word == other.m_word;
-    }
+    friend bool operator==(NodeFlowProjection, NodeFlowProjection) = default;
     
     bool operator<(NodeFlowProjection other) const
     {

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -268,14 +268,7 @@ public:
         return m_kind == Kind::RegExpObject;
     }
 
-    bool operator==(const Allocation& other) const
-    {
-        return m_identifier == other.m_identifier
-            && m_kind == other.m_kind
-            && m_fields == other.m_fields
-            && m_structures == other.m_structures
-            && m_structuresForMaterialization == other.m_structuresForMaterialization;
-    }
+    friend bool operator==(const Allocation&, const Allocation&) = default;
 
     void dump(PrintStream& out) const
     {

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
@@ -99,11 +99,7 @@ public:
         return m_kind + m_info;
     }
     
-    bool operator==(const PromotedLocationDescriptor& other) const
-    {
-        return m_kind == other.m_kind
-            && m_info == other.m_info;
-    }
+    friend bool operator==(const PromotedLocationDescriptor&, const PromotedLocationDescriptor&) = default;
     
     bool isHashTableDeletedValue() const
     {
@@ -179,11 +175,7 @@ public:
         return m_meta.hash() + WTF::PtrHash<Node*>::hash(m_base);
     }
     
-    bool operator==(const PromotedHeapLocation& other) const
-    {
-        return m_base == other.m_base
-            && m_meta == other.m_meta;
-    }
+    friend bool operator==(const PromotedHeapLocation&, const PromotedHeapLocation&) = default;
     
     bool isHashTableDeletedValue() const
     {

--- a/Source/JavaScriptCore/dfg/DFGPropertyTypeKey.h
+++ b/Source/JavaScriptCore/dfg/DFGPropertyTypeKey.h
@@ -59,11 +59,7 @@ public:
     Structure* structure() const { return m_structure; }
     UniquedStringImpl* uid() const { return m_uid; }
 
-    bool operator==(const PropertyTypeKey& other) const
-    {
-        return m_structure == other.m_structure
-            && m_uid == other.m_uid;
-    }
+    friend bool operator==(const PropertyTypeKey&, const PropertyTypeKey&) = default;
 
     unsigned hash() const
     {

--- a/Source/JavaScriptCore/dfg/DFGRegisteredStructure.h
+++ b/Source/JavaScriptCore/dfg/DFGRegisteredStructure.h
@@ -40,10 +40,7 @@ public:
     ALWAYS_INLINE Structure* get() const { return m_structure; }
     Structure* operator->() const { return get(); }
 
-    bool operator==(const RegisteredStructure& other) const
-    {
-        return get() == other.get();
-    }
+    friend bool operator==(RegisteredStructure, RegisteredStructure) = default;
 
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/heap/Allocator.h
+++ b/Source/JavaScriptCore/heap/Allocator.h
@@ -52,7 +52,7 @@ public:
     
     LocalAllocator* localAllocator() const { return m_localAllocator; }
     
-    bool operator==(const Allocator& other) const { return m_localAllocator == other.localAllocator(); }
+    friend bool operator==(Allocator, Allocator) = default;
     explicit operator bool() const { return *this != Allocator(); }
     
 private:

--- a/Source/JavaScriptCore/heap/HeapFinalizerCallback.h
+++ b/Source/JavaScriptCore/heap/HeapFinalizerCallback.h
@@ -40,11 +40,7 @@ public:
     {
     }
     
-    bool operator==(const HeapFinalizerCallback& other) const
-    {
-        return m_finalizer == other.m_finalizer
-            && m_userData == other.m_userData;
-    }
+    friend bool operator==(const HeapFinalizerCallback&, const HeapFinalizerCallback&) = default;
     
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.h
@@ -79,11 +79,7 @@ private:
         {
         }
         
-        bool operator==(const TaskWithConstraint& other) const
-        {
-            return task == other.task
-                && constraint == other.constraint;
-        }
+        friend bool operator==(const TaskWithConstraint&, const TaskWithConstraint&) = default;
         
         RefPtr<SharedTask<void(SlotVisitor&)>> task;
         MarkingConstraint* constraint { nullptr };

--- a/Source/JavaScriptCore/heap/VisitRaceKey.h
+++ b/Source/JavaScriptCore/heap/VisitRaceKey.h
@@ -47,11 +47,7 @@ public:
     {
     }
     
-    bool operator==(const VisitRaceKey& other) const
-    {
-        return m_cell == other.m_cell
-            && m_raceName == other.m_raceName;
-    }
+    friend bool operator==(const VisitRaceKey&, const VisitRaceKey&) = default;
     
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -256,12 +256,7 @@ private:
         bool caseSensitive { false };
         bool isRegex { false };
 
-        inline bool operator==(const BlackboxConfig& other) const
-        {
-            return url == other.url
-                && caseSensitive == other.caseSensitive
-                && isRegex == other.isRegex;
-        }
+        friend bool operator==(const BlackboxConfig&, const BlackboxConfig&) = default;
     };
     Vector<BlackboxConfig> m_blackboxedURLs;
 

--- a/Source/JavaScriptCore/interpreter/CallFrame.h
+++ b/Source/JavaScriptCore/interpreter/CallFrame.h
@@ -66,7 +66,7 @@ using JSInstruction = BaseInstruction<JSOpcodeTraits>;
         { }
 
         explicit operator bool() const { return !!m_bits; }
-        bool operator==(const CallSiteIndex& other) const { return m_bits == other.m_bits; }
+        friend bool operator==(CallSiteIndex, CallSiteIndex) = default;
 
         unsigned hash() const { return intHash(m_bits); }
         static CallSiteIndex deletedValue() { return fromBits(s_invalidIndex - 1); }

--- a/Source/JavaScriptCore/interpreter/ShadowChicken.h
+++ b/Source/JavaScriptCore/interpreter/ShadowChicken.h
@@ -151,16 +151,7 @@ public:
         {
         }
         
-        bool operator==(const Frame& other) const
-        {
-            return callee == other.callee
-                && frame == other.frame
-                && thisValue == other.thisValue
-                && scope == other.scope
-                && codeBlock == other.codeBlock
-                && callSiteIndex.bits() == other.callSiteIndex.bits()
-                && isTailDeleted == other.isTailDeleted;
-        }
+        friend bool operator==(const Frame&, const Frame&) = default;
         
         void dump(PrintStream&) const;
         

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -71,7 +71,7 @@ public:
     bool operator!() const { return m_gpr == InvalidGPRReg; }
     explicit operator bool() const { return m_gpr != InvalidGPRReg; }
 
-    constexpr bool operator==(JSValueRegs other) const { return m_gpr == other.m_gpr; }
+    friend constexpr bool operator==(JSValueRegs, JSValueRegs) = default;
 
     constexpr GPRReg gpr() const { return m_gpr; }
     constexpr GPRReg tagGPR() const { return InvalidGPRReg; }
@@ -196,11 +196,7 @@ public:
             || static_cast<GPRReg>(m_payloadGPR) != InvalidGPRReg;
     }
 
-    constexpr bool operator==(JSValueRegs other) const
-    {
-        return m_tagGPR == other.m_tagGPR
-            && m_payloadGPR == other.m_payloadGPR;
-    }
+    friend constexpr bool operator==(JSValueRegs, JSValueRegs) = default;
     
     constexpr GPRReg tagGPR() const { return m_tagGPR; }
     constexpr GPRReg payloadGPR() const { return m_payloadGPR; }

--- a/Source/JavaScriptCore/jit/JITAllocator.h
+++ b/Source/JavaScriptCore/jit/JITAllocator.h
@@ -53,11 +53,7 @@ public:
         return result;
     }
     
-    bool operator==(const JITAllocator& other) const
-    {
-        return m_kind == other.m_kind
-            && m_allocator == other.m_allocator;
-    }
+    friend bool operator==(const JITAllocator&, const JITAllocator&) = default;
     
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/jit/JITCompilationKey.h
+++ b/Source/JavaScriptCore/jit/JITCompilationKey.h
@@ -64,11 +64,7 @@ public:
     
     JITCompilationMode mode() const { return m_mode; }
     
-    bool operator==(const JITCompilationKey& other) const
-    {
-        return m_codeBlock == other.m_codeBlock
-            && m_mode == other.m_mode;
-    }
+    friend bool operator==(const JITCompilationKey&, const JITCompilationKey&) = default;
     
     unsigned hash() const
     {

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -137,10 +137,7 @@ public:
             MacroAssembler::firstFPRegister() + (m_index - MacroAssembler::numberOfRegisters()));
     }
 
-    constexpr bool operator==(const Reg& other) const
-    {
-        return m_index == other.m_index;
-    }
+    friend constexpr bool operator==(Reg, Reg) = default;
 
     constexpr bool operator<(const Reg& other) const
     {
@@ -191,10 +188,7 @@ public:
                 return *this;
             }
 
-            bool operator==(const iterator& other) const
-            {
-                return m_regIndex == other.m_regIndex;
-            }
+            friend bool operator==(iterator, iterator) = default;
 
         private:
             unsigned m_regIndex;

--- a/Source/JavaScriptCore/jit/RegisterAtOffset.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffset.h
@@ -59,7 +59,7 @@ public:
     size_t byteSize() const { return bytesForWidth(width()); }
     Width width() const { return m_width ? conservativeWidth(reg()) : conservativeWidthWithoutVectors(reg()); }
     int offsetAsIndex() const { ASSERT(!(offset() % sizeof(CPURegister))); return offset() / static_cast<int>(sizeof(CPURegister)); }
-    
+
     bool operator==(const RegisterAtOffset& other) const
     {
         return reg() == other.reg() && offset() == other.offset() && width() == other.width();

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -168,7 +168,7 @@ public:
         out.print("]");
     }
 
-    inline constexpr bool operator==(const RegisterSetBuilder& other) const { return m_bits == other.m_bits && m_upperBits == other.m_upperBits; }
+    friend constexpr bool operator==(const RegisterSetBuilder&, const RegisterSetBuilder&) = default;
 
 protected:
     inline constexpr void setAny(Reg reg) { ASSERT(!reg.isFPR()); add(reg, IgnoreVectors); }
@@ -335,10 +335,7 @@ public:
             return *this;
         }
 
-        inline constexpr bool operator==(const iterator& other) const
-        {
-            return m_iter == other.m_iter;
-        }
+        friend constexpr bool operator==(const iterator&, const iterator&) = default;
 
     private:
         RegisterBitSet::iterator m_iter;
@@ -415,7 +412,7 @@ public:
         out.print("]");
     }
 
-    inline constexpr bool operator==(const RegisterSet& other) const { return m_bits == other.m_bits && m_upperBits == other.m_upperBits; }
+    friend constexpr bool operator==(const RegisterSet&, const RegisterSet&) = default;
 
 private:
     RegisterBitSet m_bits = { };
@@ -463,7 +460,7 @@ public:
 
     inline constexpr unsigned hash() const { return m_bits.hash(); }
     inline uint64_t bitsForDebugging() const { return *m_bits.storage(); }
-    inline constexpr bool operator==(const ScalarRegisterSet& other) const { return m_bits == other.m_bits; }
+    friend constexpr bool operator==(const ScalarRegisterSet&, const ScalarRegisterSet&) = default;
 
     inline constexpr RegisterSet toRegisterSet() const WARN_UNUSED_RETURN
     {

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -103,10 +103,7 @@ struct SIMDInfo {
 
     constexpr SIMDInfo() = default;
 
-    friend bool operator==(const SIMDInfo& lhs, const SIMDInfo& rhs)
-    {
-        return lhs.lane == rhs.lane && lhs.signMode == rhs.signMode;
-    }
+    friend bool operator==(const SIMDInfo&, const SIMDInfo&) = default;
 };
 
 constexpr uint8_t elementCount(SIMDLane lane)

--- a/Source/JavaScriptCore/parser/ParserTokens.h
+++ b/Source/JavaScriptCore/parser/ParserTokens.h
@@ -219,12 +219,7 @@ struct JSTextPosition {
 
     operator int() const { return offset; }
 
-    bool operator==(const JSTextPosition& other) const
-    {
-        return line == other.line
-            && offset == other.offset
-            && lineStartOffset == other.lineStartOffset;
-    }
+    friend bool operator==(const JSTextPosition&, const JSTextPosition&) = default;
 
     int column() const { return offset - lineStartOffset; }
     void checkConsistency()

--- a/Source/JavaScriptCore/parser/SourceCode.h
+++ b/Source/JavaScriptCore/parser/SourceCode.h
@@ -77,14 +77,7 @@ public:
 
     SourceCode subExpression(unsigned openBrace, unsigned closeBrace, int firstLine, int startColumn) const;
 
-    bool operator==(const SourceCode& other) const
-    {
-        return m_firstLine == other.m_firstLine
-            && m_startColumn == other.m_startColumn
-            && m_provider == other.m_provider
-            && m_startOffset == other.m_startOffset
-            && m_endOffset == other.m_endOffset;
-    }
+    friend bool operator==(const SourceCode&, const SourceCode&) = default;
 
 private:
     OrdinalNumber m_firstLine;

--- a/Source/JavaScriptCore/parser/SourceCodeKey.h
+++ b/Source/JavaScriptCore/parser/SourceCodeKey.h
@@ -56,10 +56,7 @@ public:
     {
     }
 
-    inline bool operator==(const SourceCodeFlags& rhs) const
-    {
-        return m_flags == rhs.m_flags;
-    }
+    friend bool operator==(SourceCodeFlags, SourceCodeFlags) = default;
 
     unsigned bits() { return m_flags; }
 

--- a/Source/JavaScriptCore/parser/UnlinkedSourceCode.h
+++ b/Source/JavaScriptCore/parser/UnlinkedSourceCode.h
@@ -99,6 +99,8 @@ namespace JSC {
         int endOffset() const { return m_endOffset; }
         int length() const { return m_endOffset - m_startOffset; }
 
+        friend bool operator==(const UnlinkedSourceCode&, const UnlinkedSourceCode&) = default;
+
     protected:
         // FIXME: Make it Ref<SourceProvidier>.
         // https://bugs.webkit.org/show_bug.cgi?id=168325

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -69,10 +69,7 @@ public:
 
     uint16_t bits() const { return m_bits; }
 
-    bool operator==(const VariableEnvironmentEntry& other) const
-    {
-        return m_bits == other.m_bits;
-    }
+    friend bool operator==(VariableEnvironmentEntry, VariableEnvironmentEntry) = default;
 
     void dump(PrintStream&) const;
 
@@ -119,10 +116,7 @@ public:
 
     uint16_t bits() const { return m_bits; }
 
-    bool operator==(const PrivateNameEntry& other) const
-    {
-        return m_bits == other.m_bits;
-    }
+    friend bool operator==(PrivateNameEntry, PrivateNameEntry) = default;
 
     enum Traits : uint16_t {
         None = 0,

--- a/Source/JavaScriptCore/profiler/ProfilerOrigin.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOrigin.h
@@ -60,8 +60,8 @@ public:
     
     Bytecodes* bytecodes() const { return m_bytecodes; }
     BytecodeIndex bytecodeIndex() const { return m_bytecodeIndex; }
-    
-    bool operator==(const Origin&) const;
+
+    friend bool operator==(const Origin&, const Origin&) = default;
     unsigned hash() const;
     
     bool isHashTableDeletedValue() const;
@@ -73,12 +73,6 @@ private:
     Bytecodes* m_bytecodes;
     BytecodeIndex m_bytecodeIndex;
 };
-
-inline bool Origin::operator==(const Origin& other) const
-{
-    return m_bytecodes == other.m_bytecodes
-        && m_bytecodeIndex == other.m_bytecodeIndex;
-}
 
 inline unsigned Origin::hash() const
 {

--- a/Source/JavaScriptCore/profiler/ProfilerUID.h
+++ b/Source/JavaScriptCore/profiler/ProfilerUID.h
@@ -60,10 +60,7 @@ public:
         return m_uid;
     }
     
-    bool operator==(const UID& other) const
-    {
-        return m_uid == other.m_uid;
-    }
+    friend bool operator==(UID, UID) = default;
     
     explicit operator bool() const
     {

--- a/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
@@ -146,7 +146,6 @@ inline void CacheableIdentifier::visitAggregate(Visitor& visitor) const
         visitor.appendUnbarriered(cell());
 }
 
-
 inline bool CacheableIdentifier::operator==(const CacheableIdentifier& other) const
 {
     return uid() == other.uid();

--- a/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
+++ b/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
@@ -51,7 +51,7 @@ struct BasicBlockKey {
     { }
 
     bool isHashTableDeletedValue() const { return m_startOffset == -2 && m_endOffset == -2; }
-    bool operator==(const BasicBlockKey& other) const { return m_startOffset == other.m_startOffset && m_endOffset == other.m_endOffset; }
+    friend bool operator==(const BasicBlockKey&, const BasicBlockKey&) = default;
     unsigned hash() const { return m_startOffset + m_endOffset + 1; }
 
     int m_startOffset;

--- a/Source/JavaScriptCore/runtime/DOMAnnotation.h
+++ b/Source/JavaScriptCore/runtime/DOMAnnotation.h
@@ -40,11 +40,8 @@ struct DOMAttributeAnnotation {
 public:
     const ClassInfo* classInfo;
     const DOMJIT::GetterSetter* domJIT;
-};
 
-inline bool operator==(const DOMAttributeAnnotation& left, const DOMAttributeAnnotation& right)
-{
-    return left.classInfo == right.classInfo && left.domJIT == right.domJIT;
-}
+    friend bool operator==(const DOMAttributeAnnotation&, const DOMAttributeAnnotation&) = default;
+};
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h
+++ b/Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h
@@ -43,10 +43,7 @@ public:
         };
 
         FunctionRange() {}
-        bool operator==(const FunctionRange& other) const 
-        {
-            return m_start == other.m_start && m_end == other.m_end;
-        }
+        friend bool operator==(const FunctionRange&, const FunctionRange&) = default;
         unsigned hash() const
         {
             return m_start * m_end;

--- a/Source/JavaScriptCore/runtime/GenericOffset.h
+++ b/Source/JavaScriptCore/runtime/GenericOffset.h
@@ -60,10 +60,7 @@ public:
         return m_offset;
     }
     
-    bool operator==(const GenericOffset& other) const
-    {
-        return m_offset == other.m_offset;
-    }
+    friend bool operator==(GenericOffset, GenericOffset) = default;
     bool operator<(const GenericOffset& other) const
     {
         return m_offset < other.m_offset;

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -161,10 +161,7 @@ public:
     {
         return m_epochNanoseconds <= other.m_epochNanoseconds;
     }
-    constexpr bool operator==(ExactTime other) const
-    {
-        return m_epochNanoseconds == other.m_epochNanoseconds;
-    }
+    friend constexpr bool operator==(ExactTime, ExactTime) = default;
     constexpr bool operator>=(ExactTime other) const
     {
         return m_epochNanoseconds >= other.m_epochNanoseconds;
@@ -217,15 +214,7 @@ public:
     JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_DEFINE_ISO8601_PLAIN_TIME_FIELD);
 #undef JSC_DEFINE_ISO8601_DURATION_FIELD
 
-    friend bool operator==(PlainTime lhs, PlainTime rhs)
-    {
-        return lhs.hour() == rhs.hour()
-            && lhs.minute() == rhs.minute()
-            && lhs.second() == rhs.second()
-            && lhs.millisecond() == rhs.millisecond()
-            && lhs.microsecond() == rhs.microsecond()
-            && lhs.nanosecond() == rhs.nanosecond();
-    }
+    friend bool operator==(PlainTime, PlainTime) = default;
 
 private:
     uint8_t m_hour { 0 };
@@ -256,12 +245,7 @@ public:
     {
     }
 
-    friend bool operator==(PlainDate lhs, PlainDate rhs)
-    {
-        return lhs.year() == rhs.year()
-            && lhs.month() == rhs.month()
-            && lhs.day() == rhs.day();
-    }
+    friend bool operator==(PlainDate, PlainDate) = default;
 
     int32_t year() const { return m_year; }
     uint8_t month() const { return m_month; }

--- a/Source/JavaScriptCore/runtime/JSScope.h
+++ b/Source/JavaScriptCore/runtime/JSScope.h
@@ -114,7 +114,7 @@ public:
 
     // postfix ++ intentionally omitted
 
-    bool operator==(const ScopeChainIterator& other) const { return m_node == other.m_node; }
+    friend bool operator==(ScopeChainIterator, ScopeChainIterator) = default;
 
 private:
     JSScope* m_node;

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -97,7 +97,7 @@ public:
     bool operator<(const PageCount& other) const { return m_pageCount < other.m_pageCount; }
     bool operator>(const PageCount& other) const { return m_pageCount > other.m_pageCount; }
     bool operator>=(const PageCount& other) const { return m_pageCount >= other.m_pageCount; }
-    bool operator==(const PageCount& other) const { return m_pageCount == other.m_pageCount; }
+    friend bool operator==(PageCount, PageCount) = default;
     PageCount operator+(const PageCount& other) const
     {
         if (sumOverflows<uint32_t>(m_pageCount, other.m_pageCount))

--- a/Source/JavaScriptCore/runtime/PrototypeKey.h
+++ b/Source/JavaScriptCore/runtime/PrototypeKey.h
@@ -56,13 +56,7 @@ public:
     unsigned inlineCapacity() const { return m_inlineCapacity; }
     const ClassInfo* classInfo() const { return m_classInfo; }
     
-    bool operator==(const PrototypeKey& other) const
-    {
-        return m_prototype == other.m_prototype
-            && m_executable == other.m_executable
-            && m_inlineCapacity == other.m_inlineCapacity
-            && m_classInfo == other.m_classInfo;
-    }
+    friend bool operator==(const PrototypeKey&, const PrototypeKey&) = default;
     
     explicit operator bool() const { return *this != PrototypeKey(); }
     bool isHashTableDeletedValue() const { return *this == PrototypeKey(WTF::HashTableDeletedValue); }

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -85,7 +85,7 @@ public:
     static StructureID encode(const Structure*);
 
     explicit operator bool() const { return !!m_bits; }
-    bool operator==(StructureID const& other) const  { return m_bits == other.m_bits; }
+    friend bool operator==(StructureID, StructureID) = default;
     constexpr uint32_t bits() const { return m_bits; }
 
     StructureID(WTF::HashTableDeletedValueType) : m_bits(nukedStructureIDBit) { }

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -190,10 +190,7 @@ class StructureTransitionTable {
             TransitionPropertyAttributes attributes() const { return (m_encodedData >> attributesShift) & UINT8_MAX; }
             TransitionKind transitionKind() const { return static_cast<TransitionKind>(m_encodedData >> transitionKindShift); }
 
-            friend bool operator==(const Key& a, const Key& b)
-            {
-                return a.m_encodedData == b.m_encodedData;
-            }
+            friend bool operator==(Key, Key) = default;
 
         private:
             uintptr_t m_encodedData { 0 };

--- a/Source/JavaScriptCore/runtime/TypeLocationCache.h
+++ b/Source/JavaScriptCore/runtime/TypeLocationCache.h
@@ -44,13 +44,7 @@ public:
         };
 
         LocationKey() {}
-        bool operator==(const LocationKey& other) const 
-        {
-            return m_globalVariableID == other.m_globalVariableID
-                && m_sourceID == other.m_sourceID
-                && m_start == other.m_start
-                && m_end == other.m_end;
-        }
+        friend bool operator==(const LocationKey&, const LocationKey&) = default;
 
         unsigned hash() const
         {

--- a/Source/JavaScriptCore/runtime/TypeProfiler.h
+++ b/Source/JavaScriptCore/runtime/TypeProfiler.h
@@ -70,12 +70,7 @@ struct QueryKey {
             && m_searchDescriptor == TypeProfilerSearchDescriptorFunctionReturn;
     }
 
-    bool operator==(const QueryKey& other) const
-    {
-        return m_sourceID == other.m_sourceID 
-            && m_divot == other.m_divot
-            && m_searchDescriptor == other.m_searchDescriptor;
-    }
+    friend bool operator==(const QueryKey&, const QueryKey&) = default;
 
     unsigned hash() const 
     { 

--- a/Source/JavaScriptCore/runtime/VarOffset.h
+++ b/Source/JavaScriptCore/runtime/VarOffset.h
@@ -190,11 +190,7 @@ public:
         ASSERT_NOT_REACHED();
     }
     
-    bool operator==(const VarOffset& other) const
-    {
-        return m_kind == other.m_kind
-            && m_offset == other.m_offset;
-    }
+    friend bool operator==(const VarOffset&, const VarOffset&) = default;
     
     unsigned hash() const
     {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -489,7 +489,7 @@ public:
     StorageType type;
     Mutability mutability;
 
-    bool operator==(const FieldType& rhs) const { return type == rhs.type && mutability == rhs.mutability; }
+    friend bool operator==(const FieldType&, const FieldType&) = default;
 };
 
 class StructType {


### PR DESCRIPTION
#### e9e93692891c06a791d49233208a7da7c504bd4f
<pre>
Let the compiler generate more comparison operators in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=261127">https://bugs.webkit.org/show_bug.cgi?id=261127</a>

Reviewed by Keith Miller.

Let the compiler generate more comparison operators in JSC now that we
support C++20.

* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::Label::operator== const): Deleted.
* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
(JSC::AssemblerLabel::operator== const): Deleted.
* Source/JavaScriptCore/b3/B3Effects.cpp:
(JSC::B3::Effects::operator== const): Deleted.
* Source/JavaScriptCore/b3/B3Effects.h:
* Source/JavaScriptCore/b3/B3GenericFrequentedBlock.h:
(JSC::B3::GenericFrequentedBlock::operator== const): Deleted.
* Source/JavaScriptCore/b3/B3Kind.h:
(JSC::B3::Kind::operator== const): Deleted.
* Source/JavaScriptCore/b3/B3Origin.h:
(JSC::B3::Origin::operator== const): Deleted.
* Source/JavaScriptCore/b3/B3Type.h:
(JSC::B3::Type::operator== const): Deleted.
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp:
* Source/JavaScriptCore/b3/air/AirKind.h:
(JSC::B3::Air::Kind::operator== const): Deleted.
* Source/JavaScriptCore/b3/air/AirTmp.h:
(JSC::B3::Air::Tmp::operator== const): Deleted.
* Source/JavaScriptCore/b3/air/AirTmpSet.h:
(JSC::B3::Air::TmpSet::iterator::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
(JSC::SharedJITStubSet::Hash::Key::operator==): Deleted.
* Source/JavaScriptCore/bytecode/ArithProfile.h:
(JSC::ObservedType::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/BytecodeRewriter.h:
(JSC::BytecodeRewriter::InsertionPoint::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/CallVariant.h:
(JSC::CallVariant::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlockHash.h:
(JSC::CodeBlockHash::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/CodeOrigin.h:
(JSC::CodeOrigin::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/DFGExitProfile.h:
(JSC::DFG::FrequentExitSite::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/LazyOperandValueProfile.h:
(JSC::LazyOperandValueProfileKey::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/ObjectPropertyCondition.h:
(JSC::ObjectPropertyCondition::operator== const): Deleted.
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
(JSC::StructureStubInfo::BufferedStructure::operator==): Deleted.
* Source/JavaScriptCore/bytecode/VirtualRegister.h:
(JSC::VirtualRegister::operator== const): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::Variable::operator== const): Deleted.
* Source/JavaScriptCore/debugger/DebuggerScope.h:
* Source/JavaScriptCore/dfg/DFGAbstractHeap.h:
(JSC::DFG::AbstractHeap::Payload::operator== const): Deleted.
(JSC::DFG::AbstractHeap::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractValueClobberEpoch.h:
(JSC::DFG::AbstractValueClobberEpoch::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGAvailability.h:
(JSC::DFG::Availability::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp:
(JSC::DFG::AvailabilityMap::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGAvailabilityMap.h:
* Source/JavaScriptCore/dfg/DFGDesiredGlobalProperty.h:
(JSC::DFG::DesiredGlobalProperty::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGEdge.h:
(JSC::DFG::Edge::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGEpoch.h:
(JSC::DFG::Epoch::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGFlushedAt.h:
(JSC::DFG::FlushedAt::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
(JSC::DFG::HeapLocation::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp:
(JSC::DFG::IntegerCheckCombiningPhase::RangeKey::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGNodeFlowProjection.h:
(JSC::DFG::NodeFlowProjection::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h:
(JSC::DFG::PromotedLocationDescriptor::operator== const): Deleted.
(JSC::DFG::PromotedHeapLocation::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGPropertyTypeKey.h:
(JSC::DFG::PropertyTypeKey::operator== const): Deleted.
* Source/JavaScriptCore/dfg/DFGRegisteredStructure.h:
(JSC::DFG::RegisteredStructure::operator== const): Deleted.
* Source/JavaScriptCore/heap/Allocator.h:
(JSC::Allocator::operator== const): Deleted.
* Source/JavaScriptCore/heap/HeapFinalizerCallback.h:
(JSC::HeapFinalizerCallback::operator== const): Deleted.
* Source/JavaScriptCore/heap/MarkingConstraintSolver.h:
(JSC::MarkingConstraintSolver::TaskWithConstraint::operator== const): Deleted.
* Source/JavaScriptCore/heap/VisitRaceKey.h:
(JSC::VisitRaceKey::operator== const): Deleted.
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/interpreter/CallFrame.h:
(JSC::CallSiteIndex::operator== const): Deleted.
* Source/JavaScriptCore/interpreter/ShadowChicken.h:
(JSC::ShadowChicken::Frame::operator== const): Deleted.
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::JSValueRegs::operator== const): Deleted.
* Source/JavaScriptCore/jit/JITAllocator.h:
(JSC::JITAllocator::operator== const): Deleted.
* Source/JavaScriptCore/jit/JITCompilationKey.h:
(JSC::JITCompilationKey::operator== const): Deleted.
* Source/JavaScriptCore/jit/Reg.h:
(JSC::Reg::operator== const): Deleted.
(JSC::Reg::AllRegsIterable::iterator::operator== const): Deleted.
* Source/JavaScriptCore/jit/RegisterAtOffset.h:
(JSC::RegisterAtOffset::operator== const): Deleted.
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/jit/SIMDInfo.h:
(JSC::SIMDInfo::operator==): Deleted.
* Source/JavaScriptCore/parser/ParserTokens.h:
(JSC::JSTextPosition::operator== const): Deleted.
* Source/JavaScriptCore/parser/SourceCode.h:
(JSC::SourceCode::operator== const): Deleted.
* Source/JavaScriptCore/parser/SourceCodeKey.h:
(JSC::SourceCodeFlags::operator== const): Deleted.
* Source/JavaScriptCore/parser/UnlinkedSourceCode.h:
* Source/JavaScriptCore/parser/VariableEnvironment.h:
(JSC::VariableEnvironmentEntry::operator== const): Deleted.
(JSC::PrivateNameEntry::operator== const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOrigin.h:
(JSC::Profiler::Origin::operator== const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerUID.h:
(JSC::Profiler::UID::operator== const): Deleted.
* Source/JavaScriptCore/runtime/CacheableIdentifier.h:
* Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h:
* Source/JavaScriptCore/runtime/ControlFlowProfiler.h:
(JSC::BasicBlockKey::operator== const): Deleted.
* Source/JavaScriptCore/runtime/DOMAnnotation.h:
(JSC::operator==): Deleted.
* Source/JavaScriptCore/runtime/FunctionHasExecutedCache.h:
(JSC::FunctionHasExecutedCache::FunctionRange::operator== const): Deleted.
* Source/JavaScriptCore/runtime/GenericOffset.h:
(JSC::GenericOffset::operator== const): Deleted.
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/JSScope.h:
(JSC::ScopeChainIterator::operator== const): Deleted.
* Source/JavaScriptCore/runtime/PageCount.h:
(JSC::PageCount::operator== const): Deleted.
* Source/JavaScriptCore/runtime/PrototypeKey.h:
(JSC::PrototypeKey::operator== const): Deleted.
* Source/JavaScriptCore/runtime/StructureID.h:
(JSC::StructureID::operator== const): Deleted.
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
(JSC::StructureTransitionTable::Hash::Key::operator==): Deleted.
* Source/JavaScriptCore/runtime/TypeLocationCache.h:
(JSC::TypeLocationCache::LocationKey::operator== const): Deleted.
* Source/JavaScriptCore/runtime/TypeProfiler.h:
(JSC::QueryKey::operator== const): Deleted.
* Source/JavaScriptCore/runtime/VarOffset.h:
(JSC::VarOffset::operator== const): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::FieldType::operator== const): Deleted.

Canonical link: <a href="https://commits.webkit.org/267645@main">https://commits.webkit.org/267645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0781a7292f808ea3591236b2071c9cc14be205d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16101 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18295 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19807 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22318 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14862 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20138 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16425 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13905 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18766 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15542 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4126 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19911 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19990 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16221 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4215 "Passed tests") | 
<!--EWS-Status-Bubble-End-->