### PR TITLE
REGRESSION(267279@main): [ macOS wk2 ] imported/w3c/web-platform-tests/media-source/mediasource-play-then-seek-back.html is a consistent text failure.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1876,9 +1876,6 @@ compositing/hidpi-image-backing-store.html [ Failure ]
 # rdar://108846032 (REGRESSION (263506@main): [ Sonoma wk2 ] fast/layoutformattingcontext/horizontal-sizing-with-trailing-letter-spacing.html: WebCore::Layout::Line::TrimmableTrailingContent::remove)
 [ Sonoma+ ] fast/layoutformattingcontext/horizontal-sizing-with-trailing-letter-spacing.html [ Skip ]
 
-webkit.org/b/260833 [ Monterey+ ] imported/w3c/web-platform-tests/media-source/mediasource-play-then-seek-back.html [ Pass Failure ]
-webkit.org/b/260867 [ Monterey+ ] fast/canvas/webgl/texImage2D-mse-flipY-false.html [ Pass Failure ]
-
 webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html [ Pass Failure ]
 
 webkit.org/b/260917 [ Ventura ] fast/forms/border-color-relayout.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -814,6 +814,11 @@ void MediaPlayer::seekWhenPossible(const MediaTime& time)
         seekToTime(time);
 }
 
+void MediaPlayer::seeked(const MediaTime& time)
+{
+    client().mediaPlayerSeeked(time);
+}
+
 bool MediaPlayer::paused() const
 {
     return m_private->paused();

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -163,7 +163,7 @@ struct SeekTarget {
     MediaTime negativeThreshold { MediaTime::zeroTime() };
     MediaTime positiveThreshold { MediaTime::zeroTime() };
 
-    String toString() const;
+    WEBCORE_EXPORT String toString() const;
 };
 
 class MediaPlayerClient : public CanMakeWeakPtr<MediaPlayerClient> {
@@ -181,6 +181,9 @@ public:
 
     // the mute state has changed
     virtual void mediaPlayerMuteChanged() { }
+
+    // the last seek operation has completed
+    virtual void mediaPlayerSeeked(const MediaTime&) { }
 
     // time has jumped, eg. not as a result of normal playback
     virtual void mediaPlayerTimeChanged() { }
@@ -442,6 +445,7 @@ public:
     void seekWhenPossible(const MediaTime&);
     void seekToTarget(const SeekTarget&);
     bool seeking() const;
+    void seeked(const MediaTime&);
 
     static double invalidTime() { return -1.0;}
     MediaTime duration() const;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -287,6 +287,7 @@ void MediaPlayerPrivateAVFoundation::seekToTarget(const SeekTarget& target)
 
     ALWAYS_LOG(LOGIDENTIFIER, "seeking to ", adjustedTarget.time);
 
+    m_lastSeekTime = adjustedTarget.time;
     seekToTargetInternal(adjustedTarget);
 }
 
@@ -676,12 +677,18 @@ void MediaPlayerPrivateAVFoundation::seekCompleted(bool finished)
         return;
     }
 
+    if (!finished)
+        return;
+
     if (currentTextTrack())
         currentTextTrack()->endSeeking();
 
     updateStates();
-    if (auto player = m_player.get())
+
+    if (auto player = m_player.get()) {
+        player->seeked(m_lastSeekTime);
         player->timeChanged();
+    }
 }
 
 void MediaPlayerPrivateAVFoundation::didEnd()

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -335,6 +335,7 @@ private:
     ThreadSafeWeakPtr<MediaPlayer> m_player;
 
     Function<void()> m_pendingSeek;
+    MediaTime m_lastSeekTime;
 
     mutable Lock m_queuedNotificationsLock;
     Deque<Notification> m_queuedNotifications WTF_GUARDED_BY_LOCK(m_queuedNotificationsLock);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -542,7 +542,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
         m_lastSeekTime = seekedTime;
 
         ALWAYS_LOG(LOGIDENTIFIER);
-        MediaTime synchronizerTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
+        MediaTime synchronizerTime = PAL::toMediaTime([m_synchronizer currentTime]);
 
         m_synchronizerSeeking = synchronizerTime != seekedTime;
         ALWAYS_LOG(LOGIDENTIFIER, "seekedTime = ", seekedTime, ", synchronizerTime = ", synchronizerTime, "synchronizer seeking = ", m_synchronizerSeeking);
@@ -574,8 +574,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekCompleted()
         ALWAYS_LOG(LOGIDENTIFIER, "Synchronizer still seeking, bailing out");
         return;
     }
-    if (auto player = m_player.get())
+    if (auto player = m_player.get()) {
+        player->seeked(m_lastSeekTime);
         player->timeChanged();
+    }
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::seeking() const

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -287,8 +287,10 @@ void MediaPlayerPrivateWebM::seekToTarget(const SeekTarget& target)
         reenqueueMediaForTime(trackBuffer, trackId, target.time);
     }
     [m_synchronizer setRate:m_rate];
-    if (auto player = m_player.get())
+    if (auto player = m_player.get()) {
+        player->seeked(target.time);
         player->timeChanged();
+    }
 }
 
 void MediaPlayerPrivateWebM::setRateDouble(double rate)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -492,7 +492,7 @@ void MediaPlayerPrivateGStreamer::seekToTarget(const SeekTarget& inTarget)
     // Avoid useless seeking.
     if (inTarget.time == currentMediaTime()) {
         GST_DEBUG_OBJECT(pipeline(), "[Seek] Already at requested position. Aborting.");
-        timeChanged(); // needed for seeked event to be fired.
+        timeChanged(inTarget.time);
         return;
     }
 
@@ -537,7 +537,7 @@ void MediaPlayerPrivateGStreamer::seekToTarget(const SeekTarget& inTarget)
         m_isEndReached = false;
         m_isSeeking = false;
         m_cachedPosition = MediaTime::zeroTime();
-        timeChanged();
+        timeChanged(target.time);
         return;
     }
 
@@ -1245,12 +1245,15 @@ void MediaPlayerPrivateGStreamer::loadStateChanged()
     updateStates();
 }
 
-void MediaPlayerPrivateGStreamer::timeChanged()
+void MediaPlayerPrivateGStreamer::timeChanged(const MediaTime& seekedTime)
 {
     updateStates();
-    GST_DEBUG_OBJECT(pipeline(), "Emitting timeChanged notification");
-    if (auto player = m_player.get())
+    GST_DEBUG_OBJECT(pipeline(), "Emitting timeChanged notification (seekCompleted:%d)", seekedTime.isValid());
+    if (auto player = m_player.get()) {
+        if (seekedTime.isValid())
+            player->seeked(seekedTime);
         player->timeChanged();
+    }
 }
 
 void MediaPlayerPrivateGStreamer::loadingFailed(MediaPlayer::NetworkState networkError, MediaPlayer::ReadyState readyState, bool forceNotifications)
@@ -2413,7 +2416,7 @@ void MediaPlayerPrivateGStreamer::finishSeek()
     // The pipeline can still have a pending state. In this case a position query will fail.
     // Right now we can use m_seekTarget as a fallback.
     m_canFallBackToLastFinishedSeekPosition = true;
-    timeChanged();
+    timeChanged(m_seekTarget.time);
 }
 
 void MediaPlayerPrivateGStreamer::updateStates()
@@ -2756,7 +2759,7 @@ void MediaPlayerPrivateGStreamer::didEnd()
         configureMediaStreamAudioTracks();
     }
 
-    timeChanged();
+    timeChanged(MediaTime::invalidTime());
 }
 
 void MediaPlayerPrivateGStreamer::getSupportedTypes(HashSet<String>& types)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -322,7 +322,7 @@ protected:
     static void audioChangedCallback(MediaPlayerPrivateGStreamer*);
     static void textChangedCallback(MediaPlayerPrivateGStreamer*);
 
-    void timeChanged();
+    void timeChanged(const MediaTime&); // If MediaTime is valid, indicates that a seek has completed.
     void loadingFailed(MediaPlayer::NetworkState, MediaPlayer::ReadyState = MediaPlayer::ReadyState::HaveNothing, bool forceNotifications = false);
     void loadStateChanged();
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -270,8 +270,7 @@ void MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone()
         m_isSeeking = false;
         GST_DEBUG("Seek complete because of preroll. currentMediaTime = %s", currentMediaTime().toString().utf8().data());
         // By calling timeChanged(), m_isSeeking will be checked an a "seeked" event will be emitted.
-        if (auto player = m_player.get())
-            player->timeChanged();
+        timeChanged(currentMediaTime());
     }
 
     propagateReadyStateToPlayer();

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -218,8 +218,10 @@ void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
         m_seekCompleted = true;
         m_currentTime = seekTime;
 
-        if (auto player = m_player.get())
+        if (auto player = m_player.get()) {
+            player->seeked(seekTime);
             player->timeChanged();
+        }
 
         if (m_playing)
             callOnMainThread([this, weakThis = WeakPtr { *this }] {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -234,6 +234,7 @@ void RemoteMediaPlayerProxy::pause()
 
 void RemoteMediaPlayerProxy::seekToTarget(const WebCore::SeekTarget& target)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, target);
     m_player->seekToTarget(target);
 }
 
@@ -432,6 +433,12 @@ void RemoteMediaPlayerProxy::mediaPlayerVolumeChanged()
 void RemoteMediaPlayerProxy::mediaPlayerMuteChanged()
 {
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::MuteChanged(m_player->muted()), m_id);
+}
+
+void RemoteMediaPlayerProxy::mediaPlayerSeeked(const MediaTime& time)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, time);
+    m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::Seeked(time), m_id);
 }
 
 void RemoteMediaPlayerProxy::mediaPlayerTimeChanged()
@@ -968,7 +975,6 @@ void RemoteMediaPlayerProxy::updateCachedState(bool forceCurrentTimeUpdate)
         currentTimeChanged(m_player->currentTime());
 
     m_cachedState.paused = m_player->paused();
-    m_cachedState.seeking = m_player->seeking();
     maybeUpdateCachedVideoMetrics();
     if (m_bufferedChanged) {
         m_bufferedChanged = false;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -242,6 +242,7 @@ private:
     void mediaPlayerReadyStateChanged() final;
     void mediaPlayerVolumeChanged() final;
     void mediaPlayerMuteChanged() final;
+    void mediaPlayerSeeked(const MediaTime&) final;
     void mediaPlayerTimeChanged() final;
     void mediaPlayerDurationChanged() final;
     void mediaPlayerSizeChanged() final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -286,6 +286,7 @@ MediaTime MediaPlayerPrivateRemote::currentMediaTime() const
 
 void MediaPlayerPrivateRemote::seekToTarget(const WebCore::SeekTarget& target)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, target);
     m_seeking = true;
     m_cachedMediaTime = target.time;
     connection().send(Messages::RemoteMediaPlayerProxy::SeekToTarget(target), m_id);
@@ -331,6 +332,7 @@ void MediaPlayerPrivateRemote::networkStateChanged(RemoteMediaPlayerState&& stat
 
 void MediaPlayerPrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, readyState);
     m_cachedState.readyState = readyState;
     if (auto player = m_player.get())
         player->readyStateChanged();
@@ -338,6 +340,7 @@ void MediaPlayerPrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
 
 void MediaPlayerPrivateRemote::readyStateChanged(RemoteMediaPlayerState&& state)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, state.readyState);
     updateCachedState(WTFMove(state));
     if (auto player = m_player.get()) {
         player->readyStateChanged();
@@ -359,10 +362,19 @@ void MediaPlayerPrivateRemote::muteChanged(bool muted)
         player->muteChanged(muted);
 }
 
+void MediaPlayerPrivateRemote::seeked(const MediaTime& time)
+{
+    ALWAYS_LOG(LOGIDENTIFIER, time);
+    m_seeking = false;
+    m_cachedMediaTime =  time;
+    m_cachedMediaTimeQueryTime = MonotonicTime::now();
+    if (auto player = m_player.get())
+        player->seeked(time);
+}
+
 void MediaPlayerPrivateRemote::timeChanged(RemoteMediaPlayerState&& state)
 {
-    if (!state.seeking)
-        m_seeking = false;
+    ALWAYS_LOG(LOGIDENTIFIER);
     updateCachedState(WTFMove(state));
     if (auto player = m_player.get())
         player->timeChanged();

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -103,6 +103,7 @@ public:
     void readyStateChanged(RemoteMediaPlayerState&&);
     void volumeChanged(double);
     void muteChanged(bool);
+    void seeked(const MediaTime&);
     void timeChanged(RemoteMediaPlayerState&&);
     void durationChanged(RemoteMediaPlayerState&&);
     void rateChanged(double);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -29,6 +29,7 @@ messages -> MediaPlayerPrivateRemote NotRefCounted {
     FirstVideoFrameAvailable()
     VolumeChanged(double volume)
     MuteChanged(bool mute)
+    Seeked(MediaTime mediaTime)
     TimeChanged(struct WebKit::RemoteMediaPlayerState state)
     DurationChanged(struct WebKit::RemoteMediaPlayerState state)
     RateChanged(double rate)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h
@@ -58,7 +58,6 @@ struct RemoteMediaPlayerState {
     std::optional<WebCore::VideoPlaybackQualityMetrics> videoMetrics;
     std::optional<bool> documentIsCrossOrigin { true };
     bool paused { true };
-    bool seeking { false };
     bool canSaveMediaData { false };
     bool hasAudio { false };
     bool hasVideo { false };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in
@@ -43,7 +43,6 @@ struct WebKit::RemoteMediaPlayerState {
     std::optional<WebCore::VideoPlaybackQualityMetrics> videoMetrics;
     std::optional<bool> documentIsCrossOrigin;
     bool paused;
-    bool seeking;
     bool canSaveMediaData;
     bool hasAudio;
     bool hasVideo;


### PR DESCRIPTION
#### 939ec6849c62f57b06b35da53db9f9794036cdd5
<pre>
REGRESSION(267279@main): [ macOS wk2 ] imported/w3c/web-platform-tests/media-source/mediasource-play-then-seek-back.html is a consistent text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260833">https://bugs.webkit.org/show_bug.cgi?id=260833</a>
rdar://114594559

Reviewed by Jer Noble.

The `seeked` event wasn&apos;t received by the test as expected.
There were multiple reasons for this to occur:
1- The content processed assumed that the first timeUpdate message received
from the GPU process indicated that the pending seek operation had completed.
However, this wasn&apos;t always the case as timeUpdate can be send from the GPU
to the CP outside seeking (when playback has started and currentTime as progressed,
when playback has reached the end, when playback has skipped a gap etc)
Those messages are sent asynchronously from the GPU to the CP and could
have been received after the CP had started seeking, it would
incorrectly link this message to the end of the seek operation. So we
add a new IPC message `seeked` to no longer link seeking to timeUpdate and
uniquely identifies when the seek operation has been completed.
We only need to deal with this new event when the GPU process is involved
as when there&apos;s no GPU process seek/timeupdate are properly matched.

2- The MediaPlayerPrivateMediaSourceAVFObjC implementation was waiting
for a callback from the AVSampleBufferRenderSynchronizer after the seek
to complete the seek operation. However, if we seeked to the same location
as what the current time is, no callback occured. The code compared the
synchronizer&apos;s &quot;timeBase&quot; vs currentTime.

There is an extra issue with the test itself, it always assumes that the
`seeked` event will be fired in a different event loop that fired the
`seeking` event. The fixes above avoid this problem for now.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::seeked):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerSeeked):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::seekToTarget):
(WebCore::MediaPlayerPrivateAVFoundation::seekCompleted):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekCompleted):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::seekToTarget):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::seekToTarget):
(WebCore::MediaPlayerPrivateGStreamer::timeChanged):
(WebCore::MediaPlayerPrivateGStreamer::finishSeek):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer):
(WebCore::MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::seekToTarget):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerSeeked):
(WebKit::RemoteMediaPlayerProxy::updateCachedState):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::seekToTarget): Add logging.
(WebKit::MediaPlayerPrivateRemote::setReadyState): Add logging.
(WebKit::MediaPlayerPrivateRemote::readyStateChanged): Add logging.
(WebKit::MediaPlayerPrivateRemote::seeked):
(WebKit::MediaPlayerPrivateRemote::timeChanged): Add logging.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.h: Remove the seeking
attribute. It is no longer needed as &quot;seeked&quot; as its own IPC message.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in:

Canonical link: <a href="https://commits.webkit.org/267723@main">https://commits.webkit.org/267723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15749d43fccf1486d43ebf14b0a0f029d6e18521

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18438 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19997 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15167 "4 flakes 3 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22482 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20309 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14062 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15717 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4169 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->