### PR TITLE
RemoteDisplayListRecorder uses ThreadSafeWeakPtr to ImageBuffer redundantly

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -59,12 +59,6 @@ RemoteResourceCache& RemoteDisplayListRecorder::resourceCache() const
     return m_renderingBackend->remoteResourceCache();
 }
 
-GraphicsContext& RemoteDisplayListRecorder::drawingContext()
-{
-    auto imageBuffer = m_imageBuffer.get();
-    return imageBuffer->context();
-}
-
 RefPtr<ImageBuffer> RemoteDisplayListRecorder::imageBuffer(RenderingResourceIdentifier identifier) const
 {
     return m_renderingBackend->imageBuffer(identifier);
@@ -502,20 +496,18 @@ void RemoteDisplayListRecorder::fillEllipse(const FloatRect& rect)
 
 void RemoteDisplayListRecorder::convertToLuminanceMask()
 {
-    auto imageBuffer = m_imageBuffer.get();
-    imageBuffer->convertToLuminanceMask();
+    m_imageBuffer->convertToLuminanceMask();
 }
 
 void RemoteDisplayListRecorder::transformToColorSpace(const WebCore::DestinationColorSpace& colorSpace)
 {
-    auto imageBuffer = m_imageBuffer.get();
-    imageBuffer->transformToColorSpace(colorSpace);
+    m_imageBuffer->transformToColorSpace(colorSpace);
 }
 
 #if ENABLE(VIDEO)
 void RemoteDisplayListRecorder::paintFrameForMedia(MediaPlayerIdentifier identifier, const FloatRect& destination)
 {
-    m_renderingBackend->gpuConnectionToWebProcess().performWithMediaPlayerOnMainThread(identifier, [imageBuffer = m_imageBuffer.get(), destination](MediaPlayer& player) {
+    m_renderingBackend->gpuConnectionToWebProcess().performWithMediaPlayerOnMainThread(identifier, [imageBuffer = m_imageBuffer, destination](MediaPlayer& player) {
         // It is currently not safe to call paintFrameForMedia() off the main thread.
         imageBuffer->context().paintFrameForMedia(player, destination);
     });
@@ -625,15 +617,13 @@ void RemoteDisplayListRecorder::applyDeviceScaleFactor(float scaleFactor)
 
 void RemoteDisplayListRecorder::flushContext(IPC::Semaphore&& semaphore)
 {
-    auto imageBuffer = m_imageBuffer.get();
-    imageBuffer->flushDrawingContext();
+    m_imageBuffer->flushDrawingContext();
     semaphore.signal();
 }
 
 void RemoteDisplayListRecorder::flushContextSync(CompletionHandler<void()>&& completionHandler)
 {
-    auto imageBuffer = m_imageBuffer.get();
-    imageBuffer->flushDrawingContext();
+    m_imageBuffer->flushDrawingContext();
     completionHandler();
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -143,7 +143,7 @@ private:
     void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
 
     RemoteResourceCache& resourceCache() const;
-    WebCore::GraphicsContext& drawingContext();
+    WebCore::GraphicsContext& drawingContext() { return m_imageBuffer->context(); }
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier) const;
     std::optional<WebCore::SourceImage> sourceImage(WebCore::RenderingResourceIdentifier) const;
 
@@ -165,7 +165,7 @@ private:
     void setSharedVideoFrameMemory(SharedMemory::Handle&&);
 #endif
 
-    ThreadSafeWeakPtr<WebCore::ImageBuffer> m_imageBuffer;
+    Ref<WebCore::ImageBuffer> m_imageBuffer;
     WebCore::RenderingResourceIdentifier m_imageBufferIdentifier;
     RefPtr<RemoteRenderingBackend> m_renderingBackend;
     std::unique_ptr<WebCore::ControlFactory> m_controlFactory;


### PR DESCRIPTION
#### 1a615c7e8bc035090660e4ce098d3dea0388e069
<pre>
RemoteDisplayListRecorder uses ThreadSafeWeakPtr to ImageBuffer redundantly
<a href="https://bugs.webkit.org/show_bug.cgi?id=261167">https://bugs.webkit.org/show_bug.cgi?id=261167</a>
rdar://114994553

Reviewed by Antti Koivisto.

The weak ptr was never checked for null, so it wasn&apos;t expected to function
as vehicle to detect destruction.

There is no circular dependency between the ImageBuffer and the recorder,
so just use normal Ref.

The image buffer will anyway outlive the recorder, as the recorder is always
removed from the instance list before the RemoteImageBuffers.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::convertToLuminanceMask):
(WebKit::RemoteDisplayListRecorder::transformToColorSpace):
(WebKit::RemoteDisplayListRecorder::flushContext):
(WebKit::RemoteDisplayListRecorder::flushContextSync):
(WebKit::RemoteDisplayListRecorder::drawingContext): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
(WebKit::RemoteDisplayListRecorder::drawingContext):

Canonical link: <a href="https://commits.webkit.org/267664@main">https://commits.webkit.org/267664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/404118c647bbcd2b6f435bfdba73f3f140c66596

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18369 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19885 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15064 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20215 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13974 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15612 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4141 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->