### PR TITLE
Simplify the CodeGeneratorExtensions.pm generated code for the most common optional argument case.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -193,20 +193,33 @@ NSString *toNSString(JSContextRef context, JSValueRef value, NullStringPolicy nu
         FALLTHROUGH;
 
     case NullStringPolicy::NoNullString:
+        // Don't try to convert other objects into strings.
+        if (!JSValueIsString(context, value))
+            return nil;
+
         JSRetainPtr<JSStringRef> string(Adopt, JSValueToStringCopy(context, value, 0));
         return CFBridgingRelease(JSStringCopyCFString(nullptr, string.get()));
     }
 }
 
-NSDictionary *toNSDictionary(JSContextRef context, JSValueRef value)
+NSDictionary *toNSDictionary(JSContextRef context, JSValueRef valueRef)
 {
     ASSERT(context);
 
-    if (!JSValueIsObject(context, value))
+    if (!JSValueIsObject(context, valueRef))
         return nil;
 
-    JSObjectRef object = JSValueToObject(context, value, nullptr);
+    JSObjectRef object = JSValueToObject(context, valueRef, nullptr);
     if (!object)
+        return nil;
+
+    // Don't try to convert functions.
+    if (JSObjectIsFunction(context, object))
+        return nil;
+
+    // Don't try to convert promises or regular expressions.
+    JSValue *value = [JSValue valueWithJSValueRef:valueRef inContext:[JSContext contextWithJSGlobalContextRef:JSContextGetGlobalContext(context)]];
+    if (value._isThenable || value._isRegularExpression)
         return nil;
 
     JSPropertyNameArrayRef propertyNames = JSObjectCopyPropertyNames(context, object);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -43,6 +43,8 @@ TEST(WKWebExtensionAPIExtension, GetURL)
         @"browser.test.assertThrows(() => browser.extension.getURL(), /required argument is missing/i)",
         @"browser.test.assertThrows(() => browser.extension.getURL(null), /'resourcePath' value is invalid, because a string is expected/i)",
         @"browser.test.assertThrows(() => browser.extension.getURL(undefined), /'resourcePath' value is invalid, because a string is expected/i)",
+        @"browser.test.assertThrows(() => browser.extension.getURL(42), /'resourcePath' value is invalid, because a string is expected/i)",
+        @"browser.test.assertThrows(() => browser.extension.getURL(/test/), /'resourcePath' value is invalid, because a string is expected/i)",
 
         // Normal Cases
         @"browser.test.assertEq(browser.extension.getURL(''), `${baseURL}/`)",
@@ -59,8 +61,6 @@ TEST(WKWebExtensionAPIExtension, GetURL)
 
         // Unexpected Cases
         // FIXME: <https://webkit.org/b/248154> browser.extension.getURL() has some edge cases that should be failures or return different results
-        @"browser.test.assertEq(browser.extension.getURL(42), `${baseURL}/42`)",
-        @"browser.test.assertEq(browser.extension.getURL(/test/), `${baseURL}/test/`)",
         @"browser.test.assertEq(browser.extension.getURL('//'), 'test-extension://')",
         @"browser.test.assertEq(browser.extension.getURL('//example'), `test-extension://example`)",
         @"browser.test.assertEq(browser.extension.getURL('///'), 'test-extension:///')",

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -53,6 +53,8 @@ TEST(WKWebExtensionAPIRuntime, GetURL)
         @"browser.test.assertThrows(() => browser.runtime.getURL(), /required argument is missing/i)",
         @"browser.test.assertThrows(() => browser.runtime.getURL(null), /'resourcePath' value is invalid, because a string is expected/i)",
         @"browser.test.assertThrows(() => browser.runtime.getURL(undefined), /'resourcePath' value is invalid, because a string is expected/i)",
+        @"browser.test.assertThrows(() => browser.runtime.getURL(42), /'resourcePath' value is invalid, because a string is expected/i)",
+        @"browser.test.assertThrows(() => browser.runtime.getURL(/test/), /'resourcePath' value is invalid, because a string is expected/i)",
 
         // Normal Cases
         @"browser.test.assertEq(browser.runtime.getURL(''), `${baseURL}/`)",
@@ -69,8 +71,6 @@ TEST(WKWebExtensionAPIRuntime, GetURL)
 
         // Unexpected Cases
         // FIXME: <https://webkit.org/b/248154> browser.runtime.getURL() has some edge cases that should be failures or return different results
-        @"browser.test.assertEq(browser.runtime.getURL(42), `${baseURL}/42`)",
-        @"browser.test.assertEq(browser.runtime.getURL(/test/), `${baseURL}/test/`)",
         @"browser.test.assertEq(browser.runtime.getURL('//'), 'test-extension://')",
         @"browser.test.assertEq(browser.runtime.getURL('//example'), `test-extension://example`)",
         @"browser.test.assertEq(browser.runtime.getURL('///'), 'test-extension:///')",


### PR DESCRIPTION
#### 77ea37f47beef56db7979962d266e459efdf4d2f
<pre>
Simplify the CodeGeneratorExtensions.pm generated code for the most common optional argument case.
<a href="https://webkit.org/b/261163">https://webkit.org/b/261163</a>
rdar://problem/114986995

Reviewed by Brian Weinstein.

Refine the argument handling for the Web Extension code generator.

* Streamlined argument handling for the common 2 and 3 argument cases, specifically when the last argument is optional.
* Replaced the previous loop-based method for these cases with more direct conditional checks.
* Complex handling remains in place for scenarios with multiple optional arguments beyond 3 total arguments.
* Cuts down the functions using the complex method from roughly 50 to just 7.
* Helps both improved readability and potential generated code performance.

* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSString): Only try to convert strings.
(WebKit::toNSDictionary): Don&apos;t try to convert functions or promises.
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267695@main">https://commits.webkit.org/267695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd460b9419b14be36f7adeb184e0813ec667cf5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19228 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/17636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17907 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/17645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/20047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/16213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16618 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2132 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->