### PR TITLE
Avoid linear search in ScrollingStateTree::insertNode() when node is already present at desired index

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -131,25 +131,18 @@ void ScrollingStateNode::removeFromParent()
 
 void ScrollingStateNode::removeChild(ScrollingStateNode& childNode)
 {
-    auto childIndex = indexOfChild(childNode);
-    if (childIndex != notFound)
-        removeChildAtIndex(childIndex);
-}
-
-void ScrollingStateNode::removeChildAtIndex(size_t index)
-{
-    if (index < m_children.size()) {
-        m_children.remove(index);
-        setPropertyChanged(Property::ChildNodes);
-    } else
-        ASSERT_NOT_REACHED();
-}
-
-size_t ScrollingStateNode::indexOfChild(ScrollingStateNode& childNode) const
-{
-    return m_children.findIf([&](auto& child) {
+    auto didRemove = m_children.removeFirstMatching([&](auto& child) {
         return child.ptr() == &childNode;
     });
+    if (didRemove)
+        setPropertyChanged(Property::ChildNodes);
+}
+
+RefPtr<ScrollingStateNode> ScrollingStateNode::childAtIndex(size_t index) const
+{
+    if (index >= m_children.size())
+        return nullptr;
+    return m_children[index].copyRef();
 }
 
 void ScrollingStateNode::setLayer(const LayerRepresentation& layerRepresentation)

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -316,10 +316,9 @@ public:
 
     // Note that node ownership is via the parent, so these functions can trigger node deletion.
     void removeFromParent();
-    void removeChildAtIndex(size_t index);
     void removeChild(ScrollingStateNode&);
 
-    size_t indexOfChild(ScrollingStateNode&) const;
+    RefPtr<ScrollingStateNode> childAtIndex(size_t) const;
 
     String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const;
 

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -141,18 +141,15 @@ ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, Scrol
             if (!parentID)
                 return newNodeID;
 
-            size_t currentIndex = parent->indexOfChild(*node);
-            if (currentIndex == childIndex)
+            if (parent->childAtIndex(childIndex) == node)
                 return newNodeID;
 
-            ASSERT(currentIndex != notFound);
-            Ref protectedNode { *node };
-            parent->removeChildAtIndex(currentIndex);
+            parent->removeChild(*node);
 
             if (childIndex == notFound)
-                parent->appendChild(WTFMove(protectedNode));
+                parent->appendChild(node.releaseNonNull());
             else
-                parent->insertChild(WTFMove(protectedNode), childIndex);
+                parent->insertChild(node.releaseNonNull(), childIndex);
 
             return newNodeID;
         }


### PR DESCRIPTION
#### 78a45ba1d6081c4040d09569c134c3490f9f0e16
<pre>
Avoid linear search in ScrollingStateTree::insertNode() when node is already present at desired index
<a href="https://bugs.webkit.org/show_bug.cgi?id=261209">https://bugs.webkit.org/show_bug.cgi?id=261209</a>

Reviewed by Simon Fraser.

Avoid linear search in ScrollingStateTree::insertNode() when node is already
present at desired index.

We used to do a linear search to find the index of `child` and then compare it
with `childIndex`. Instead, we now lookup the node at `childIndex` (which is
cheap) and compare it to `child`. This allows us to drop some now unused code
as well.

* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::removeChild):
(WebCore::ScrollingStateNode::childAtIndex const):
(WebCore::ScrollingStateNode::removeChildAtIndex): Deleted.
(WebCore::ScrollingStateNode::indexOfChild const): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::insertNode):

Canonical link: <a href="https://commits.webkit.org/267698@main">https://commits.webkit.org/267698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe03004c391e4d7e6d8f0c5c23735b582bc62075

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18440 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20001 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22484 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15720 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->