### PR TITLE
[GStreamer][WebRTC] Some tests hitting hashtable asserts

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -86,8 +86,12 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
                 auto* frameMeta = VIDEO_FRAME_METADATA_CAST(meta);
                 destroyVideoFrameMetadataPrivate(frameMeta->priv);
             },
-            [](GstBuffer* buffer, GstMeta* meta, GstBuffer*, GQuark type, gpointer) -> gboolean {
+            [](GstBuffer* buffer, GstMeta* meta, GstBuffer*, GQuark type, gpointer data) -> gboolean {
                 if (!GST_META_TRANSFORM_IS_COPY(type))
+                    return FALSE;
+
+                auto transformCopy = reinterpret_cast<GstMetaTransformCopy*>(data);
+                if (!transformCopy->region)
                     return FALSE;
 
                 auto* frameMeta = VIDEO_FRAME_METADATA_CAST(meta);


### PR DESCRIPTION
#### 0580cc9765f27145c9b0155a4724160dd692a4b8
<pre>
[GStreamer][WebRTC] Some tests hitting hashtable asserts
<a href="https://bugs.webkit.org/show_bug.cgi?id=261148">https://bugs.webkit.org/show_bug.cgi?id=261148</a>

Reviewed by Xabier Rodriguez-Calvar.

Bail out from meta copy function if the transform type is not supported. The same check is done in
other implementations such as GstVideoMeta.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(videoFrameMetadataGetInfo):

Canonical link: <a href="https://commits.webkit.org/267721@main">https://commits.webkit.org/267721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a8d27f14193ed40134d713023ac55d1ebb648c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16153 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17450 "Found 2 Binding test failures: JSTestConditionallyReadWrite.cpp, JSTestGlobalObject.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18341 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19862 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22363 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20185 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13955 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15592 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4167 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->