### PR TITLE
ImageBufferBackend::toBackendCoordinates is a redundant function

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -512,7 +512,8 @@ RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destina
     if (!backend)
         return nullptr;
     ASSERT(PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat));
-    auto sourceRectScaled = backend->toBackendCoordinates(sourceRect);
+    auto sourceRectScaled = sourceRect;
+    sourceRectScaled.scale(resolutionScale());
     auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
     if (!destination)
         return nullptr;
@@ -525,8 +526,10 @@ void ImageBuffer::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& 
     auto* backend = ensureBackendCreated();
     if (!backend)
         return;
-    auto sourceRectScaled = backend->toBackendCoordinates(sourceRect);
-    auto destinationPointScaled = backend->toBackendCoordinates(destinationPoint);
+    auto sourceRectScaled = sourceRect;
+    sourceRectScaled.scale(resolutionScale());
+    auto destinationPointScaled = destinationPoint;
+    destinationPointScaled.scale(resolutionScale());
     backend->putPixelBuffer(pixelBuffer, sourceRectScaled, destinationPointScaled, destinationFormat);
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -160,15 +160,6 @@ public:
 
     const Parameters& parameters() { return m_parameters; }
 
-    template<typename T>
-    T toBackendCoordinates(T t) const
-    {
-        static_assert(std::is_same<T, IntPoint>::value || std::is_same<T, IntSize>::value || std::is_same<T, IntRect>::value);
-        if (resolutionScale() != 1)
-            t.scale(resolutionScale());
-        return t;
-    }
-
     WEBCORE_EXPORT virtual String debugDescription() const = 0;
 
 protected:

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -113,9 +113,7 @@ void ImageBufferCairoSurfaceBackend::putPixelBuffer(const PixelBuffer& pixelBuff
 {
     ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, cairo_image_surface_get_data(m_surface.get()));
 
-    IntRect srcRectScaled = toBackendCoordinates(srcRect);
-    IntPoint destPointScaled = toBackendCoordinates(destPoint);
-    cairo_surface_mark_dirty_rectangle(m_surface.get(), destPointScaled.x(), destPointScaled.y(), srcRectScaled.width(), srcRectScaled.height());
+    cairo_surface_mark_dirty_rectangle(m_surface.get(), destPoint.x(), destPoint.y(), srcRect.width(), srcRect.height());
 }
 
 String ImageBufferCairoSurfaceBackend::debugDescription() const


### PR DESCRIPTION
#### c102029b036a7b0ff8df06206e243f0e86d7f1ad
<pre>
ImageBufferBackend::toBackendCoordinates is a redundant function
<a href="https://bugs.webkit.org/show_bug.cgi?id=261198">https://bugs.webkit.org/show_bug.cgi?id=261198</a>
rdar://115051175

Reviewed by Matt Woodrow.

Currently RemoteImageBufferProxy::getPixelBuffer is incorrect because
it needs a backend to call to toBackendCoordinates.
It&apos;s better to not have the helper, the info is already available
in ImageBuffer.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::getPixelBuffer const):
(WebCore::ImageBuffer::putPixelBuffer):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::toBackendCoordinates const): Deleted.

* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::putPixelBuffer):
ImageBufferBackend arguments are already in backend coordinates, no need
to map

Canonical link: <a href="https://commits.webkit.org/267774@main">https://commits.webkit.org/267774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8190b83d835d2332d8eab0185ed4cfcaf65ed783

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18419 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19970 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22462 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15692 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4205 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->