### PR TITLE
REGRESSION(267279@main): media/media-source/media-source-seek-detach-crash.html causes a crash

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -188,8 +188,10 @@ const PlatformTimeRanges& MediaSource::buffered() const
 
 void MediaSource::seekToTarget(const SeekTarget& target, CompletionHandler<void(const MediaTime&)>&& completionHandler)
 {
-    if (isClosed())
+    if (isClosed()) {
+        completionHandler(MediaTime::invalidTime());
         return;
+    }
 
     ALWAYS_LOG(LOGIDENTIFIER, target.time);
 
@@ -256,8 +258,10 @@ void MediaSource::completeSeek()
         {
             auto seekTime = time;
             for (auto& result : seekResults) {
-                if (result.isInvalid())
+                if (result.isInvalid()) {
                     completionHandler(MediaTime::invalidTime());
+                    return;
+                }
                 if (abs(time - result) > abs(time - seekTime))
                     seekTime = result;
             }


### PR DESCRIPTION
#### f790c5f884db22b3b48c5f6858f449d3dc003dbc
<pre>
REGRESSION(267279@main): media/media-source/media-source-seek-detach-crash.html causes a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=261202">https://bugs.webkit.org/show_bug.cgi?id=261202</a>
rdar://115055098

Reviewed by Youenn Fablet.

Call completionHandler immediately when MediaSource is closed.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::seekToTarget):
(WebCore::MediaSource::completeSeek): Fly-by fix, exit loop early when an error has occurred.

Canonical link: <a href="https://commits.webkit.org/267675@main">https://commits.webkit.org/267675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/974aa4d9c8d5b5c5e0d38c83471de19cb2b66c49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17845 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17915 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19984 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15806 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20300 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16560 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15705 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->