### PR TITLE
Move RemoteImageBuffer methods from RemoteDisplayListRecorder to RemoteImageBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -61,9 +61,6 @@ public:
     WEBCORE_EXPORT Recorder(const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode = DrawGlyphsMode::Normal);
     WEBCORE_EXPORT virtual ~Recorder();
 
-    virtual void convertToLuminanceMask() = 0;
-    virtual void transformToColorSpace(const DestinationColorSpace&) = 0;
-
     // Records possible pending commands. Should be used when recording is known to end.
     WEBCORE_EXPORT void commitRecording();
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -40,9 +40,6 @@ public:
 
     bool isEmpty() const { return m_displayList.isEmpty(); }
 
-    void convertToLuminanceMask() final { }
-    void transformToColorSpace(const DestinationColorSpace&) final { }
-
 private:
     void recordSave() final;
     void recordRestore() final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -41,6 +41,11 @@
 #include <WebCore/ARKitBadgeSystemImage.h>
 #endif
 
+#if PLATFORM(COCOA) && ENABLE(VIDEO)
+#include "IPCSemaphore.h"
+#include "RemoteVideoFrameObjectHeap.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -494,16 +499,6 @@ void RemoteDisplayListRecorder::fillEllipse(const FloatRect& rect)
     handleItem(DisplayList::FillEllipse(rect));
 }
 
-void RemoteDisplayListRecorder::convertToLuminanceMask()
-{
-    m_imageBuffer->convertToLuminanceMask();
-}
-
-void RemoteDisplayListRecorder::transformToColorSpace(const WebCore::DestinationColorSpace& colorSpace)
-{
-    m_imageBuffer->transformToColorSpace(colorSpace);
-}
-
 #if ENABLE(VIDEO)
 void RemoteDisplayListRecorder::paintFrameForMedia(MediaPlayerIdentifier identifier, const FloatRect& destination)
 {
@@ -613,18 +608,6 @@ void RemoteDisplayListRecorder::applyFillPattern()
 void RemoteDisplayListRecorder::applyDeviceScaleFactor(float scaleFactor)
 {
     handleItem(DisplayList::ApplyDeviceScaleFactor(scaleFactor));
-}
-
-void RemoteDisplayListRecorder::flushContext(IPC::Semaphore&& semaphore)
-{
-    m_imageBuffer->flushDrawingContext();
-    semaphore.signal();
-}
-
-void RemoteDisplayListRecorder::flushContextSync(CompletionHandler<void()>&& completionHandler)
-{
-    m_imageBuffer->flushDrawingContext();
-    completionHandler();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -111,8 +111,6 @@ public:
     void fillPathSegment(const WebCore::PathSegment&);
     void fillPath(const WebCore::Path&);
     void fillEllipse(const WebCore::FloatRect&);
-    void convertToLuminanceMask();
-    void transformToColorSpace(const WebCore::DestinationColorSpace&);
 #if ENABLE(VIDEO)
     void paintFrameForMedia(WebCore::MediaPlayerIdentifier, const WebCore::FloatRect& destination);
 #endif
@@ -134,8 +132,6 @@ public:
     void applyFillPattern();
 #endif
     void applyDeviceScaleFactor(float);
-    void flushContext(IPC::Semaphore&&);
-    void flushContextSync(CompletionHandler<void()>&&);
 
 private:
     RemoteDisplayListRecorder(WebCore::ImageBuffer&, WebCore::RenderingResourceIdentifier, RemoteRenderingBackend&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -79,8 +79,6 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     FillPathSegment(WebCore::PathSegment segment) StreamBatched
     FillPath(WebCore::Path path)
     FillEllipse(WebCore::FloatRect rect)
-    ConvertToLuminanceMask()
-    TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)
 #if ENABLE(VIDEO)
     PaintFrameForMedia(WebCore::MediaPlayerIdentifier identifier, WebCore::FloatRect destination)
 #endif
@@ -102,8 +100,6 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     ApplyFillPattern()
 #endif
     ApplyDeviceScaleFactor(float scaleFactor)
-    FlushContext(IPC::Semaphore semaphore) NotStreamEncodable
-    FlushContextSync() -> () Synchronous
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     PaintVideoFrame(struct WebKit::SharedVideoFrame frame, WebCore::FloatRect rect, bool shouldDiscardAlpha) NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "IPCSemaphore.h"
 #include "RemoteImageBufferMessages.h"
 #include "StreamConnectionWorkQueue.h"
 #include <WebCore/GraphicsContext.h>
@@ -152,6 +153,32 @@ void RemoteImageBuffer::getFilteredImage(Ref<WebCore::Filter> filter, Completion
             handle = WTFMove(*bitmapHandle);
     }();
     completionHandler(WTFMove(handle));
+}
+
+void RemoteImageBuffer::convertToLuminanceMask()
+{
+    assertIsCurrent(workQueue());
+    m_imageBuffer->convertToLuminanceMask();
+}
+
+void RemoteImageBuffer::transformToColorSpace(const WebCore::DestinationColorSpace& colorSpace)
+{
+    assertIsCurrent(workQueue());
+    m_imageBuffer->transformToColorSpace(colorSpace);
+}
+
+void RemoteImageBuffer::flushContext(IPC::Semaphore&& semaphore)
+{
+    assertIsCurrent(workQueue());
+    m_imageBuffer->flushDrawingContext();
+    semaphore.signal();
+}
+
+void RemoteImageBuffer::flushContextSync(CompletionHandler<void()>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
+    m_imageBuffer->flushDrawingContext();
+    completionHandler();
 }
 
 IPC::StreamConnectionWorkQueue& RemoteImageBuffer::workQueue() const

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -33,6 +33,7 @@
 #include <WebCore/ImageBuffer.h>
 
 namespace IPC {
+class Semaphore;
 class StreamConnectionWorkQueue;
 }
 
@@ -61,6 +62,10 @@ private:
     void putPixelBuffer(Ref<WebCore::PixelBuffer>, WebCore::IntRect srcRect, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
     void getShareableBitmap(WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
     void getFilteredImage(Ref<WebCore::Filter>, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
+    void convertToLuminanceMask();
+    void transformToColorSpace(const WebCore::DestinationColorSpace&);
+    void flushContext(IPC::Semaphore&&);
+    void flushContextSync(CompletionHandler<void()>&&);
 
     RefPtr<RemoteRenderingBackend> m_backend;
     Ref<WebCore::ImageBuffer> m_imageBuffer;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -29,6 +29,10 @@ messages -> RemoteImageBuffer NotRefCounted Stream {
     PutPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
     GetShareableBitmap(enum:bool WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply
     GetFilteredImage(Ref<WebCore::Filter> filter) -> (WebKit::ShareableBitmap::Handle handle) Synchronous NotStreamEncodableReply
+    ConvertToLuminanceMask()
+    TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)
+    FlushContext(IPC::Semaphore semaphore) NotStreamEncodable
+    FlushContextSync() -> () Synchronous
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -57,16 +57,6 @@ RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy(RemoteImageBuffer
 {
 }
 
-void RemoteDisplayListRecorderProxy::convertToLuminanceMask()
-{
-    send(Messages::RemoteDisplayListRecorder::ConvertToLuminanceMask());
-}
-
-void RemoteDisplayListRecorderProxy::transformToColorSpace(const DestinationColorSpace& colorSpace)
-{
-    send(Messages::RemoteDisplayListRecorder::TransformToColorSpace(colorSpace));
-}
-
 template<typename T>
 ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
 {
@@ -81,26 +71,6 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
         auto& parameters = m_renderingBackend->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteDisplayListRecorderProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
             parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
-    }
-#else
-    UNUSED_VARIABLE(result);
-#endif
-}
-
-template<typename T>
-ALWAYS_INLINE void RemoteDisplayListRecorderProxy::sendSync(T&& message)
-{
-    auto imageBuffer = m_imageBuffer.get();
-    if (UNLIKELY(!(m_renderingBackend && imageBuffer)))
-        return;
-
-    imageBuffer->backingStoreWillChange();
-    auto result = m_renderingBackend->streamConnection().sendSync(WTFMove(message), m_destinationBufferIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
-#if !RELEASE_LOG_DISABLED
-    if (UNLIKELY(!result.succeeded())) {
-        auto& parameters = m_renderingBackend->parameters();
-        RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteDisplayListRecorderProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error));
     }
 #else
     UNUSED_VARIABLE(result);
@@ -572,16 +542,6 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(Filter& filter)
 
     m_renderingBackend->remoteResourceCacheProxy().recordFilterUse(filter);
     return true;
-}
-
-void RemoteDisplayListRecorderProxy::flushContext(const IPC::Semaphore& semaphore)
-{
-    send(Messages::RemoteDisplayListRecorder::FlushContext(semaphore));
-}
-
-void RemoteDisplayListRecorderProxy::flushContextSync()
-{
-    sendSync(Messages::RemoteDisplayListRecorder::FlushContextSync());
 }
 
 RefPtr<ImageBuffer> RemoteDisplayListRecorderProxy::createImageBuffer(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod> renderingMethod) const

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -48,15 +48,10 @@ public:
     RemoteDisplayListRecorderProxy(RemoteImageBufferProxy&, RemoteRenderingBackendProxy&, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&);
     ~RemoteDisplayListRecorderProxy() = default;
 
-    void convertToLuminanceMask() final;
-    void transformToColorSpace(const WebCore::DestinationColorSpace&) final;
-    void flushContext(const IPC::Semaphore&);
-    void flushContextSync();
     void disconnect();
 
 private:
     template<typename T> void send(T&& message);
-    template<typename T> void sendSync(T&& message);
 
     friend class WebCore::DrawGlyphsRecorder;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -101,6 +101,8 @@ private:
     void prepareForBackingStoreChange();
 
     void assertDispatcherIsCurrent() const;
+    template<typename T> void send(T&& message);
+    template<typename T> void sendSync(T&& message);
 
     IPC::StreamClientConnection& streamConnection() const;
 


### PR DESCRIPTION
#### d9f5ea75d6257fa10cbfc0bfb2a2a8d69478f1f9
<pre>
Move RemoteImageBuffer methods from RemoteDisplayListRecorder to RemoteImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=261141">https://bugs.webkit.org/show_bug.cgi?id=261141</a>
rdar://114970484

Reviewed by Matt Woodrow.

Move convertToLuminanceMask, transformToColorSpace, flushContext,
flushContextSync to RemoteImageBuffer, as these are ImageBuffer methods.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
(): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::convertToLuminanceMask): Deleted.
(WebKit::RemoteDisplayListRecorder::transformToColorSpace): Deleted.
(WebKit::RemoteDisplayListRecorder::flushContext): Deleted.
(WebKit::RemoteDisplayListRecorder::flushContextSync): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::convertToLuminanceMask):
(WebKit::RemoteImageBuffer::transformToColorSpace):
(WebKit::RemoteImageBuffer::flushContext):
(WebKit::RemoteImageBuffer::flushContextSync):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::convertToLuminanceMask): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::transformToColorSpace): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::sendSync): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::flushContext): Deleted.
(WebKit::RemoteDisplayListRecorderProxy::flushContextSync): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::send):
(WebKit::RemoteImageBufferProxy::sendSync):
(WebKit::RemoteImageBufferProxy::convertToLuminanceMask):
(WebKit::RemoteImageBufferProxy::transformToColorSpace):
(WebKit::RemoteImageBufferProxy::flushDrawingContext):
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/267777@main">https://commits.webkit.org/267777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002d3a03fb1f5eeaeb719b7f4417438ce94da882

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18536 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19497 "Failed to checkout and rebase branch from PR 17427") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18151 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/19497 "Failed to checkout and rebase branch from PR 17427") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18179 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20348 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16093 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20535 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16839 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15955 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4206 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->