### PR TITLE
Remove unneeded PaginatedLayoutStateMaintainer

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -583,14 +583,6 @@ void LocalFrameViewLayoutContext::pushLayoutState(RenderElement& root)
     m_layoutStateStack.append(makeUnique<RenderLayoutState>(root));
 }
 
-bool LocalFrameViewLayoutContext::pushLayoutStateForPaginationIfNeeded(RenderBlockFlow& layoutRoot)
-{
-    if (layoutState())
-        return false;
-    m_layoutStateStack.append(makeUnique<RenderLayoutState>(layoutRoot, RenderLayoutState::IsPaginated::Yes));
-    return true;
-}
-    
 bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged)
 {
     // We push LayoutState even if layoutState is disabled because it stores layoutDelta too.

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -136,7 +136,6 @@ private:
     friend class LayoutStateMaintainer;
     friend class LayoutStateDisabler;
     friend class SubtreeLayoutStateMaintainer;
-    friend class PaginatedLayoutStateMaintainer;
 
     void performLayout();
     bool canPerformLayout() const;
@@ -157,7 +156,6 @@ private:
     // These functions may only be accessed by LayoutStateMaintainer.
     // Subtree push/pop
     void pushLayoutState(RenderElement&);
-    bool pushLayoutStateForPaginationIfNeeded(RenderBlockFlow&);
     bool pushLayoutState(RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageHeight = 0_lu, bool pageHeightChanged = false);
     void popLayoutState();
 

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -38,9 +38,9 @@
 
 namespace WebCore {
 
-RenderLayoutState::RenderLayoutState(RenderElement& renderer, IsPaginated isPaginated)
+RenderLayoutState::RenderLayoutState(RenderElement& renderer)
     : m_clipped(false)
-    , m_isPaginated(isPaginated == IsPaginated::Yes)
+    , m_isPaginated(false)
     , m_pageLogicalHeightChanged(false)
 #if ASSERT_ENABLED
     , m_layoutDeltaXSaturated(false)
@@ -334,18 +334,6 @@ SubtreeLayoutStateMaintainer::~SubtreeLayoutStateMaintainer()
         if (m_didDisablePaintOffsetCache)
             m_context->enablePaintOffsetCache();
     }
-}
-
-PaginatedLayoutStateMaintainer::PaginatedLayoutStateMaintainer(RenderBlockFlow& flow)
-    : m_context(flow.view().frameView().layoutContext())
-    , m_pushed(m_context.pushLayoutStateForPaginationIfNeeded(flow))
-{
-}
-
-PaginatedLayoutStateMaintainer::~PaginatedLayoutStateMaintainer()
-{
-    if (m_pushed)
-        m_context.popLayoutState();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -66,8 +66,7 @@ public:
     {
     }
     RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<TextBoxTrim>);
-    enum class IsPaginated : bool { No, Yes };
-    explicit RenderLayoutState(RenderElement&, IsPaginated = IsPaginated::No);
+    explicit RenderLayoutState(RenderElement&);
 
     bool isPaginated() const { return m_isPaginated; }
 
@@ -201,16 +200,6 @@ public:
 
 private:
     LocalFrameViewLayoutContext& m_context;
-};
-
-class PaginatedLayoutStateMaintainer {
-public:
-    PaginatedLayoutStateMaintainer(RenderBlockFlow&);
-    ~PaginatedLayoutStateMaintainer();
-
-private:
-    LocalFrameViewLayoutContext& m_context;
-    bool m_pushed { false };
 };
 
 inline void RenderLayoutState::addTextBoxTrimStart()


### PR DESCRIPTION
#### 24f3755bef3603a022644c621f92a645f6694b61
<pre>
Remove unneeded PaginatedLayoutStateMaintainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=261155">https://bugs.webkit.org/show_bug.cgi?id=261155</a>

Reviewed by Simon Fraser.

Remove unneeded PaginatedLayoutStateMaintainer.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::pushLayoutStateForPaginationIfNeeded): Deleted.
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
(WebCore::PaginatedLayoutStateMaintainer::PaginatedLayoutStateMaintainer): Deleted.
(WebCore::PaginatedLayoutStateMaintainer::~PaginatedLayoutStateMaintainer): Deleted.
* Source/WebCore/rendering/RenderLayoutState.h:

Canonical link: <a href="https://commits.webkit.org/267647@main">https://commits.webkit.org/267647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fde5dc37990888c86e23d7e4effdb80b39f507d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16150 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17447 "Found 2 Binding test failures: JSTestConditionallyReadWrite.cpp, JSTestGlobalObject.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18339 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19859 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22364 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13954 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15589 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->