### PR TITLE
Deploy more smart pointers in ProvisionalPageProxy.cpp

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -125,6 +125,9 @@ public:
     void processDidTerminate();
 
 private:
+    Ref<WebPageProxy> protectedPage() const;
+    RefPtr<WebFrameProxy> protectedMainFrame() const;
+
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -815,6 +815,11 @@ ProcessID WebPageProxy::gpuProcessID() const
     return 0;
 }
 
+Ref<WebProcessProxy> WebPageProxy::protectedProcess() const
+{
+    return m_process;
+}
+
 ProcessID WebPageProxy::processID() const
 {
     if (m_isClosed)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1432,6 +1432,7 @@ public:
 
     WebProcessProxy& ensureRunningProcess();
     WebProcessProxy& process() const { return m_process; }
+    Ref<WebProcessProxy> protectedProcess() const;
     ProcessID processID() const;
 
     ProcessID gpuProcessID() const;


### PR DESCRIPTION
#### b5d01959bf366d5985ac0f016343bc117291aa2a
<pre>
Deploy more smart pointers in ProvisionalPageProxy.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=261182">https://bugs.webkit.org/show_bug.cgi?id=261182</a>

Reviewed by Chris Dumez.

Deployed more smart pointers as warned by the clang static analyzer.

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::protectedPage const):
(WebKit::ProvisionalPageProxy::protectedMainFrame const):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
(WebKit::ProvisionalPageProxy::didCreateMainFrame):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::protectedProcess const):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/267660@main">https://commits.webkit.org/267660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d50745b3bd2e275b50fed5302648a430be6e2c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19095 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18382 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19912 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15089 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22410 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15906 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20235 "1 api test failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16490 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13997 "1 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20007 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2115 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->