### PR TITLE
Seeing 5 windows opened, even though only tapped on 3 model links from Safari

### DIFF
--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -80,9 +80,7 @@ private:
         Initial,
         Began,
         Loading,
-        Failed,
-        Succeeded,
-        Ended
+        Viewing
     };
 
     State m_state { State::Initial };


### PR DESCRIPTION
#### 8c3dd61568c98905d1eb9bdeb901fbe099e6b5c4
<pre>
Seeing 5 windows opened, even though only tapped on 3 model links from Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=261232">https://bugs.webkit.org/show_bug.cgi?id=261232</a>
rdar://114172309

Reviewed by Mike Wyrzykowski.

On iOS the AR Quick Look feature is modal, which means only one preview
is open at a time. On visionOS the preview opens in a separate app, allowing
for the case where the user can tap many times and multiple windows open.
Furthermore, the communication with the system is a bit limited, which
can create a situation where more windows open than the user requested.

Limit this so that only one Quick Look can be downloading at a time. This
will still allow the user to open multiple models, but not get into this
confusing situation.

It isn&apos;t a great fix. A future change would be to keep a list of
active previews, with an upper limit, so that the user isn&apos;t blocked
from opening another file while a large file is being downloaded.

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/SystemPreviewController.h:

Canonical link: <a href="https://commits.webkit.org/267708@main">https://commits.webkit.org/267708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfd6a5c031a56ee8d51d1fb394a427f2d1330697

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16321 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20048 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15205 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22520 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20349 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14096 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20128 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2138 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->