### PR TITLE
Validate WebCodecs encoder HEVC codec string parameters

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string
+

--- a/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.html
+++ b/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.js
+++ b/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.js
@@ -1,0 +1,54 @@
+const validButUnsupportedConfigs = [
+  {
+    comment: 'Possible future HEVC codec string',
+    config: {
+      codec: 'hvc1.C99.6FFFFFF.L93',
+      width: 640,
+      height: 480,
+    },
+  },
+];
+
+validButUnsupportedConfigs.forEach(entry => {
+  let config = entry.config;
+  promise_test(
+      async t => {
+        let support = await VideoEncoder.isConfigSupported(config);
+        assert_false(support.supported);
+
+        let new_config = support.config;
+        assert_equals(new_config.codec, config.codec);
+        assert_equals(new_config.width, config.width);
+        assert_equals(new_config.height, config.height);
+        if (config.bitrate)
+          assert_equals(new_config.bitrate, config.bitrate);
+        if (config.framerate)
+          assert_equals(new_config.framerate, config.framerate);
+      },
+      'Test that VideoEncoder.isConfigSupported() doesn\'t support config: ' +
+          entry.comment);
+});
+
+validButUnsupportedConfigs.forEach(entry => {
+  async_test(
+      t => {
+        let codec = new VideoEncoder({
+          output: t.unreached_func('unexpected output'),
+          error: t.step_func_done(e => {
+            assert_true(e instanceof DOMException);
+            assert_equals(e.name, 'NotSupportedError');
+            assert_equals(codec.state, 'closed', 'state');
+          })
+        });
+        codec.configure(entry.config);
+        codec.flush()
+            .then(t.unreached_func('flush succeeded unexpectedly'))
+            .catch(t.step_func(e => {
+              assert_true(e instanceof DOMException);
+              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(codec.state, 'closed', 'state');
+            }));
+      },
+      'Test that VideoEncoder.configure() doesn\'t support config: ' +
+          entry.comment);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -19,7 +19,7 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height i
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd sized frames for H264
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -19,7 +19,7 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height i
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd sized frames for H264
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1153,6 +1153,7 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_hevc [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_annexb [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_hevc [ Pass ]
+http/wpt/webcodecs/hevc-encoder-config.https.any.html [ Failure ]
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -89,7 +89,7 @@ private:
     void decodeFrame(VideoDecoderIdentifier, int64_t timeStamp, const IPC::DataReference&);
     void setFrameSize(VideoDecoderIdentifier, uint16_t width, uint16_t height);
 
-    void createEncoder(VideoEncoderIdentifier, VideoCodecType, const Vector<std::pair<String, String>>&, bool useLowLatency, bool useAnnexB, CompletionHandler<void(bool)>&&);
+    void createEncoder(VideoEncoderIdentifier, VideoCodecType, const String& codecString, const Vector<std::pair<String, String>>&, bool useLowLatency, bool useAnnexB, CompletionHandler<void(bool)>&&);
     void releaseEncoder(VideoEncoderIdentifier);
     void initializeEncoder(VideoEncoderIdentifier, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     void encodeFrame(VideoEncoderIdentifier, SharedVideoFrame&&, int64_t timeStamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame);

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in
@@ -31,7 +31,7 @@ messages -> LibWebRTCCodecsProxy NotRefCounted {
     DecodeFrame(WebKit::VideoDecoderIdentifier id, int64_t timeStamp, IPC::DataReference data)
     SetFrameSize(WebKit::VideoDecoderIdentifier id, uint16_t width, uint16_t height)
 
-    CreateEncoder(WebKit::VideoEncoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, Vector<std::pair<String, String>> parameters, bool useLowLatency, bool useAnnexB) -> (bool success);
+    CreateEncoder(WebKit::VideoEncoderIdentifier id, enum:uint8_t WebKit::VideoCodecType codecType, String codecString, Vector<std::pair<String, String>> parameters, bool useLowLatency, bool useAnnexB) -> (bool success);
     ReleaseEncoder(WebKit::VideoEncoderIdentifier id)
     InitializeEncoder(WebKit::VideoEncoderIdentifier id, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate)
     EncodeFrame(WebKit::VideoEncoderIdentifier id, struct WebKit::SharedVideoFrame buffer, int64_t timeStamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -177,7 +177,7 @@ void RemoteVideoCodecFactory::createEncoder(const String& codec, const WebCore::
         }
     }
 
-    WebProcess::singleton().libWebRTCCodecs().createEncoderAndWaitUntilReady(*type, parameters, config.isRealtime, config.useAnnexB, [config, createCallback = WTFMove(createCallback), descriptionCallback = WTFMove(descriptionCallback), outputCallback = WTFMove(outputCallback), postTaskCallback = WTFMove(postTaskCallback)](auto* internalEncoder) mutable {
+    WebProcess::singleton().libWebRTCCodecs().createEncoderAndWaitUntilReady(*type, codec, parameters, config.isRealtime, config.useAnnexB, [config, createCallback = WTFMove(createCallback), descriptionCallback = WTFMove(descriptionCallback), outputCallback = WTFMove(outputCallback), postTaskCallback = WTFMove(postTaskCallback)](auto* internalEncoder) mutable {
         if (!internalEncoder) {
             postTaskCallback([createCallback = WTFMove(createCallback)]() mutable {
                 createCallback(makeUnexpected("Encoder creation failed"_s));

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -120,6 +120,7 @@ public:
     public:
         VideoEncoderIdentifier identifier;
         VideoCodecType type;
+        String codec;
         Vector<std::pair<String, String>> parameters;
         std::optional<EncoderInitializationData> initializationData;
         void* encodedImageCallback WTF_GUARDED_BY_LOCK(encodedImageCallbackLock) { nullptr };
@@ -136,7 +137,7 @@ public:
     };
 
     Encoder* createEncoder(VideoCodecType, const std::map<std::string, std::string>&);
-    void createEncoderAndWaitUntilReady(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
+    void createEncoderAndWaitUntilReady(VideoCodecType, const String& codec, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
     int32_t releaseEncoder(Encoder&);
     int32_t initializeEncoder(Encoder&, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     int32_t encodeFrame(Encoder&, const WebCore::VideoFrame&, int64_t timestamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame);
@@ -190,7 +191,7 @@ private:
     WorkQueue& workQueue() const { return m_queue; }
 
     Decoder* createDecoderInternal(VideoCodecType, const String& codec, Function<void(Decoder(*))>&&);
-    Encoder* createEncoderInternal(VideoCodecType, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
+    Encoder* createEncoderInternal(VideoCodecType, const String& codec, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
     template<typename Frame> int32_t encodeFrameInternal(Encoder&, const Frame&, bool shouldEncodeAsKeyFrame, WebCore::VideoFrameRotation, MediaTime, int64_t timestamp, std::optional<uint64_t> duration);
 
 private:


### PR DESCRIPTION
#### 06e4a711b6fddcbdc963b31843579570e5636259
<pre>
Validate WebCodecs encoder HEVC codec string parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=261156">https://bugs.webkit.org/show_bug.cgi?id=261156</a>
rdar://114980549

Reviewed by Eric Carlson.

Pass the codec string from WebProcess to GPUProcess when creating an encoder.
Have LibWebRTCCodecsProxy::createEncoder validate the codec string before instantiating one.
Add a test to cover this case.
This test should be removed once <a href="https://github.com/web-platform-tests/wpt/pull/41540">https://github.com/web-platform-tests/wpt/pull/41540</a> is merged.

* LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.html: Added.
* LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.js: Added.
(validButUnsupportedConfigs.forEach.entry.promise_test.async t):
* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.messages.in:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::validateEncoderCodecString):
(WebKit::LibWebRTCCodecsProxy::createEncoder):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createEncoder):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::createEncoder):
(WebKit::LibWebRTCCodecs::createEncoderAndWaitUntilReady):
(WebKit::LibWebRTCCodecs::createEncoderInternal):
(WebKit::LibWebRTCCodecs::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Canonical link: <a href="https://commits.webkit.org/267689@main">https://commits.webkit.org/267689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f8af34f2a9813ce3bab5fe6fd9865091066346

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17372 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18425 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19976 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20293 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14049 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4153 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->