### PR TITLE
Avoid copying range and consuming tokens from this copied range in CSSVariableData()

### DIFF
--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -65,10 +65,7 @@ CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSPars
     : m_context(context)
 {
     StringBuilder stringBuilder;
-    CSSParserTokenRange localRange = range;
-
-    while (!localRange.atEnd()) {
-        CSSParserToken token = localRange.consume();
+    for (auto& token : range) {
         if (token.hasStringBacking())
             stringBuilder.append(token.value());
     }


### PR DESCRIPTION
#### 5e7400cc3d50fe4b4657242113ef03de1868bec3
<pre>
Avoid copying range and consuming tokens from this copied range in CSSVariableData()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261239">https://bugs.webkit.org/show_bug.cgi?id=261239</a>

Reviewed by Simon Fraser.

Avoid copying range and consuming tokens from this copied range in CSSVariableData().
We can simply iterate over the provided range, no need to copy or consume.

* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::CSSVariableData):

Canonical link: <a href="https://commits.webkit.org/267712@main">https://commits.webkit.org/267712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b0d3893adeb997a721abf8082bb2a15e7ac5e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17929 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20070 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22531 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20365 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14105 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15772 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4162 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->