### PR TITLE
Default link colors lack sufficient contrast in the dark color scheme

### DIFF
--- a/LayoutTests/css-dark-mode/link-colors-expected.html
+++ b/LayoutTests/css-dark-mode/link-colors-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<style>
+
+.light {
+    color: #0000EE;
+}
+
+.light:visited {
+    color: #551A8B;
+}
+
+.dark {
+    color: #9E9EFF;
+}
+
+.dark:visited {
+    color: #D0ADF0;
+}
+
+</style>
+
+<a class="light" href="https://www.webkit.org">Light</a>
+<a class="light" href="">Light :visited</a>
+
+<a class="dark" href="https://www.webkit.org">Dark</a>
+<a class="dark" href="">Dark :visited</a>

--- a/LayoutTests/css-dark-mode/link-colors.html
+++ b/LayoutTests/css-dark-mode/link-colors.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<style>
+
+.light {
+    color-scheme: light;
+}
+
+.dark {
+    color-scheme: dark;
+}
+
+</style>
+
+<a class="light" href="https://www.webkit.org">Light</a>
+<a class="light" href="">Light :visited</a>
+
+<a class="dark" href="https://www.webkit.org">Dark</a>
+<a class="dark" href="">Dark :visited</a>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -987,19 +987,40 @@ const Color& Document::themeColor()
     return m_cachedThemeColor;
 }
 
+Color Document::linkColor(const RenderStyle& style) const
+{
+    if (m_linkColor.isValid())
+        return m_linkColor;
+    return StyleColor::colorFromKeyword(CSSValueWebkitLink, styleColorOptions(&style));
+}
+
+Color Document::visitedLinkColor(const RenderStyle& style) const
+{
+    if (m_visitedLinkColor.isValid())
+        return m_visitedLinkColor;
+    return StyleColor::colorFromKeyword(CSSValueWebkitLink, styleColorOptions(&style) | StyleColorOptions::ForVisitedLink);
+}
+
+Color Document::activeLinkColor(const RenderStyle& style) const
+{
+    if (m_activeLinkColor.isValid())
+        return m_activeLinkColor;
+    return StyleColor::colorFromKeyword(CSSValueWebkitActivelink, styleColorOptions(&style));
+}
+
 void Document::resetLinkColor()
 {
-    m_linkColor = StyleColor::colorFromKeyword(CSSValueWebkitLink, styleColorOptions(nullptr));
+    m_linkColor = { };
 }
 
 void Document::resetVisitedLinkColor()
 {
-    m_visitedLinkColor = StyleColor::colorFromKeyword(CSSValueWebkitLink, styleColorOptions(nullptr) | StyleColorOptions::ForVisitedLink);
+    m_visitedLinkColor = { };
 }
 
 void Document::resetActiveLinkColor()
 {
-    m_activeLinkColor = StyleColor::colorFromKeyword(CSSValueWebkitActivelink, styleColorOptions(nullptr));
+    m_activeLinkColor = { };
 }
 
 DOMImplementation& Document::implementation()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -829,9 +829,9 @@ public:
     void setTextColor(const Color& color) { m_textColor = color; }
     const Color& textColor() const { return m_textColor; }
 
-    const Color& linkColor() const { return m_linkColor; }
-    const Color& visitedLinkColor() const { return m_visitedLinkColor; }
-    const Color& activeLinkColor() const { return m_activeLinkColor; }
+    Color linkColor(const RenderStyle&) const;
+    Color visitedLinkColor(const RenderStyle&) const;
+    Color activeLinkColor(const RenderStyle&) const;
     void setLinkColor(const Color& c) { m_linkColor = c; }
     void setVisitedLinkColor(const Color& c) { m_visitedLinkColor = c; }
     void setActiveLinkColor(const Color& c) { m_activeLinkColor = c; }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1696,6 +1696,9 @@ auto RenderTheme::colorCache(OptionSet<StyleColorOptions> options) const -> Colo
 
 Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOptions> options) const
 {
+    auto useDarkAppearance = options.contains(StyleColorOptions::UseDarkAppearance);
+    auto forVisitedLink = options.contains(StyleColorOptions::ForVisitedLink);
+
     switch (cssValueId) {
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-canvas
     // Background of application content or documents.
@@ -1721,7 +1724,7 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
     // Text in active links. For light backgrounds, traditionally red.
     case CSSValueActivetext:
     case CSSValueWebkitActivelink: // Non-standard addition.
-        return Color::red;
+        return useDarkAppearance ? SRGBA<uint8_t> { 255, 158, 158 } : Color::red;
 
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-buttonface
     // The face background color for push buttons.
@@ -1802,8 +1805,11 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
         return Color::black;
 
     // Non-standard addition.
-    case CSSValueWebkitLink:
-        return options.contains(StyleColorOptions::ForVisitedLink) ? SRGBA<uint8_t> { 85, 26, 139 } : SRGBA<uint8_t> { 0, 0, 238 };
+    case CSSValueWebkitLink: {
+        if (useDarkAppearance)
+            return forVisitedLink ? SRGBA<uint8_t> { 208, 173, 240 } : SRGBA<uint8_t> { 158, 158, 255 };
+        return forVisitedLink ? SRGBA<uint8_t> { 85, 26, 139 } : SRGBA<uint8_t> { 0, 0, 238 };
+    }
 
     // Deprecated system-colors:
     // https://drafts.csswg.org/css-color-4/#deprecated-system-colors

--- a/Source/WebCore/style/ColorFromPrimitiveValue.cpp
+++ b/Source/WebCore/style/ColorFromPrimitiveValue.cpp
@@ -50,9 +50,9 @@ StyleColor colorFromPrimitiveValue(const Document& document, RenderStyle& style,
     case CSSValueInternalDocumentTextColor:
         return { document.textColor() };
     case CSSValueWebkitLink:
-        return { forVisitedLink == ForVisitedLink::Yes ? document.visitedLinkColor() : document.linkColor() };
+        return { forVisitedLink == ForVisitedLink::Yes ? document.visitedLinkColor(style) : document.linkColor(style) };
     case CSSValueWebkitActivelink:
-        return { document.activeLinkColor() };
+        return { document.activeLinkColor(style) };
     case CSSValueWebkitFocusRingColor:
         return { RenderTheme::singleton().focusRingColor(document.styleColorOptions(&style)) };
     case CSSValueCurrentcolor:


### PR DESCRIPTION
#### 5413aa7d4157f6ff5865f169742255366e984c60
<pre>
Default link colors lack sufficient contrast in the dark color scheme
<a href="https://bugs.webkit.org/show_bug.cgi?id=209851">https://bugs.webkit.org/show_bug.cgi?id=209851</a>
rdar://61149466

Reviewed by Tim Nguyen and Megan Gardner.

Currently, link colors are the same in both the light and dark color schemes.
This results in a lack of contrast against dark backgrounds.

To fix, dark-mode specific link colors are defined. The definitions match the
values used by Chromium, and are not taken from the system link color. This
approach was chosen as the default link color in the light color scheme is
defined by <a href="https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3">https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3</a>,
and also does not come from the system.

* LayoutTests/css-dark-mode/link-colors-expected.html: Added.
* LayoutTests/css-dark-mode/link-colors.html: Added.
* Source/WebCore/dom/Document.cpp:

Link colors can be adjusted by HTML using the `link`, `alink`, and `vlink`
attributes. Adjust logic to ensure that a static link color is only used if the
corresponding attribute is specified. Without these changes, the dark mode
color would never be used, as the light mode color is stored as the default.

(WebCore::Document::linkColor const):
(WebCore::Document::visitedLinkColor const):
(WebCore::Document::activeLinkColor const):
(WebCore::Document::resetLinkColor):
(WebCore::Document::resetVisitedLinkColor):
(WebCore::Document::resetActiveLinkColor):
* Source/WebCore/dom/Document.h:
(WebCore::Document::linkColor const): Deleted.
(WebCore::Document::visitedLinkColor const): Deleted.
(WebCore::Document::activeLinkColor const): Deleted.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::systemColor const):

Add definitions for colors under the dark color scheme.

* Source/WebCore/style/ColorFromPrimitiveValue.cpp:
(WebCore::Style::colorFromPrimitiveValue):

Pass in `StyleColorOptions` when determining the link color, so that it can be
resolved against the used color scheme.

Canonical link: <a href="https://commits.webkit.org/267847@main">https://commits.webkit.org/267847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfd7c04f3b41e3189ad633ab24933a3b78f32d86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18676 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18279 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20470 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15507 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22764 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16523 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20629 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14342 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4252 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->