### PR TITLE
Teach the opportunistic task scheduler about zero-delay timers and requestAnimationFrame

### DIFF
--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class Document;
+class ImminentlyScheduledWorkScope;
 class Page;
 class RequestAnimationFrameCallback;
 class UserGestureToken;
@@ -78,6 +79,7 @@ private:
     struct CallbackData {
         Ref<RequestAnimationFrameCallback> callback;
         RefPtr<UserGestureToken> userGestureTokenToForward;
+        RefPtr<ImminentlyScheduledWorkScope> scheduledWorkScope;
     };
     Vector<CallbackData> m_callbackDataList;
 

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -200,6 +200,7 @@ int DOMTimer::install(ScriptExecutionContext& context, Function<void(ScriptExecu
 {
     Ref<DOMTimer> timer = adoptRef(*new DOMTimer(context, WTFMove(action), timeout, type));
     timer->suspendIfNeeded();
+    timer->makeImminentlyScheduledWorkScopeIfPossible(context);
 
     // Keep asking for the next id until we're given one that we don't already have.
     do {
@@ -246,8 +247,10 @@ void DOMTimer::removeById(ScriptExecutionContext& context, int timeoutId)
 
     InspectorInstrumentation::didRemoveTimer(context, timeoutId);
 
-    if (auto timer = context.takeTimeout(timeoutId))
+    if (auto timer = context.takeTimeout(timeoutId)) {
+        timer->clearImminentlyScheduledWorkScope();
         timer->m_timer = nullptr;
+    }
 }
 
 inline bool DOMTimer::isDOMTimersThrottlingEnabled(const Document& document) const
@@ -345,6 +348,7 @@ void DOMTimer::fired()
 
         updateThrottlingStateIfNecessary(fireState);
 
+        clearImminentlyScheduledWorkScope();
         return;
     }
 
@@ -371,6 +375,8 @@ void DOMTimer::fired()
         }
         nestedTimers->stopTracking();
     }
+
+    clearImminentlyScheduledWorkScope();
 }
 
 void DOMTimer::stop()
@@ -380,6 +386,8 @@ void DOMTimer::stop()
     // which will cause a memory leak.
     m_timer = nullptr;
     m_action = nullptr;
+
+    clearImminentlyScheduledWorkScope();
 }
 
 void DOMTimer::updateTimerIntervalIfNecessary()
@@ -440,6 +448,27 @@ std::optional<MonotonicTime> ScriptExecutionContext::alignedFireTime(bool hasRea
 const char* DOMTimer::activeDOMObjectName() const
 {
     return "DOMTimer";
+}
+
+void DOMTimer::makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext& context)
+{
+    if (!m_oneShot || m_currentTimerInterval > 1_ms)
+        return;
+
+    RefPtr document = dynamicDowncast<Document>(context);
+    if (!document)
+        return;
+
+    auto* page = document->page();
+    if (!page)
+        return;
+
+    m_imminentlyScheduledWorkScope = page->opportunisticTaskScheduler().makeScheduledWorkScope();
+}
+
+void DOMTimer::clearImminentlyScheduledWorkScope()
+{
+    m_imminentlyScheduledWorkScope = nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -39,6 +39,7 @@ namespace WebCore {
 
 class DOMTimerFireState;
 class Document;
+class ImminentlyScheduledWorkScope;
 class ScheduledAction;
 
 class DOMTimer final : public RefCounted<DOMTimer>, public ActiveDOMObject, public CanMakeWeakPtr<DOMTimer> {
@@ -82,6 +83,9 @@ private:
     const char* activeDOMObjectName() const final;
     void stop() final;
 
+    void makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext&);
+    void clearImminentlyScheduledWorkScope();
+
     enum TimerThrottleState {
         Undetermined,
         ShouldThrottle,
@@ -98,6 +102,7 @@ private:
     bool m_hasReachedMaxNestingLevel;
     Seconds m_currentTimerInterval;
     RefPtr<UserGestureToken> m_userGestureTokenToForward;
+    RefPtr<ImminentlyScheduledWorkScope> m_imminentlyScheduledWorkScope;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -32,17 +32,21 @@
 
 namespace WebCore {
 
-class Page;
 class OpportunisticTaskScheduler;
+class Page;
 
-class OpportunisticTaskDeferralScope {
-    WTF_MAKE_NONCOPYABLE(OpportunisticTaskDeferralScope); WTF_MAKE_FAST_ALLOCATED;
+class ImminentlyScheduledWorkScope : public RefCounted<ImminentlyScheduledWorkScope> {
 public:
-    OpportunisticTaskDeferralScope(OpportunisticTaskScheduler&);
-    OpportunisticTaskDeferralScope(OpportunisticTaskDeferralScope&&);
-    ~OpportunisticTaskDeferralScope();
+    static Ref<ImminentlyScheduledWorkScope> create(OpportunisticTaskScheduler& scheduler)
+    {
+        return adoptRef(*new ImminentlyScheduledWorkScope(scheduler));
+    }
+
+    ~ImminentlyScheduledWorkScope();
 
 private:
+    ImminentlyScheduledWorkScope(OpportunisticTaskScheduler&);
+
     WeakPtr<OpportunisticTaskScheduler> m_scheduler;
 };
 
@@ -56,20 +60,19 @@ public:
     ~OpportunisticTaskScheduler();
 
     void reschedule(MonotonicTime deadline);
+    bool hasImminentlyScheduledWork() const { return m_imminentlyScheduledWorkCount; }
 
-    WARN_UNUSED_RETURN std::unique_ptr<OpportunisticTaskDeferralScope> makeDeferralScope();
+    WARN_UNUSED_RETURN Ref<ImminentlyScheduledWorkScope> makeScheduledWorkScope();
 
 private:
-    friend class OpportunisticTaskDeferralScope;
+    friend class ImminentlyScheduledWorkScope;
 
     OpportunisticTaskScheduler(Page&);
     void runLoopObserverFired();
 
-    void incrementDeferralCount();
-    void decrementDeferralCount();
-
     WeakPtr<Page> m_page;
-    uint64_t m_taskDeferralCount { 0 };
+    uint64_t m_imminentlyScheduledWorkCount { 0 };
+    uint64_t m_runloopCountAfterBeingScheduled { 0 };
     MonotonicTime m_currentDeadline;
     std::unique_ptr<RunLoopObserver> m_runLoopObserver;
 };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1490,12 +1490,12 @@ void Page::didCommitLoad()
         geolocationController->didNavigatePage();
 #endif
 
-    m_opportunisticTaskDeferralScopeForFirstPaint = m_opportunisticTaskScheduler->makeDeferralScope();
+    m_isWaitingForFirstMeaningfulPaint = true;
 }
 
 void Page::didFirstMeaningfulPaint()
 {
-    m_opportunisticTaskDeferralScopeForFirstPaint = nullptr;
+    m_isWaitingForFirstMeaningfulPaint = false;
 }
 
 void Page::didFinishLoad()
@@ -4535,12 +4535,15 @@ void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::opt
     }
 }
 
-void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
+void Page::opportunisticallyRunIdleCallbacks()
 {
-    TraceScope tracingScope(PerformOpportunisticallyScheduledTasksStart, PerformOpportunisticallyScheduledTasksEnd, (deadline - MonotonicTime::now()).microseconds());
-    forEachWindowEventLoop([&](WindowEventLoop& eventLoop) {
+    forEachWindowEventLoop([&](auto& eventLoop) {
         eventLoop.opportunisticallyRunIdleCallbacks();
     });
+}
+
+void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
+{
     commonVM().performOpportunisticallyScheduledTasks(deadline);
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -127,7 +127,6 @@ class MediaPlaybackTarget;
 class MediaRecorderProvider;
 class MediaSessionCoordinatorPrivate;
 class ModelPlayerProvider;
-class OpportunisticTaskDeferralScope;
 class PageConfiguration;
 class PageConsoleClient;
 class PageDebuggable;
@@ -1053,7 +1052,10 @@ public:
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
     WEBCORE_EXPORT void removeRootFrame(LocalFrame&);
 
+    void opportunisticallyRunIdleCallbacks();
     void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+
+    bool isWaitingForFirstMeaningfulPaint() const { return m_isWaitingForFirstMeaningfulPaint; }
 
 private:
     struct Navigation {
@@ -1411,7 +1413,7 @@ private:
     std::unique_ptr<AttachmentElementClient> m_attachmentElementClient;
 #endif
 
-    std::unique_ptr<OpportunisticTaskDeferralScope> m_opportunisticTaskDeferralScopeForFirstPaint;
+    bool m_isWaitingForFirstMeaningfulPaint { false };
     Ref<OpportunisticTaskScheduler> m_opportunisticTaskScheduler;
 
 #if ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### 7d1d62ffe5fa58d48631c47750b62ceb59b9d019
<pre>
Teach the opportunistic task scheduler about zero-delay timers and requestAnimationFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=261205">https://bugs.webkit.org/show_bug.cgi?id=261205</a>
rdar://113237238

Reviewed by Yusuke Suzuki.

Refine heuristics used to schedule incremental sweeping in `OpportunisticTaskScheduler`, such that
it&apos;s aware of both one-shot zero-delay timers and pending rAF callbacks. Earlier versions of this
task scheduler (prior to `266680@main`) attempted to avoid scheduling work in both DOM timers and
rAF by exiting early if any `OpportunisticTaskDeferralScope` was held, but this has the additional
effect of preventing opportunistic tasks from being scheduled in many cases where it&apos;s necessary to
maintain performance on some critical benchmarks. As such, our current approach ignores pending
timers and rAF altogether, and simply schedules an opportunistic task at the first turn of the
runloop after finalizing a rendering update.

We take a slightly different approach in this patch; rather than limit opportunistically scheduled
tasks to non-deferral scopes, we instead use information about whether there is imminently scheduled
work as one of several pieces of information used to heurisitcally choose when to schedule
opportunistic tasks.

See below for more details.

* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::registerCallback):
(WebCore::ScriptedAnimationController::serviceRequestAnimationFrameCallbacks):
* Source/WebCore/dom/ScriptedAnimationController.h:

Grab a `ImminentlyScheduledWorkScope` while a rAF callback is pending.

* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::install):
(WebCore::DOMTimer::removeById):
(WebCore::DOMTimer::fired):
(WebCore::DOMTimer::stop):
(WebCore::DOMTimer::makeImminentlyScheduledWorkScopeIfPossible):
(WebCore::DOMTimer::clearImminentlyScheduledWorkScope):
* Source/WebCore/page/DOMTimer.h:

Similarly, grab a `ImminentlyScheduledWorkScope` when a one-shot, low-delay DOM timer is pending.

This essentially restores the codepath that was removed in `266680@main`, but renames the &quot;task
deferral&quot; scopes to &quot;imminently scheduled work&quot; instead, to reflect the fact that it&apos;s only used to
provide a hint to the scheduler that there&apos;s imminently scheduled work.

* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::reschedule):

We also turn `OpportunisticTaskScheduler` into a repeating runloop observer, so that we can choose
which runloop after a rendering update we should schedule the opportunistic task (or none at all).
We currently always schedule an opportunistic task after the first turn of the runloop after
finalizing the rendering update, but with this patch, we may now wait for a few turns of the runloop
to pass before scheduling the task (or we may not schedule a task during the rendering update at
all).

(WebCore::OpportunisticTaskScheduler::makeScheduledWorkScope):
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):

Implement the main heuristic here — if we have no imminent work, we schedule the opportunistic task
right away (matching behavior on trunk). Otherwise, we&apos;ll schedule work only if we have (relatively)
a lot of time until the next rendering update, or if the runloop has turned at least a few times
since the end of the rendering update. We start with this simple heuristic for now; in subsequent
patches, we&apos;ll continue to refine this heuristic to account for additional signals such as heap
size and object count, current GC phase, and other state from JavaScriptCore.

Note that we preserve the existing behavior of scheduling at most one opportunistic task per
rendering update. In future patches (especially if we can further quantize GC phases), we should
also consider allowing multiple opportunistic tasks per rendering update, at much smaller time
slices.

(WebCore::ImminentlyScheduledWorkScope::ImminentlyScheduledWorkScope):
(WebCore::ImminentlyScheduledWorkScope::~ImminentlyScheduledWorkScope):

Rename `OpportunisticTaskDeferralScope` to `ImminentlyScheduledWorkScope`, to better reflect the
fact that it&apos;s only used to provide a hint to the scheduler that there&apos;s imminently scheduled work,
rather than always deferring opportunistic tasks during the scope.

(WebCore::OpportunisticTaskDeferralScope::OpportunisticTaskDeferralScope): Deleted.
(WebCore::OpportunisticTaskDeferralScope::~OpportunisticTaskDeferralScope): Deleted.
(WebCore::OpportunisticTaskScheduler::makeDeferralScope): Deleted.
(WebCore::OpportunisticTaskScheduler::incrementDeferralCount): Deleted.
(WebCore::OpportunisticTaskScheduler::decrementDeferralCount): Deleted.
* Source/WebCore/page/OpportunisticTaskScheduler.h:
(WebCore::ImminentlyScheduledWorkScope::create):
(WebCore::OpportunisticTaskScheduler::hasImminentlyScheduledWork const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::didFirstMeaningfulPaint):

Replace the task deferral scope here with just a simple boolean flag indicating whether we&apos;re
waiting for the first meaningful paint. If so, we&apos;ll bail from opportunistic tasks altogether.

(WebCore::Page::opportunisticallyRunIdleCallbacks):

Split out logic for scheduling idle callbacks from the rest of the opportunistically scheduled
tasks, so that we can safely bail if the page itself is destroyed during idle callbacks. We also
move the `TraceScope` to `OpportunisticTaskScheduler`, where we already have the (approximate)
remaining time — this allows us to avoid an extra syscall to `mach_absolute_time` when creating the
trace scope.

(WebCore::Page::performOpportunisticallyScheduledTasks):
* Source/WebCore/page/Page.h:
(WebCore::Page::isWaitingForFirstMeaningfulPaint const):

Remove the former task deferral scope used to avoid opportunistic tasks prior to first meaningful
paint; instead, just make this a boolean flag and return early from `OpportunisticTaskScheduler` in
the case when it&apos;s set.

Canonical link: <a href="https://commits.webkit.org/267818@main">https://commits.webkit.org/267818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c0836f2054ed07337198e48b8e92e647125b516

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18639 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20414 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22730 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20589 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14301 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16004 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4238 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->