### PR TITLE
REGRESSION(267655@main): inspector/sampling-profiler/many-call-frames.html is a constant text failure.

### DIFF
--- a/LayoutTests/inspector/sampling-profiler/many-call-frames-expected.txt
+++ b/LayoutTests/inspector/sampling-profiler/many-call-frames-expected.txt
@@ -4,7 +4,7 @@
 PASS: Should have seen stacktrace:
 [
   {
-    "name": "top"
+    "name": "stacktraceTop"
   },
   {
     "name": "g"

--- a/LayoutTests/inspector/sampling-profiler/many-call-frames.html
+++ b/LayoutTests/inspector/sampling-profiler/many-call-frames.html
@@ -17,15 +17,15 @@ function c() { d(); }
 function d() { e(); }
 function e() { f(); }
 function f() { g(); }
-function g() { top(); }
+function g() { stacktraceTop(); }
 
-function top() {
+function stacktraceTop() {
     for (let i = 0; i < 10000; i++) {
         i++;
         i--;
     }
 }
-noInline(top);
+noInline(stacktraceTop);
 
 function test()
 {
@@ -39,7 +39,7 @@ function test()
                 let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
 
                 let trace = [
-                    {name: "top"},
+                    {name: "stacktraceTop"},
                     {name: "g"},
                     {name: "f"},
                     {name: "e"},

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2854,5 +2854,3 @@ webkit.org/b/261000 media/video-orientation-canvas.html [ Pass Failure ]
 [ Release ] imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-with-transform-and-preserve-3D.html [ ImageOnlyFailure ]
 
 webkit.org/b/157589 fast/text-autosizing/ios/text-autosizing-after-back.html [ Pass Timeout ]
-
-webkit.org/b/261213 inspector/sampling-profiler/many-call-frames.html [ Failure ]


### PR DESCRIPTION
#### ff020b48aec1c17f402657ab06aa41bf35d9b986
<pre>
REGRESSION(267655@main): inspector/sampling-profiler/many-call-frames.html is a constant text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261213">https://bugs.webkit.org/show_bug.cgi?id=261213</a>
&lt;rdar://115064790&gt;

Reviewed by Yusuke Suzuki.

267655@main introduced throwing a TypeError for top-level global fun shadowing non-configurable
global properties like &quot;top&quot;, aligning JSC with other runtimes.

This change renames &quot;top&quot; function in a Web Inspector test to fix it.

* LayoutTests/inspector/sampling-profiler/many-call-frames-expected.txt:
* LayoutTests/inspector/sampling-profiler/many-call-frames.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/267711@main">https://commits.webkit.org/267711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac550621b79eb762764bd6ed7178430055b41915

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16309 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18459 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20035 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22507 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20336 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14084 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15692 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20117 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2141 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->