### PR TITLE
WebVTT Timestamp Object need one leading zero if the hours component is less than ten

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
@@ -9,6 +9,6 @@ PASS VTTCue.getCueAsHTML(), <ruby>
 PASS VTTCue.getCueAsHTML(), <rt>
 PASS VTTCue.getCueAsHTML(), <v>
 PASS VTTCue.getCueAsHTML(), <v a b>
-FAIL VTTCue.getCueAsHTML(), <1:00:00.500> assert_equals: data expected "01:00:00.500" but got "1:00:00.500"
+PASS VTTCue.getCueAsHTML(), <1:00:00.500>
 FAIL VTTCue.getCueAsHTML(), x\0 assert_equals: data expected "x\0" but got "x\ufffd"
 


### PR DESCRIPTION
#### 46510aee943163967d2d9f6d5f99e5e09ce95a52
<pre>
WebVTT Timestamp Object need one leading zero if the hours component is less than ten
<a href="https://bugs.webkit.org/show_bug.cgi?id=261201">https://bugs.webkit.org/show_bug.cgi?id=261201</a>

Reviewed by Eric Carlson.

According to the spec, one leading zero is required if the hours
component is less than ten when timestamp construction. This commit updates
the WebVTT parser to follow the spec.

<a href="https://www.w3.org/TR/webvtt1/#dom-construction-rules">https://www.w3.org/TR/webvtt1/#dom-construction-rules</a>

* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::appendNumber):
(WebCore::serializeTimestamp):
(WebCore::WebVTTTreeBuilder::constructTreeFromToken):

Canonical link: <a href="https://commits.webkit.org/268503@main">https://commits.webkit.org/268503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/381ae0efda5f517760dba46ae2eae8ca9f80540a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19875 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22285 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24083 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22055 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15721 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17698 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->