### PR TITLE
[iOS] Don't crash if -[LSBundleProxy bundleIdentifier] returns nil

### DIFF
--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -135,7 +135,13 @@ void AudioSessionIOS::setHostProcessAttribution(audit_token_t auditToken)
         return;
     }
 
-    [[PAL::getAVAudioSessionClass() sharedInstance] setHostProcessAttribution:@[ bundleProxy.bundleIdentifier ] error:&error];
+    auto bundleIdentifier = @[ bundleProxy.bundleIdentifier ];
+    if (!bundleIdentifier) {
+        RELEASE_LOG_ERROR(WebRTC, "-[LSBundleProxy bundleIdentifier] returned nil!");
+        return;
+    }
+
+    [[PAL::getAVAudioSessionClass() sharedInstance] setHostProcessAttribution:bundleIdentifier error:&error];
     if (error)
         RELEASE_LOG_ERROR(WebRTC, "Failed to set attribution bundleID with error: %@.", error.localizedDescription);
 #else


### PR DESCRIPTION
#### 362ae6dc9ae1b509a7c026cfcde64cad07e9db9e
<pre>
[iOS] Don&apos;t crash if -[LSBundleProxy bundleIdentifier] returns nil
<a href="https://bugs.webkit.org/show_bug.cgi?id=261162">https://bugs.webkit.org/show_bug.cgi?id=261162</a>
rdar://114802443

Reviewed by Jean-Yves Avenard.

* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::setHostProcessAttribution): Log an error message and return
early if -[LSBundleProxy bundleIdentifier] returns nil.

Canonical link: <a href="https://commits.webkit.org/267651@main">https://commits.webkit.org/267651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/717458d020bfbc47b05ae3e547e16dbbc60377e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16154 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17451 "Found 2 Binding test failures: JSTestConditionallyReadWrite.cpp, JSTestGlobalObject.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18342 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19863 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22367 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13956 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15593 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4134 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->