### PR TITLE
Replace WebCore::notifyHistoryItemChanged with a proper client callback

### DIFF
--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -49,34 +49,14 @@ int64_t HistoryItem::generateSequenceNumber()
     return ++next;
 }
 
-static void defaultNotifyHistoryItemChanged(HistoryItem&)
-{
-}
-
-void (*notifyHistoryItemChanged)(HistoryItem&) = defaultNotifyHistoryItemChanged;
-
-HistoryItem::HistoryItem()
-    : HistoryItem({ }, { })
-{
-}
-
-HistoryItem::HistoryItem(const String& urlString, const String& title)
-    : HistoryItem(urlString, title, { })
-{
-}
-
-HistoryItem::HistoryItem(const String& urlString, const String& title, const String& alternateTitle)
-    : HistoryItem(urlString, title, alternateTitle, BackForwardItemIdentifier::generate())
-{
-}
-
-HistoryItem::HistoryItem(const String& urlString, const String& title, const String& alternateTitle, BackForwardItemIdentifier BackForwardItemIdentifier)
+HistoryItem::HistoryItem(Client& client, const String& urlString, const String& title, const String& alternateTitle, std::optional<BackForwardItemIdentifier> identifier)
     : m_urlString(urlString)
     , m_originalURLString(urlString)
     , m_title(title)
     , m_displayTitle(alternateTitle)
     , m_pruningReason(PruningReason::None)
-    , m_identifier(BackForwardItemIdentifier)
+    , m_identifier(identifier ? *identifier : BackForwardItemIdentifier::generate())
+    , m_client(client)
 {
 }
 
@@ -85,7 +65,7 @@ HistoryItem::~HistoryItem()
     ASSERT(!m_cachedPage);
 }
 
-inline HistoryItem::HistoryItem(const HistoryItem& item)
+HistoryItem::HistoryItem(const HistoryItem& item)
     : RefCounted<HistoryItem>()
     , m_urlString(item.m_urlString)
     , m_originalURLString(item.m_originalURLString)
@@ -109,6 +89,7 @@ inline HistoryItem::HistoryItem(const HistoryItem& item)
     , m_scaleIsInitial(item.m_scaleIsInitial)
 #endif
     , m_identifier(item.m_identifier)
+    , m_client(item.m_client)
 {
 }
 
@@ -477,7 +458,7 @@ bool HistoryItem::isCurrentDocument(Document& document) const
 
 void HistoryItem::notifyChanged()
 {
-    notifyHistoryItemChanged(*this);
+    m_client->historyItemChanged(*this);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1187,6 +1187,13 @@ public:
     RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) final { return nullptr; }
 };
 
+class EmptyHistoryItemClient final : public HistoryItemClient {
+public:
+    static Ref<EmptyHistoryItemClient> create() { return adoptRef(*new EmptyHistoryItemClient); }
+private:
+    void historyItemChanged(const HistoryItem&) { }
+};
+
 PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier> identifier, PAL::SessionID sessionID)
 {
     PageConfiguration pageConfiguration {
@@ -1208,6 +1215,7 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         makeUniqueRef<DummyStorageProvider>(),
         makeUniqueRef<DummyModelPlayerProvider>(),
         EmptyBadgeClient::create(),
+        EmptyHistoryItemClient::create(),
 #if ENABLE(CONTEXT_MENUS)
         makeUniqueRef<EmptyContextMenuClient>(),
 #endif

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class HistoryItem;
+class HistoryItemClient;
 class LocalFrame;
 class SerializedScriptValue;
 
@@ -94,8 +95,8 @@ private:
     void goToItem(HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
 
     void initializeItem(HistoryItem&);
-    Ref<HistoryItem> createItem();
-    Ref<HistoryItem> createItemTree(LocalFrame& targetFrame, bool clipAtTarget);
+    Ref<HistoryItem> createItem(HistoryItemClient&);
+    Ref<HistoryItem> createItemTree(HistoryItemClient&, LocalFrame& targetFrame, bool clipAtTarget);
 
     void recursiveSetProvisionalItem(HistoryItem&, HistoryItem*);
     void recursiveGoToItem(HistoryItem&, HistoryItem*, FrameLoadType, ShouldTreatAsContinuingLoad);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -376,6 +376,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_opportunisticTaskScheduler(OpportunisticTaskScheduler::create(*this))
     , m_contentSecurityPolicyModeForExtension(WTFMove(pageConfiguration.contentSecurityPolicyModeForExtension))
     , m_badgeClient(WTFMove(pageConfiguration.badgeClient))
+    , m_historyItemClient(WTFMove(pageConfiguration.historyItemClient))
 {
     updateTimerThrottlingState();
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -114,6 +114,7 @@ class FormData;
 class HTMLElement;
 class HTMLMediaElement;
 class HistoryItem;
+class HistoryItemClient;
 class OpportunisticTaskScheduler;
 class ImageAnalysisQueue;
 class ImageOverlayController;
@@ -1044,6 +1045,7 @@ public:
 #endif
 
     BadgeClient& badgeClient() { return m_badgeClient.get(); }
+    HistoryItemClient& historyItemClient() { return m_historyItemClient.get(); }
 
     void willBeginScrolling();
     void didFinishScrolling();
@@ -1428,6 +1430,7 @@ private:
     ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension { ContentSecurityPolicyModeForExtension::None };
 
     Ref<BadgeClient> m_badgeClient;
+    Ref<HistoryItemClient> m_historyItemClient;
 
     HashMap<RegistrableDomain, uint64_t> m_noiseInjectionHashSalts;
 };

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -90,6 +90,7 @@ PageConfiguration::PageConfiguration(
     UniqueRef<StorageProvider>&& storageProvider,
     UniqueRef<ModelPlayerProvider>&& modelPlayerProvider,
     Ref<BadgeClient>&& badgeClient,
+    Ref<HistoryItemClient>&& historyItemClient,
 #if ENABLE(CONTEXT_MENUS)
     UniqueRef<ContextMenuClient>&& contextMenuClient,
 #endif
@@ -122,6 +123,7 @@ PageConfiguration::PageConfiguration(
     , storageProvider(WTFMove(storageProvider))
     , modelPlayerProvider(WTFMove(modelPlayerProvider))
     , badgeClient(WTFMove(badgeClient))
+    , historyItemClient(WTFMove(historyItemClient))
 {
 }
 

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -63,6 +63,7 @@ class DatabaseProvider;
 class DiagnosticLoggingClient;
 class DragClient;
 class EditorClient;
+class HistoryItemClient;
 class InspectorClient;
 class LocalFrameLoaderClient;
 class MediaRecorderProvider;
@@ -108,6 +109,7 @@ public:
         UniqueRef<StorageProvider>&&,
         UniqueRef<ModelPlayerProvider>&&,
         Ref<BadgeClient>&&,
+        Ref<HistoryItemClient>&&,
 #if ENABLE(CONTEXT_MENUS)
         UniqueRef<ContextMenuClient>&&,
 #endif
@@ -194,6 +196,7 @@ public:
 #endif
 
     Ref<BadgeClient> badgeClient;
+    Ref<HistoryItemClient> historyItemClient;
 
     ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
 };

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -847,6 +847,7 @@ WebProcess/WebPage/WebCookieJar.cpp
 WebProcess/WebPage/WebDocumentLoader.cpp
 WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
+WebProcess/WebPage/WebHistoryItemClient.cpp
 WebProcess/WebPage/WebOpenPanelResultListener.cpp
 WebProcess/WebPage/WebPage.cpp @no-unify
 WebProcess/WebPage/WebPageGroupProxy.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7325,6 +7325,8 @@
 		F6113E27126CE19B0057D0A7 /* WKUserContentURLPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKUserContentURLPattern.h; sourceTree = "<group>"; };
 		F634445512A885C8000612D8 /* APISecurityOrigin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APISecurityOrigin.h; sourceTree = "<group>"; };
 		F6A90811133C1F3D0082C3F4 /* WebCookieManagerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCookieManagerMac.mm; sourceTree = "<group>"; };
+		FA96E4AC2AA90A1E0090C5A3 /* WebHistoryItemClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebHistoryItemClient.cpp; sourceTree = "<group>"; };
+		FA96E4AD2AA90A1E0090C5A3 /* WebHistoryItemClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebHistoryItemClient.h; sourceTree = "<group>"; };
 		FA9CD6332A01B21700EA5CAC /* NetworkOriginAccessPatterns.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkOriginAccessPatterns.cpp; sourceTree = "<group>"; };
 		FA9CD6342A01B21700EA5CAC /* NetworkOriginAccessPatterns.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkOriginAccessPatterns.h; sourceTree = "<group>"; };
 		FAA4E2FE2A1575A3003F5E50 /* WebFrameLoaderClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameLoaderClient.cpp; sourceTree = "<group>"; };
@@ -12197,6 +12199,8 @@
 				E55CFD4C279D31C3002F1020 /* WebFoundTextRangeController.h */,
 				BC111ADC112F5B9300337BAB /* WebFrame.cpp */,
 				BC032D8910F437A00058C15A /* WebFrame.h */,
+				FA96E4AC2AA90A1E0090C5A3 /* WebHistoryItemClient.cpp */,
+				FA96E4AD2AA90A1E0090C5A3 /* WebHistoryItemClient.h */,
 				BC857F8412B82D0B00EDEB2E /* WebOpenPanelResultListener.cpp */,
 				BC857F8312B82D0B00EDEB2E /* WebOpenPanelResultListener.h */,
 				BC963D6A113DD19200574BE2 /* WebPage.cpp */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -139,7 +139,7 @@ static Ref<FormData> toFormData(const HTTPBody& httpBody)
     return formData;
 }
 
-static void applyFrameState(HistoryItem& historyItem, const FrameState& frameState)
+static void applyFrameState(WebCore::HistoryItemClient& client, HistoryItem& historyItem, const FrameState& frameState)
 {
     historyItem.setOriginalURLString(frameState.originalURLString);
     historyItem.setReferrer(frameState.referrer);
@@ -176,19 +176,19 @@ static void applyFrameState(HistoryItem& historyItem, const FrameState& frameSta
 #endif
 
     for (const auto& childFrameState : frameState.children) {
-        Ref<HistoryItem> childHistoryItem = HistoryItem::create(childFrameState.urlString, { }, { });
-        applyFrameState(childHistoryItem, childFrameState);
+        Ref<HistoryItem> childHistoryItem = HistoryItem::create(client, childFrameState.urlString, { }, { });
+        applyFrameState(client, childHistoryItem, childFrameState);
 
         historyItem.addChildItem(WTFMove(childHistoryItem));
     }
 }
 
-Ref<HistoryItem> toHistoryItem(const BackForwardListItemState& itemState)
+Ref<HistoryItem> toHistoryItem(WebCore::HistoryItemClient& client, const BackForwardListItemState& itemState)
 {
-    Ref<HistoryItem> historyItem = HistoryItem::create(itemState.pageState.mainFrameState.urlString, itemState.pageState.title, { }, itemState.identifier);
+    Ref<HistoryItem> historyItem = HistoryItem::create(client, itemState.pageState.mainFrameState.urlString, itemState.pageState.title, { }, itemState.identifier);
     historyItem->setShouldOpenExternalURLsPolicy(itemState.pageState.shouldOpenExternalURLsPolicy);
     historyItem->setStateObject(itemState.pageState.sessionStateObject.get());
-    applyFrameState(historyItem, itemState.pageState.mainFrameState);
+    applyFrameState(client, historyItem, itemState.pageState.mainFrameState);
 
     return historyItem;
 }

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
 
 #include "Logging.h"
+#include <WebCore/AnimationFrameRate.h>
 #include <WebCore/Scrollbar.h>
 #include <wtf/SystemTracing.h>
 

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -66,11 +66,6 @@ void WebBackForwardListProxy::addItemFromUIProcess(const BackForwardItemIdentifi
     clearCachedListCounts();
 }
 
-static void WK2NotifyHistoryItemChanged(HistoryItem& item)
-{
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::UpdateBackForwardItem(toBackForwardListItemState(item)), 0);
-}
-
 HistoryItem* WebBackForwardListProxy::itemForID(const BackForwardItemIdentifier& itemID)
 {
     return idToHistoryItemMap().get(itemID);
@@ -89,8 +84,6 @@ void WebBackForwardListProxy::removeItem(const BackForwardItemIdentifier& itemID
 WebBackForwardListProxy::WebBackForwardListProxy(WebPage& page)
     : m_page(&page)
 {
-    // FIXME: This means that if we mix legacy WebKit and modern WebKit in the same process, we won't get both notifications.
-    WebCore::notifyHistoryItemChanged = WK2NotifyHistoryItemChanged;
 }
 
 void WebBackForwardListProxy::addItem(Ref<HistoryItem>&& item)

--- a/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h
+++ b/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,22 @@
 
 #pragma once
 
-#include <wtf/Forward.h>
-
-namespace WebCore {
-class HistoryItem;
-class HistoryItemClient;
-};
+#include <WebCore/HistoryItem.h>
+#include <wtf/Scope.h>
 
 namespace WebKit {
 
-struct BackForwardListItemState;
+class WebHistoryItemClient final : public WebCore::HistoryItemClient {
+public:
+    static Ref<WebHistoryItemClient> create() { return adoptRef(*new WebHistoryItemClient); }
 
-BackForwardListItemState toBackForwardListItemState(const WebCore::HistoryItem&);
-Ref<WebCore::HistoryItem> toHistoryItem(WebCore::HistoryItemClient&, const BackForwardListItemState&);
+    ScopeExit<CompletionHandler<void()>> ignoreChangesForScope();
 
-} // namespace WebKit
+private:
+    WebHistoryItemClient() = default;
+    void historyItemChanged(const WebCore::HistoryItem&) final;
+
+    bool m_shouldIgnoreChanges { false };
+};
+
+}

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -325,6 +325,7 @@ class WebDateTimeChooser;
 class WebDocumentLoader;
 class WebEvent;
 class WebFoundTextRangeController;
+class WebHistoryItemClient;
 class PlaybackSessionManager;
 class VideoFullscreenManager;
 class WebBackForwardListItem;
@@ -2604,6 +2605,8 @@ private:
 #if ENABLE(APP_HIGHLIGHTS)
     WebCore::HighlightVisibility m_appHighlightsVisible { WebCore::HighlightVisibility::Hidden };
 #endif
+
+    Ref<WebHistoryItemClient> m_historyItemClient;
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     HashSet<String> m_linkDecorationFilteringData;

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -659,6 +659,8 @@
 		F4F665C21DD67672007714B4 /* WebAutocapitalizeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F665C11DD67672007714B4 /* WebAutocapitalizeTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F834AAD70E64B1C700E2737C /* WebTextIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = F834AAD50E64B1C700E2737C /* WebTextIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F834AAD80E64B1C700E2737C /* WebTextIterator.mm in Sources */ = {isa = PBXBuildFile; fileRef = F834AAD60E64B1C700E2737C /* WebTextIterator.mm */; };
+		FA96E4B02AAAFA920090C5A3 /* LegacyHistoryItemClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FA96E4AE2AAAFA920090C5A3 /* LegacyHistoryItemClient.h */; };
+		FA96E4B12AAAFA920090C5A3 /* LegacyHistoryItemClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA96E4AF2AAAFA920090C5A3 /* LegacyHistoryItemClient.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -1509,6 +1511,8 @@
 		F834AAD60E64B1C700E2737C /* WebTextIterator.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebTextIterator.mm; sourceTree = "<group>"; };
 		F8CA15B5029A39D901000122 /* WebAuthenticationPanel.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = WebAuthenticationPanel.h; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
 		F8CA15B6029A39D901000122 /* WebAuthenticationPanel.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = WebAuthenticationPanel.m; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
+		FA96E4AE2AAAFA920090C5A3 /* LegacyHistoryItemClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyHistoryItemClient.h; sourceTree = "<group>"; };
+		FA96E4AF2AAAFA920090C5A3 /* LegacyHistoryItemClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LegacyHistoryItemClient.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2493,6 +2497,8 @@
 				A10C1D4418202FFB0036883A /* ios */,
 				B82958D1132707D0000D0E79 /* CorrectionPanel.h */,
 				B82958D2132707D0000D0E79 /* CorrectionPanel.mm */,
+				FA96E4AE2AAAFA920090C5A3 /* LegacyHistoryItemClient.h */,
+				FA96E4AF2AAAFA920090C5A3 /* LegacyHistoryItemClient.mm */,
 				5CB05C7F29CA0E7000CC1AA0 /* LegacySocketProvider.cpp */,
 				5CB05C7E29CA0E7000CC1AA0 /* LegacySocketProvider.h */,
 				5CA46E7721F1451D00CE86B4 /* NetworkStorageSessionMap.cpp */,
@@ -2829,6 +2835,7 @@
 				93D437991D57ABEF00AB85EA /* ExceptionHandlers.h in Headers */,
 				1A60519417502A5D00BC62F5 /* HistoryPropertyList.h in Headers */,
 				9364006F23996E81001E185E /* InProcessIDBServer.h in Headers */,
+				FA96E4B02AAAFA920090C5A3 /* LegacyHistoryItemClient.h in Headers */,
 				5CB05C8229CA0E7000CC1AA0 /* LegacySocketProvider.h in Headers */,
 				5CA46E7821F1451D00CE86B4 /* NetworkStorageSessionMap.h in Headers */,
 				E1531BD82187B954002E3F81 /* NSURLDownloadSPI.h in Headers */,
@@ -3397,6 +3404,7 @@
 				B82958D4132707D0000D0E79 /* CorrectionPanel.mm in Sources */,
 				1A60519317502A5D00BC62F5 /* HistoryPropertyList.mm in Sources */,
 				9364006E23996E81001E185E /* InProcessIDBServer.cpp in Sources */,
+				FA96E4B12AAAFA920090C5A3 /* LegacyHistoryItemClient.mm in Sources */,
 				A10C1D601820300E0036883A /* PopupMenuIOS.mm in Sources */,
 				5C40CD2122D8F9C000E9DAD5 /* PopupMenuMac.mm in Sources */,
 				A10C1D611820300E0036883A /* SearchPopupMenuIOS.cpp in Sources */,

--- a/Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h
@@ -39,7 +39,7 @@ class HistoryItem;
 WebCore::HistoryItem* core(WebHistoryItem *item);
 WebHistoryItem *kit(WebCore::HistoryItem* item);
 
-extern void WKNotifyHistoryItemChanged(WebCore::HistoryItem&);
+extern void WKNotifyHistoryItemChanged();
 
 @interface WebHistoryItem ()
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,12 @@
 
 #pragma once
 
-#include <wtf/Forward.h>
+#include <WebCore/HistoryItem.h>
 
-namespace WebCore {
-class HistoryItem;
-class HistoryItemClient;
+class LegacyHistoryItemClient final : public WebCore::HistoryItemClient {
+public:
+    static LegacyHistoryItemClient& singleton();
+private:
+    LegacyHistoryItemClient() = default;
+    void historyItemChanged(const WebCore::HistoryItem&) final;
 };
-
-namespace WebKit {
-
-struct BackForwardListItemState;
-
-BackForwardListItemState toBackForwardListItemState(const WebCore::HistoryItem&);
-Ref<WebCore::HistoryItem> toHistoryItem(WebCore::HistoryItemClient&, const BackForwardListItemState&);
-
-} // namespace WebKit

--- a/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "LegacyHistoryItemClient.h"
 
-#include <wtf/Forward.h>
+#import "WebHistoryItemInternal.h"
 
-namespace WebCore {
-class HistoryItem;
-class HistoryItemClient;
-};
+LegacyHistoryItemClient& LegacyHistoryItemClient::singleton()
+{
+    static NeverDestroyed<Ref<LegacyHistoryItemClient>> client { adoptRef(*new LegacyHistoryItemClient) };
+    return client.get().get();
+}
 
-namespace WebKit {
-
-struct BackForwardListItemState;
-
-BackForwardListItemState toBackForwardListItemState(const WebCore::HistoryItem&);
-Ref<WebCore::HistoryItem> toHistoryItem(WebCore::HistoryItemClient&, const BackForwardListItemState&);
-
-} // namespace WebKit
+void LegacyHistoryItemClient::historyItemChanged(const WebCore::HistoryItem&)
+{
+    WKNotifyHistoryItemChanged();
+}

--- a/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
@@ -341,11 +341,6 @@ enum {
     static bool didFirstTimeInitialization;
     if (!didFirstTimeInitialization) {
         didFirstTimeInitialization = true;
-        
-        // Need to tell WebCore what function to call for the "History Item has Changed" notification.
-        // Note: We also do this in WebHistoryItem's init method.
-        // FIXME: This means that if we mix legacy WebKit and modern WebKit in the same process, we won't get both notifications.
-        WebCore::notifyHistoryItemChanged = WKNotifyHistoryItemChanged;
 
 #if !PLATFORM(IOS_FAMILY)
         if (!WebKitLinkedOnOrAfter(WEBKIT_FIRST_VERSION_WITH_MAIN_THREAD_EXCEPTIONS))

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -37,6 +37,7 @@
 #import "DOMInternal.h"
 #import "DOMNodeInternal.h"
 #import "DOMRangeInternal.h"
+#import "LegacyHistoryItemClient.h"
 #import "LegacySocketProvider.h"
 #import "PageStorageSessionProvider.h"
 #import "SocketStreamHandleImpl.h"
@@ -1520,6 +1521,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         makeUniqueRef<WebCore::DummyStorageProvider>(),
         makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
         WebCore::EmptyBadgeClient::create(),
+        LegacyHistoryItemClient::singleton(),
 #if ENABLE(CONTEXT_MENUS)
         makeUniqueRef<WebContextMenuClient>(self),
 #endif
@@ -1781,6 +1783,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         makeUniqueRef<WebCore::DummyStorageProvider>(),
         makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
         WebCore::EmptyBadgeClient::create(),
+        LegacyHistoryItemClient::singleton(),
 #if ENABLE(APPLE_PAY)
         makeUniqueRef<WebPaymentCoordinatorClient>(),
 #endif


### PR DESCRIPTION
#### def02cb5c4c24ed8a05e4e5075eb6ec95216ef80
<pre>
Replace WebCore::notifyHistoryItemChanged with a proper client callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=261223">https://bugs.webkit.org/show_bug.cgi?id=261223</a>
rdar://115072660

Reviewed by Chris Dumez.

Using a process-global function pointer with little context doesn&apos;t allow us to manage state and scope very well.
A client object does.

* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
(WebCore::m_client):
(WebCore::HistoryItem::notifyChanged):
(WebCore::defaultNotifyHistoryItemChanged): Deleted.
(WebCore::m_identifier): Deleted.
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::create):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::FrameLoader::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::FrameLoader::HistoryController::createItem):
(WebCore::FrameLoader::HistoryController::createItemTree):
(WebCore::FrameLoader::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::FrameLoader::HistoryController::pushState):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/Page.cpp:
(WebCore::m_historyItemClient):
(WebCore::m_badgeClient): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::historyItemClient):
* Source/WebCore/page/PageConfiguration.cpp:
(WebCore::PageConfiguration::PageConfiguration):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::applyFrameState):
(WebKit::toHistoryItem):
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.h:
* Source/WebKit/WebProcess/WebPage/HistoryItemClient.cpp: Copied from Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.h.
(WebKit::HistoryItemClient::ignoreChangesForScope):
(WebKit::HistoryItemClient::historyItemChanged):
* Source/WebKit/WebProcess/WebPage/HistoryItemClient.h: Copied from Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.h.
(WebKit::HistoryItemClient::create):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::WebBackForwardListProxy):
(WebKit::WK2NotifyHistoryItemChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
(WebKit::WebPage::restoreSessionInternal):
(WebKit::WebPage::setCurrentHistoryItemForReattach):
(WebKit::m_appHighlightsVisible): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(WKNotifyHistoryItemChanged):
(GlobalHistoryItemClient::create):
(GlobalHistoryItemClient::historyItemChanged):
(globalHistoryItemClient):
(-[WebHistoryItem init]):
(-[WebHistoryItem initWithURLString:title:lastVisitedTimeInterval:]):
(-[WebHistoryItem initWithURLString:title:displayTitle:lastVisitedTimeInterval:]):
(-[WebHistoryItem initWithWebCoreHistoryItem:]):
* Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h:
* Source/WebKitLegacy/mac/WebView/WebFrameView.mm:
(-[WebFrameView initWithFrame:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(LegacyHistoryItemClient::create):
(LegacyHistoryItemClient::historyItemChanged):
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView initSimpleHTMLDocumentWithStyle:frame:preferences:groupName:]):

Canonical link: <a href="https://commits.webkit.org/267857@main">https://commits.webkit.org/267857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/379145bd7db31b981365a99c120c4ef2f9c7492f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17759 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16612 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18658 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20449 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22755 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20616 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14327 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20396 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2195 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->