### PR TITLE
REGRESSION(267604@main): Causes PLT regressions

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -247,13 +247,7 @@ GraphicsContext& ImageBuffer::context() const
 {
     ASSERT(m_backend);
     ASSERT(volatilityState() == VolatilityState::NonVolatile);
-    auto& context = m_backend->context();
-    if (!m_hasInitializedContext) {
-        context.applyDeviceScaleFactor(m_parameters.resolutionScale);
-        context.setCTM(m_backendInfo.baseTransform);
-        m_hasInitializedContext = true;
-    }
-    return context;
+    return m_backend->context();
 }
 
 void ImageBuffer::flushDrawingContext()
@@ -280,7 +274,6 @@ void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
 
     m_backend = WTFMove(backend);
     ++m_backendGeneration;
-    m_hasInitializedContext = false;
 }
 
 std::unique_ptr<ImageBufferBackend> ImageBuffer::takeBackend()
@@ -553,10 +546,8 @@ bool ImageBuffer::isInUse() const
 
 void ImageBuffer::releaseGraphicsContext()
 {
-    if (auto* backend = ensureBackendCreated()) {
-        m_hasInitializedContext = false;
+    if (auto* backend = ensureBackendCreated())
         return backend->releaseGraphicsContext();
-    }
 }
 
 bool ImageBuffer::setVolatile()

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -237,7 +237,6 @@ protected:
     std::unique_ptr<ImageBufferBackend> m_backend;
     RenderingResourceIdentifier m_renderingResourceIdentifier;
     unsigned m_backendGeneration { 0 };
-    mutable bool m_hasInitializedContext { false }; // FIXME: will be replaced with std::unique_ptr<GraphicsContext>.
 };
 
 class SerializedImageBuffer {

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -147,6 +147,7 @@ public:
     virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() { return nullptr; }
 
     static constexpr bool isOriginAtBottomLeftCorner = false;
+    virtual bool originAtBottomLeftCorner() const { return isOriginAtBottomLeftCorner; }
 
     static constexpr bool canMapBackingStore = true;
     static constexpr RenderingMode renderingMode = RenderingMode::Unaccelerated;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -70,6 +70,17 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
 
 ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
+bool ImageBufferCGBackend::originAtBottomLeftCorner() const
+{
+    return isOriginAtBottomLeftCorner;
+}
+
+void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
+{
+    context.applyDeviceScaleFactor(m_parameters.resolutionScale);
+    context.setCTM(calculateBaseTransform(m_parameters, originAtBottomLeftCorner()));
+}
+
 String ImageBufferCGBackend::debugDescription() const
 {
     TextStream stream;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -43,11 +43,13 @@ public:
 
 protected:
     using ImageBufferBackend::ImageBufferBackend;
+    void applyBaseTransform(GraphicsContextCG&) const;
 
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
     String debugDescription() const override;
 
+    bool originAtBottomLeftCorner() const override;
     mutable std::unique_ptr<GraphicsContextCG> m_context;
 };
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -103,6 +103,7 @@ ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& paramet
     ASSERT(m_dataProvider);
     m_context = WTFMove(context);
     ASSERT(m_context);
+    applyBaseTransform(*m_context);
 }
 
 ImageBufferCGBitmapBackend::~ImageBufferCGBitmapBackend() = default;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -115,8 +115,10 @@ ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend()
 
 GraphicsContext& ImageBufferIOSurfaceBackend::context()
 {
-    if (!m_context)
+    if (!m_context) {
         m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext());
+        applyBaseTransform(*m_context);
+    }
     return *m_context;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -108,6 +108,11 @@ ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const Param
     , m_bitmap(WTFMove(bitmap))
     , m_context(WTFMove(context))
 {
+    // ShareableBitmap ensures that the coordinate space in the context that we're adopting
+    // has a top-left origin, so we don't ever need to flip here, so we don't call setupContext().
+    // However, ShareableBitmap does not have a notion of scale, so we must apply the device
+    // scale factor to the context ourselves.
+    m_context->applyDeviceScaleFactor(resolutionScale());
 }
 
 ImageBufferBackendHandle ImageBufferShareableBitmapBackend::createBackendHandle(SharedMemory::Protection protection) const

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -65,6 +65,8 @@ private:
     void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
+    bool originAtBottomLeftCorner() const final { return isOriginAtBottomLeftCorner; }
+
     unsigned bytesPerRow() const final;
 
     WebCore::VolatilityState volatilityState() const final { return m_volatilityState; }

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -64,6 +64,7 @@ ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSu
     , m_ioSurfacePool(ioSurfacePool)
 {
     m_context = makeUnique<GraphicsContextCG>(lockAndContext.context.get());
+    applyBaseTransform(*m_context);
 }
 
 ImageBufferShareableMappedIOSurfaceBitmapBackend::~ImageBufferShareableMappedIOSurfaceBitmapBackend()
@@ -101,6 +102,7 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
         if (lockAndContext) {
             m_lock = WTFMove(lockAndContext->lock);
             m_context = makeUnique<GraphicsContextCG>(lockAndContext->context.get());
+            applyBaseTransform(*m_context);
             return *m_context;
         }
     }
@@ -108,6 +110,7 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
     // return an object.
     RELEASE_LOG(RemoteLayerBuffers, "ImageBufferShareableMappedIOSurfaceBitmapBackend::context() - failed to create or update the context");
     m_context = makeUnique<GraphicsContextCG>(nullptr);
+    applyBaseTransform(*m_context);
     return *m_context;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -55,6 +55,7 @@ public:
     ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
     void setOwnershipIdentity(const WebCore::ProcessIdentity&) final;
     WebCore::GraphicsContext& context() final;
+    bool originAtBottomLeftCorner() const override { return isOriginAtBottomLeftCorner; }
 private:
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }


### PR DESCRIPTION
#### d810ebc5110aadd0b8c3a679deff875b81a68a56
<pre>
REGRESSION(267604@main): Causes PLT regressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=261166">https://bugs.webkit.org/show_bug.cgi?id=261166</a>
rdar://problem/114993825

Unreviewed, revert due to PLT regressions.

Reverts:
267632@main  REGRESSION(267604@main) Tiles sometimes render upside down
267604@main  Some ImageBufferBackend implementations use resolutionScale

Canonical link: <a href="https://commits.webkit.org/267642@main">https://commits.webkit.org/267642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b05a2d996a89636e08e74c47ad487c427e42e15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19064 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17744 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19881 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15707 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16059 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16460 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15610 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4124 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/19980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->