### PR TITLE
[motion-path] Implement offset-position support for circle() / ellipse()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5283,10 +5283,6 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-009.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/motion/offset-path-url-010.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyFailure ]
 
-# CSS motion path: circle/ellipse offset-position support.
-imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-002.html [ ImageOnlyFailure ]
-
 # CSS motion path: https://bugs.webkit.org/show_bug.cgi?id=261217
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-inset-001.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/css/BasicShapeFunctions.cpp
+++ b/Source/WebCore/css/BasicShapeFunctions.cpp
@@ -208,6 +208,7 @@ Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionDa
         circle->setRadius(cssValueToBasicShapeRadius(conversionData, circleValue.radius()));
         circle->setCenterX(convertToCenterCoordinate(conversionData, circleValue.centerX()));
         circle->setCenterY(convertToCenterCoordinate(conversionData, circleValue.centerY()));
+        circle->setPositionWasOmitted(!circleValue.centerX() && !circleValue.centerY());
         return circle;
     }
     if (value.isEllipse()) {
@@ -217,6 +218,7 @@ Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionDa
         ellipse->setRadiusY(cssValueToBasicShapeRadius(conversionData, ellipseValue.radiusY()));
         ellipse->setCenterX(convertToCenterCoordinate(conversionData, ellipseValue.centerX()));
         ellipse->setCenterY(convertToCenterCoordinate(conversionData, ellipseValue.centerY()));
+        ellipse->setPositionWasOmitted(!ellipseValue.centerX() && !ellipseValue.centerY());
         return ellipse;
     }
     if (value.isPolygon()) {

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -34,6 +34,7 @@ class BoxPathOperation;
 class RenderElement;
 class PathOperation;
 class RayPathOperation;
+class ShapePathOperation;
 
 struct MotionPathData {
     FloatRoundedRect containingBlockBoundingRect;
@@ -50,6 +51,7 @@ public:
     static std::optional<Path> computePathForRay(const RayPathOperation&, const TransformOperationData&);
     static double lengthForRayPath(const RayPathOperation&, const MotionPathData&);
     static double lengthForRayContainPath(const FloatRect& elementRect, double computedPathLength);
+    WEBCORE_EXPORT static std::optional<Path> computePathForShape(const ShapePathOperation&, const TransformOperationData&);
 };
 
 class TransformOperationData {

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -147,9 +147,7 @@ public:
     CSSBoxType referenceBox() const { return m_referenceBox; }
     const std::optional<Path> getPath(const TransformOperationData& data) const final
     {
-        if (data.motionPathData())
-            return pathForReferenceRect(data.motionPathData()->containingBlockBoundingRect.rect());
-        return pathForReferenceRect(data.boundingBox());
+        return MotionPath::computePathForShape(*this, data);
     }
 
 private:

--- a/Source/WebCore/rendering/shapes/Shape.cpp
+++ b/Source/WebCore/rendering/shapes/Shape.cpp
@@ -105,7 +105,7 @@ Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPo
         const auto& circle = downcast<BasicShapeCircle>(basicShape);
         float centerX = floatValueForCenterCoordinate(circle.centerX(), boxWidth);
         float centerY = floatValueForCenterCoordinate(circle.centerY(), boxHeight);
-        float radius = circle.floatValueForRadiusInBox(boxWidth, boxHeight);
+        float radius = circle.floatValueForRadiusInBox(boxWidth, boxHeight, { centerX, centerY });
         FloatPoint logicalCenter = physicalPointToLogical(FloatPoint(centerX, centerY), logicalBoxSize.height(), writingMode);
         logicalCenter.moveBy(borderBoxOffset);
 


### PR DESCRIPTION
#### ff4be937a37273cf6ca0a491f28a902406dd78f4
<pre>
[motion-path] Implement offset-position support for circle() / ellipse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261178">https://bugs.webkit.org/show_bug.cgi?id=261178</a>
rdar://114951375

Reviewed by Simon Fraser.

When the position is not specified for circle or ellipse, use offset-position
instead. Also update normalPositionForOffsetPath to have offset-position: normal
default to the center of the containing block rect for shape path operations.

* LayoutTests/TestExpectations:
* Source/WebCore/css/BasicShapeFunctions.cpp:
(WebCore::basicShapeForValue):
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::computePathForShape):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::Shape::createShape):
* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::BasicShapeCircle::floatValueForRadiusInBox const):
(WebCore::BasicShapeCircle::pathForCenterCoordinate const):
(WebCore::BasicShapeCircle::path):
(WebCore::BasicShapeEllipse::pathForCenterCoordinate const):
(WebCore::BasicShapeEllipse::path):
* Source/WebCore/rendering/style/BasicShapes.h:
(WebCore::BasicShapeHasCenterCoordinate::setPositionWasOmitted):
(WebCore::BasicShapeHasCenterCoordinate::positionWasOmitted const):

Canonical link: <a href="https://commits.webkit.org/267810@main">https://commits.webkit.org/267810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b51d24bb2ba2cdbb018607827991bcfa6c60dbe2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18207 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20415 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22728 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20587 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20369 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2180 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->