### PR TITLE
Crash under NavigationState::NavigationClient::didCommitNavigation()

### DIFF
--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -60,7 +60,8 @@ void FrameLoadState::didSuspend()
 
 void FrameLoadState::didExplicitOpen(const URL& url)
 {
-    m_url = url;
+    ASSERT(!url.isNull());
+    m_url = url.isNull() ? aboutBlankURL() : url;
     m_provisionalURL = { };
 }
 
@@ -85,7 +86,8 @@ void FrameLoadState::didCommitLoad()
     ASSERT(m_state == State::Provisional);
 
     m_state = State::Committed;
-    m_url = m_provisionalURL;
+    ASSERT(!m_provisionalURL.isNull());
+    m_url = m_provisionalURL.isNull() ? aboutBlankURL() : m_provisionalURL;
     m_provisionalURL = { };
 }
 
@@ -110,7 +112,8 @@ void FrameLoadState::didFailLoad()
 
 void FrameLoadState::didSameDocumentNotification(const URL& url)
 {
-    m_url = url;
+    ASSERT(!url.isNull());
+    m_url = url.isNull() ? aboutBlankURL() : url;
 }
 
 void FrameLoadState::setUnreachableURL(const URL& unreachableURL)

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -339,7 +339,8 @@ void PageLoadState::didCommitLoad(const Transaction::Token& token, const WebCore
     m_uncommittedState.hasInsecureContent = hasInsecureContent;
     m_uncommittedState.certificateInfo = certificateInfo;
 
-    m_uncommittedState.url = m_uncommittedState.provisionalURL;
+    ASSERT(!m_uncommittedState.provisionalURL.isNull());
+    m_uncommittedState.url = m_uncommittedState.provisionalURL.isNull() ? aboutBlankURL().string() : m_uncommittedState.provisionalURL;
     m_uncommittedState.provisionalURL = String();
     m_uncommittedState.negotiatedLegacyTLS = usedLegacyTLS;
     m_uncommittedState.wasPrivateRelayed = wasPrivateRelayed;


### PR DESCRIPTION
#### 648f84844d05410eba37da2758244db02cf17cb8
<pre>
Crash under NavigationState::NavigationClient::didCommitNavigation()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261172">https://bugs.webkit.org/show_bug.cgi?id=261172</a>
rdar://113459568

Reviewed by Sihui Liu.

The crash in the wild seems to indicate that WKFrameCopyURL() may return null
when called from the didCommitLoadForFrame() navigation delegate. It seems
unexpected for the committed URL to be null when we&apos;ve just committed a load
in the frame.

I have not been able to reproduce the issue with our tests or regular browsing
so I am adding assertions and defaulting the committed URL to &quot;about:blank&quot; if
it is null upon commit.

* Source/WebKit/UIProcess/FrameLoadState.cpp:
(WebKit::FrameLoadState::didExplicitOpen):
(WebKit::FrameLoadState::didCommitLoad):
(WebKit::FrameLoadState::didSameDocumentNotification):
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::commitChanges):

Canonical link: <a href="https://commits.webkit.org/267696@main">https://commits.webkit.org/267696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a92d44ed2828b3bbd94447a20ccd7b62b4480649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19983 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15156 "9 flakes 3 failures") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20299 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14051 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15704 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4155 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->