### PR TITLE
[WebCrypto] Implement the X25519 algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any-expected.txt
@@ -1,18 +1,18 @@
 
 PASS setup - define tests
-FAIL X25519 good parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 mixed case parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 with null length assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 short result assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 non-multiple of 8 bits assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
+PASS X25519 good parameters
+PASS X25519 mixed case parameters
+PASS X25519 with null length
+PASS X25519 short result
+PASS X25519 non-multiple of 8 bits
 PASS X25519 missing public property
 PASS X25519 public property of algorithm is not a CryptoKey
-FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 no deriveBits usage for base key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 base key is not a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a secret key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 asking for too many bits assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "OperationError" but got "TypeError"
+FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Type error expected "InvalidAccessError" but got "TypeError"
+PASS X25519 no deriveBits usage for base key
+PASS X25519 base key is not a private key
+PASS X25519 public property value is a private key
+PASS X25519 public property value is a secret key
+PASS X25519 asking for too many bits
 FAIL X448 good parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
 FAIL X448 mixed case parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
 FAIL X448 with null length assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any.worker-expected.txt
@@ -1,18 +1,18 @@
 
 PASS setup - define tests
-FAIL X25519 good parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 mixed case parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 with null length assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 short result assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 non-multiple of 8 bits assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
+PASS X25519 good parameters
+PASS X25519 mixed case parameters
+PASS X25519 with null length
+PASS X25519 short result
+PASS X25519 non-multiple of 8 bits
 PASS X25519 missing public property
 PASS X25519 public property of algorithm is not a CryptoKey
-FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 no deriveBits usage for base key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 base key is not a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a secret key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 asking for too many bits assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey expected "OperationError" but got "TypeError"
+FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Type error expected "InvalidAccessError" but got "TypeError"
+PASS X25519 no deriveBits usage for base key
+PASS X25519 base key is not a private key
+PASS X25519 public property value is a private key
+PASS X25519 public property value is a secret key
+PASS X25519 asking for too many bits
 FAIL X448 good parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
 FAIL X448 mixed case parameters assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code
 FAIL X448 with null length assert_unreached: deriveBits failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveBits must be an instance of CryptoKey Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any-expected.txt
@@ -1,14 +1,14 @@
 
 PASS setup - define tests
-FAIL X25519 good parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 mixed case parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
+PASS X25519 good parameters
+PASS X25519 mixed case parameters
 PASS X25519 missing public property
 PASS X25519 public property of algorithm is not a CryptoKey
-FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 no deriveKey usage for base key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 base key is not a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a secret key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
+FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Type error expected "InvalidAccessError" but got "TypeError"
+PASS X25519 no deriveKey usage for base key
+PASS X25519 base key is not a private key
+PASS X25519 public property value is a private key
+PASS X25519 public property value is a secret key
 FAIL X448 good parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
 FAIL X448 mixed case parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
 PASS X448 missing public property

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any.worker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS setup - define tests
-FAIL X25519 good parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
-FAIL X25519 mixed case parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
+PASS X25519 good parameters
+PASS X25519 mixed case parameters
 PASS X25519 missing public property
 PASS X25519 public property of algorithm is not a CryptoKey
-FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 no deriveKey usage for base key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 base key is not a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a private key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
-FAIL X25519 public property value is a secret key assert_equals: Should throw correct error, not TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey expected "InvalidAccessError" but got "TypeError"
+FAIL X25519 mismatched algorithms assert_equals: Should throw correct error, not TypeError: Type error expected "InvalidAccessError" but got "TypeError"
+PASS X25519 no deriveKey usage for base key
+PASS X25519 base key is not a private key
+PASS X25519 public property value is a private key
+PASS X25519 public property value is a secret key
 FAIL X448 good parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
 FAIL X448 mixed case parameters assert_unreached: deriveKey failed with error TypeError: Argument 2 ('baseKey') to SubtleCrypto.deriveKey must be an instance of CryptoKey Reached unreachable code
 PASS X448 missing public property

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any-expected.txt
@@ -323,36 +323,36 @@ PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, false, [decrypt, s
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, true, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, RED, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, 7, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
-FAIL Bad usages: generateKey({name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: X25519}, false, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: X25519}, true, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
+PASS Bad usages: generateKey({name: X25519}, true, [encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Empty usages: generateKey({name: X25519}, false, [])
+PASS Empty usages: generateKey({name: X25519}, true, [])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any.worker-expected.txt
@@ -323,36 +323,36 @@ PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, false, [decrypt, s
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, true, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, RED, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
 PASS Bad algorithm: generateKey({name: EC, namedCurve: P521}, 7, [decrypt, sign, deriveBits, decrypt, sign, deriveBits])
-FAIL Bad usages: generateKey({name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: X25519}, false, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
-FAIL Empty usages: generateKey({name: X25519}, true, []) assert_equals: Empty usages not supported expected "SyntaxError" but got "NotSupportedError"
+PASS Bad usages: generateKey({name: X25519}, true, [encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: generateKey({name: X25519}, true, [sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: generateKey({name: X25519}, true, [verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: generateKey({name: X25519}, true, [wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveBits, unwrapKey])
+PASS Bad usages: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Empty usages: generateKey({name: X25519}, false, [])
+PASS Empty usages: generateKey({name: X25519}, true, [])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL Success: generateKey({name: X25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Success: generateKey({name: X25519}, false, [deriveKey])
+PASS Success: generateKey({name: X25519}, true, [deriveKey])
+PASS Success: generateKey({name: X25519}, false, [deriveBits, deriveKey])
+PASS Success: generateKey({name: X25519}, true, [deriveBits, deriveKey])
+PASS Success: generateKey({name: X25519}, false, [deriveBits])
+PASS Success: generateKey({name: X25519}, true, [deriveBits])
+PASS Success: generateKey({name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Success: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Success: generateKey({name: x25519}, false, [deriveKey])
+PASS Success: generateKey({name: x25519}, true, [deriveKey])
+PASS Success: generateKey({name: x25519}, false, [deriveBits, deriveKey])
+PASS Success: generateKey({name: x25519}, true, [deriveBits, deriveKey])
+PASS Success: generateKey({name: x25519}, false, [deriveBits])
+PASS Success: generateKey({name: x25519}, true, [deriveBits])
+PASS Success: generateKey({name: x25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Success: generateKey({name: x25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any.worker-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL Success: generateKey({name: X25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Success: generateKey({name: x25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Success: generateKey({name: X25519}, false, [deriveKey])
+PASS Success: generateKey({name: X25519}, true, [deriveKey])
+PASS Success: generateKey({name: X25519}, false, [deriveBits, deriveKey])
+PASS Success: generateKey({name: X25519}, true, [deriveBits, deriveKey])
+PASS Success: generateKey({name: X25519}, false, [deriveBits])
+PASS Success: generateKey({name: X25519}, true, [deriveBits])
+PASS Success: generateKey({name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Success: generateKey({name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Success: generateKey({name: x25519}, false, [deriveKey])
+PASS Success: generateKey({name: x25519}, true, [deriveKey])
+PASS Success: generateKey({name: x25519}, false, [deriveBits, deriveKey])
+PASS Success: generateKey({name: x25519}, true, [deriveBits, deriveKey])
+PASS Success: generateKey({name: x25519}, false, [deriveBits])
+PASS Success: generateKey({name: x25519}, true, [deriveBits])
+PASS Success: generateKey({name: x25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Success: generateKey({name: x25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, deriveKey, deriveBits])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt
@@ -19,24 +19,24 @@ FAIL Good parameters: Ed448 bits (jwk, object(kty, crv, x), {name: Ed448}, false
 FAIL Good parameters: Ed448 bits (raw, buffer(57), {name: Ed448}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (pkcs8, buffer(73), {name: Ed448}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (jwk, object(crv, d, x, kty), {name: Ed448}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, true, [])
+PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, true, [])
+PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, true, [])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey])
+FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits, deriveKey])
+FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits])
+FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, false, [])
+PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, false, [])
+PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, false, [])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveKey])
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveKey])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits])
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits])
 FAIL Good parameters: X448 bits (spki, buffer(68), {name: X448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: X448 bits (jwk, object(kty, crv, x), {name: X448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: X448 bits (raw, buffer(56), {name: X448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt
@@ -19,24 +19,24 @@ FAIL Good parameters: Ed448 bits (jwk, object(kty, crv, x), {name: Ed448}, false
 FAIL Good parameters: Ed448 bits (raw, buffer(57), {name: Ed448}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (pkcs8, buffer(73), {name: Ed448}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: Ed448 bits (jwk, object(crv, d, x, kty), {name: Ed448}, false, [sign]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, false, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits, deriveKey]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
-FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits]) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
+PASS Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, true, [])
+PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, true, [])
+PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, true, [])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveKey])
+FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits, deriveKey])
+FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits, deriveKey]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, true, [deriveBits])
+FAIL Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, true, [deriveBits]) assert_true: Round trip works expected true got false
+PASS Good parameters: X25519 bits (spki, buffer(44), {name: X25519}, false, [])
+PASS Good parameters: X25519 bits (jwk, object(kty, crv, x), {name: X25519}, false, [])
+PASS Good parameters: X25519 bits (raw, buffer(32), {name: X25519}, false, [])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveKey])
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveKey])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Good parameters: X25519 bits (pkcs8, buffer(48), {name: X25519}, false, [deriveBits])
+PASS Good parameters: X25519 bits (jwk, object(crv, d, x, kty), {name: X25519}, false, [deriveBits])
 FAIL Good parameters: X448 bits (spki, buffer(68), {name: X448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: X448 bits (jwk, object(kty, crv, x), {name: X448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code
 FAIL Good parameters: X448 bits (raw, buffer(56), {name: X448}, true, []) assert_unreached: Threw an unexpected error: NotSupportedError: The operation is not supported. Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any-expected.txt
@@ -1,196 +1,196 @@
 
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: X25519}, true, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: X25519}, false, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: X25519}, true, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: X25519}, false, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, true, []) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, false, []) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
+PASS Bad usages: importKey(spki, {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [sign])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [sign])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [verify])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [verify])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [deriveKey])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [deriveKey])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [deriveBits])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [verify])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [verify])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveBits])
+PASS Bad key length: importKey(spki, {name: X25519}, true, [])
+PASS Bad key length: importKey(spki, {name: X25519}, false, [])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Bad key length: importKey(jwk (public) , {name: X25519}, true, [])
+PASS Bad key length: importKey(jwk (public) , {name: X25519}, false, [])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, true, [])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, false, [])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker-expected.txt
@@ -1,196 +1,196 @@
 
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(spki, {name: X25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [encrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [decrypt]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [sign]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [verify]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [wrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [unwrapKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveKey]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveBits]) assert_equals: Bad usages not supported. expected "SyntaxError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: X25519}, true, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(spki, {name: X25519}, false, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: X25519}, true, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk (public) , {name: X25519}, false, []) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Bad key length not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'x' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Missing JWK 'kty' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, true, []) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, false, []) assert_equals: Missing JWK 'crv' parameter not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
-FAIL Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits]) assert_equals: Invalid key pair not supported. expected "DataError" but got "NotSupportedError"
+PASS Bad usages: importKey(spki, {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [sign])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [sign])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [verify])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [verify])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [deriveKey])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [deriveKey])
+PASS Bad usages: importKey(spki, {name: X25519}, true, [deriveBits])
+PASS Bad usages: importKey(spki, {name: X25519}, false, [deriveBits])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, encrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, decrypt])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, sign])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, verify])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, wrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits, unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [encrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [decrypt])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [sign])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [verify])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [verify])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [wrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [unwrapKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveKey])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, true, [deriveBits])
+PASS Bad usages: importKey(jwk (public) , {name: X25519}, false, [deriveBits])
+PASS Bad key length: importKey(spki, {name: X25519}, true, [])
+PASS Bad key length: importKey(spki, {name: X25519}, false, [])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits, deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits, deriveKey])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveBits])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveBits])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Bad key length: importKey(pkcs8, {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Bad key length: importKey(jwk (public) , {name: X25519}, true, [])
+PASS Bad key length: importKey(jwk (public) , {name: X25519}, false, [])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'kty' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, true, [])
+PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: X25519}, false, [])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits])
+PASS Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -166,6 +166,7 @@ crypto/mac/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp
 crypto/mac/CryptoAlgorithmRSA_OAEPMac.cpp
 crypto/mac/CryptoAlgorithmRSA_PSSMac.cpp
 crypto/mac/CryptoAlgorithmRegistryMac.cpp
+crypto/mac/CryptoAlgorithmX25519Cocoa.cpp
 crypto/mac/CryptoKeyECMac.cpp
 crypto/mac/CryptoKeyOKPCocoa.cpp
 crypto/mac/CryptoKeyMac.cpp

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -58,7 +58,7 @@ void CryptoAlgorithmX25519::generateKey(const CryptoAlgorithmParameters&, bool e
     callback(WTFMove(pair));
 }
 
-#if !USE(GCRYPT)
+#if !PLATFORM(COCOA) && !USE(GCRYPT)
 std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&)
 {
     return std::nullopt;

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
@@ -48,6 +48,7 @@
 #include "CryptoAlgorithmSHA256.h"
 #include "CryptoAlgorithmSHA384.h"
 #include "CryptoAlgorithmSHA512.h"
+#include "CryptoAlgorithmX25519.h"
 
 namespace WebCore {
 
@@ -75,6 +76,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmSHA256>();
     registerAlgorithm<CryptoAlgorithmSHA384>();
     registerAlgorithm<CryptoAlgorithmSHA512>();
+    registerAlgorithm<CryptoAlgorithmX25519>();
 }
 
 }

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmX25519Cocoa.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmX25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoKeyOKP.h"
+#include <pal/spi/cocoa/CoreCryptoSPI.h>
+
+namespace WebCore {
+
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)
+{
+    if (baseKey.platformKey().size() != 32 || publicKey.platformKey().size() != 32)
+        return std::nullopt;
+
+    ccec25519pubkey derivedKey;
+    static_assert(sizeof(derivedKey) == 32);
+    cccurve25519(derivedKey, baseKey.platformKey().data(), publicKey.platformKey().data());
+    return Vector<uint8_t>(derivedKey, 32);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)


### PR DESCRIPTION
#### 347b6d7cc7de1c10b2659e52da57da5b4e5d2564
<pre>
[WebCrypto] Implement the X25519 algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=258279">https://bugs.webkit.org/show_bug.cgi?id=258279</a>

Reviewed by Youenn Fablet and Žan Doberšek.

We have already implemented the X25519 algorithm for the GTK+ port in r267602
so this PR implements the same WebCrypto operations for the mac port. With
this change we can consider that the implementation of the X25519 algorithm
is complete now.

It&apos;s worth mentioning that this feature has been implemented behind the
&apos;WebCryptoX25519&apos; runtime flag, which as this point is enabled only for
testing purposes.

This PR also completes the work described in the bug 245778 of implementing
the Curve25519 algorithms on the WebCrypto API.

* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_X25519.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker-expected.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
* Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp:
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms):
* Source/WebCore/crypto/mac/CryptoAlgorithmX25519Cocoa.cpp: Added.
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::isPlatformSupportedCurve):
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):

Canonical link: <a href="https://commits.webkit.org/267782@main">https://commits.webkit.org/267782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82ab33ff8289a95bc50d8b9a57177c5e89f7edd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18313 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19829 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22336 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20156 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15564 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4212 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->