### PR TITLE
DrawingAreaProxy should hold a CheckedRef to WebPageProxy instead of a raw reference

### DIFF
--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -52,6 +52,11 @@ DrawingAreaProxy::DrawingAreaProxy(DrawingAreaType type, WebPageProxy& webPagePr
 
 DrawingAreaProxy::~DrawingAreaProxy() = default;
 
+Ref<WebPageProxy> DrawingAreaProxy::protectedWebPageProxy() const
+{
+    return m_webPageProxy.get();
+}
+
 void DrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
 {
     for (auto& name : messageReceiverNames())
@@ -96,7 +101,7 @@ MachSendRight DrawingAreaProxy::createFence()
 #if PLATFORM(MAC)
 void DrawingAreaProxy::didChangeViewExposedRect()
 {
-    if (!m_webPageProxy.hasRunningProcess())
+    if (!m_webPageProxy->hasRunningProcess())
         return;
 
     if (!m_viewExposedRectChangedTimer.isActive())
@@ -105,14 +110,14 @@ void DrawingAreaProxy::didChangeViewExposedRect()
 
 void DrawingAreaProxy::viewExposedRectChangedTimerFired()
 {
-    if (!m_webPageProxy.hasRunningProcess())
+    if (!m_webPageProxy->hasRunningProcess())
         return;
 
-    auto viewExposedRect = m_webPageProxy.viewExposedRect();
+    auto viewExposedRect = m_webPageProxy->viewExposedRect();
     if (viewExposedRect == m_lastSentViewExposedRect)
         return;
 
-    m_webPageProxy.send(Messages::DrawingArea::SetViewExposedRect(viewExposedRect), m_identifier);
+    m_webPageProxy->send(Messages::DrawingArea::SetViewExposedRect(viewExposedRect), m_identifier);
     m_lastSentViewExposedRect = viewExposedRect;
 }
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <stdint.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TypeCasts.h>
@@ -139,9 +140,11 @@ public:
 protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&);
 
+    Ref<WebPageProxy> protectedWebPageProxy() const;
+
     DrawingAreaType m_type;
     DrawingAreaIdentifier m_identifier;
-    WebPageProxy& m_webPageProxy;
+    CheckedRef<WebPageProxy> m_webPageProxy;
 
     WebCore::IntSize m_size;
     WebCore::IntSize m_scrollOffset;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -54,12 +54,13 @@ TiledCoreAnimationDrawingAreaProxy::~TiledCoreAnimationDrawingAreaProxy()
 
 void TiledCoreAnimationDrawingAreaProxy::deviceScaleFactorDidChange()
 {
-    m_webPageProxy.send(Messages::DrawingArea::SetDeviceScaleFactor(m_webPageProxy.deviceScaleFactor()), m_identifier);
+    auto webPageProxy = protectedWebPageProxy();
+    webPageProxy->send(Messages::DrawingArea::SetDeviceScaleFactor(webPageProxy->deviceScaleFactor()), m_identifier);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::sizeDidChange()
 {
-    if (!m_webPageProxy.hasRunningProcess())
+    if (!m_webPageProxy->hasRunningProcess())
         return;
 
     // We only want one UpdateGeometry message in flight at once, so if we've already sent one but
@@ -72,12 +73,12 @@ void TiledCoreAnimationDrawingAreaProxy::sizeDidChange()
 
 void TiledCoreAnimationDrawingAreaProxy::colorSpaceDidChange()
 {
-    m_webPageProxy.send(Messages::DrawingArea::SetColorSpace(m_webPageProxy.colorSpace()), m_identifier);
+    protectedWebPageProxy()->send(Messages::DrawingArea::SetColorSpace(m_webPageProxy->colorSpace()), m_identifier);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::minimumSizeForAutoLayoutDidChange()
 {
-    if (!m_webPageProxy.hasRunningProcess())
+    if (!m_webPageProxy->hasRunningProcess())
         return;
 
     // We only want one UpdateGeometry message in flight at once, so if we've already sent one but
@@ -90,7 +91,7 @@ void TiledCoreAnimationDrawingAreaProxy::minimumSizeForAutoLayoutDidChange()
 
 void TiledCoreAnimationDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange()
 {
-    if (!m_webPageProxy.hasRunningProcess())
+    if (!m_webPageProxy->hasRunningProcess())
         return;
 
     // We only want one UpdateGeometry message in flight at once, so if we've already sent one but
@@ -103,17 +104,17 @@ void TiledCoreAnimationDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChan
 
 void TiledCoreAnimationDrawingAreaProxy::enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext& layerTreeContext)
 {
-    m_webPageProxy.enterAcceleratedCompositingMode(layerTreeContext);
+    protectedWebPageProxy()->enterAcceleratedCompositingMode(layerTreeContext);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext& layerTreeContext)
 {
-    m_webPageProxy.updateAcceleratedCompositingMode(layerTreeContext);
+    protectedWebPageProxy()->updateAcceleratedCompositingMode(layerTreeContext);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::didFirstLayerFlush(uint64_t /* backingStoreStateID */, const LayerTreeContext& layerTreeContext)
 {
-    m_webPageProxy.didFirstLayerFlush(layerTreeContext);
+    protectedWebPageProxy()->didFirstLayerFlush(layerTreeContext);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::didUpdateGeometry()
@@ -122,8 +123,8 @@ void TiledCoreAnimationDrawingAreaProxy::didUpdateGeometry()
 
     m_isWaitingForDidUpdateGeometry = false;
 
-    IntSize minimumSizeForAutoLayout = m_webPageProxy.minimumSizeForAutoLayout();
-    IntSize sizeToContentAutoSizeMaximumSize = m_webPageProxy.sizeToContentAutoSizeMaximumSize();
+    IntSize minimumSizeForAutoLayout = protectedWebPageProxy()->minimumSizeForAutoLayout();
+    IntSize sizeToContentAutoSizeMaximumSize = protectedWebPageProxy()->sizeToContentAutoSizeMaximumSize();
 
     // If the WKView was resized while we were waiting for a DidUpdateGeometry reply from the web process,
     // we need to resend the new size here.
@@ -134,23 +135,24 @@ void TiledCoreAnimationDrawingAreaProxy::didUpdateGeometry()
 void TiledCoreAnimationDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStateChangeID, WebProcessProxy& process)
 {
     Seconds activityStateUpdateTimeout = Seconds::fromMilliseconds(250);
-    process.connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::DidUpdateActivityState>(m_webPageProxy.webPageID(), activityStateUpdateTimeout, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+    process.connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::DidUpdateActivityState>(protectedWebPageProxy()->webPageID(), activityStateUpdateTimeout, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::willSendUpdateGeometry()
 {
-    m_lastSentMinimumSizeForAutoLayout = m_webPageProxy.minimumSizeForAutoLayout();
-    m_lastSentSizeToContentAutoSizeMaximumSize = m_webPageProxy.sizeToContentAutoSizeMaximumSize();
+    auto webPageProxy = protectedWebPageProxy();
+    m_lastSentMinimumSizeForAutoLayout = webPageProxy->minimumSizeForAutoLayout();
+    m_lastSentSizeToContentAutoSizeMaximumSize = webPageProxy->sizeToContentAutoSizeMaximumSize();
     m_lastSentSize = m_size;
     m_isWaitingForDidUpdateGeometry = true;
 }
 
 MachSendRight TiledCoreAnimationDrawingAreaProxy::createFence()
 {
-    if (!m_webPageProxy.hasRunningProcess())
+    if (!m_webPageProxy->hasRunningProcess())
         return MachSendRight();
 
-    RetainPtr<CAContext> rootLayerContext = [m_webPageProxy.acceleratedCompositingRootLayer() context];
+    RetainPtr<CAContext> rootLayerContext = [m_webPageProxy->acceleratedCompositingRootLayer() context];
     if (!rootLayerContext)
         return MachSendRight();
 
@@ -158,26 +160,26 @@ MachSendRight TiledCoreAnimationDrawingAreaProxy::createFence()
     // will likely get dropped on the floor (if the Web process is terminated)
     // or queued up until process launch completes, and there's nothing useful
     // to synchronize in these cases.
-    if (!m_webPageProxy.process().connection())
+    auto connection = m_webPageProxy->process().connection();
+    if (!connection)
         return MachSendRight();
 
     // Don't fence if we have incoming synchronous messages, because we may not
     // be able to reply to the message until the fence times out.
-    if (m_webPageProxy.process().connection()->hasIncomingSyncMessage())
+    if (connection->hasIncomingSyncMessage())
         return MachSendRight();
 
     MachSendRight fencePort = MachSendRight::adopt([rootLayerContext createFencePort]);
 
     // Invalidate the fence if a synchronous message arrives while it's installed,
     // because we won't be able to reply during the fence-wait.
-    uint64_t callbackID = m_webPageProxy.process().connection()->installIncomingSyncMessageCallback([rootLayerContext] {
+    uint64_t callbackID = connection->installIncomingSyncMessageCallback([rootLayerContext] {
         [rootLayerContext invalidateFences];
     });
-    RefPtr<WebPageProxy> retainedPage = &m_webPageProxy;
-    [CATransaction addCommitHandler:[callbackID, retainedPage] {
-        if (!retainedPage->hasRunningProcess())
+    [CATransaction addCommitHandler:[callbackID, protectedPae = protectedWebPageProxy()] {
+        if (!protectedPae->hasRunningProcess())
             return;
-        if (Connection* connection = retainedPage->process().connection())
+        if (RefPtr connection = protectedPae->process().connection())
             connection->uninstallIncomingSyncMessageCallback(callbackID);
     } forPhase:kCATransactionPhasePostCommit];
 
@@ -189,7 +191,7 @@ void TiledCoreAnimationDrawingAreaProxy::sendUpdateGeometry()
     ASSERT(!m_isWaitingForDidUpdateGeometry);
 
     willSendUpdateGeometry();
-    m_webPageProxy.sendWithAsyncReply(Messages::DrawingArea::UpdateGeometry(m_size, std::nullopt, true /* flushSynchronously */, createFence()), [weakThis = WeakPtr { *this }] {
+    protectedWebPageProxy()->sendWithAsyncReply(Messages::DrawingArea::UpdateGeometry(m_size, std::nullopt, true /* flushSynchronously */, createFence()), [weakThis = WeakPtr { *this }] {
         if (!weakThis)
             return;
         weakThis->didUpdateGeometry();
@@ -198,12 +200,12 @@ void TiledCoreAnimationDrawingAreaProxy::sendUpdateGeometry()
 
 void TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom(double scale, FloatPoint origin)
 {
-    m_webPageProxy.send(Messages::DrawingArea::AdjustTransientZoom(scale, origin), m_identifier);
+    protectedWebPageProxy()->send(Messages::DrawingArea::AdjustTransientZoom(scale, origin), m_identifier);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::commitTransientZoom(double scale, FloatPoint origin)
 {
-    m_webPageProxy.send(Messages::DrawingArea::CommitTransientZoom(scale, origin), m_identifier);
+    protectedWebPageProxy()->send(Messages::DrawingArea::CommitTransientZoom(scale, origin), m_identifier);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::dispatchPresentationCallbacksAfterFlushingLayers(IPC::Connection& connection, Vector<IPC::AsyncReplyID>&& callbackIDs)
@@ -216,9 +218,9 @@ void TiledCoreAnimationDrawingAreaProxy::dispatchPresentationCallbacksAfterFlush
 
 std::optional<WebCore::FramesPerSecond> TiledCoreAnimationDrawingAreaProxy::displayNominalFramesPerSecond()
 {
-    if (!m_webPageProxy.displayID())
+    if (!m_webPageProxy->displayID())
         return std::nullopt;
-    return m_webPageProxy.process().nominalFramesPerSecondForDisplay(*m_webPageProxy.displayID());
+    return m_webPageProxy->process().nominalFramesPerSecondForDisplay(*m_webPageProxy->displayID());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -59,14 +59,14 @@ void DrawingAreaProxyWC::sizeDidChange()
 {
     discardBackingStore();
     m_currentBackingStoreStateID++;
-    m_webPageProxy.send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size), m_identifier);
+    protectedWebPageProxy()->send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size), m_identifier);
 }
 
 void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, UpdateInfo&& updateInfo)
 {
     if (backingStoreStateID == m_currentBackingStoreStateID)
         incorporateUpdate(WTFMove(updateInfo));
-    m_webPageProxy.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
+    protectedWebPageProxy()->send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
 }
 
 void DrawingAreaProxyWC::enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&)
@@ -87,11 +87,11 @@ void DrawingAreaProxyWC::incorporateUpdate(UpdateInfo&& updateInfo)
         for (const auto& rect : updateInfo.updateRects)
             damageRegion.unite(rect);
     } else
-        damageRegion = WebCore::IntRect({ }, m_webPageProxy.viewSize());
+        damageRegion = WebCore::IntRect({ }, m_webPageProxy->viewSize());
 
     m_backingStore->incorporateUpdate(WTFMove(updateInfo));
 
-    m_webPageProxy.setViewNeedsDisplay(damageRegion);
+    protectedWebPageProxy()->setViewNeedsDisplay(damageRegion);
 }
 
 void DrawingAreaProxyWC::discardBackingStore()


### PR DESCRIPTION
#### d7c53fae1c3d76cf6aa7cbf4478aeeda1a5df358
<pre>
DrawingAreaProxy should hold a CheckedRef to WebPageProxy instead of a raw reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=261188">https://bugs.webkit.org/show_bug.cgi?id=261188</a>

Reviewed by Chris Dumez.

Use CheckedRef to point to WebPageProxy as warned by the clang static analyzer.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::forceUpdateIfNeeded):
(WebKit::DrawingAreaProxyCoordinatedGraphics::incorporateUpdate):
(WebKit::DrawingAreaProxyCoordinatedGraphics::sizeDidChange):
(WebKit::DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange):
(WebKit::DrawingAreaProxyCoordinatedGraphics::adjustTransientZoom):
(WebKit::DrawingAreaProxyCoordinatedGraphics::commitTransientZoom):
(WebKit::DrawingAreaProxyCoordinatedGraphics::update):
(WebKit::DrawingAreaProxyCoordinatedGraphics::targetRefreshRateDidChange):
(WebKit::DrawingAreaProxyCoordinatedGraphics::alwaysUseCompositing const):
(WebKit::DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode):
(WebKit::DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode):
(WebKit::DrawingAreaProxyCoordinatedGraphics::updateAcceleratedCompositingMode):
(WebKit::DrawingAreaProxyCoordinatedGraphics::sendUpdateGeometry):
(WebKit::DrawingAreaProxyCoordinatedGraphics::discardBackingStore):
(WebKit::DrawingAreaProxyCoordinatedGraphics::dispatchAfterEnsuringDrawing):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::protectedWebPageProxy const):
(WebKit::DrawingAreaProxy::didChangeViewExposedRect):
(WebKit::DrawingAreaProxy::viewExposedRectChangedTimerFired):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::sizeDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::viewWillStartLiveResize):
(WebKit::RemoteLayerTreeDrawingAreaProxy::viewWillEndLiveResize):
(WebKit::RemoteLayerTreeDrawingAreaProxy::deviceScaleFactorDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didUpdateGeometry):
(WebKit::RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry):
(WebKit::RemoteLayerTreeDrawingAreaProxy::processStateForConnection):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::acceleratedAnimationDidStart):
(WebKit::RemoteLayerTreeDrawingAreaProxy::acceleratedAnimationDidEnd):
(WebKit::RemoteLayerTreeDrawingAreaProxy::indicatorLocation const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::indicatorScale const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::windowKindDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::minimumSizeForAutoLayoutDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::createScrollingCoordinatorProxy const):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::colorSpaceDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::createFence):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::deviceScaleFactorDidChange):
(WebKit::TiledCoreAnimationDrawingAreaProxy::sizeDidChange):
(WebKit::TiledCoreAnimationDrawingAreaProxy::colorSpaceDidChange):
(WebKit::TiledCoreAnimationDrawingAreaProxy::minimumSizeForAutoLayoutDidChange):
(WebKit::TiledCoreAnimationDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange):
(WebKit::TiledCoreAnimationDrawingAreaProxy::enterAcceleratedCompositingMode):
(WebKit::TiledCoreAnimationDrawingAreaProxy::updateAcceleratedCompositingMode):
(WebKit::TiledCoreAnimationDrawingAreaProxy::didFirstLayerFlush):
(WebKit::TiledCoreAnimationDrawingAreaProxy::didUpdateGeometry):
(WebKit::TiledCoreAnimationDrawingAreaProxy::waitForDidUpdateActivityState):
(WebKit::TiledCoreAnimationDrawingAreaProxy::willSendUpdateGeometry):
(WebKit::TiledCoreAnimationDrawingAreaProxy::createFence):
(WebKit::TiledCoreAnimationDrawingAreaProxy::sendUpdateGeometry):
(WebKit::TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom):
(WebKit::TiledCoreAnimationDrawingAreaProxy::commitTransientZoom):
(WebKit::TiledCoreAnimationDrawingAreaProxy::displayNominalFramesPerSecond):
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
(WebKit::DrawingAreaProxyWC::sizeDidChange):
(WebKit::DrawingAreaProxyWC::update):
(WebKit::DrawingAreaProxyWC::incorporateUpdate):

Canonical link: <a href="https://commits.webkit.org/267845@main">https://commits.webkit.org/267845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b7468c15436fda6da0d066ee96efe271b4c4153

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16205 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17864 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19925 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15104 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22421 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14005 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15649 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20019 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2190 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->