### PR TITLE
[TextureMapper] Use linear sampling when blurring for better performance

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
@@ -328,8 +328,15 @@ static constexpr float kernelHalfSizeToBlurRadius(unsigned kernelHalfSize)
     return (kernelHalfSize - 1) / 2.f;
 }
 
+static constexpr unsigned kernelHalfSizeToSimplifiedKernelHalfSize(unsigned kernelHalfSize)
+{
+    return kernelHalfSize / 2 + 1;
+}
+
 // Max kernel size is 21
 static constexpr unsigned GaussianKernelMaxHalfSize = 11;
+
+static constexpr unsigned SimplifiedGaussianKernelMaxHalfSize = kernelHalfSizeToSimplifiedKernelHalfSize(GaussianKernelMaxHalfSize);
 
 static constexpr float GaussianBlurMaxRadius = kernelHalfSizeToBlurRadius(GaussianKernelMaxHalfSize);
 
@@ -339,24 +346,48 @@ static inline float gauss(float x, float radius)
 }
 
 // returns kernel half size
-static int computeGaussianKernel(float radius, std::array<float, GaussianKernelMaxHalfSize>& kernel)
+static int computeGaussianKernel(float radius, std::array<float, SimplifiedGaussianKernelMaxHalfSize>& kernel, std::array<float, SimplifiedGaussianKernelMaxHalfSize>& offset)
 {
     unsigned kernelHalfSize = blurRadiusToKernelHalfSize(radius);
     ASSERT(kernelHalfSize <= GaussianKernelMaxHalfSize);
 
-    kernel[0] = 1; // gauss(0, radius);
-    float sum = kernel[0];
+    float fullKernel[GaussianKernelMaxHalfSize];
+
+    fullKernel[0] = 1; // gauss(0, radius);
+    float sum = fullKernel[0];
     for (unsigned i = 1; i < kernelHalfSize; ++i) {
-        kernel[i] = gauss(i, radius);
-        sum += 2 * kernel[i];
+        fullKernel[i] = gauss(i, radius);
+        sum += 2 * fullKernel[i];
     }
 
     // Normalize the kernel.
     float scale = 1 / sum;
     for (unsigned i = 0; i < kernelHalfSize; ++i)
-        kernel[i] *= scale;
+        fullKernel[i] *= scale;
 
-    return kernelHalfSize;
+    unsigned simplifiedKernelHalfSize = kernelHalfSizeToSimplifiedKernelHalfSize(kernelHalfSize);
+
+    // Simplify the kernel by utilizing linear interpolation during texture sampling
+    // full kernel                                                  simplified kernel
+    // |  0  |  1  |  2  |  3  |  4  |  5  |    --- simplify -->    |  0  | 1&2 | 3&4 |  5  |
+    // (kernelHalfSize = 6)
+    kernel[0] = fullKernel[0];
+    for (unsigned i = 1; i < simplifiedKernelHalfSize; i ++) {
+        unsigned offset1 = 2 * i - 1;
+        unsigned offset2 = 2 * i;
+
+        if (offset2 >= kernelHalfSize) {
+            // no pair to simplify
+            kernel[i] = fullKernel[offset1];
+            offset[i] = offset1;
+            break;
+        }
+
+        kernel[i] = fullKernel[offset1] + fullKernel[offset2];
+        offset[i] = (fullKernel[offset1] * offset1 + fullKernel[offset2] * offset2) / kernel[i];
+    }
+
+    return simplifiedKernelHalfSize;
 }
 
 static void prepareFilterProgram(TextureMapperShaderProgram& program, const FilterOperation& operation)
@@ -836,10 +867,12 @@ void TextureMapperGL::drawBlurred(const BitmapTexture& sourceTexture, const Floa
     auto directionVector = direction == Direction::X ? FloatPoint(1, 0) : FloatPoint(0, 1);
     glUniform2f(program->blurDirectionLocation(), directionVector.x(), directionVector.y());
 
-    std::array<float, GaussianKernelMaxHalfSize> kernel;
-    int kernelHalfSize = computeGaussianKernel(radius, kernel);
-    glUniform1fv(program->gaussianKernelLocation(), GaussianKernelMaxHalfSize, kernel.data());
-    glUniform1i(program->gaussianKernelHalfSizeLocation(), kernelHalfSize);
+    std::array<float, SimplifiedGaussianKernelMaxHalfSize> kernel;
+    std::array<float, SimplifiedGaussianKernelMaxHalfSize> offset;
+    int simplifiedKernelHalfSize = computeGaussianKernel(radius, kernel, offset);
+    glUniform1fv(program->gaussianKernelLocation(), SimplifiedGaussianKernelMaxHalfSize, kernel.data());
+    glUniform1fv(program->gaussianKernelOffsetLocation(), SimplifiedGaussianKernelMaxHalfSize, offset.data());
+    glUniform1i(program->gaussianKernelHalfSizeLocation(), simplifiedKernelHalfSize);
 
     auto textureBlurMatrix = TransformationMatrix::identity;
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -145,7 +145,7 @@ static const char* vertexTemplateCommon =
 #define ENABLE_APPLIER(Name) "#define ENABLE_"#Name"\n#define apply"#Name"IfNeeded apply"#Name"\n"
 #define DISABLE_APPLIER(Name) "#define apply"#Name"IfNeeded noop\n"
 #define BLUR_CONSTANTS \
-    GLSL_DIRECTIVE(define GAUSSIAN_KERNEL_MAX_HALF_SIZE 11)
+    GLSL_DIRECTIVE(define GAUSSIAN_KERNEL_MAX_HALF_SIZE 6)
 
 
 #define OES_EGL_IMAGE_EXTERNAL_DIRECTIVE \
@@ -210,6 +210,7 @@ static const char* fragmentTemplateCommon =
         uniform vec4 u_color;
         uniform vec2 u_texelSize;
         uniform float u_gaussianKernel[GAUSSIAN_KERNEL_MAX_HALF_SIZE];
+        uniform float u_gaussianKernelOffset[GAUSSIAN_KERNEL_MAX_HALF_SIZE];
         uniform int u_gaussianKernelHalfSize;
         uniform vec2 u_blurDirection;
         uniform int u_roundedRectNumber;
@@ -363,7 +364,7 @@ static const char* fragmentTemplateCommon =
             vec4 total = texture2D(s_sampler, texCoord) * u_gaussianKernel[0];
 
             for (int i = 1; i < u_gaussianKernelHalfSize; i++) {
-                vec2 offset = step * float(i);
+                vec2 offset = step * u_gaussianKernelOffset[i];
                 total += texture2D(s_sampler, clamp(texCoord + offset, min, max)) * u_gaussianKernel[i];
                 total += texture2D(s_sampler, clamp(texCoord - offset, min, max)) * u_gaussianKernel[i];
             }
@@ -380,7 +381,7 @@ static const char* fragmentTemplateCommon =
             float total = texture2D(s_sampler, texCoord).a * u_gaussianKernel[0];
 
             for (int i = 1; i < u_gaussianKernelHalfSize; i++) {
-                vec2 offset = step * float(i);
+                vec2 offset = step * u_gaussianKernelOffset[i];
                 total += texture2D(s_sampler, clamp(texCoord + offset, min, max)).a * u_gaussianKernel[i];
                 total += texture2D(s_sampler, clamp(texCoord - offset, min, max)).a * u_gaussianKernel[i];
             }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
@@ -47,6 +47,7 @@ namespace WebCore {
     macro(filterAmount) \
     macro(texelSize) \
     macro(gaussianKernel) \
+    macro(gaussianKernelOffset) \
     macro(gaussianKernelHalfSize) \
     macro(blurDirection) \
     macro(roundedRectNumber) \


### PR DESCRIPTION
#### 437b5540d082a86c275db503fe8db8e0de51bbcc
<pre>
[TextureMapper] Use linear sampling when blurring for better performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=261102">https://bugs.webkit.org/show_bug.cgi?id=261102</a>

Reviewed by Fujii Hironori.

To reduce the GPU load for gaussian blur, this fix reduces the size of
kernel use for the blur.

By adjusting the position(offset) to sample the texture and the weight
of each element of the kernel so that the linear interpolation during
texture sampling samples two texels and properly weights them, we can
reduce the size of the kernel without changing behaviour.

* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::kernelHalfSizeToSimplifiedKernelHalfSize):
(WebCore::computeGaussianKernel):
(WebCore::TextureMapperGL::drawBlurred):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:

Canonical link: <a href="https://commits.webkit.org/267715@main">https://commits.webkit.org/267715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76f7aff03e7b6f6e7ca4fcd0b47e086c554583a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17958 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18008 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20102 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15914 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20394 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15793 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2143 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->