### PR TITLE
REGRESSION(266293@main): media/audioSession/audioSessionState.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2733,8 +2733,6 @@ webkit.org/b/259712 [ Monterey+ ] media/media-source/media-source-paint-after-di
 
 webkit.org/b/259489 [ Monterey+ ] http/tests/media/hls/track-in-band-multiple-cues.html [ Pass Failure ]
 
-webkit.org/b/259524 [ Monterey+ ] media/audioSession/audioSessionState.html [ Pass Failure ]
-
 # rdar://110876540 ASSERTION FAILED: firstChild(): [ macOS ] (258183)
 [ Debug ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Pass Crash ]
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -672,6 +672,7 @@ void Internals::resetToConsistentState(Page& page)
 #if USE(AUDIO_SESSION)
     AudioSession::sharedSession().setCategoryOverride(AudioSessionCategory::None);
     AudioSession::sharedSession().tryToSetActive(false);
+    AudioSession::sharedSession().endInterruptionForTesting();
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -118,6 +118,7 @@ private:
     bool m_isPlayingToBluetoothOverrideChanged { false };
     std::optional<RemoteAudioSessionConfiguration> m_configuration;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
+    bool m_isInterruptedForTesting { false };
 };
 
 }


### PR DESCRIPTION
#### cfee0fec20b654c0f06d3a820725b40ebb158ee9
<pre>
REGRESSION(266293@main): media/audioSession/audioSessionState.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259524">https://bugs.webkit.org/show_bug.cgi?id=259524</a>
rdar://112914519

Reviewed by Jean-Yves Avenard.

The flakiness was due to the following steps:
1. With internals, we simulate beginning an interruption from WebProcess, which is sent to GPU process, which does the interuption business.
2. This triggers notification to the WebProcess that the AudioSession state changed. DOMAudioSession schedules a task to check this and fires an event if needed.
3. Very close to simulating the beginning of the interruption, the WebProcess also tries to activate its audio session. On GPUProcess side, this succeeeds, which triggers ending the interruption.
4. The WebProcess is then notified and DOMAudioSession quickly schedules a task to check this and fires an event as needed.
5. In case the WebProcess beginning and end of interruptions are very close, the first DOMAudioSession task will not see a change of the DOMAudioSession state and will quit early without firing an event.

To prevent the flakiness, we enforce RemoteAudioSession::tryToSetActiveInternal to fail when we are in a test interruption and active is true, like would happen in case of a phone call interruption.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::tryToSetActiveInternal):
(WebKit::RemoteAudioSession::endAudioSessionInterruption):
(WebKit::RemoteAudioSession::beginInterruptionForTesting):
(WebKit::RemoteAudioSession::endInterruptionForTesting):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:

Canonical link: <a href="https://commits.webkit.org/267683@main">https://commits.webkit.org/267683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7feb23bc90ace222820e67c07e989f4674aa642

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17854 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17921 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19993 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22479 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20306 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14057 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15713 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4151 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->