### PR TITLE
Only use CSSVariableReferenceValues for storing values that actually contain variable references

### DIFF
--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -61,7 +61,8 @@ bool CSSVariableData::operator==(const CSSVariableData& other) const
     return tokens() == other.tokens();
 }
 
-CSSVariableData::CSSVariableData(const CSSParserTokenRange& range)
+CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSParserContext& context)
+    : m_context(context)
 {
     StringBuilder stringBuilder;
     CSSParserTokenRange localRange = range;

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include <wtf/text/WTFString.h>
 
@@ -39,23 +40,25 @@ class CSSVariableData : public RefCounted<CSSVariableData> {
     WTF_MAKE_NONCOPYABLE(CSSVariableData);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSVariableData);
 public:
-    static Ref<CSSVariableData> create(const CSSParserTokenRange& range)
+    static Ref<CSSVariableData> create(const CSSParserTokenRange& range, const CSSParserContext& context = strictCSSParserContext())
     {
-        return adoptRef(*new CSSVariableData(range));
+        return adoptRef(*new CSSVariableData(range, context));
     }
 
     CSSParserTokenRange tokenRange() const { return m_tokens; }
+    const CSSParserContext& context() const { return m_context; }
 
     const Vector<CSSParserToken>& tokens() const { return m_tokens; }
 
     bool operator==(const CSSVariableData& other) const;
 
 private:
-    CSSVariableData(const CSSParserTokenRange&);
+    CSSVariableData(const CSSParserTokenRange&, const CSSParserContext&);
     template<typename CharacterType> void updateTokens(const CSSParserTokenRange&);
 
     String m_backingString;
     Vector<CSSParserToken> m_tokens;
+    const CSSParserContext m_context;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include "CSSParserContext.h"
 #include "CSSValue.h"
 #include "CSSValueKeywords.h"
 
@@ -38,6 +37,7 @@ namespace WebCore {
 class CSSParserToken;
 class CSSParserTokenRange;
 class CSSVariableData;
+struct CSSParserContext;
 
 namespace Style {
 class BuilderState;
@@ -46,13 +46,13 @@ class BuilderState;
 class CSSVariableReferenceValue : public CSSValue {
 public:
     static Ref<CSSVariableReferenceValue> create(const CSSParserTokenRange&, const CSSParserContext&);
-    static Ref<CSSVariableReferenceValue> create(Ref<CSSVariableData>&&, const CSSParserContext& = strictCSSParserContext());
+    static Ref<CSSVariableReferenceValue> create(Ref<CSSVariableData>&&);
 
     bool equals(const CSSVariableReferenceValue&) const;
     String customCSSText() const;
 
     RefPtr<CSSVariableData> resolveVariableReferences(Style::BuilderState&) const;
-    const CSSParserContext& context() const { return m_context; }
+    const CSSParserContext& context() const;
 
     // The maximum number of tokens that may be produced by a var() reference or var() fallback value.
     // https://drafts.csswg.org/css-variables/#long-variables
@@ -61,7 +61,7 @@ public:
     const CSSVariableData& data() const { return m_data.get(); }
 
 private:
-    explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&, const CSSParserContext&);
+    explicit CSSVariableReferenceValue(Ref<CSSVariableData>&&);
 
     std::optional<Vector<CSSParserToken>> resolveTokenRange(CSSParserTokenRange, Style::BuilderState&) const;
     bool resolveVariableReference(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, Style::BuilderState&) const;
@@ -70,7 +70,6 @@ private:
 
     Ref<CSSVariableData> m_data;
     mutable String m_stringValue;
-    const CSSParserContext m_context;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -41,6 +41,8 @@ class StyleSheetContents;
 // This class refers to half-open intervals [first, last).
 class CSSParserTokenRange {
 public:
+    CSSParserTokenRange() = default;
+
     template<size_t inlineBuffer>
     CSSParserTokenRange(const Vector<CSSParserToken, inlineBuffer>& vector)
         : m_first(vector.begin())
@@ -101,8 +103,8 @@ private:
         , m_last(last)
     { }
 
-    const CSSParserToken* m_first;
-    const CSSParserToken* m_last;
+    const CSSParserToken* m_first { nullptr };
+    const CSSParserToken* m_last { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -179,7 +179,10 @@ RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseDeclarationValue(const At
     if (type->cssWideKeyword)
         return CSSCustomPropertyValue::createWithID(variableName, *type->cssWideKeyword);
 
-    return CSSCustomPropertyValue::createUnresolved(variableName, CSSVariableReferenceValue::create(range, parserContext));
+    if (type->hasReferences)
+        return CSSCustomPropertyValue::createUnresolved(variableName, CSSVariableReferenceValue::create(range, parserContext));
+
+    return CSSCustomPropertyValue::createSyntaxAll(variableName, CSSVariableData::create(range, parserContext));
 }
 
 RefPtr<CSSCustomPropertyValue> CSSVariableParser::parseInitialValueForUniversalSyntax(const AtomString& variableName, CSSParserTokenRange range)

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -31,6 +31,7 @@
 #include "CSSUnparsedValue.h"
 
 #include "CSSOMVariableReferenceValue.h"
+#include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSTokenizer.h"
 #include "CSSVariableReferenceValue.h"

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -183,7 +183,7 @@ void Builder::applyCustomProperty(const AtomString& name)
         auto isNewCycle = m_state.m_inCycleCustomProperties.add(name).isNewEntry;
         if (isNewCycle) {
             // Continue resolving dependencies so we detect cycles for them as well.
-            resolveCustomPropertyValueWithVariableReferences(customPropertyValue.get());
+            resolveCustomPropertyValue(customPropertyValue.get());
         }
         return;
     }
@@ -204,7 +204,7 @@ void Builder::applyCustomProperty(const AtomString& name)
         return CSSCustomPropertyValue::createWithID(name, CSSValueUnset);
     };
 
-    auto resolvedValue = resolveCustomPropertyValueWithVariableReferences(customPropertyValue.get());
+    auto resolvedValue = resolveCustomPropertyValue(customPropertyValue.get());
 
     if (!resolvedValue || m_state.m_inCycleCustomProperties.contains(name))
         resolvedValue = createInvalidOrUnset();
@@ -397,22 +397,32 @@ Ref<CSSValue> Builder::resolveVariableReferences(CSSPropertyID propertyID, CSSVa
     return *variableValue;
 }
 
-RefPtr<CSSCustomPropertyValue> Builder::resolveCustomPropertyValueWithVariableReferences(CSSCustomPropertyValue& value)
+RefPtr<CSSCustomPropertyValue> Builder::resolveCustomPropertyValue(CSSCustomPropertyValue& value)
 {
-    if (!std::holds_alternative<Ref<CSSVariableReferenceValue>>(value.value()))
+    if (value.containsCSSWideKeyword())
         return &value;
-
-    auto& variableReferenceValue = std::get<Ref<CSSVariableReferenceValue>>(value.value()).get();
 
     auto name = value.name();
     auto* registered = m_state.document().customPropertyRegistry().get(name);
-    auto& syntax = registered ? registered->syntax : CSSCustomPropertySyntax::universal();
 
-    auto resolvedData = variableReferenceValue.resolveVariableReferences(m_state);
+    if (value.isResolved() && !registered)
+        return &value;
+
+    auto resolvedData = switchOn(value.value(), [&](const Ref<CSSVariableReferenceValue>& variableReferenceValue) {
+        return variableReferenceValue->resolveVariableReferences(m_state);
+    }, [&](const Ref<CSSVariableData>& data) -> RefPtr<CSSVariableData> {
+        return data.ptr();
+    }, [&](auto&) -> RefPtr<CSSVariableData> {
+        return nullptr;
+    });
+
     if (!resolvedData)
         return nullptr;
 
-    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(syntax, resolvedData->tokens(), variableReferenceValue.context());
+    if (!registered)
+        return CSSCustomPropertyValue::createSyntaxAll(name, *resolvedData);
+
+    auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(registered->syntax, resolvedData->tokens(), resolvedData->context());
 
     // https://drafts.css-houdini.org/css-properties-values-api/#dependency-cycles
     bool hasCycles = false;
@@ -440,7 +450,7 @@ RefPtr<CSSCustomPropertyValue> Builder::resolveCustomPropertyValueWithVariableRe
     if (isFontDependent)
         m_state.updateFont();
 
-    return CSSPropertyParser::parseTypedCustomPropertyValue(name, syntax, resolvedData->tokens(), m_state, variableReferenceValue.context());
+    return CSSPropertyParser::parseTypedCustomPropertyValue(name, registered->syntax, resolvedData->tokens(), m_state, resolvedData->context());
 }
 
 const PropertyCascade* Builder::ensureRollbackCascadeForRevert()

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -63,7 +63,7 @@ private:
     void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask);
 
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
-    RefPtr<CSSCustomPropertyValue> resolveCustomPropertyValueWithVariableReferences(CSSCustomPropertyValue&);
+    RefPtr<CSSCustomPropertyValue> resolveCustomPropertyValue(CSSCustomPropertyValue&);
 
     const PropertyCascade* ensureRollbackCascadeForRevert();
     const PropertyCascade* ensureRollbackCascadeForRevertLayer();


### PR DESCRIPTION
#### 7baf601ffa8bc860d7dcabb656d6de284afed5cb
<pre>
Only use CSSVariableReferenceValues for storing values that actually contain variable references
<a href="https://bugs.webkit.org/show_bug.cgi?id=261158">https://bugs.webkit.org/show_bug.cgi?id=261158</a>
rdar://114983076

Reviewed by Alan Baradlay.

Currently all regular custom properties gets stored as CSSVariableReferenceValues even
when they don&apos;t contains any references. They should use the plain CSSVariableData instead
for efficiency.

* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::isCurrentColor const):
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::CSSVariableData):

Move parser context from CSSVariableReferenceValue to CSSVariableData. It is needed for
resolving registered custom properties.

* Source/WebCore/css/CSSVariableData.h:
(WebCore::CSSVariableData::create):
(WebCore::CSSVariableData::context const):
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::CSSVariableReferenceValue):
(WebCore::CSSVariableReferenceValue::create):
(WebCore::CSSVariableReferenceValue::context const):
(WebCore::CSSVariableReferenceValue::resolveVariableFallback const):
(WebCore::CSSVariableReferenceValue::resolveVariableReferences const):
* Source/WebCore/css/CSSVariableReferenceValue.h:
(WebCore::CSSVariableReferenceValue::context const): Deleted.
* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::CSSVariableParser::parseDeclarationValue):

If there are no references create a plain CSSVariableData instead of CSSVariableReferenceValue.

* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomProperty):
(WebCore::Style::Builder::resolveCustomPropertyValue):

In case we have a variable containing CSSVariableData we can just return it directly and
not do anything with the tokens.

(WebCore::Style::Builder::resolveCustomPropertyValueWithVariableReferences): Deleted.

Rename for clarity. Also registered properties need resolving.

* Source/WebCore/style/StyleBuilder.h:

Canonical link: <a href="https://commits.webkit.org/267643@main">https://commits.webkit.org/267643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af7056fa3b7b56fd406921e9d80a300e705e0b5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16152 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17449 "Found 2 Binding test failures: JSTestConditionallyReadWrite.cpp, JSTestGlobalObject.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19861 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20187 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13953 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15591 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4125 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->