### PR TITLE
To avoid circular dependency, use the intrinsic size of replaced element as width

### DIFF
--- a/LayoutTests/fast/css-intrinsic-dimensions/fit-content-container-with-replaced-child-expected.txt
+++ b/LayoutTests/fast/css-intrinsic-dimensions/fit-content-container-with-replaced-child-expected.txt
@@ -1,0 +1,9 @@
+Tests that intrinsic width values on replaced element with fit-content container work.
+ PASS
+ PASS
+ PASS
+ PASS
+ PASS
+ PASS
+ PASS
+ PASS

--- a/LayoutTests/fast/css-intrinsic-dimensions/fit-content-container-with-replaced-child.html
+++ b/LayoutTests/fast/css-intrinsic-dimensions/fit-content-container-with-replaced-child.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<style>
+.container {
+    border: 5px solid blue;
+}
+.child {
+    background-color: lime;
+}
+body {
+    width: 500px;
+}
+</style>
+Tests that intrinsic width values on replaced element with fit-content container work.
+<!-- The 300px expected values are the 300px intrinsic width of a canvas. -->
+<!-- width tests with fit-content container -->
+<div class="container" style="width: fit-content;">
+    <canvas class="child" style="width: max-content;" data-expected-width="300"></canvas>
+</div>
+<div class="container" style="width: fit-content;">
+    <canvas class="child" style="width: min-content;" data-expected-width="300"></canvas>
+</div>
+<div class="container" style="width: fit-content;">
+    <canvas class="child" style="width: fit-content;" data-expected-width="300"></canvas>
+</div>
+<div class="container" style="width: fit-content;">
+    <canvas class="child" style="width: -webkit-fill-available;" data-expected-width="300"></canvas>
+</div>
+<!-- width tests with fill-available container -->
+<div class="container" style="width: -webkit-fill-available;">
+    <canvas class="child" style="width: max-content;" data-expected-width="300"></canvas>
+</div>
+<div class="container" style="width: -webkit-fill-available;">
+    <canvas class="child" style="width: min-content;" data-expected-width="300"></canvas>
+</div>
+<div class="container" style="width: -webkit-fill-available;">
+    <canvas class="child" style="width: fit-content;" data-expected-width="300"></canvas>
+</div>
+<div class="container" style="width: -webkit-fill-available;">
+    <canvas class="child" style="width: -webkit-fill-available;" data-expected-width="490"></canvas>
+</div>
+<script src="../../resources/check-layout.js"></script>
+<script>
+checkLayout(".container");
+</script>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2006, 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2011-2012. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -699,9 +700,10 @@ void RenderReplaced::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());
 
-    // We cannot resolve any percent logical width here as the available logical
-    // width may not be set on our containing block.
-    if (style().logicalWidth().isPercentOrCalculated())
+    // We cannot resolve some logical width here (i.e. percent, fill-available or fit-content)
+    // as the available logical width may not be set on our containing block.
+    const auto& logicalWidth = style().logicalWidth();
+    if (logicalWidth.isPercentOrCalculated() || logicalWidth.isFillAvailable() || logicalWidth.isFitContent())
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
     else
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = computeReplacedLogicalWidth(ComputePreferred);


### PR DESCRIPTION
#### 7c273eb0afa7e23994b45e94fb805512d75e3d41
<pre>
To avoid circular dependency, use the intrinsic size of replaced element as width

<a href="https://bugs.webkit.org/show_bug.cgi?id=261154">https://bugs.webkit.org/show_bug.cgi?id=261154</a>

Reviewed by Simon Fraser.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/e5ade991aba279d218cfe1c4dfd125a9383f8533">https://chromium.googlesource.com/chromium/src.git/+/e5ade991aba279d218cfe1c4dfd125a9383f8533</a>

For container with &apos;fit-content&apos; width value, when computing the width of
its child, it tries to get container&apos;s available logical width, which has not
been set. Because the container&apos;s width depends on the child.

* Source/WebCore/rendering/RenderReplaced.cpp:
(RenderReplaced::computePreferredLogicalWidths):
* LayoutTests/fast/css-intrinsic-dimensions/fit-content-container-with-replaced-child.html: Add Test Case
* LayoutTests/fast/css-intrinsic-dimensions/fit-content-container-with-replaced-child-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/267648@main">https://commits.webkit.org/267648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10a112b3c8fb77eb55cf8c951a006de5b4ca7649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18338 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19858 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22366 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13971 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->