### PR TITLE
Crash under -[NSEvent _trackSwipeEventWithOptions:dampenAmountThresholdMin:max:trackingDistance:axis:velocityFilterClass:usingHandler:]

### DIFF
--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -49,6 +49,7 @@
 #import <WebCore/WebActionDisablingCALayerDelegate.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/NSEventSPI.h>
+#import <wtf/BlockObjCExceptions.h>
 
 static const double minElasticMagnification = 0.75;
 static const double maxElasticMagnification = 4;
@@ -261,6 +262,7 @@ void ViewGestureController::trackSwipeGesture(PlatformScrollEvent event, SwipeDi
     RetainPtr<WKSwipeCancellationTracker> swipeCancellationTracker = adoptNS([[WKSwipeCancellationTracker alloc] init]);
     m_swipeCancellationTracker = swipeCancellationTracker;
 
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
     [event trackSwipeEventWithOptions:NSEventSwipeTrackingConsumeMouseEvents dampenAmountThresholdMin:minProgress max:maxProgress usingHandler:^(CGFloat progress, NSEventPhase phase, BOOL isComplete, BOOL *stop) {
         if ([swipeCancellationTracker isCancelled]) {
             *stop = YES;
@@ -277,6 +279,7 @@ void ViewGestureController::trackSwipeGesture(PlatformScrollEvent event, SwipeDi
         if (isComplete)
             this->endSwipeGesture(targetItem.get(), swipeCancelled);
     }];
+    END_BLOCK_OBJC_EXCEPTIONS
 }
 
 FloatRect ViewGestureController::windowRelativeBoundsForCustomSwipeViews() const


### PR DESCRIPTION
#### 6f953477b997e27556cae4916aa00846d091e079
<pre>
Crash under -[NSEvent _trackSwipeEventWithOptions:dampenAmountThresholdMin:max:trackingDistance:axis:velocityFilterClass:usingHandler:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=261174">https://bugs.webkit.org/show_bug.cgi?id=261174</a>
rdar://114552141

Reviewed by Tim Horton.

AppKit is throwing an exception for some reason about the event type or phase, but it&apos;s not clear why.
For now, just catch the exception.

* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::trackSwipeGesture):

Canonical link: <a href="https://commits.webkit.org/267673@main">https://commits.webkit.org/267673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c92b2e21f8b1155676cfa63f4ab208306f064be0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16187 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18377 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19904 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15082 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22403 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13990 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15629 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4146 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->