### PR TITLE
assertIsCurrent(WorkQueue::main()) will never assert

### DIFF
--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -60,6 +60,7 @@ public:
     WTF_EXPORT_PRIVATE static uint32_t currentSequence();
 
 protected:
+    static constexpr uint32_t mainThreadID { 1 };
     static std::atomic<uint32_t> s_uid;
     static ThreadLikeAssertion createThreadLikeAssertion(uint32_t);
 };
@@ -99,9 +100,9 @@ public:
     ThreadLikeAssertion& operator=(ThreadLikeAssertion&&);
 
     void reset() { *this = currentThreadLike; }
+    bool isCurrent() const; // Public as used in API tests.
 private:
     constexpr ThreadLikeAssertion(uint32_t uid);
-    bool isCurrent() const;
 #if ASSERT_ENABLED
     uint32_t m_uid;
 #endif

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -205,6 +205,11 @@ void WorkQueue::assertIsCurrent() const
 {
     WTF::assertIsCurrent(threadLikeAssertion());
 }
+
+ThreadLikeAssertion WorkQueue::threadLikeAssertion() const
+{
+    return createThreadLikeAssertion(m_threadID);
+}
 #endif
 
 ConcurrentWorkQueue::ConcurrentWorkQueue(const char* name, QOS qos)

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -36,6 +36,9 @@ namespace WTF {
 
 WorkQueueBase::WorkQueueBase(RunLoop& runLoop)
     : m_runLoop(&runLoop)
+#if ASSERT_ENABLED
+    , m_threadID(mainThreadID)
+#endif
 {
 }
 
@@ -81,12 +84,5 @@ WorkQueue::WorkQueue(MainTag)
     : WorkQueueBase(RunLoop::main())
 {
 }
-
-#if ASSERT_ENABLED
-ThreadLikeAssertion WorkQueue::threadLikeAssertion() const
-{
-    return createThreadLikeAssertion(m_threadID);
-}
-#endif
 
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
@@ -354,4 +354,25 @@ TEST(WTF_WorkQueue, ThreadSafetyAnalysisAssertIsCurrentWorks)
         EXPECT_EQ(iterationCount + 1, holder.result);
 }
 
+#if ASSERT_ENABLED
+#define MAYBE_MainWorkQueueIsCurrent MainWorkQueueIsCurrent
+#else
+#define MAYBE_MainWorkQueueIsCurrent DISABLED_MainWorkQueueIsCurrent
+#endif
+TEST(WTF_WorkQueue, MAYBE_MainWorkQueueIsCurrent)
+{
+    assertIsCurrent(WorkQueue::main());
+    auto queue = WorkQueue::create("com.apple.WebKit.Test.MainWorkQueueIsCurrent");
+    queue->dispatch([] {
+        auto threadLikeAssertion = WorkQueue::main().threadLikeAssertion();
+        EXPECT_FALSE(threadLikeAssertion.isCurrent());
+        threadLikeAssertion.reset(); // To prevent assertion in ThreadLikeAssertion destructor.
+    });
+    queue->dispatchSync([] {
+        auto threadLikeAssertion = WorkQueue::main().threadLikeAssertion();
+        EXPECT_FALSE(threadLikeAssertion.isCurrent());
+        threadLikeAssertion.reset(); // To prevent assertion in ThreadLikeAssertion destructor.
+    });
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 0945d4c2ea7ee0c0007cf09e85a3055ea5309e4a
<pre>
assertIsCurrent(WorkQueue::main()) will never assert
<a href="https://bugs.webkit.org/show_bug.cgi?id=261139">https://bugs.webkit.org/show_bug.cgi?id=261139</a>
rdar://114970446

Reviewed by Kimmo Kinnunen.

Initialise the WorkQueue threadID to 1 when creating WorkQueue::main. We can
make this assumption as the first thread ever created is the Main Thread.
Simplify WorkQueue::threadLikeAssertion() now that WorkQueue::m_threadID
is always set to either the RunLoop&apos;s uid or the dispatch_queue sequence id.

Add API test.

* Source/WTF/wtf/ThreadAssertions.h:
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::WorkQueue::threadLikeAssertion const):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::WorkQueueBase::platformInitialize):
(WTF::WorkQueue::threadLikeAssertion const): Deleted.
* Source/WTF/wtf/generic/WorkQueueGeneric.cpp:
(WTF::WorkQueueBase::WorkQueueBase):
(WTF::WorkQueue::threadLikeAssertion const): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267640@main">https://commits.webkit.org/267640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f816c254ed9a04efe3e5e497da7f3b2a39f28388

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19871 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22371 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/14921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20194 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16487 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16451 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18828 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15601 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4370 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19971 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/20053 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16284 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4225 "Passed tests") | 
<!--EWS-Status-Bubble-End-->