### PR TITLE
[TextureMapper] Shrink texture before applying large radius blur

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h
@@ -69,13 +69,9 @@ public:
     RefPtr<BitmapTexture> applyFilters(TextureMapper&, const FilterOperations&, bool defersLastFilterPass) override;
     struct FilterInfo {
         RefPtr<const FilterOperation> filter;
-        unsigned pass;
-        RefPtr<BitmapTexture> contentTexture;
 
-        FilterInfo(RefPtr<const FilterOperation>&& f = nullptr, unsigned p = 0, RefPtr<BitmapTexture>&& t = nullptr)
+        FilterInfo(RefPtr<const FilterOperation>&& f = nullptr)
             : filter(WTFMove(f))
-            , pass(p)
-            , contentTexture(WTFMove(t))
             { }
     };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp
@@ -48,8 +48,7 @@ void TextureMapperGCGLPlatformLayer::paintToTextureMapper(TextureMapper& texture
     auto attrs = m_context.contextAttributes();
     TextureMapperGL& texmapGL = static_cast<TextureMapperGL&>(textureMapper);
     TextureMapperGL::Flags flags = TextureMapperGL::ShouldFlipTexture | (attrs.alpha ? TextureMapperGL::ShouldBlend : 0);
-    IntSize textureSize(m_context.m_currentWidth, m_context.m_currentHeight);
-    texmapGL.drawTexture(m_context.m_compositorTexture, flags, textureSize, targetRect, matrix, opacity);
+    texmapGL.drawTexture(m_context.m_compositorTexture, flags, targetRect, matrix, opacity);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
@@ -66,10 +66,10 @@ public:
     void drawBorder(const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;
     void drawNumber(int number, const Color&, const FloatPoint&, const TransformationMatrix&) override;
     void drawTexture(const BitmapTexture&, const FloatRect&, const TransformationMatrix&, float opacity, unsigned exposedEdges) override;
-    virtual void drawTexture(GLuint texture, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges = AllEdges);
-    void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
-    void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const IntSize& textureSize, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexture(GLuint texture, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexturePlanarYUV(const std::array<GLuint, 3>& textures, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, std::optional<GLuint> alphaPlane, unsigned exposedEdges = AllEdges);
+    void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
+    void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, Flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, unsigned exposedEdges = AllEdges);
     void drawSolidColor(const FloatRect&, const TransformationMatrix&, const Color&, bool) override;
     void clearColor(const Color&) override;
 
@@ -89,6 +89,14 @@ public:
     void drawTextureExternalOES(GLuint texture, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
 
 private:
+    enum class Direction { X, Y };
+
+    RefPtr<BitmapTexture> applyBlurFilter(RefPtr<BitmapTexture> sourceTexture, const BlurFilterOperation&);
+    RefPtr<BitmapTexture> applyDropShadowFilter(RefPtr<BitmapTexture> sourceTexture, const DropShadowFilterOperation&);
+    RefPtr<BitmapTexture> applySinglePassFilter(RefPtr<BitmapTexture> sourceTexture, const RefPtr<const FilterOperation>&, bool shouldDefer);
+
+    void drawTextureCopy(const BitmapTexture& sourceTexture, const FloatRect& sourceRect, const FloatRect& targetRect);
+    void drawBlurred(const BitmapTexture& sourceTexture, const FloatRect&, float radius, Direction, bool alphaBlur = false);
     void drawFilterPass(const BitmapTexture& sourceTexture, const BitmapTexture* contentTexture, const FilterOperation&, int pass);
     void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, uint32_t texture, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
     void drawTexturedQuadWithProgram(TextureMapperShaderProgram&, const Vector<std::pair<GLuint, GLuint> >& texturesAndSamplers, Flags, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -102,7 +102,7 @@ void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textu
     if (m_hasManagedTexture) {
         ASSERT(m_texture);
         BitmapTextureGL* textureGL = static_cast<BitmapTextureGL*>(m_texture.get());
-        texmapGL.drawTexture(textureGL->id(), m_extraFlags | textureGL->colorConvertFlags(), textureGL->size(), targetRect, modelViewMatrix, opacity);
+        texmapGL.drawTexture(textureGL->id(), m_extraFlags | textureGL->colorConvertFlags(), targetRect, modelViewMatrix, opacity);
         return;
     }
 
@@ -122,7 +122,7 @@ void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textu
     WTF::switchOn(m_variant,
         [&](const RGBTexture& texture) {
             ASSERT(texture.id);
-            texmapGL.drawTexture(texture.id, m_extraFlags, m_size, targetRect, modelViewMatrix, opacity);
+            texmapGL.drawTexture(texture.id, m_extraFlags, targetRect, modelViewMatrix, opacity);
         },
         [&](const YUVTexture& texture) {
             switch (texture.numberOfPlanes) {
@@ -130,22 +130,22 @@ void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textu
                 ASSERT(texture.yuvPlane[0] == texture.yuvPlane[1] && texture.yuvPlane[1] == texture.yuvPlane[2]);
                 ASSERT(texture.yuvPlaneOffset[0] == 2 && texture.yuvPlaneOffset[1] == 1 && !texture.yuvPlaneOffset[2]);
                 texmapGL.drawTexturePackedYUV(texture.planes[texture.yuvPlane[0]],
-                    texture.yuvToRgbMatrix, m_extraFlags, m_size, targetRect, modelViewMatrix, opacity);
+                    texture.yuvToRgbMatrix, m_extraFlags, targetRect, modelViewMatrix, opacity);
                 break;
             case 2:
                 ASSERT(!texture.yuvPlaneOffset[0]);
                 texmapGL.drawTextureSemiPlanarYUV(std::array<GLuint, 2> { texture.planes[texture.yuvPlane[0]], texture.planes[texture.yuvPlane[1]] }, !!texture.yuvPlaneOffset[1],
-                    texture.yuvToRgbMatrix, m_extraFlags, m_size, targetRect, modelViewMatrix, opacity);
+                    texture.yuvToRgbMatrix, m_extraFlags, targetRect, modelViewMatrix, opacity);
                 break;
             case 3:
                 ASSERT(!texture.yuvPlaneOffset[0] && !texture.yuvPlaneOffset[1] && !texture.yuvPlaneOffset[2]);
                 texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { texture.planes[texture.yuvPlane[0]], texture.planes[texture.yuvPlane[1]], texture.planes[texture.yuvPlane[2]] },
-                    texture.yuvToRgbMatrix, m_extraFlags, m_size, targetRect, modelViewMatrix, opacity, std::nullopt);
+                    texture.yuvToRgbMatrix, m_extraFlags, targetRect, modelViewMatrix, opacity, std::nullopt);
                 break;
             case 4:
                 ASSERT(!texture.yuvPlaneOffset[0] && !texture.yuvPlaneOffset[1] && !texture.yuvPlaneOffset[2]);
                 texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { texture.planes[texture.yuvPlane[0]], texture.planes[texture.yuvPlane[1]], texture.planes[texture.yuvPlane[2]] },
-                    texture.yuvToRgbMatrix, m_extraFlags, m_size, targetRect, modelViewMatrix, opacity, texture.planes[texture.yuvPlane[3]]);
+                    texture.yuvToRgbMatrix, m_extraFlags, targetRect, modelViewMatrix, opacity, texture.planes[texture.yuvPlane[3]]);
                 break;
             }
         },

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -234,28 +234,28 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
     case DMABufFormat::FourCC::ABGR8888:
         // Either no colorspace or the SRGB colorspace was defined for this object. Other options are not meaningful.
         ASSERT(m_object.colorSpace == DMABufColorSpace::Invalid || m_object.colorSpace == DMABufColorSpace::SRGB);
-        texmapGL.drawTexture(data.texture[0], m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+        texmapGL.drawTexture(data.texture[0], m_flags, targetRect, modelViewMatrix, opacity);
         break;
     case DMABufFormat::FourCC::I420:
     case DMABufFormat::FourCC::Y444:
     case DMABufFormat::FourCC::Y41B:
     case DMABufFormat::FourCC::Y42B:
         texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { data.texture[0], data.texture[1], data.texture[2] },
-            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, std::nullopt);
+            yuvToRGB, m_flags, targetRect, modelViewMatrix, opacity, std::nullopt);
         break;
     case DMABufFormat::FourCC::YV12:
         texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { data.texture[0], data.texture[2], data.texture[1] },
-            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, std::nullopt);
+            yuvToRGB, m_flags, targetRect, modelViewMatrix, opacity, std::nullopt);
         break;
     case DMABufFormat::FourCC::A420:
         texmapGL.drawTexturePlanarYUV(std::array<GLuint, 3> { data.texture[0], data.texture[1], data.texture[2] },
-            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity, data.texture[3]);
+            yuvToRGB, m_flags, targetRect, modelViewMatrix, opacity, data.texture[3]);
         break;
     case DMABufFormat::FourCC::NV12:
     case DMABufFormat::FourCC::NV21:
         texmapGL.drawTextureSemiPlanarYUV(std::array<GLuint, 2> { data.texture[0], data.texture[1] },
             (m_object.format.fourcc == DMABufFormat::FourCC::NV21),
-            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+            yuvToRGB, m_flags, targetRect, modelViewMatrix, opacity);
         break;
     case DMABufFormat::FourCC::YUY2:
     case DMABufFormat::FourCC::YVYU:
@@ -264,7 +264,7 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
     case DMABufFormat::FourCC::VUYA:
     case DMABufFormat::FourCC::AYUV:
         texmapGL.drawTexturePackedYUV(data.texture[0],
-            yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+            yuvToRGB, m_flags, targetRect, modelViewMatrix, opacity);
         break;
     case DMABufFormat::FourCC::P010:
     case DMABufFormat::FourCC::P016:
@@ -272,7 +272,7 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
         // threat it as a regular semi-planar YUV format, thus ignoring the two least significant
         // bits when rendering.
         texmapGL.drawTextureSemiPlanarYUV(std::array<GLuint, 2> { data.texture[0], data.texture[1] },
-            false, yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+            false, yuvToRGB, m_flags, targetRect, modelViewMatrix, opacity);
         break;
     default:
         break;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
@@ -45,12 +45,15 @@ namespace WebCore {
     macro(color) \
     macro(yuvToRgb) \
     macro(filterAmount) \
+    macro(texelSize) \
     macro(gaussianKernel) \
-    macro(blurRadius) \
-    macro(shadowOffset) \
+    macro(gaussianKernelHalfSize) \
+    macro(blurDirection) \
     macro(roundedRectNumber) \
     macro(roundedRect) \
-    macro(roundedRectInverseTransformMatrix)
+    macro(roundedRectInverseTransformMatrix) \
+    macro(textureCopyMatrix) \
+    macro(textureBlurMatrix)
 
 #define TEXMAP_SAMPLER_VARIABLES(macro)           \
     macro(sampler)                                \
@@ -105,6 +108,8 @@ public:
         RoundedRectClip  = 1L << 23,
         Premultiply      = 1L << 24,
         TextureYUVA      = 1L << 25,
+        TextureCopy      = 1L << 26,
+        AlphaToShadow    = 1L << 27,
     };
 
     enum class VariableID {
@@ -168,7 +173,9 @@ template<> struct EnumTraits<WebCore::TextureMapperShaderProgram::Option> {
         WebCore::TextureMapperShaderProgram::TextureExternalOES,
         WebCore::TextureMapperShaderProgram::RoundedRectClip,
         WebCore::TextureMapperShaderProgram::Premultiply,
-        WebCore::TextureMapperShaderProgram::TextureYUVA
+        WebCore::TextureMapperShaderProgram::TextureYUVA,
+        WebCore::TextureMapperShaderProgram::TextureCopy,
+        WebCore::TextureMapperShaderProgram::AlphaToShadow
     >;
 };
 


### PR DESCRIPTION
#### 57b05d82091bb5917db172f2aa00276b2a85a5f5
<pre>
[TextureMapper] Shrink texture before applying large radius blur
<a href="https://bugs.webkit.org/show_bug.cgi?id=261101">https://bugs.webkit.org/show_bug.cgi?id=261101</a>

Reviewed by Fujii Hironori.

As Bug231653 pointed out, current blurring causes a mosaic artifacts
when the blur radius is large.

This is because the size of kernel for gaussian blur is fixed and the
implementation just expanded the kernel according to the blur radius.
So the radius is too large, kernel size is smaller than the number of
pixels which should be convolved in a pixel, that is there are unsampled
pixels between the pixels that the adjacent elements of the kernel
sample.

This periodical missing of pixels leads to the mosaic artifact.

This fix first shrinks the texture so that there is no gap between
kernel elements, and aligns the kernel elements to pixels precisely.

* Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h:
(WebCore::BitmapTextureGL::FilterInfo::FilterInfo):
* Source/WebCore/platform/graphics/texmap/TextureMapperGCGLPlatformLayer.cpp:
(WebCore::TextureMapperGCGLPlatformLayer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::optionsForFilterType):
(WebCore::blurRadiusToKernelHalfSize):
(WebCore::kernelHalfSizeToBlurRadius):
(WebCore::gauss):
(WebCore::computeGaussianKernel):
(WebCore::prepareFilterProgram):
(WebCore::TextureMapperGL::drawTexture):
(WebCore::TextureMapperGL::drawTexturePlanarYUV):
(WebCore::TextureMapperGL::drawTextureSemiPlanarYUV):
(WebCore::TextureMapperGL::drawTexturePackedYUV):
(WebCore::TextureMapperGL::drawTextureCopy):
(WebCore::TextureMapperGL::drawBlurred):
(WebCore::TextureMapperGL::applyBlurFilter):
(WebCore::TextureMapperGL::applyDropShadowFilter):
(WebCore::TextureMapperGL::applySinglePassFilter):
(WebCore::TextureMapperGL::applyFilter):
(WebCore::gaussianKernel): Deleted.
(WebCore::TextureMapperGL::drawFilterPass): Deleted.
(WebCore::getPassesRequiredForFilter): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::TextureMapperShaderProgram::create):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:

Canonical link: <a href="https://commits.webkit.org/267646@main">https://commits.webkit.org/267646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d372d52e007cb0837cd6ea6de9b26f2489208b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18312 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19828 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22335 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20155 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13925 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15563 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19932 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2112 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->