### PR TITLE
[JSC] Make sure WEBASSEMBLY is disabled when JIT is

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -606,6 +606,13 @@
 /* Disable JIT on all other 32bit architectures. */
 #undef ENABLE_JIT
 #define ENABLE_JIT 0
+/* Disable WEBASSEMBLY as well, because it doesn't build without JIT anymore */
+#undef ENABLE_WEBASSEMBLY
+#define ENABLE_WEBASSEMBLY 0
+#undef ENABLE_WEBASSEMBLY_OMGJIT
+#define ENABLE_WEBASSEMBLY_OMGJIT 0
+#undef ENABLE_WEBASSEMBLY_BBQJIT
+#define ENABLE_WEBASSEMBLY_BBQJIT 0
 #endif
 #endif
 


### PR DESCRIPTION
* follow-up fix for: https://bugs.webkit.org/show_bug.cgi?id=242172

* in https://github.com/WebKit/WebKit/commit/a2ec4ef1997d6fafa6ffc607bffb54e76168a918 #if !CPU(ARM_HARDFP) was removed from explit WEBASSEMBLY disabling, so now for softfp ARM we can end with JIT disabled and WEBASSEMBLY enabled causing build to fail with: http://errors.yoctoproject.org/Errors/Details/734587/

<pre>
In file included from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:32,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h:33,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:31,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:57:
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmCallee.h: In member function 'std::tuple<void*, void*> JSC::Wasm::JITCallee::rangeImpl() const': TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmCallee.h:95:47: error: invalid use of incomplete type 'class JSC::Compilation'
   95 |         void* start = m_entrypoint.compilation->codeRef().executableMemory()->start().untaggedPtr();
      |                                               ^~
In file included from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmGlobal.h:31,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h:31:
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmFormat.h:49:7: note: forward declaration of 'class JSC::Compilation'
   49 | class Compilation;
      |       ^~~~~~~~~~~
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmCallee.h:96:45: error: invalid use of incomplete type 'class JSC::Compilation'
   96 |         void* end = m_entrypoint.compilation->codeRef().executableMemory()->end().untaggedPtr();
      |                                             ^~
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmFormat.h:49:7: note: forward declaration of 'class JSC::Compilation'
   49 | class Compilation;
      |       ^~~~~~~~~~~
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmCallee.h: In member function 'WTF::CodePtr<(WTF::PtrTag)33222, WTF::FunctionAttributes::None> JSC::Wasm::JITCallee::entrypointImpl() const':
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmCallee.h:100:86: error: invalid use of incomplete type 'class JSC::Compilation'
  100 |     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint.compilation->code().retagged<WasmEntryPtrTag>(); }
      |                                                                                      ^~
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmFormat.h:49:7: note: forward declaration of 'class JSC::Compilation'
   49 | class Compilation;
      |       ^~~~~~~~~~~
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmCallee.h:100:121: error: expected primary-expression before ')' token
  100 |     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint.compilation->code().retagged<WasmEntryPtrTag>(); }
      |                                                                                                                         ^
In file included from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/recipe-sysroot/usr/include/c++/13.2.0/memory:78,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/build/WTF/Headers/wtf/StdLibExtras.h:30,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/build/WTF/Headers/wtf/FastMalloc.h:26,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/config.h:39,
                 from TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:26:
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/recipe-sysroot/usr/include/c++/13.2.0/bits/unique_ptr.h: In instantiation of 'void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = JSC::Compilation]':
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/recipe-sysroot/usr/include/c++/13.2.0/bits/unique_ptr.h:404:17:   required from 'std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = JSC::Compilation; _Dp = std::default_delete<JSC::Compilation>]'
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/webkitgtk-2.40.5/Source/JavaScriptCore/wasm/WasmFormat.h:537:8:   required from here
TOPDIR/tmp-glibc/work/cortexa15t2-vfp-oe-linux-gnueabi/webkitgtk/2.40.5/recipe-sysroot/usr/include/c++/13.2.0/bits/unique_ptr.h:97:23: error: invalid application of 'sizeof' to incomplete type 'JSC::Compilation'
   97 |         static_assert(sizeof(_Tp)>0,
      |                       ^~~~~~~~~~~
ninja: build stopped: subcommand failed.
</pre>

* explicitly disable WEBASSEMBLY when disabling JIT to avoid this<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c7be46c6c74da5a399594f6c201e963caa5fc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16164 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18351 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19876 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22379 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/14926 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20202 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16492 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13966 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18834 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15606 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4371 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19976 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/20059 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16289 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4226 "Passed tests") | 
<!--EWS-Status-Bubble-End-->