### PR TITLE
REGRESSION(267604@main) Tiles sometimes render upside down

### DIFF
--- a/Source/JavaScriptCore/create_hash_table
+++ b/Source/JavaScriptCore/create_hash_table
@@ -24,7 +24,7 @@
  
 use strict;
 use warnings;
-use bigint;
+use Math::BigInt;
 use Getopt::Long qw(:config pass_through);
 
 my $file = shift @ARGV or die("Must provide source file as final argument.");

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
@@ -48,8 +48,10 @@ namespace JSC {
 
 namespace Wasm {
 
+class BBQDisassembler;
 class MemoryInformation;
 class OptimizingJITCallee;
+class TierUpCount;
 
 struct CompilationContext {
     std::unique_ptr<CCallHelpers> jsEntrypointJIT;

--- a/Source/WebCore/bindings/scripts/Hasher.pm
+++ b/Source/WebCore/bindings/scripts/Hasher.pm
@@ -27,7 +27,7 @@
 package Hasher;
 
 use strict;
-use bigint;
+use Math::BigInt;
 
 my $mask64 = 2**64 - 1;
 my $mask32 = 2**32 - 1;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
@@ -69,7 +69,7 @@ private:
         size_t partialTrailingContentLength { 0 };
         std::optional<InlineLayoutUnit> overflowLogicalWidth { };
     };
-    enum MayOverConstrainLine : bool { No, Yes };
+    enum MayOverConstrainLine : uint8_t { No, Yes, OnlyWhenFirstFloatOnLine };
     bool tryPlacingFloatBox(const Box&, MayOverConstrainLine);
     Result handleInlineContent(const InlineItemRange& needsLayoutRange, const LineCandidate&);
     UsedConstraints adjustedLineRectWithCandidateInlineContent(const LineCandidate&) const;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -249,6 +249,7 @@ GraphicsContext& ImageBuffer::context() const
     ASSERT(volatilityState() == VolatilityState::NonVolatile);
     auto& context = m_backend->context();
     if (!m_hasInitializedContext) {
+        context.applyDeviceScaleFactor(m_parameters.resolutionScale);
         context.setCTM(m_backendInfo.baseTransform);
         m_hasInitializedContext = true;
     }
@@ -552,9 +553,10 @@ bool ImageBuffer::isInUse() const
 
 void ImageBuffer::releaseGraphicsContext()
 {
-    if (auto* backend = ensureBackendCreated())
+    if (auto* backend = ensureBackendCreated()) {
+        m_hasInitializedContext = false;
         return backend->releaseGraphicsContext();
-    m_hasInitializedContext = false;
+    }
 }
 
 bool ImageBuffer::setVolatile()

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -70,11 +70,6 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
 
 ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
-void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
-{
-    context.applyDeviceScaleFactor(m_parameters.resolutionScale);
-}
-
 String ImageBufferCGBackend::debugDescription() const
 {
     TextStream stream;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -43,7 +43,6 @@ public:
 
 protected:
     using ImageBufferBackend::ImageBufferBackend;
-    void applyBaseTransform(GraphicsContextCG&) const;
 
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -103,7 +103,6 @@ ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& paramet
     ASSERT(m_dataProvider);
     m_context = WTFMove(context);
     ASSERT(m_context);
-    applyBaseTransform(*m_context);
 }
 
 ImageBufferCGBitmapBackend::~ImageBufferCGBitmapBackend() = default;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -115,10 +115,8 @@ ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend()
 
 GraphicsContext& ImageBufferIOSurfaceBackend::context()
 {
-    if (!m_context) {
+    if (!m_context)
         m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext());
-        applyBaseTransform(*m_context);
-    }
     return *m_context;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -64,7 +64,6 @@ ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSu
     , m_ioSurfacePool(ioSurfacePool)
 {
     m_context = makeUnique<GraphicsContextCG>(lockAndContext.context.get());
-    applyBaseTransform(*m_context);
 }
 
 ImageBufferShareableMappedIOSurfaceBitmapBackend::~ImageBufferShareableMappedIOSurfaceBitmapBackend()
@@ -102,7 +101,6 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
         if (lockAndContext) {
             m_lock = WTFMove(lockAndContext->lock);
             m_context = makeUnique<GraphicsContextCG>(lockAndContext->context.get());
-            applyBaseTransform(*m_context);
             return *m_context;
         }
     }
@@ -110,7 +108,6 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
     // return an object.
     RELEASE_LOG(RemoteLayerBuffers, "ImageBufferShareableMappedIOSurfaceBitmapBackend::context() - failed to create or update the context");
     m_context = makeUnique<GraphicsContextCG>(nullptr);
-    applyBaseTransform(*m_context);
     return *m_context;
 }
 

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -5851,6 +5851,7 @@
       "emails" : [
          "olivier.blin@softathome.com"
       ],
+      "github" : "blino",
       "name" : "Olivier Blin",
       "nicks" : [
          "blino"


### PR DESCRIPTION
#### da0741f8a7b91878483fe8436c241fc6848190b8
<pre>
REGRESSION(267604@main) Tiles sometimes render upside down
<a href="https://bugs.webkit.org/show_bug.cgi?id=261157">https://bugs.webkit.org/show_bug.cgi?id=261157</a>
rdar://114966792

Reviewed by Simon Fraser.

Remove the double setup for the ImageBufferBackend base transform.
These hunks were missing from 267604@main.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::context const):
(WebCore::ImageBuffer::releaseGraphicsContext):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::applyBaseTransform const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::context):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::context):

Canonical link: <a href="https://commits.webkit.org/267632@main">https://commits.webkit.org/267632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a24c3e89eb93da223d13b11ab2ccbd5caeabf8da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19856 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15680 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20181 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13949 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15586 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4115 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->