### PR TITLE
Split webkitpy.common.net.bugzilla.TestExpectationUpdater

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/__init__.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/__init__.py
@@ -1,7 +1,8 @@
 # Required for Python to search this directory for module files
 
-# We only export public API here.
-from webkitpy.common.net.bugzilla.bugzilla import Bugzilla
-# Unclear if Bug and Attachment need to be public classes.
-from webkitpy.common.net.bugzilla.bug import Bug
 from webkitpy.common.net.bugzilla.attachment import Attachment
+from webkitpy.common.net.bugzilla.bug import Bug
+from webkitpy.common.net.bugzilla.bugzilla import Bugzilla
+
+# Unclear if Bug and Attachment need to be public classes.
+__all__ = ["Attachment", "Bug", "Bugzilla"]

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/ews.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/ews.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import requests
+
+try:
+    from urllib.parse import urljoin, urlsplit, urlunsplit
+except ImportError:
+    from urlparse import urljoin, urlsplit, urlunsplit
+
+
+class EWS(object):
+    def __init__(self, buildbot_url):
+        self.buildbot_url = buildbot_url
+        self._api_v2_url = urljoin(buildbot_url, "api/v2/")
+        self._builders = {}
+        self._session = requests.Session()
+
+    @classmethod
+    def from_webapp_url(cls, url):
+        split = urlsplit(url)
+        split.query = ""
+        split.fragment = ""
+        return cls(urlunsplit(split))
+
+    def builders(self, invalidate_cache=False):
+        if not invalidate_cache and self.buildbot_url in self._builders:
+            return self._builders
+
+        r = self._session.get(urljoin(self._api_v2_url, "builders"))
+        r.raise_for_status()
+        builders = r.json()["builders"]
+        builders_by_builderid = {builder["builderid"]: builder for builder in builders}
+        assert len(builders) == len(builders_by_builderid)
+        self._builders = builders_by_builderid
+
+        return self._builders
+
+    def steps_from_build_number(self, builderid_or_buildername, build_number):
+        r = self._session.get(
+            urljoin(
+                self._api_v2_url,
+                "builders/{}/builds/{}/steps".format(
+                    builderid_or_buildername, build_number
+                ),
+            )
+        )
+        r.raise_for_status()
+        return r.json()["steps"]

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2017 Apple Inc. All rights reserved.
+# Copyright (C) 2020 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer.
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials
+#    provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+import json
+import logging
+import re
+
+import requests
+
+from webkitpy.common.config.urls import ewsserver_default_host
+from webkitpy.common.net.bugzilla import bugzilla
+from webkitpy.common.net.bugzilla.ews import EWS
+
+try:
+    from urllib.parse import urljoin, urlsplit
+except ImportError:
+    from urlparse import urljoin, urlsplit
+
+
+# Buildbot status codes referenced from https://github.com/buildbot/buildbot/blob/master/master/buildbot/process/results.py
+EWS_STATECODES = {
+    "SUCCESS": 0,
+    "WARNINGS": 1,
+    "FAILURE": 2,
+    "SKIPPED": 3,
+    "EXCEPTION": 4,
+    "RETRY": 5,
+    "CANCELLED": 6,
+}
+
+
+_log = logging.getLogger(__name__)
+
+
+def _platform_name_for_bot(bot_name):
+    name = bot_name
+    if "mac" in name and name.endswith("-wk2"):
+        return "mac-wk2"
+    if "mac" in name and not name.endswith("-wk2"):
+        return "mac-wk1"
+    if "simulator" in name:
+        return "ios-wk2"
+    if "win-future" in name:
+        return "win"
+    if "gtk" in name:
+        return "gtk"
+    if "wpe" in name:
+        return "wpe"
+    if "-debug" in name:
+        name = name.replace("-debug", "")
+    return name
+
+
+def _get_first_layout_test_step(steps):
+    # pick the first run as the one for updating the layout tests.
+    layout_tests_steps = [step for step in steps if step["name"] == "layout-tests"]
+
+    if not layout_tests_steps:
+        return None
+
+    if len(layout_tests_steps) > 1:
+        msg = "multiple layout-tests steps in one build?!"
+        raise ValueError(msg)
+
+    return layout_tests_steps[0]
+
+
+def _is_relevant_results(bot_name, step, bot_filter_name=None):
+    if step["name"] != "layout-tests":
+        return False
+
+    if not step["complete"]:
+        _log.info(
+            (
+                "Skipping to process unfinished layout-tests run for bot {}. "
+                "Please retry later"
+            ).format(bot_name)
+        )
+        return False
+
+    if bot_filter_name and bot_filter_name not in bot_name:
+        return False
+
+    if step["results"] not in (
+        EWS_STATECODES["FAILURE"],
+        EWS_STATECODES["WARNINGS"],
+    ):
+        return False
+
+    return True
+
+
+def lookup_ews_results(ews_build_urls, bot_filter_name=None):
+    ews_results = {}
+    ews_servers = {}
+
+    for url in ews_build_urls:
+        m = re.match("(http.*webkit.org)/#/builders/([0-9]+)/builds/([0-9]+)$", url)
+        if not m:
+            msg = "The URL {} from EWS has an unexpected format".format(url)
+            raise ValueError(msg)
+
+        buildbot_server, builder_id, build_number = m.groups()
+
+        ews = ews_servers.setdefault(buildbot_server, EWS(buildbot_server))
+        builder = ews.builders()[int(builder_id)]
+        steps = ews.steps_from_build_number(builder_id, build_number)
+
+        bot_name = builder["description"]
+        platform = _platform_name_for_bot(bot_name)
+
+        layout_tests_step = _get_first_layout_test_step(steps)
+        if layout_tests_step is None:
+            continue
+
+        if not _is_relevant_results(bot_name, layout_tests_step, bot_filter_name):
+            continue
+
+        for tests_urls in layout_tests_step["urls"]:
+            tests_url = urljoin(buildbot_server, tests_urls["url"])
+            if not urlsplit(tests_url).path.endswith(".zip"):
+                continue
+
+            ews_results.setdefault(platform, []).append(tests_url)
+            break
+
+    return ews_results
+
+
+def lookup_ews_results_from_bugzilla_patch(patch, bot_filter_name=None):
+    _log.info(
+        "Looking for EWS results in patch attachment %s from bug %s"
+        % (patch.id(), patch.bug().id())
+    )
+    ews_bubbles_url = "https://{}/status/{}/".format(ewsserver_default_host, patch.id())
+    _log.debug("Querying bubble status at {}".format(ews_bubbles_url))
+    ews_bubbles_status_request = requests.get(ews_bubbles_url)
+    ews_bubbles_status_request.raise_for_status()
+    ews_bubbles_status = json.loads(ews_bubbles_status_request.text)
+
+    ews_bubbles_urls = [v["url"] for v in ews_bubbles_status.values()]
+
+    return lookup_ews_results(ews_bubbles_urls, bot_filter_name)
+
+
+def lookup_ews_results_from_bugzilla(
+    bugzilla_id, is_bug_id=True, attachment_fetcher=None, bot_filter_name=None
+):
+    attachment_fetcher = (
+        bugzilla.Bugzilla() if attachment_fetcher is None else attachment_fetcher
+    )
+
+    if is_bug_id:
+        bug_info = attachment_fetcher.fetch_bug(bugzilla_id)
+        attachments = [
+            attachments
+            for attachments in bug_info.attachments(include_obsolete=False)
+            if attachments.is_patch()
+        ]
+
+        if len(attachments) > 1:
+            msg = (
+                "Found more than one non-obsolete patch in bug {}. "
+                "Please specify which one to process."
+            ).format(bugzilla_id)
+            raise RuntimeError(msg)
+
+        if len(attachments) < 1:
+            msg = (
+                "Couldn't find any non-obsolete patch in bug {}. "
+                "Please specify which one to process."
+            ).format(bugzilla_id)
+            raise RuntimeError(msg)
+
+        patch = attachments[0]
+
+    else:
+        patch = attachment_fetcher.fetch_attachment(bugzilla_id)
+
+    if not patch.is_patch():
+        msg = "Attachment {} its not a patch. Can't continue.".format(bugzilla_id)
+        raise RuntimeError(msg)
+
+    return lookup_ews_results_from_bugzilla_patch(patch, bot_filter_name)

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py
@@ -1,0 +1,240 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer.
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials
+#    provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+import json
+import unittest
+
+from webkitpy.common.net.bugzilla.attachment import Attachment
+from webkitpy.common.net.bugzilla.results_fetcher import (
+    _is_relevant_results,
+    lookup_ews_results_from_bugzilla,
+)
+from webkitpy.thirdparty import mock
+
+
+class MockAttachment(Attachment):
+    def __init__(self, attachment_dictionary, contents, is_patch, is_obsolete):
+        Attachment.__init__(self, attachment_dictionary, self)
+        self._contents = contents
+        self._is_patch = is_patch
+        self._is_obsolete = is_obsolete
+
+    def contents(self):
+        return self._contents
+
+    def is_patch(self):
+        return self._is_patch
+
+    def is_obsolete(self):
+        return self._is_obsolete
+
+
+class MockBugzilla:
+    def fetch_bug(self, _):
+        return self
+
+    def attachments(self, include_obsolete=False):
+        attachments = []
+        attachments.append(
+            MockAttachment(
+                {"id": 1, "name": "Test case"},
+                "How to reproduce the issue",
+                False,
+                False,
+            )
+        )
+
+        if include_obsolete:
+            attachments.append(
+                MockAttachment({"id": 2, "name": "Patch"}, "Patch v1", True, True)
+            )
+            attachments.append(
+                MockAttachment({"id": 3, "name": "Patch"}, "Patch v2", True, True)
+            )
+
+        attachments.append(
+            MockAttachment({"id": 4, "name": "Patch"}, "Patch v3", True, False)
+        )
+
+        return attachments
+
+
+class MockRequestsGet:
+    def __init__(self, url):
+        self._urls_data = {
+            "https://ews.webkit.org/status/4/": b'{"mac-wk1": {"url": "https://ews-build.webkit.org/#/builders/1/builds/99"}, "mac-wk2": {"url": "https://ews-build.webkit.org/#/builders/2/builds/99"}, "mac-debug-wk1": {"url": "https://ews-build.webkit.org/#/builders/3/builds/99"}, "ios-wk2": {"url": "https://ews-build.webkit.org/#/builders/4/builds/99"}, "win": {"url": "https://ews-build.webkit.org/#/builders/5/builds/99"}}',
+            "https://ews-build.webkit.org/api/v2/builders": b'{"builders": [{"builderid": 1, "description": "mac-wk1"}, {"builderid": 2, "description": "mac-wk2"}, {"builderid": 3, "description": "mac-debug-wk1"}, {"builderid": 4, "description": "ios-wk2"}, {"builderid": 5, "description": "win"}]}',
+            "https://ews-build.webkit.org/api/v2/builders/1/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-wk1/r12345.zip" } ] } ] }',
+            "https://ews-build.webkit.org/api/v2/builders/2/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-wk2/r12345.zip" } ] } ] }',
+            "https://ews-build.webkit.org/api/v2/builders/3/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-debug-wk1/r12345.zip" } ] } ] }',
+            "https://ews-build.webkit.org/api/v2/builders/4/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/ios-wk2/r12345.zip" }  ] } ] }',
+            "https://ews-build.webkit.org/api/v2/builders/5/builds/99/steps": b'{ "steps": [ { "complete": true, "name": "layout-tests", "results": 2, "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/win/r12345.zip" }  ] } ] }',
+        }
+        self._url = url
+        if url not in self._urls_data:
+            msg = "url {} not mocked".format(url)
+            raise ValueError(msg)
+
+    @property
+    def content(self):
+        c = self._urls_data[self._url]
+        assert isinstance(c, bytes)
+        return c
+
+    @property
+    def text(self):
+        return self.content.decode("utf-8")
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return json.loads(self.content)
+
+
+class ResultsFetcherTest(unittest.TestCase):
+    def test_is_relevant_results(self):
+        # Incomplete.
+        self.assertFalse(
+            _is_relevant_results(
+                "foo",
+                {
+                    "buildid": 588706,
+                    "complete": False,
+                    "complete_at": None,
+                    "hidden": False,
+                    "name": "layout-tests",
+                    "number": 17,
+                    "results": None,
+                    "started_at": 1693871103,
+                    "state_string": "layout-tests running",
+                    "stepid": 8989299,
+                    "urls": [],
+                },
+            )
+        )
+
+        # Completed, failures.
+        self.assertTrue(
+            _is_relevant_results(
+                "foo",
+                {
+                    "buildid": 588183,
+                    "complete": True,
+                    "complete_at": 1693846670,
+                    "hidden": False,
+                    "name": "layout-tests",
+                    "number": 17,
+                    "results": 2,
+                    "started_at": 1693844047,
+                    "state_string": "Exiting early after 60 failures. 47470 tests run. 60 failures",
+                    "stepid": 8980814,
+                    "urls": [
+                        {
+                            "name": "view layout test results",
+                            "url": "https://ews-build.s3-us-west-2.amazonaws.com/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS/8d9c2057-13881/results.html",
+                        },
+                        {
+                            "name": "download layout test results",
+                            "url": "https://ews-build.s3-us-west-2.amazonaws.com/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS/8d9c2057-13881.zip",
+                        },
+                    ],
+                },
+            )
+        )
+
+        # Completed with failures, but re-run.
+        self.assertFalse(
+            _is_relevant_results(
+                "foo",
+                {
+                    "buildid": 588183,
+                    "complete": True,
+                    "complete_at": 1693849318,
+                    "hidden": False,
+                    "name": "re-run-layout-tests",
+                    "number": 23,
+                    "results": 2,
+                    "started_at": 1693846711,
+                    "state_string": "Exiting early after 60 failures. 47458 tests run. 60 failures",
+                    "stepid": 8982249,
+                    "urls": [
+                        {
+                            "name": "view layout test results",
+                            "url": "https://ews-build.s3-us-west-2.amazonaws.com/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS/8d9c2057-13881-rerun/results.html",
+                        },
+                        {
+                            "name": "download layout test results",
+                            "url": "https://ews-build.s3-us-west-2.amazonaws.com/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS/8d9c2057-13881-rerun.zip",
+                        },
+                    ],
+                },
+            )
+        )
+
+        # Complete with warnings.
+        self.assertTrue(
+            _is_relevant_results(
+                "foo",
+                {
+                    "buildid": 588085,
+                    "complete": True,
+                    "complete_at": 1693846848,
+                    "hidden": False,
+                    "name": "layout-tests",
+                    "number": 17,
+                    "results": 1,
+                    "started_at": 1693842245,
+                    "state_string": "Ignored 1 pre-existing failure based on results-db",
+                    "stepid": 8979256,
+                    "urls": [
+                        {
+                            "name": "view layout test results",
+                            "url": "https://ews-build.s3-us-west-2.amazonaws.com/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS/13436a69-13880/results.html",
+                        },
+                        {
+                            "name": "download layout test results",
+                            "url": "https://ews-build.s3-us-west-2.amazonaws.com/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS/13436a69-13880.zip",
+                        },
+                    ],
+                },
+            )
+        )
+
+    def test_lookup_ews_results_from_bugzilla(self):
+        with mock.patch("requests.Session.get", MockRequestsGet), mock.patch("requests.get", MockRequestsGet):
+            actual = lookup_ews_results_from_bugzilla("123456", True, MockBugzilla())
+            expected = {
+                "mac-wk1": [
+                    "https://ews-build.webkit.org/results/mac-wk1/r12345.zip",
+                    "https://ews-build.webkit.org/results/mac-debug-wk1/r12345.zip",
+                ],
+                "mac-wk2": ["https://ews-build.webkit.org/results/mac-wk2/r12345.zip"],
+                "ios-wk2": ["https://ews-build.webkit.org/results/ios-wk2/r12345.zip"],
+                "win": ["https://ews-build.webkit.org/results/win/r12345.zip"],
+            }
+            self.assertEqual(expected, actual)

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
@@ -31,17 +31,17 @@ import io
 import logging
 import zipfile
 
-from webkitpy.common.config.urls import ewsserver_default_host
+import requests
+
 from webkitpy.common.host import Host
 from webkitpy.common.net.bugzilla import bugzilla
+from webkitpy.common.net.bugzilla.results_fetcher import (
+    lookup_ews_results_from_bugzilla,
+)
 from webkitpy.common.net.layouttestresults import LayoutTestResults
 from webkitpy.common.webkit_finder import WebKitFinder
 from webkitpy.layout_tests.controllers.test_result_writer import TestResultWriter
 from webkitpy.layout_tests.models import test_expectations
-
-import json
-import re
-import requests
 
 # Buildbot status codes referenced from https://github.com/buildbot/buildbot/blob/master/master/buildbot/process/results.py
 EWS_STATECODES = {'SUCCESS': 0, 'WARNINGS': 1, 'FAILURE': 2, 'SKIPPED': 3, 'EXCEPTION': 4, 'RETRY': 5, 'CANCELLED': 6}
@@ -78,141 +78,92 @@ def argument_parser():
 
 class TestExpectationUpdater(object):
 
-    def __init__(self, host, bugzilla_id, is_bug_id=True, bot_filter_name=None, attachment_fetcher=bugzilla.Bugzilla(), unzip=None):
-        self.host = host
-        self.filesystem = self.host.filesystem
+    def __init__(self, host, bugzilla_id, is_bug_id=True, bot_filter_name=None, attachment_fetcher=None):
+        self.attachment_fetcher = bugzilla.Bugzilla() if attachment_fetcher is None else attachment_fetcher
+
+        self.filesystem = host.filesystem
         self.bot_filter_name = bot_filter_name
-        self.unzip = unzip if unzip else lambda content: zipfile.ZipFile(io.BytesIO(content))
+        self.bugzilla_id = bugzilla_id
+        self.is_bug_id = is_bug_id
+
         self.layout_test_repository = WebKitFinder(self.filesystem).path_from_webkit_base("LayoutTests")
-        if is_bug_id:
-            bug_info = attachment_fetcher.fetch_bug(bugzilla_id)
-            attachments = [attachments for attachments in bug_info.attachments(include_obsolete=False) if attachments.is_patch()]
-            if len(attachments) > 1:
-                raise RuntimeError("Found more than one non-obsolete patch in bug {}. Please specify which one to process.".format(bugzilla_id))
-            if len(attachments) < 1:
-                raise RuntimeError("Couldn't find any non-obsolete patch in bug {}. Please specify which one to process.".format(bugzilla_id))
-            self.patch = attachments[0]
-        else:
-            self.patch = attachment_fetcher.fetch_attachment(bugzilla_id)
-        if not self.patch.is_patch():
-            raise RuntimeError("Attachment {} its not a patch. Can't continue.".format(bugzilla_id))
 
-    def _platform_name(self, bot_name):
-        name = bot_name
-        if "mac" in name and name.endswith("-wk2"):
-            return "mac-wk2"
-        if "mac" in name and not name.endswith("-wk2"):
-            return "mac-wk1"
-        if "simulator" in name:
-            return "ios-wk2"
-        if "win-future" in name:
-            return "win"
-        if "gtk" in name:
-            return "gtk"
-        if "wpe" in name:
-            return "wpe"
-        if "-debug" in name:
-            name = name.replace("-debug", "")
-        return name
+        self.ews_results = None
 
-    def _get_layout_tests_run(self, bot_name, ews_build_url):
-        if not re.match("http.*webkit.org/#/builders/[0-9]+/builds/[0-9]+$", ews_build_url):
-            raise ValueError("The URL {} from EWS has an unexpected format".format(ews_build_url))
-        ews_buildbot_server, ews_buildbot_path = ews_build_url.split('#')
-        ews_buildbot_steps_url = "{}api/v2{}/steps".format(ews_buildbot_server, ews_buildbot_path)
-        ews_buildbot_steps_request = requests.get(ews_buildbot_steps_url)
-        ews_buildbot_steps = json.loads(ews_buildbot_steps_request.text)
-        _log.debug("Trying to finding failed layout test run for bot {} at url {}".format(bot_name, ews_buildbot_steps_url))
-        for step in ews_buildbot_steps['steps']:
-            # pick the first run as the one for updating the layout tests.
-            if step['name'] != 'layout-tests':
-                continue
-            if not step['complete']:
-                _log.info("Skipping to process unfinished layout-tests run for bot {}. Please retry later".format(bot_name))
-                continue
-            for url_entry in step['urls']:
-                url = url_entry['url']
-                if url.endswith('.zip'):
-                    if url.startswith('/'):
-                        url = "{}{}".format(ews_buildbot_server, url.lstrip('/'))
-                    return {"layout-tests-results-string": step['state_string'], "layout-tests-archive-url": url}
-        return None
+    def _tests_to_update(self, platform_name):
+        urls = self.ews_results[platform_name]
+        if len(urls) == 0:
+            return {}
 
-    def _lookup_ews_results(self):
-        _log.info("Looking for EWS results in patch attachment %s from bug %s" % (self.patch.id(), self.patch.bug().id()))
-        ews_bubbles_url = "https://{}/status/{}/".format(ewsserver_default_host, self.patch.id())
-        _log.debug("Querying bubble status at {}".format(ews_bubbles_url))
-        ews_bubbles_status_request = requests.get(ews_bubbles_url)
-        ews_bubbles_status = json.loads(ews_bubbles_status_request.text)
-        self.ews_results = {}
-        for bot in ews_bubbles_status:
-            if ews_bubbles_status[bot]['state'] is None:
-                _log.info("EWS bot {} has still not finished. Ignoring".format(bot))
-                continue
-            _log.debug("Found EWS run at {} for bot {} with state {}".format(ews_bubbles_status[bot]['url'], bot,
-                       [STATE for STATE in EWS_STATECODES.keys()][ews_bubbles_status[bot]['state']]))
-            if self.bot_filter_name:
-                if self.bot_filter_name in bot:
-                    self.ews_results[bot] = self._get_layout_tests_run(bot, ews_bubbles_status[bot]['url'])
-            elif ews_bubbles_status[bot]['state'] in [EWS_STATECODES['FAILURE'], EWS_STATECODES['WARNINGS']]:
-                self.ews_results[bot] = self._get_layout_tests_run(bot, ews_bubbles_status[bot]['url'])
+        # Take the last run for a given platform. Because that's what the
+        # unittests expect.
+        url = urls[-1]
 
-        # Delete entries with null value (if any)
-        for bot in self.ews_results.keys():
-            if not self.ews_results[bot]:
-                del self.ews_results[bot]
-
-        if len(self.ews_results) == 0:
-            if self.bot_filter_name:
-                raise RuntimeError("Couldn't find any failed EWS result in attachment/patch {} that matches filter name.".format(self.patch.id(), self.bot_filter_name))
-            raise RuntimeError("Couldn't find any failed EWS result for attachment/patch {}. Try to specify a bot filter name manually.".format(self.patch.id()))
-
-    def _tests_to_update(self, bot_name):
-        _log.info("{} archive: {}".format(bot_name, self.ews_results[bot_name]['layout-tests-archive-url']))
-        _log.info("{} status: {}".format(bot_name, self.ews_results[bot_name]['layout-tests-results-string']))
-        layout_tests_archive_request = requests.get(self.ews_results[bot_name]['layout-tests-archive-url'])
+        _log.info("{} archive: {}".format(platform_name, url))
+        layout_tests_archive_request = requests.get(url)
         layout_tests_archive_content = layout_tests_archive_request.content
-        zip_file = self.unzip(layout_tests_archive_content)
+        zip_file = zipfile.ZipFile(io.BytesIO(layout_tests_archive_content))
         results = LayoutTestResults.results_from_string(zip_file.read("full_results.json"))
         results_to_update = [result.test_name for result in results.failing_test_results() if result.type in [test_expectations.TEXT, test_expectations.MISSING]]
         return {result: zip_file.read(TestResultWriter.actual_filename(result, self.filesystem)) for result in results_to_update}
 
     def _file_content_if_exists(self, filename):
-        return self.filesystem.read_text_file(filename) if self.filesystem.exists(filename) else ""
+        return self.filesystem.read_binary_file(filename) if self.filesystem.exists(filename) else b""
 
-    def _update_for_generic_bot(self, bot_name):
-        for test_name, expected_content in self._tests_to_update(bot_name).items():
+    def _update_for_generic_bot(self, platform_name):
+        for test_name, expected_content in self._tests_to_update(platform_name).items():
             expected_filename = self.filesystem.join(self.layout_test_repository, TestResultWriter.expected_filename(test_name, self.filesystem))
             if expected_content != self._file_content_if_exists(expected_filename):
-                _log.info("Updating " + test_name + " for " + bot_name + " (" + expected_filename + ")")
+                _log.info("Updating " + test_name + " for " + platform_name + " (" + expected_filename + ")")
                 self.filesystem.maybe_make_directory(self.filesystem.dirname(expected_filename))
-                self.filesystem.write_text_file(expected_filename, expected_content)
+                self.filesystem.write_binary_file(expected_filename, expected_content)
 
-    def _update_for_platform_specific_bot(self, bot_name):
-        platform_name = self._platform_name(bot_name)
-        for test_name, expected_content in self._tests_to_update(bot_name).items():
+    def _update_for_platform_specific_bot(self, platform_name):
+        for test_name, expected_content in self._tests_to_update(platform_name).items():
             expected_filename = self.filesystem.join(self.layout_test_repository, TestResultWriter.expected_filename(test_name, self.filesystem, platform_name))
             generic_expected_filename = self.filesystem.join(self.layout_test_repository, TestResultWriter.expected_filename(test_name, self.filesystem))
             if expected_content != self._file_content_if_exists(generic_expected_filename):
                 if expected_content != self._file_content_if_exists(expected_filename):
-                    _log.info("Updating " + test_name + " for " + bot_name + " (" + expected_filename + ")")
+                    _log.info("Updating " + test_name + " for " + platform_name + " (" + expected_filename + ")")
                     self.filesystem.maybe_make_directory(self.filesystem.dirname(expected_filename))
-                    self.filesystem.write_text_file(expected_filename, expected_content)
+                    self.filesystem.write_binary_file(expected_filename, expected_content)
             elif self.filesystem.exists(expected_filename):
-                _log.info("Updating " + test_name + " for " + bot_name + " ( REMOVED: " + expected_filename + ")")
+                _log.info("Updating " + test_name + " for " + platform_name + " ( REMOVED: " + expected_filename + ")")
                 self.filesystem.remove(expected_filename)
 
     def do_update(self):
-        self._lookup_ews_results()
-        generic_bots = [bot_name for bot_name in self.ews_results.keys() if self._platform_name(bot_name) == "mac-wk2"]
-        platform_bots = [bot_name for bot_name in self.ews_results.keys() if self._platform_name(bot_name) != "mac-wk2"]
+        self.ews_results = lookup_ews_results_from_bugzilla(
+            self.bugzilla_id,
+            self.is_bug_id,
+            self.attachment_fetcher,
+            self.bot_filter_name,
+        )
+
+        if len(self.ews_results) == 0:
+            if self.bot_filter_name:
+                msg = (
+                    "Couldn't find any failed EWS result in attachment/patch {} that "
+                    "matches filter name."
+                ).format(self.patch.id())
+                raise RuntimeError(msg)
+
+            msg = (
+                "Couldn't find any failed EWS result for attachment/patch {}. "
+                "Try to specify a bot filter name manually."
+            ).format(self.patch.id())
+            raise RuntimeError(msg)
+
+        generic_bots = [platform_name for platform_name in self.ews_results if platform_name == "mac-wk2"]
+        platform_bots = [platform_name for platform_name in self.ews_results if platform_name != "mac-wk2"]
+
         # First update the generic results, so updates for platform bots can use this new generic result as base.
-        for bot_name in generic_bots:
-            _log.info("Updating results from bot {} (generic)".format(bot_name))
-            self._update_for_generic_bot(bot_name)
-        for bot_name in platform_bots:
-            _log.info("Updating results from bot {} (platform)".format(bot_name))
-            self._update_for_platform_specific_bot(bot_name)
+        for platform_name in generic_bots:
+            _log.info("Updating results from bot {} (generic)".format(platform_name))
+            self._update_for_generic_bot(platform_name)
+
+        for platform_name in platform_bots:
+            _log.info("Updating results from bot {} (platform)".format(platform_name))
+            self._update_for_platform_specific_bot(platform_name)
 
 
 def main(_argv, _stdout, _stderr):
@@ -220,7 +171,8 @@ def main(_argv, _stdout, _stderr):
     options, args = parser.parse_known_args(_argv)
 
     if not args:
-        raise Exception("Please provide a bug id or use -a option")
+        msg = 'Please provide a bug id or use -a option'
+        raise Exception(msg)
 
     configure_logging(options.debug)
 

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
@@ -25,123 +25,551 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
+import io
+import json
 import unittest
+import zipfile
 
 from webkitpy.common.host_mock import MockHost
-from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.common.system.executive_mock import MockExecutive2
 from webkitpy.common.net.bugzilla.test_expectation_updater import TestExpectationUpdater
-from webkitpy.common.net.bugzilla.attachment import Attachment
+from webkitpy.common.system.executive_mock import MockExecutive2
+from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.thirdparty import mock
 
-FAKE_FILES = {
-    '/tests/csswg/css-fake-1/empty_dir/README.txt': '',
-    '/mock-checkout/LayoutTests/w3c/css-fake-1/README.txt': '',
-}
+
+def _make_zip_filelike(files):
+    f = io.BytesIO()
+    with zipfile.ZipFile(f, "w", compression=zipfile.ZIP_STORED) as zf:
+        for name, content in files.items():
+            if name.endswith(".json"):
+                content = "ADD_RESULTS(" + json.dumps(content) + ");"
+            zf.writestr(name, content)
+    f.seek(0)
+    return f
 
 
-class MockAttachment(Attachment):
-    def __init__(self, attachment_dictionary, contents, is_patch, is_obsolete):
-        Attachment.__init__(self, attachment_dictionary, self)
-        self._contents = contents
-        self._is_patch = is_patch
-        self._is_obsolete = is_obsolete
+_mac_wk2_zip = _make_zip_filelike(
+    {
+        "full_results.json": {
+            "tests": {
+                "http": {
+                    "tests": {
+                        "media": {
+                            "hls": {
+                                "video-controls-live-stream.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TEXT PASS",
+                                },
+                                "video-duration-accessibility.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TEXT PASS",
+                                },
+                            }
+                        }
+                    }
+                },
+                "imported": {
+                    "w3c": {
+                        "web-platform-tests": {
+                            "html": {
+                                "browsers": {
+                                    "windows": {
+                                        "browsing-context.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        }
+                                    }
+                                }
+                            },
+                            "fetch": {
+                                "api": {
+                                    "redirect": {
+                                        "redirect-count.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-location.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-count-worker.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-count-cross-origin.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-location-worker.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    }
+                },
+                "media": {
+                    "track": {
+                        "track-in-band-style.html": {
+                            "report": "FLAKY",
+                            "expected": "PASS",
+                            "actual": "TEXT PASS",
+                        }
+                    }
+                },
+            },
+            "skipped": 3348,
+            "num_regressions": 6,
+            "other_crashes": {},
+            "interrupted": False,
+            "num_missing": 0,
+            "layout_tests_dir": "/Volumes/Data/EWS/WebKit/LayoutTests",
+            "version": 4,
+            "num_passes": 44738,
+            "pixel_tests_enabled": False,
+            "date": "07:18PM on April 08, 2017",
+            "has_pretty_patch": True,
+            "fixable": 3357,
+            "num_flaky": 3,
+            "uses_expectations_file": True,
+        },
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-actual.txt": "a",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-worker-actual.txt": "b",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-actual.txt": "c",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-worker-actual.txt": "d",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-actual.txt": "e",
+        "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "f",
+    }
+)
 
-    def contents(self):
-        return self._contents
+_mac_wk1a_zip = _make_zip_filelike(
+    {
+        "full_results.json": {
+            "tests": {
+                "http": {
+                    "tests": {
+                        "loading": {
+                            "resourceLoadStatistics": {
+                                "non-prevalent-resource-without-user-interaction.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TIMEOUT PASS",
+                                    "has_stderr": True,
+                                }
+                            }
+                        }
+                    }
+                },
+                "imported": {
+                    "w3c": {
+                        "web-platform-tests": {
+                            "IndexedDB": {
+                                "abort-in-initial-upgradeneeded.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TEXT PASS",
+                                }
+                            },
+                            "html": {
+                                "browsers": {
+                                    "windows": {
+                                        "browsing-context.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        }
+                                    }
+                                }
+                            },
+                            "fetch": {
+                                "api": {
+                                    "redirect": {
+                                        "redirect-count.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-location.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-count-worker.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-count-cross-origin.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-location-worker.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                    }
+                                }
+                            },
+                        },
+                        "IndexedDB-private-browsing": {
+                            "idbfactory_open9.html": {
+                                "report": "FLAKY",
+                                "expected": "PASS",
+                                "actual": "TIMEOUT PASS",
+                                "has_stderr": True,
+                            }
+                        },
+                    },
+                    "blink": {
+                        "storage": {
+                            "indexeddb": {
+                                "blob-delete-objectstore-db.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TIMEOUT PASS",
+                                    "has_stderr": True,
+                                }
+                            }
+                        }
+                    },
+                },
+            },
+            "skipped": 3537,
+            "num_regressions": 6,
+            "other_crashes": {},
+            "interrupted": False,
+            "num_missing": 0,
+            "layout_tests_dir": "/Volumes/Data/EWS/WebKit/LayoutTests",
+            "version": 4,
+            "num_passes": 44561,
+            "pixel_tests_enabled": False,
+            "date": "07:18PM on April 08, 2017",
+            "has_pretty_patch": True,
+            "fixable": 3547,
+            "num_flaky": 4,
+            "uses_expectations_file": True,
+        },
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-actual.txt": "a",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-worker-actual.txt": "b",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-actual.txt": "c",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-worker-actual.txt": "d",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-actual.txt": "e",
+        "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "f-wk1a",
+    }
+)
 
-    def is_patch(self):
-        return self._is_patch
+_mac_wk1b_zip = _make_zip_filelike(
+    {
+        "full_results.json": {
+            "tests": {
+                "http": {
+                    "tests": {
+                        "loading": {
+                            "resourceLoadStatistics": {
+                                "non-prevalent-resource-without-user-interaction.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TIMEOUT PASS",
+                                    "has_stderr": True,
+                                }
+                            }
+                        }
+                    }
+                },
+                "imported": {
+                    "w3c": {
+                        "web-platform-tests": {
+                            "IndexedDB": {
+                                "abort-in-initial-upgradeneeded.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TEXT PASS",
+                                }
+                            },
+                            "html": {
+                                "browsers": {
+                                    "windows": {
+                                        "browsing-context.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        }
+                                    }
+                                }
+                            },
+                            "fetch": {
+                                "api": {
+                                    "redirect": {
+                                        "redirect-count.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-location.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-count-worker.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-count-cross-origin.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                        "redirect-location-worker.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        },
+                                    }
+                                }
+                            },
+                        },
+                        "IndexedDB-private-browsing": {
+                            "idbfactory_open9.html": {
+                                "report": "FLAKY",
+                                "expected": "PASS",
+                                "actual": "TIMEOUT PASS",
+                                "has_stderr": True,
+                            }
+                        },
+                    },
+                    "blink": {
+                        "storage": {
+                            "indexeddb": {
+                                "blob-delete-objectstore-db.html": {
+                                    "report": "FLAKY",
+                                    "expected": "PASS",
+                                    "actual": "TIMEOUT PASS",
+                                    "has_stderr": True,
+                                }
+                            }
+                        }
+                    },
+                },
+            },
+            "skipped": 3537,
+            "num_regressions": 6,
+            "other_crashes": {},
+            "interrupted": False,
+            "num_missing": 0,
+            "layout_tests_dir": "/Volumes/Data/EWS/WebKit/LayoutTests",
+            "version": 4,
+            "num_passes": 44561,
+            "pixel_tests_enabled": False,
+            "date": "07:18PM on April 08, 2017",
+            "has_pretty_patch": True,
+            "fixable": 3547,
+            "num_flaky": 4,
+            "uses_expectations_file": True,
+        },
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-actual.txt": "a",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-worker-actual.txt": "b",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-actual.txt": "c",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-worker-actual.txt": "d",
+        "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-actual.txt": "e",
+        "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "f-wk1b",
+    }
+)
 
-    def is_obsolete(self):
-        return self._is_obsolete
+_ios_zip = _make_zip_filelike(
+    {
+        "full_results.json": {
+            "tests": {
+                "imported": {
+                    "w3c": {
+                        "web-platform-tests": {
+                            "url": {
+                                "interfaces.html": {
+                                    "report": "REGRESSION",
+                                    "expected": "PASS",
+                                    "actual": "TEXT",
+                                }
+                            },
+                            "html": {
+                                "browsers": {
+                                    "windows": {
+                                        "browsing-context.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        }
+                                    },
+                                    "the-window-object": {
+                                        "apis-for-creating-and-navigating-browsing-contexts-by-name": {
+                                            "open-features-tokenization-001.html": {
+                                                "report": "REGRESSION",
+                                                "expected": "PASS",
+                                                "actual": "TEXT",
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                            "dom": {
+                                "events": {
+                                    "EventTarget-dispatchEvent.html": {
+                                        "report": "REGRESSION",
+                                        "expected": "PASS",
+                                        "actual": "TEXT",
+                                    }
+                                }
+                            },
+                        }
+                    }
+                },
+                "animations": {
+                    "trigger-container-scroll-empty.html": {
+                        "report": "FLAKY",
+                        "expected": "PASS",
+                        "actual": "TEXT PASS",
+                    }
+                },
+            },
+            "skipped": 9881,
+            "num_regressions": 4,
+            "other_crashes": {},
+            "interrupted": False,
+            "num_missing": 0,
+            "layout_tests_dir": "/Volumes/Data/EWS/WebKit/LayoutTests",
+            "version": 4,
+            "num_passes": 38225,
+            "pixel_tests_enabled": False,
+            "date": "07:33PM on April 08, 2017",
+            "has_pretty_patch": True,
+            "fixable": 48110,
+            "num_flaky": 1,
+            "uses_expectations_file": True,
+        },
+        "imported/w3c/web-platform-tests/dom/events/EventTarget-dispatchEvent-actual.txt": "g",
+        "imported/w3c/web-platform-tests/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001-actual.txt": "h",
+        "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "i",
+        "imported/w3c/web-platform-tests/url/interfaces-actual.txt": "j",
+    }
+)
+
+_win_zip = _make_zip_filelike(
+    {
+        "full_results.json": {
+            "tests": {
+                "imported": {
+                    "w3c": {
+                        "web-platform-tests": {
+                            "url": {
+                                "interfaces.html": {
+                                    "report": "REGRESSION",
+                                    "expected": "PASS",
+                                    "actual": "TEXT",
+                                }
+                            },
+                            "html": {
+                                "browsers": {
+                                    "windows": {
+                                        "browsing-context.html": {
+                                            "report": "REGRESSION",
+                                            "expected": "PASS",
+                                            "actual": "TEXT",
+                                        }
+                                    },
+                                    "the-window-object": {
+                                        "apis-for-creating-and-navigating-browsing-contexts-by-name": {
+                                            "open-features-tokenization-001.html": {
+                                                "report": "REGRESSION",
+                                                "expected": "PASS",
+                                                "actual": "TEXT",
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                            "dom": {
+                                "events": {
+                                    "EventTarget-dispatchEvent.html": {
+                                        "report": "REGRESSION",
+                                        "expected": "PASS",
+                                        "actual": "TEXT",
+                                    }
+                                }
+                            },
+                        }
+                    }
+                },
+                "animations": {
+                    "trigger-container-scroll-empty.html": {
+                        "report": "FLAKY",
+                        "expected": "PASS",
+                        "actual": "TEXT PASS",
+                    }
+                },
+            },
+            "skipped": 9881,
+            "num_regressions": 4,
+            "other_crashes": {},
+            "interrupted": False,
+            "num_missing": 0,
+            "layout_tests_dir": "/Volumes/Data/EWS/WebKit/LayoutTests",
+            "version": 4,
+            "num_passes": 38225,
+            "pixel_tests_enabled": False,
+            "date": "07:33PM on April 08, 2017",
+            "has_pretty_patch": True,
+            "fixable": 48110,
+            "num_flaky": 1,
+            "uses_expectations_file": True,
+        },
+        "imported/w3c/web-platform-tests/dom/events/EventTarget-dispatchEvent-actual.txt": "g",
+        "imported/w3c/web-platform-tests/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001-actual.txt": "h",
+        "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "i",
+        "imported/w3c/web-platform-tests/url/interfaces-actual.txt": "j",
+    }
+)
 
 
-class MockBugzilla():
-    def fetch_bug(self, id):
-        return self
-
-    def attachments(self, include_obsolete=False):
-        attachments = []
-        attachments.append(MockAttachment({"id": 1, "name": "Test case"}, "How to reproduce the issue", False, False))
-        if include_obsolete:
-            attachments.append(MockAttachment({"id": 2, "name": "Patch"}, "Patch v1", True, True))
-            attachments.append(MockAttachment({"id": 3, "name": "Patch"}, "Patch v2", True, True))
-        attachments.append(MockAttachment({"id": 4, "name": "Patch"}, "Patch v3", True, False))
-        return attachments
-
-
-class MockRequestsGet():
+class MockRequestsGet:
     def __init__(self, url):
         self._urls_data = {
-            'https://ews.webkit.org/status/4/': '{"mac-wk1": {"url": "https://ews-build.webkit.org/#/builders/1/builds/99", "state": 2}, "mac-wk2": {"url": "https://ews-build.webkit.org/#/builders/2/builds/99", "state": 2}, "mac-debug-wk1": {"url": "https://ews-build.webkit.org/#/builders/3/builds/99", "state": 2}, "ios-wk2": {"url": "https://ews-build.webkit.org/#/builders/4/builds/99", "state": 2}, "win": {"url": "https://ews-build.webkit.org/#/builders/5/builds/99", "state": 2}}',
-            'https://ews-build.webkit.org/api/v2/builders/1/builds/99/steps': '{ "steps": [ { "complete": true, "name": "layout-tests", "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-wk1/r12345.zip" } ] } ] }',
-            'https://ews-build.webkit.org/api/v2/builders/2/builds/99/steps': '{ "steps": [ { "complete": true, "name": "layout-tests", "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-wk2/r12345.zip" } ] } ] }',
-            'https://ews-build.webkit.org/api/v2/builders/3/builds/99/steps': '{ "steps": [ { "complete": true, "name": "layout-tests", "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/mac-debug-wk1/r12345.zip" } ] } ] }',
-            'https://ews-build.webkit.org/api/v2/builders/4/builds/99/steps': '{ "steps": [ { "complete": true, "name": "layout-tests", "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/ios-wk2/r12345.zip" }  ] } ] }',
-            'https://ews-build.webkit.org/api/v2/builders/5/builds/99/steps': '{ "steps": [ { "complete": true, "name": "layout-tests", "state_string": "Ran layout tests",  "urls": [ { "name": "download layout test results", "url": "/results/win/r12345.zip" }  ] } ] }',
-            "https://ews-build.webkit.org/results/mac-wk1/r12345.zip": "mac-wk1a",
-            "https://ews-build.webkit.org/results/mac-debug-wk1/r12345.zip": "mac-wk1b",
-            "https://ews-build.webkit.org/results/mac-wk2/r12345.zip": "mac-wk2",
-            "https://ews-build.webkit.org/results/ios-wk2/r12345.zip": "ios-wk2",
-            "https://ews-build.webkit.org/results/win/r12345.zip": "win"
+            "https://ews-build.webkit.org/results/mac-wk1/r12345.zip": _mac_wk1a_zip.getvalue(),
+            "https://ews-build.webkit.org/results/mac-debug-wk1/r12345.zip": _mac_wk1b_zip.getvalue(),
+            "https://ews-build.webkit.org/results/mac-wk2/r12345.zip": _mac_wk2_zip.getvalue(),
+            "https://ews-build.webkit.org/results/ios-wk2/r12345.zip": _ios_zip.getvalue(),
+            "https://ews-build.webkit.org/results/win/r12345.zip": _win_zip.getvalue(),
         }
         self._url = url
         if url not in self._urls_data:
-            raise ValueError("url {} not mocked".format(url))
+            msg = 'url {} not mocked'.format(url)
+            raise ValueError(msg)
 
     @property
     def content(self):
-        return self._urls_data[self._url]
+        c = self._urls_data[self._url]
+        assert isinstance(c, bytes)
+        return c
 
     @property
     def text(self):
-        return str(self.content)
+        return self.content.decode("utf-8")
 
+    def raise_for_status(self):
+        pass
 
-class MockZip():
-    def __init__(self):
-        self.content = None
-        mac_wk2_files = {
-            "full_results.json": 'ADD_RESULTS({"tests":{"http":{"tests":{"media":{"hls":{"video-controls-live-stream.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"},"video-duration-accessibility.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}}}}},"imported":{"w3c":{"web-platform-tests":{"html":{"browsers":{"windows":{"browsing-context.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}},"fetch":{"api":{"redirect":{"redirect-count.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-location.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-count-worker.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-count-cross-origin.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-location-worker.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}}}},"media":{"track":{"track-in-band-style.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}}}},"skipped":3348,"num_regressions":6,"other_crashes":{},"interrupted":false,"num_missing":0,"layout_tests_dir":"/Volumes/Data/EWS/WebKit/LayoutTests","version":4,"num_passes":44738,"pixel_tests_enabled":false,"date":"07:18PM on April 08, 2017","has_pretty_patch":true,"fixable":3357,"num_flaky":3,"uses_expectations_file":true});',
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-actual.txt": "a",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-worker-actual.txt": "b",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-actual.txt": "c",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-worker-actual.txt": "d",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-actual.txt": "e",
-            "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "f"}
-        mac_wk1a_files = {"full_results.json": 'ADD_RESULTS({"tests":{"http":{"tests":{"loading":{"resourceLoadStatistics":{"non-prevalent-resource-without-user-interaction.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}}}},"imported":{"w3c":{"web-platform-tests":{"IndexedDB":{"abort-in-initial-upgradeneeded.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}},"html":{"browsers":{"windows":{"browsing-context.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}},"fetch":{"api":{"redirect":{"redirect-count.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-location.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-count-worker.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-count-cross-origin.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-location-worker.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}},"IndexedDB-private-browsing":{"idbfactory_open9.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}},"blink":{"storage":{"indexeddb":{"blob-delete-objectstore-db.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}}}}},"skipped":3537,"num_regressions":6,"other_crashes":{},"interrupted":false,"num_missing":0,"layout_tests_dir":"/Volumes/Data/EWS/WebKit/LayoutTests","version":4,"num_passes":44561,"pixel_tests_enabled":false,"date":"07:18PM on April 08, 2017","has_pretty_patch":true,"fixable":3547,"num_flaky":4,"uses_expectations_file":true});',
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-actual.txt": "a",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-worker-actual.txt": "b",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-actual.txt": "c",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-worker-actual.txt": "d",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-actual.txt": "e",
-            "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "f-wk1a"}
-        mac_wk1b_files = {"full_results.json": 'ADD_RESULTS({"tests":{"http":{"tests":{"loading":{"resourceLoadStatistics":{"non-prevalent-resource-without-user-interaction.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}}}},"imported":{"w3c":{"web-platform-tests":{"IndexedDB":{"abort-in-initial-upgradeneeded.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}},"html":{"browsers":{"windows":{"browsing-context.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}},"fetch":{"api":{"redirect":{"redirect-count.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-location.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-count-worker.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-count-cross-origin.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"redirect-location-worker.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}},"IndexedDB-private-browsing":{"idbfactory_open9.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}},"blink":{"storage":{"indexeddb":{"blob-delete-objectstore-db.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS","has_stderr":true}}}}}},"skipped":3537,"num_regressions":6,"other_crashes":{},"interrupted":false,"num_missing":0,"layout_tests_dir":"/Volumes/Data/EWS/WebKit/LayoutTests","version":4,"num_passes":44561,"pixel_tests_enabled":false,"date":"07:18PM on April 08, 2017","has_pretty_patch":true,"fixable":3547,"num_flaky":4,"uses_expectations_file":true});',
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-actual.txt": "a",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-worker-actual.txt": "b",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-actual.txt": "c",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-worker-actual.txt": "d",
-            "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-actual.txt": "e",
-            "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "f-wk1b"}
-        ios_files = {"full_results.json": 'ADD_RESULTS({"tests":{"imported":{"w3c":{"web-platform-tests":{"url":{"interfaces.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}},"html":{"browsers":{"windows":{"browsing-context.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}},"the-window-object":{"apis-for-creating-and-navigating-browsing-contexts-by-name":{"open-features-tokenization-001.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}},"dom":{"events":{"EventTarget-dispatchEvent.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}}},"animations":{"trigger-container-scroll-empty.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}}},"skipped":9881,"num_regressions":4,"other_crashes":{},"interrupted":false,"num_missing":0,"layout_tests_dir":"/Volumes/Data/EWS/WebKit/LayoutTests","version":4,"num_passes":38225,"pixel_tests_enabled":false,"date":"07:33PM on April 08, 2017","has_pretty_patch":true,"fixable":48110,"num_flaky":1,"uses_expectations_file":true});',
-            "imported/w3c/web-platform-tests/dom/events/EventTarget-dispatchEvent-actual.txt": "g",
-            "imported/w3c/web-platform-tests/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001-actual.txt": "h",
-            "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "i",
-            "imported/w3c/web-platform-tests/url/interfaces-actual.txt": "j"}
-        win_files = {"full_results.json": 'ADD_RESULTS({"tests":{"imported":{"w3c":{"web-platform-tests":{"url":{"interfaces.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}},"html":{"browsers":{"windows":{"browsing-context.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}},"the-window-object":{"apis-for-creating-and-navigating-browsing-contexts-by-name":{"open-features-tokenization-001.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}},"dom":{"events":{"EventTarget-dispatchEvent.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}}}}},"animations":{"trigger-container-scroll-empty.html":{"report":"FLAKY","expected":"PASS","actual":"TEXT PASS"}}},"skipped":9881,"num_regressions":4,"other_crashes":{},"interrupted":false,"num_missing":0,"layout_tests_dir":"/Volumes/Data/EWS/WebKit/LayoutTests","version":4,"num_passes":38225,"pixel_tests_enabled":false,"date":"07:33PM on April 08, 2017","has_pretty_patch":true,"fixable":48110,"num_flaky":1,"uses_expectations_file":true});',
-            "imported/w3c/web-platform-tests/dom/events/EventTarget-dispatchEvent-actual.txt": "g",
-            "imported/w3c/web-platform-tests/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001-actual.txt": "h",
-            "imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-actual.txt": "i",
-            "imported/w3c/web-platform-tests/url/interfaces-actual.txt": "j"}
-        self.files = {"mac-wk2": mac_wk2_files, "mac-wk1a": mac_wk1a_files, "mac-wk1b": mac_wk1b_files, "ios-wk2": ios_files, "win": win_files}
-
-    def unzip(self, content):
-        self.content = content
-        return self
-
-    def read(self, filename):
-        return self.files[self.content][filename]
+    def json(self):
+        return json.loads(self.content)
 
 
 class TestExpectationUpdaterTest(unittest.TestCase):
@@ -161,9 +589,18 @@ class TestExpectationUpdaterTest(unittest.TestCase):
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-expected.txt': "i",
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/url/interfaces-expected.txt': "j-mac-wk2"})
 
-        mock_zip = MockZip()
-        with mock.patch('webkitpy.common.net.bugzilla.test_expectation_updater.requests.get', MockRequestsGet):
-            updater = TestExpectationUpdater(host, "123456", True, False, MockBugzilla(), lambda content: mock_zip.unzip(content))
+        ews_results = {
+            "mac-wk1": [
+                "https://ews-build.webkit.org/results/mac-wk1/r12345.zip",
+                "https://ews-build.webkit.org/results/mac-debug-wk1/r12345.zip",
+            ],
+            "mac-wk2": ["https://ews-build.webkit.org/results/mac-wk2/r12345.zip"],
+            "ios-wk2": ["https://ews-build.webkit.org/results/ios-wk2/r12345.zip"],
+            "win": ["https://ews-build.webkit.org/results/win/r12345.zip"],
+        }
+
+        with mock.patch('webkitpy.common.net.bugzilla.test_expectation_updater.lookup_ews_results_from_bugzilla', mock.Mock(return_value=ews_results)), mock.patch('requests.get', MockRequestsGet):
+            updater = TestExpectationUpdater(host, "123456", True, False, None)
             updater.do_update()
             # mac-wk2 expectation
             self.assertTrue(self._is_matching(host, "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-expected.txt", "a"))
@@ -176,5 +613,3 @@ class TestExpectationUpdaterTest(unittest.TestCase):
             self.assertFalse(self._exists(host, "platform/mac-wk1/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-expected.txt"))
             # windows specific expectation
             self.assertTrue(self._is_matching(host, "platform/win/imported/w3c/web-platform-tests/url/interfaces-expected.txt", "j"))
-
-

--- a/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py
+++ b/Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py
@@ -38,10 +38,15 @@ _log = logging.getLogger(__name__)
 
 _JSON_PREFIX = "ADD_RESULTS("
 _JSON_SUFFIX = ");"
+_JSON_PREFIX_B = b"ADD_RESULTS("
+_JSON_SUFFIX_B = b");"
 
 
 def has_json_wrapper(string):
-    return string.startswith(_JSON_PREFIX) and string.endswith(_JSON_SUFFIX)
+    if isinstance(string, bytes):
+        return string.startswith(_JSON_PREFIX_B) and string.endswith(_JSON_SUFFIX_B)
+    else:
+        return string.startswith(_JSON_PREFIX) and string.endswith(_JSON_SUFFIX)
 
 
 def strip_json_wrapper(json_content):


### PR DESCRIPTION
#### 5b3cad0ec99c990022c2a6d704a8b5cf1b951b74
<pre>
Split webkitpy.common.net.bugzilla.TestExpectationUpdater
<a href="https://bugs.webkit.org/show_bug.cgi?id=261171">https://bugs.webkit.org/show_bug.cgi?id=261171</a>

Reviewed by Jonathan Bedard.

This patch does a number of things:

 * Split test_expectation_updater.TestExpectationUpdater into:
   * ews.EWS
   * results_fetcher.lookup_ews_results_from_bugzilla
   * test_expectation_updater.TestExpectationUpdater

 * Replace the MockZip with code that just generates a real ZipFile
   (revealing various places where we have str/bytes mixed on Python 3).

This almost entirely is just moving code around; there should be no
functional change.

* Tools/Scripts/webkitpy/common/net/bugzilla/__init__.py:
* Tools/Scripts/webkitpy/common/net/bugzilla/ews.py: Added.
(EWS):
(EWS.__init__):
(EWS.from_webapp_url):
(EWS.builders):
(EWS.steps_from_build_number):
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py: Added.
(_platform_name_for_bot):
(_get_first_layout_test_step):
(_is_relevant_results):
(lookup_ews_results):
(lookup_ews_results_from_bugzilla_patch):
(lookup_ews_results_from_bugzilla):
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py: Added.
(MockAttachment):
(MockAttachment.__init__):
(MockAttachment.contents):
(MockAttachment.is_patch):
(MockAttachment.is_obsolete):
(MockBugzilla):
(MockBugzilla.fetch_bug):
(MockBugzilla.attachments):
(MockRequestsGet):
(MockRequestsGet.__init__):
(MockRequestsGet.content):
(MockRequestsGet.text):
(MockRequestsGet.raise_for_status):
(MockRequestsGet.json):
(ResultsFetcherTest):
(ResultsFetcherTest.test_is_relevant_results):
(ResultsFetcherTest.test_lookup_ews_results_from_bugzilla):
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py:
(TestExpectationUpdater.__init__):
(TestExpectationUpdater._tests_to_update):
(TestExpectationUpdater._file_content_if_exists):
(TestExpectationUpdater._update_for_generic_bot):
(TestExpectationUpdater._update_for_platform_specific_bot):
(TestExpectationUpdater.do_update):
(main):
(TestExpectationUpdater._platform_name): Deleted.
(TestExpectationUpdater._get_layout_tests_run): Deleted.
(TestExpectationUpdater._lookup_ews_results): Deleted.
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py:
(_make_zip_filelike):
(MockRequestsGet):
(MockRequestsGet.__init__):
(MockRequestsGet.content):
(MockRequestsGet.text):
(MockRequestsGet.raise_for_status):
(MockRequestsGet.json):
(TestExpectationUpdaterTest.test_update_test_expectations):
(MockAttachment): Deleted.
(MockAttachment.__init__): Deleted.
(MockAttachment.contents): Deleted.
(MockAttachment.is_patch): Deleted.
(MockAttachment.is_obsolete): Deleted.
(MockBugzilla): Deleted.
(MockBugzilla.fetch_bug): Deleted.
(MockBugzilla.attachments): Deleted.
(MockZip): Deleted.
(MockZip.__init__): Deleted.
(MockZip.unzip): Deleted.
(MockZip.read): Deleted.
* Tools/Scripts/webkitpy/layout_tests/layout_package/json_results_generator.py:
(has_json_wrapper):

Canonical link: <a href="https://commits.webkit.org/267690@main">https://commits.webkit.org/267690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1f5ac090446ec79bd42e975526a4f359efaecab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17895 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17956 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20034 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17568 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16195 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20335 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16606 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15746 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2128 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->