### PR TITLE
[motion-path] Have basic shapes use an offset containing block rect

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5280,9 +5280,6 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-009.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/motion/offset-path-url-010.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyFailure ]
 
-# CSS motion path: https://bugs.webkit.org/show_bug.cgi?id=261217
-imported/w3c/web-platform-tests/css/motion/offset-path-shape-inset-001.html [ ImageOnlyFailure ]
-
 # CSS motion path: positioning inset shapes with border-radius.
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-inset-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-shape-xywh-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-007-expected.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;basic-shape&gt; circle() path with offset from container</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  position: relative;
+  transform: translate(420.231px, 311.969px) rotate(154.813deg);
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-007-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-007-ref.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;basic-shape&gt; circle() path with offset from container</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  position: relative;
+  transform: translate(420.231px, 311.969px) rotate(154.813deg);
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-007.html
@@ -1,9 +1,8 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>CSS Motion Path test: &lt;basic-shape&gt; circle() path with offset-distance</title>
+<title>CSS Motion Path test: &lt;basic-shape&gt; circle() path with offset from container</title>
 <meta name=fuzzy content="0-170;0-550">
-<link rel="author" title="Daniil Sakhapov" href="sakhapov@google.com">
-<link rel="match" href="offset-path-shape-circle-003-ref.html">
+<link rel="match" href="offset-path-shape-circle-007-ref.html">
 <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
 
 <style>
@@ -15,6 +14,8 @@
   height: 400px;
 }
 #box {
+  top: 100px;
+  left: 100px;
   background-color: green;
   position: relative;
   offset-path: circle(farthest-side at top);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-006-expected.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;basic-shape&gt; ellipse() path with offset from container</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 400px;
+  height: 200px;
+}
+#box {
+  background-color: green;
+  position: relative;
+  transform: translate(8.6px, 91.4px) rotate(-135deg);
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-006-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-006-ref.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;basic-shape&gt; ellipse() path with offset from container</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 400px;
+  height: 200px;
+}
+#box {
+  background-color: green;
+  position: relative;
+  transform: translate(8.6px, 91.4px) rotate(-135deg);
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-006.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; ellipse() path with offset from container</title>
+<!-- Chrome currently passes with 13 max pixel difference and 473 total different pixels -->
+<!-- You can increase the numbers to handle anti-aliasing -->
+<meta name="fuzzy" content="maxDifference=0-150; totalPixels=0-530">
+<link rel="match" href="offset-path-shape-ellipse-006-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 400px;
+  height: 200px;
+}
+#box {
+  top: 100px;
+  left: 100px;
+  background-color: green;
+  position: relative;
+  offset-path: ellipse(farthest-side farthest-side at top);
+  offset-distance: 37.5%;
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-inset-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-inset-001.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSS Motion Path test: &lt;basic-shape&gt; inset() path with explicit arguments</title>
-<meta name=fuzzy content="0-30;0-200">
+<meta name=fuzzy content="0-80;0-230">
 <link rel="author" title="Daniil Sakhapov" href="sakhapov@google.com">
 <link rel="match" href="offset-path-shape-inset-001-ref.html">
 <link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">


### PR DESCRIPTION
#### f6fd650e3830ebe58caebefa3914dd243b19f0ae
<pre>
[motion-path] Have basic shapes use an offset containing block rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=261217">https://bugs.webkit.org/show_bug.cgi?id=261217</a>
rdar://115068196

Reviewed by Tim Nguyen.

Update basic shapes to use an offset containing block rect in
MotionPath::computePathForShape.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::offsetRectForData):
(WebCore::MotionPath::computePathForBox):
(WebCore::MotionPath::computePathForShape):
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/PathOperation.h:

Canonical link: <a href="https://commits.webkit.org/267866@main">https://commits.webkit.org/267866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c427da1cefbd41d10adeea850dc27c7c3b69281

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18691 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20524 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15542 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22784 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4267 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->