### PR TITLE
Deploy more smart pointers in RemotePageProxy, ResponsivenessTimer, SpeechRecognitionPermissionManager, and SuspendedPageProxy

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -50,8 +50,7 @@ class SandboxExtensionHandle;
 
 struct AuxiliaryProcessCreationParameters;
 
-class AuxiliaryProcessProxy : public ThreadSafeRefCounted<AuxiliaryProcessProxy, WTF::DestructionThread::MainRunLoop>, public CanMakeThreadSafeCheckedPtr,
-    public ResponsivenessTimer::Client, private ProcessLauncher::Client, public IPC::Connection::Client {
+class AuxiliaryProcessProxy : public ThreadSafeRefCounted<AuxiliaryProcessProxy, WTF::DestructionThread::MainRunLoop>, public ResponsivenessTimer::Client, private ProcessLauncher::Client, public IPC::Connection::Client {
     WTF_MAKE_NONCOPYABLE(AuxiliaryProcessProxy);
 
 protected:

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -57,7 +57,7 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
 
 void RemotePageProxy::injectPageIntoNewProcess()
 {
-    auto* page = m_page.get();
+    RefPtr page = m_page.get();
     if (!page) {
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
@@ -67,7 +67,7 @@ void ResponsivenessTimer::timerFired()
     if (!m_isResponsive)
         return;
 
-    Ref protectedClient { m_client };
+    Ref protectedClient { m_client.get() };
 
     if (!mayBecomeUnresponsive()) {
         m_waitingForTimer = true;
@@ -75,11 +75,11 @@ void ResponsivenessTimer::timerFired()
         return;
     }
 
-    m_client.willChangeIsResponsive();
+    protectedClient->willChangeIsResponsive();
     m_isResponsive = false;
-    m_client.didChangeIsResponsive();
+    protectedClient->didChangeIsResponsive();
 
-    m_client.didBecomeUnresponsive();
+    protectedClient->didBecomeUnresponsive();
 }
     
 void ResponsivenessTimer::start()
@@ -119,7 +119,7 @@ bool ResponsivenessTimer::mayBecomeUnresponsive() const
     if (isLibgmallocEnabled)
         return false;
 
-    return m_client.mayBecomeUnresponsive();
+    return m_client->mayBecomeUnresponsive();
 #endif
 }
 
@@ -134,14 +134,14 @@ void ResponsivenessTimer::startWithLazyStop()
 void ResponsivenessTimer::stop()
 {
     if (!m_isResponsive) {
-        Ref protectedClient { m_client };
+        Ref protectedClient { m_client.get() };
 
         // We got a life sign from the web process.
-        m_client.willChangeIsResponsive();
+        protectedClient->willChangeIsResponsive();
         m_isResponsive = true;
-        m_client.didChangeIsResponsive();
+        protectedClient->didChangeIsResponsive();
 
-        m_client.didBecomeResponsive();
+        protectedClient->didBecomeResponsive();
     }
 
     m_waitingForTimer = false;

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.h
@@ -26,13 +26,14 @@
 #ifndef ResponsivenessTimer_h
 #define ResponsivenessTimer_h
 
+#include <wtf/CheckedRef.h>
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
 
 class ResponsivenessTimer {
 public:
-    class Client {
+    class Client : public CanMakeThreadSafeCheckedPtr {
     public:
         virtual ~Client() { }
         virtual void didBecomeUnresponsive() = 0;
@@ -80,7 +81,7 @@ private:
 
     bool mayBecomeUnresponsive() const;
 
-    ResponsivenessTimer::Client& m_client;
+    CheckedRef<ResponsivenessTimer::Client> m_client;
 
     RunLoop::Timer m_timer;
     MonotonicTime m_restartFireTime;

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SpeechRecognitionPermissionRequest.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
 
@@ -45,6 +46,8 @@ public:
     WebPageProxy& page() { return m_page; }
 
 private:
+    Ref<WebPageProxy> protectedPage() const;
+
     void startNextRequest();
     void startProcessingRequest();
     void continueProcessingRequest();
@@ -53,7 +56,7 @@ private:
     void requestSpeechRecognitionServiceAccess();
     void requestUserPermission(WebCore::SpeechRecognitionRequest& request);
 
-    WebPageProxy& m_page;
+    CheckedRef<WebPageProxy> m_page;
     Deque<Ref<SpeechRecognitionPermissionRequest>> m_requests;
     CheckResult m_microphoneCheck { CheckResult::Unknown };
     CheckResult m_speechRecognitionServiceCheck { CheckResult::Unknown };

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -55,9 +55,9 @@ static HashSet<SuspendedPageProxy*>& allSuspendedPages()
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode)
 {
     for (auto* suspendedPage : allSuspendedPages()) {
-        auto& process = suspendedPage->process();
-        if (&process.processPool() == &processPool && process.registrableDomain() == registrableDomain && process.websiteDataStore() == &dataStore && process.crossOriginMode() != CrossOriginMode::Isolated && process.lockdownMode() == lockdownMode && !process.wasTerminated())
-            return &process;
+        Ref process = suspendedPage->process();
+        if (&process->processPool() == &processPool && process->registrableDomain() == registrableDomain && process->websiteDataStore() == &dataStore && process->crossOriginMode() != CrossOriginMode::Isolated && process->lockdownMode() == lockdownMode && !process->wasTerminated())
+            return process;
     }
     return nullptr;
 }
@@ -139,6 +139,11 @@ SuspendedPageProxy::~SuspendedPageProxy()
     m_process->removeSuspendedPageProxy(*this);
 }
 
+Ref<WebPageProxy> SuspendedPageProxy::protectedPage() const
+{
+    return m_page.get();
+}
+
 HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> SuspendedPageProxy::takeRemotePageMap()
 {
     return std::exchange(m_remotePageMap, { });
@@ -146,7 +151,7 @@ HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> SuspendedPageProxy
 
 void SuspendedPageProxy::didDestroyNavigation(uint64_t navigationID)
 {
-    m_page.didDestroyNavigationShared(m_process.copyRef(), navigationID);
+    protectedPage()->didDestroyNavigationShared(m_process.copyRef(), navigationID);
 }
 
 WebBackForwardCache& SuspendedPageProxy::backForwardCache() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -32,6 +32,7 @@
 #include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -61,7 +62,7 @@ public:
 
     static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode);
 
-    WebPageProxy& page() const { return m_page; }
+    WebPageProxy& page() const { return m_page.get(); }
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
@@ -89,6 +90,8 @@ public:
 #endif
 
 private:
+    Ref<WebPageProxy> protectedPage() const;
+
     enum class SuspensionState : uint8_t { Suspending, FailedToSuspend, Suspended, Resumed };
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
@@ -106,7 +109,7 @@ private:
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
     bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
 
-    WebPageProxy& m_page;
+    CheckedRef<WebPageProxy> m_page;
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     Ref<WebFrameProxy> m_mainFrame;


### PR DESCRIPTION
#### 973b655f2b728c91811d3fd6bf4640f6b04e058f
<pre>
Deploy more smart pointers in RemotePageProxy, ResponsivenessTimer, SpeechRecognitionPermissionManager, and SuspendedPageProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=261184">https://bugs.webkit.org/show_bug.cgi?id=261184</a>

Reviewed by Chris Dumez.

Deployed more smart pointers as warned by the clang static analyzer.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
* Source/WebKit/UIProcess/ResponsivenessTimer.cpp:
(WebKit::ResponsivenessTimer::timerFired):
(WebKit::ResponsivenessTimer::mayBecomeUnresponsive const):
(WebKit::ResponsivenessTimer::stop):
* Source/WebKit/UIProcess/ResponsivenessTimer.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
(WebKit::SpeechRecognitionPermissionManager::protectedPage const):
(WebKit::SpeechRecognitionPermissionManager::startProcessingRequest):
(WebKit::SpeechRecognitionPermissionManager::continueProcessingRequest):
(WebKit::SpeechRecognitionPermissionManager::requestUserPermission):
(WebKit::SpeechRecognitionPermissionManager::decideByDefaultAction):
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
(WebKit::SuspendedPageProxy::protectedPage const):
(WebKit::SuspendedPageProxy::didDestroyNavigation):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/267704@main">https://commits.webkit.org/267704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8522a0b37f20852f13ed0200cea55abf96e5df77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18385 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19919 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15096 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22416 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14003 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15644 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20014 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2136 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->