### PR TITLE
PlaybackSessionManagerProxy should use WeakPtrs

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -52,8 +52,6 @@ public:
     }
     virtual ~PlaybackSessionModelContext() { }
 
-    void invalidate() { m_manager = nullptr; }
-
     // PlaybackSessionModel
     void addClient(WebCore::PlaybackSessionModelClient&) final;
     void removeClient(WebCore::PlaybackSessionModelClient&)final;
@@ -140,7 +138,7 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    PlaybackSessionManagerProxy* m_manager;
+    WeakPtr<PlaybackSessionManagerProxy> m_manager;
     PlaybackSessionContextIdentifier m_contextId;
     HashSet<WebCore::PlaybackSessionModelClient*> m_clients;
     double m_playbackStartedTime { 0 };
@@ -174,8 +172,15 @@ private:
 #endif
 };
 
-class PlaybackSessionManagerProxy : public RefCounted<PlaybackSessionManagerProxy>, private IPC::MessageReceiver {
+class PlaybackSessionManagerProxy
+    : public RefCounted<PlaybackSessionManagerProxy>
+    , public CanMakeWeakPtr<PlaybackSessionManagerProxy>
+    , private IPC::MessageReceiver {
 public:
+    using CanMakeWeakPtr<PlaybackSessionManagerProxy>::WeakPtrImplType;
+    using CanMakeWeakPtr<PlaybackSessionManagerProxy>::WeakValueType;
+    using CanMakeWeakPtr<PlaybackSessionManagerProxy>::weakPtrFactory;
+
     static Ref<PlaybackSessionManagerProxy> create(WebPageProxy&);
     virtual ~PlaybackSessionManagerProxy();
 
@@ -258,7 +263,7 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    WebPageProxy* m_page;
+    WeakPtr<WebPageProxy> m_page;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -44,7 +44,7 @@ using namespace WebCore;
 #pragma mark - PlaybackSessionModelContext
 
 PlaybackSessionModelContext::PlaybackSessionModelContext(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)
-    : m_manager(&manager)
+    : m_manager(manager)
     , m_contextId(contextId)
 {
 }
@@ -377,7 +377,7 @@ Ref<PlaybackSessionManagerProxy> PlaybackSessionManagerProxy::create(WebPageProx
 }
 
 PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
-    : m_page(&page)
+    : m_page(page)
 #if !RELEASE_LOG_DISABLED
     , m_logger(page.logger())
     , m_logIdentifier(page.logIdentifier())


### PR DESCRIPTION
#### 50253341f5a3fc15e3bcb960efb285c4a5ee8529
<pre>
PlaybackSessionManagerProxy should use WeakPtrs
<a href="https://bugs.webkit.org/show_bug.cgi?id=261222">https://bugs.webkit.org/show_bug.cgi?id=261222</a>
rdar://115071751

Reviewed by Jer Noble.

Changed PlaybackSessionModelContext::m_manager from a PlaybackSessionManagerProxy* to a
WeakPtr&lt;PlaybackSessionManagerProxy&gt;. Changed PlaybackSessionManagerProxy::m_page from a
WebPageProxy* to a WeakPtr&lt;WebPageProxy&gt;. Removed the unused
PlaybackSessionModelContext::invalidate() function.

* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::PlaybackSessionModelContext):
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):

Canonical link: <a href="https://commits.webkit.org/267916@main">https://commits.webkit.org/267916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a320cebeea59d2e557fb758ef17c6be09483568

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16880 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20742 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15732 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22979 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20848 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14567 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16277 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4296 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->