### PR TITLE
WebCodecs/WebRTC VP9 color space is not correctly set for libvpx encoders

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js
@@ -79,6 +79,8 @@ async function runFullCycleTest(t, options) {
   await checkEncoderSupport(t, encoder_config);
   let decoder = new VideoDecoder({
     output(frame) {
+      t.add_cleanup(() => { frame.close() });
+
       assert_equals(frame.visibleRect.width, w, "visibleRect.width");
       assert_equals(frame.visibleRect.height, h, "visibleRect.height");
       assert_equals(frame.timestamp, next_ts++, "decode timestamp");

--- a/LayoutTests/webrtc/vp9.html
+++ b/LayoutTests/webrtc/vp9.html
@@ -20,25 +20,33 @@ test(() => {
 
     let codecs = RTCRtpSender.getCapabilities("video").codecs;
     vp9Codecs = codecs.filter(codec => codec.mimeType === "video/VP9");
-    assert_equals(vp9Codecs.length, 0, "no vp9 codec");
+
+    if (window.internals)
+        assert_equals(vp9Codecs.length, 0, "no vp9 codec");
 
     if (window.internals)
         window.internals.setWebRTCVP9Support(true, false);
 
     codecs = RTCRtpSender.getCapabilities("video").codecs;
     vp9Codecs = codecs.filter(codec => codec.mimeType === "video/VP9");
-    assert_equals(vp9Codecs.length, 1, "One vp9 codec");
-    assert_equals(vp9Codecs[0].sdpFmtpLine, "profile-id=0", "profile 0");
+
+    if (window.internals) {
+        assert_equals(vp9Codecs.length, 1, "One vp9 codec");
+        assert_equals(vp9Codecs[0].sdpFmtpLine, "profile-id=0", "profile 0");
+    }
 
     if (window.internals)
         window.internals.setWebRTCVP9Support(true, true);
 
     codecs = RTCRtpSender.getCapabilities("video").codecs;
     vp9Codecs = codecs.filter(codec => codec.mimeType === "video/VP9");
-    assert_equals(vp9Codecs[0].sdpFmtpLine, "profile-id=0", "first codec");
-    assert_equals(vp9Codecs[1].sdpFmtpLine, "profile-id=2", "second codec");
 
-    hasVP9 = true;
+    if (window.internals) {
+        assert_equals(vp9Codecs[0].sdpFmtpLine, "profile-id=0", "first codec");
+        assert_equals(vp9Codecs[1].sdpFmtpLine, "profile-id=2", "second codec");
+    }
+
+    hasVP9 = vp9Codecs.length > 0;
 }, "VP9 in sender getCapabilities");
 
 test(() => {
@@ -122,9 +130,15 @@ if (hasVP9) {
                 });
                 setTimeout(() => reject("Test timed out"), 5000);
             });
-        }).then((remoteStream) => {
+        }).then(async (remoteStream) => {
             video.srcObject = remoteStream;
-            return video.play();
+            await video.play();
+
+            const frame = new VideoFrame(video);
+            test.add_cleanup(() => frame.close());
+            assert_equals(frame.colorSpace.primaries, "bt709", "primaries");
+            assert_equals(frame.colorSpace.transfer, "bt709", "transfer");
+            assert_equals(frame.colorSpace.matrix, "bt709", "matrix");
         });
     }, "Setting video exchange");
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -96,7 +96,7 @@ void LibWebRTCVPXVideoEncoder::create(Type type, const VideoEncoder::Config& con
             callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
 
             VideoEncoder::ActiveConfiguration configuration;
-            configuration.colorSpace = PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Smpte170m, false };
+            configuration.colorSpace = PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };
             descriptionCallback(WTFMove(configuration));
         });
     });

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 static PlatformVideoColorSpace defaultVPXColorSpace()
 {
-    return { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Smpte170m, false };
+    return { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };
 }
 
 Ref<VideoFrameLibWebRTC> VideoFrameLibWebRTC::create(MediaTime presentationTime, bool isMirrored, Rotation rotation, std::optional<PlatformVideoColorSpace>&& colorSpace, rtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer, ConversionCallback&& conversionCallback)


### PR DESCRIPTION
#### 8bf16504d7fa82206bfd237c094b116199e702ac
<pre>
WebCodecs/WebRTC VP9 color space is not correctly set for libvpx encoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=261133">https://bugs.webkit.org/show_bug.cgi?id=261133</a>
rdar://114963848

Reviewed by Eric Carlson.

libvpx encoder is using Bt709 for transfer and matrix, we update the code accordingly.
We override the values for VTB VP9 like we do for VTB H264.
We should probably synchronize these values with vpcC provided values when we have these values, which might happen for WebCodecs.

We update LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js so that no video frame is GCed unclosed if a test fails.
We update LayoutTests/webrtc/vp9.html to check for color space information as well as allow running the tests in browsers.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js:
(async runFullCycleTest):
* LayoutTests/webrtc/vp9.html:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderVTBVP9.mm:
(overrideVP9ColorSpaceAttachments):
(vp9DecompressionOutputCallback):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::create):
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
(WebCore::defaultVPXColorSpace):

Canonical link: <a href="https://commits.webkit.org/267638@main">https://commits.webkit.org/267638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a59400aaccdda1f6e156199269c910ac3e5b9e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18305 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19821 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20148 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13919 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4121 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->