### PR TITLE
Add argument parsing and error handling for the tabs Web Extension APIs.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
@@ -45,4 +45,23 @@ struct WebKit::WebExtensionTabParameters {
     std::optional<bool> showingReaderMode;
 }
 
+struct WebKit::WebExtensionTabQueryParameters {
+    std::optional<Vector<String>> urlPatterns;
+    std::optional<String> titlePattern;
+
+    std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<OptionSet<WebKit::WebExtensionWindow::TypeFilter>> windowType;
+    std::optional<bool> currentWindow;
+    std::optional<bool> frontmostWindow;
+    std::optional<size_t> index;
+
+    std::optional<bool> active;
+    std::optional<bool> audible;
+    std::optional<bool> hidden;
+    std::optional<bool> loading;
+    std::optional<bool> muted;
+    std::optional<bool> pinned;
+    std::optional<bool> selected;
+}
+
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabQueryParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabQueryParameters.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "WebExtensionWindow.h"
+#include "WebExtensionWindowIdentifier.h"
+#include <wtf/Forward.h>
+
+namespace WebKit {
+
+struct WebExtensionTabQueryParameters {
+    std::optional<Vector<String>> urlPatterns;
+    std::optional<String> titlePattern;
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<OptionSet<WebExtensionWindow::TypeFilter>> windowType;
+    std::optional<bool> currentWindow;
+    std::optional<bool> frontmostWindow;
+    std::optional<size_t> index;
+
+    std::optional<bool> active;
+    std::optional<bool> audible;
+    std::optional<bool> hidden;
+    std::optional<bool> loading;
+    std::optional<bool> muted;
+    std::optional<bool> pinned;
+    std::optional<bool> selected;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -499,6 +499,7 @@
 		1CBBE4A019B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CBBE49E19B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp */; };
 		1CBBE4A119B66C53006B7D81 /* WebInspectorUIMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CBBE49F19B66C53006B7D81 /* WebInspectorUIMessages.h */; };
 		1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CF7FFA62AA7AD66003609F0 /* WebExtensionTabQueryParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF7FFA52AA7AD66003609F0 /* WebExtensionTabQueryParameters.h */; };
 		1D4D737023A9E54700717A25 /* RemoteMediaResourceManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D4D736B23A9DF5500717A25 /* RemoteMediaResourceManagerMessageReceiver.cpp */; };
 		1D4D737123A9E56200717A25 /* RemoteMediaResourceManagerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4D736C23A9DF6000717A25 /* RemoteMediaResourceManagerMessages.h */; };
 		1DB01943211CF002009FB3E8 /* WKShareSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DE0D095211CC21300439B5F /* WKShareSheet.h */; };
@@ -3841,6 +3842,7 @@
 		1CEF45BB27BCA46A00C3A6BC /* WebGPUShaderModuleCompilationHint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUShaderModuleCompilationHint.cpp; sourceTree = "<group>"; };
 		1CEF45BC27BCA46A00C3A6BC /* WebGPUShaderModuleCompilationHint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUShaderModuleCompilationHint.h; sourceTree = "<group>"; };
 		1CF18F3E26BB5D90004B1722 /* LogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogInitialization.cpp; sourceTree = "<group>"; };
+		1CF7FFA52AA7AD66003609F0 /* WebExtensionTabQueryParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionTabQueryParameters.h; sourceTree = "<group>"; };
 		1D0B66192624C11800F9712F /* WebMediaKeySystemClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebMediaKeySystemClient.cpp; sourceTree = "<group>"; };
 		1D0B661A2624C19600F9712F /* MediaKeySystemPermissionRequestManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MediaKeySystemPermissionRequestManager.cpp; path = EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp; sourceTree = "<group>"; };
 		1D0ECEAA23FC858400D172F6 /* RemoteMediaPlayerProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteMediaPlayerProxyCocoa.mm; sourceTree = "<group>"; };
@@ -11961,6 +11963,7 @@
 				1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */,
 				1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */,
 				1C4957A02A983E2B007D0B64 /* WebExtensionTabParameters.h */,
+				1CF7FFA52AA7AD66003609F0 /* WebExtensionTabQueryParameters.h */,
 				337822452947FBA4002106BB /* WebExtensionUtilities.h */,
 				337822462947FBA4002106BB /* WebExtensionUtilities.mm */,
 				1C49579E2A983DF1007D0B64 /* WebExtensionWindow.serialization.in */,
@@ -14981,6 +14984,7 @@
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
 				1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */,
 				1C4957A12A983E2B007D0B64 /* WebExtensionTabParameters.h in Headers */,
+				1CF7FFA62AA7AD66003609F0 /* WebExtensionTabQueryParameters.h in Headers */,
 				1CAB9B8728F746AA00E6C77E /* WebExtensionURLSchemeHandler.h in Headers */,
 				337822472947FBA5002106BB /* WebExtensionUtilities.h in Headers */,
 				1C66BDDE2A8AEADE009D4452 /* WebExtensionWindow.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -39,128 +39,524 @@
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxy.h"
 #import "WebExtensionTabParameters.h"
+#import "WebExtensionTabQueryParameters.h"
 #import "WebExtensionUtilities.h"
+#import "WebExtensionWindowIdentifier.h"
 #import "WebProcess.h"
+#import <wtf/cocoa/VectorCocoa.h>
+
+static NSString * const idKey = @"id";
+static NSString * const urlKey = @"url";
+static NSString * const titleKey = @"title";
+
+static NSString * const windowIdKey = @"windowId";
+static NSString * const indexKey = @"index";
+static NSString * const openerTabIdKey = @"openerTabId";
+
+static NSString * const widthKey = @"width";
+static NSString * const heightKey = @"height";
+
+static NSString * const activeKey = @"active";
+static NSString * const highlightedKey = @"highlighted";
+static NSString * const selectedKey = @"selected";
+static NSString * const incognitoKey = @"incognito";
+static NSString * const pinnedKey = @"pinned";
+static NSString * const audibleKey = @"audible";
+
+static NSString * const mutedInfoKey = @"mutedInfo";
+static NSString * const mutedKey = @"muted";
+
+static NSString * const statusKey = @"status";
+static NSString * const loadingKey = @"loading";
+static NSString * const completeKey = @"complete";
+
+static NSString * const isArticleKey = @"isArticle";
+static NSString * const isInReaderModeKey = @"isInReaderMode";
+static NSString * const openInReaderModeKey = @"openInReaderMode";
+
+static NSString * const currentWindowKey = @"currentWindow";
+static NSString * const hiddenKey = @"hidden";
+static NSString * const lastFocusedWindowKey = @"lastFocusedWindow";
+static NSString * const windowTypeKey = @"windowType";
+
+static NSString * const emptyURLValue = @"";
 
 namespace WebKit {
 
 NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
 {
-    // FIXME: Implemnet.
+    ASSERT(parameters.identifier);
 
-    return @{ };
+    auto *result = [NSMutableDictionary dictionary];
+
+    result[idKey] = @(toWebAPI(parameters.identifier.value()));
+
+    if (parameters.url)
+        result[urlKey] = (NSString *)parameters.url.value().string();
+    else
+        result[urlKey] = emptyURLValue;
+
+    if (parameters.title)
+        result[titleKey] = (NSString *)parameters.title.value();
+
+    if (parameters.windowIdentifier)
+        result[windowIdKey] = @(toWebAPI(parameters.windowIdentifier.value()));
+
+    if (parameters.index)
+        result[indexKey] = @(parameters.index.value());
+
+    if (parameters.size) {
+        auto size = parameters.size.value();
+        result[widthKey] = @(size.width);
+        result[heightKey] = @(size.height);
+    }
+
+    if (parameters.parentTabIdentifier)
+        result[openerTabIdKey] = @(toWebAPI(parameters.parentTabIdentifier.value()));
+
+    if (parameters.active)
+        result[activeKey] = @(parameters.active.value());
+
+    if (parameters.selected) {
+        result[selectedKey] = @(parameters.selected.value());
+        result[highlightedKey] = @(parameters.selected.value());
+    }
+
+    if (parameters.pinned)
+        result[pinnedKey] = @(parameters.pinned.value());
+
+    if (parameters.audible)
+        result[audibleKey] = @(parameters.audible.value());
+
+    if (parameters.muted)
+        result[mutedInfoKey] = @{ mutedKey: @(parameters.muted.value()) };
+
+    if (parameters.loading)
+        result[statusKey] = parameters.loading.value() ? loadingKey : completeKey;
+
+    if (parameters.privateBrowsing)
+        result[incognitoKey] = @(parameters.privateBrowsing.value());
+
+    if (parameters.readerModeAvailable)
+        result[isArticleKey] = @(parameters.readerModeAvailable.value());
+
+    if (parameters.showingReaderMode)
+        result[isInReaderModeKey] = @(parameters.showingReaderMode.value());
+
+    return [result copy];
 }
 
-bool WebExtensionAPITabs::isPropertyAllowed(String name, WebPage*)
+bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtensionTabParameters& parameters, NSString *sourceKey, NSString **outExceptionString)
 {
-    // FIXME: Implement.
+    if (!parseTabUpdateOptions(options, parameters, sourceKey, outExceptionString))
+        return false;
+
+    static NSArray<NSString *> *optionalKeys = @[
+        indexKey,
+        openInReaderModeKey,
+        titleKey,
+        windowIdKey,
+    ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        indexKey: NSNumber.class,
+        openInReaderModeKey: @YES.class,
+        titleKey: NSString.class,
+        windowIdKey: NSNumber.class,
+    };
+
+    if (!validateDictionary(options, sourceKey, nil, optionalKeys, types, outExceptionString))
+        return false;
+
+    if (NSNumber *windowId = objectForKey<NSNumber>(options, windowIdKey)) {
+        parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
+
+        if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
+            *outExceptionString = toErrorString(nil, windowIdKey, @"'%@' is not a window identifier", windowId);
+            return false;
+        }
+    }
+
+    if (NSNumber *index = objectForKey<NSNumber>(options, indexKey))
+        parameters.index = index.unsignedIntegerValue;
+
+    if (NSNumber *openInReaderMode = objectForKey<NSNumber>(options, openInReaderModeKey))
+        parameters.showingReaderMode = openInReaderMode.boolValue;
+
+    if (NSString *title = objectForKey<NSString>(options, titleKey))
+        parameters.title = title;
 
     return true;
 }
 
-void WebExtensionAPITabs::createTab(NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtensionTabParameters& parameters, NSString *sourceKey, NSString **outExceptionString)
+{
+    static NSArray<NSString *> *optionalKeys = @[
+        activeKey,
+        highlightedKey,
+        mutedKey,
+        openerTabIdKey,
+        pinnedKey,
+        selectedKey,
+        urlKey,
+    ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        activeKey: @YES.class,
+        highlightedKey: @YES.class,
+        mutedKey: @YES.class,
+        openerTabIdKey: NSNumber.class,
+        pinnedKey: @YES.class,
+        selectedKey: @YES.class,
+        urlKey: NSString.class,
+    };
+
+    if (!validateDictionary(options, sourceKey, nil, optionalKeys, types, outExceptionString))
+        return false;
+
+    if (NSString *url = objectForKey<NSString>(options, urlKey)) {
+        parameters.url = URL { url };
+
+        if (!parameters.url.value().isValid()) {
+            *outExceptionString = toErrorString(nil, urlKey, @"'%@' is not a valid URL", url);
+            return false;
+        }
+    }
+
+    if (NSNumber *openerTabId = objectForKey<NSNumber>(options, openerTabIdKey)) {
+        parameters.parentTabIdentifier = toWebExtensionTabIdentifier(openerTabId.doubleValue);
+
+        if (!parameters.parentTabIdentifier || !isValid(parameters.parentTabIdentifier.value())) {
+            *outExceptionString = toErrorString(nil, openerTabIdKey, @"'%@' is not a tab identifier", openerTabId);
+            return false;
+        }
+    }
+
+    if (NSNumber *active = objectForKey<NSNumber>(options, activeKey))
+        parameters.active = active.boolValue;
+
+    if (NSNumber *pinned = objectForKey<NSNumber>(options, pinnedKey))
+        parameters.pinned = pinned.boolValue;
+
+    if (NSNumber *muted = objectForKey<NSNumber>(options, mutedKey))
+        parameters.muted = muted.boolValue;
+
+    if (NSNumber *selected = objectForKey<NSNumber>(options, selectedKey))
+        parameters.selected = selected.boolValue;
+
+    if (NSNumber *highlighted = objectForKey<NSNumber>(options, highlightedKey))
+        parameters.selected = highlighted.boolValue;
+
+    return true;
+}
+
+bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensionTabQueryParameters& parameters, NSString *sourceKey, NSString **outExceptionString)
+{
+    static NSArray<NSString *> *optionalKeys = @[
+        activeKey,
+        audibleKey,
+        currentWindowKey,
+        hiddenKey,
+        highlightedKey,
+        indexKey,
+        lastFocusedWindowKey,
+        mutedKey,
+        pinnedKey,
+        selectedKey,
+        statusKey,
+        titleKey,
+        urlKey,
+        windowIdKey,
+        windowTypeKey,
+    ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        activeKey: @YES.class,
+        audibleKey: @YES.class,
+        currentWindowKey: @YES.class,
+        hiddenKey: @YES.class,
+        highlightedKey: @YES.class,
+        indexKey: NSNumber.class,
+        lastFocusedWindowKey: @YES.class,
+        mutedKey: @YES.class,
+        pinnedKey: @YES.class,
+        selectedKey: @YES.class,
+        statusKey: NSString.class,
+        titleKey: NSString.class,
+        urlKey: [NSOrderedSet orderedSetWithObjects:NSString.class, @[ NSString.class ], nil],
+        windowIdKey: NSNumber.class,
+        windowTypeKey: NSString.class,
+    };
+
+    if (!validateDictionary(options, sourceKey, nil, optionalKeys, types, outExceptionString))
+        return false;
+
+    if (NSNumber *windowId = objectForKey<NSNumber>(options, windowIdKey)) {
+        parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
+
+        if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
+            *outExceptionString = toErrorString(nil, windowIdKey, @"'%@' is not a window identifier", windowId);
+            return false;
+        }
+    }
+
+    if (NSString *windowType = objectForKey<NSString>(options, windowTypeKey)) {
+        OptionSet<WebExtensionWindow::TypeFilter> windowTypeFilter;
+        if (!WebExtensionAPIWindows::parseWindowTypeFilter(windowType, windowTypeFilter, windowTypeKey, outExceptionString))
+            return false;
+
+        parameters.windowType = windowTypeFilter;
+    }
+
+    if (NSNumber *currentWindow = objectForKey<NSNumber>(options, currentWindowKey))
+        parameters.currentWindow = currentWindow.boolValue;
+
+    if (NSNumber *lastFocusedWindow = objectForKey<NSNumber>(options, lastFocusedWindowKey))
+        parameters.frontmostWindow = lastFocusedWindow.boolValue;
+
+    if (NSString *url = objectForKey<NSString>(options, urlKey, true))
+        parameters.urlPatterns = { url };
+    else if (NSArray *urls = objectForKey<NSArray>(options, urlKey, true))
+        parameters.urlPatterns = makeVector<String>(urls);
+
+    if (NSString *title = objectForKey<NSString>(options, titleKey, true))
+        parameters.titlePattern = title;
+
+    if (NSNumber *audible = objectForKey<NSNumber>(options, audibleKey))
+        parameters.audible = audible.boolValue;
+
+    if (NSNumber *hidden = objectForKey<NSNumber>(options, hiddenKey))
+        parameters.hidden = hidden.boolValue;
+
+    if (NSNumber *index = objectForKey<NSNumber>(options, indexKey))
+        parameters.index = index.unsignedIntegerValue;
+
+    if (NSNumber *active = objectForKey<NSNumber>(options, activeKey))
+        parameters.active = active.boolValue;
+
+    if (NSNumber *pinned = objectForKey<NSNumber>(options, pinnedKey))
+        parameters.pinned = pinned.boolValue;
+
+    if (NSNumber *selected = objectForKey<NSNumber>(options, selectedKey))
+        parameters.selected = selected.boolValue;
+
+    if (NSNumber *highlighted = objectForKey<NSNumber>(options, highlightedKey))
+        parameters.selected = highlighted.boolValue;
+
+    if (NSNumber *muted = objectForKey<NSNumber>(options, mutedKey))
+        parameters.muted = muted.boolValue;
+
+    return true;
+}
+
+static bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **outExceptionString)
+{
+    if (UNLIKELY(!isValid(identifier))) {
+        if (isNone(identifier))
+            *outExceptionString = toErrorString(nil, @"tabID", @"'tabs.TAB_ID_NONE' is not allowed");
+        else if (identifier)
+            *outExceptionString = toErrorString(nil, @"tabID", @"'%llu' is not a tab identifier", identifier.value().toUInt64());
+        else
+            *outExceptionString = toErrorString(nil, @"tabID", @"it is not a tab identifier");
+        return false;
+    }
+
+    return true;
+}
+
+bool WebExtensionAPITabs::isPropertyAllowed(String name, WebPage*)
+{
+    // FIXME: <https://webkit.org/b/260994> Implement.
+
+    return true;
+}
+
+void WebExtensionAPITabs::createTab(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create
 
-    // FIXME: Implement.
+    WebExtensionTabParameters parameters;
+    if (!parseTabCreateOptions(options, parameters, @"properties", outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
-void WebExtensionAPITabs::query(NSDictionary *queryInfo, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::query(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query
 
-    // FIXME: Implement.
+    WebExtensionTabQueryParameters parameters;
+    if (!parseTabQueryOptions(options, parameters, @"info", outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::get(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/get
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::getCurrent(Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent
 
-    // FIXME: Implement.
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::getSelected(double windowID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected
 
-    // FIXME: Implement.
+    auto windowIdentifer = toWebExtensionWindowIdentifier(windowID);
+    if (!isValid(windowIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::duplicate(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
-void WebExtensionAPITabs::update(double tabID, NSDictionary *updateProperties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::update(double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    WebExtensionTabParameters parameters;
+    if (!parseTabUpdateOptions(options, parameters, @"properties", outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove
 
-    // FIXME: Implement.
+    if (!validateObject(tabIDs, @"tabIDs", [NSOrderedSet orderedSetWithObjects:NSNumber.class, @[ NSNumber.class ], nil], outExceptionString))
+        return;
+
+    Vector<WebExtensionTabIdentifier> identifiers;
+
+    if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs)) {
+        auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
+        if (!isValid(tabIdentifer)) {
+            *outExceptionString = toErrorString(nil, @"tabIDs", @"'%@' is not a tab identifier", tabID);
+            return;
+        }
+
+        identifiers.append(tabIdentifer.value());
+    } else if (NSArray *tabIDArray = dynamic_objc_cast<NSArray>(tabIDs)) {
+        identifiers.reserveInitialCapacity(tabIDArray.count);
+
+        for (NSNumber *tabID in tabIDArray) {
+            auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
+            if (!isValid(tabIdentifer)) {
+                *outExceptionString = toErrorString(nil, @"tabIDs", @"'%@' is not a tab identifier", tabID);
+                return;
+            }
+
+            identifiers.uncheckedAppend(tabIdentifer.value());
+        }
+    }
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::reload(double tabID, NSDictionary *reloadProperties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::goBack(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goBack
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::goForward(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goForward
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::getZoom(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::setZoom(double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::detectLanguage(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 void WebExtensionAPITabs::toggleReaderMode(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode
 
-    // FIXME: Implement.
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (!isValid(tabIdentifer, outExceptionString))
+        return;
+
+    // FIXME: <https://webkit.org/b/260994> Implement.
 }
 
 WebExtensionAPIEvent& WebExtensionAPITabs::onActivated()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -229,6 +229,21 @@ bool WebExtensionAPIWindows::parseWindowTypesFilter(NSDictionary *options, Optio
     return true;
 }
 
+bool WebExtensionAPIWindows::parseWindowTypeFilter(NSString *windowType, OptionSet<WindowTypeFilter>& windowTypeFilter, NSString *sourceKey, NSString **outExceptionString)
+{
+    if ([windowType isEqualToString:normalKey])
+        windowTypeFilter.add(WindowTypeFilter::Normal);
+    else if ([windowType isEqualToString:popupKey])
+        windowTypeFilter.add(WindowTypeFilter::Popup);
+
+    if (!windowTypeFilter) {
+        *outExceptionString = toErrorString(nil, sourceKey, @"it must specify either 'normal' or 'popup'");
+        return false;
+    }
+
+    return true;
+}
+
 bool WebExtensionAPIWindows::parseWindowGetOptions(NSDictionary *options, PopulateTabs& populate, OptionSet<WindowTypeFilter>& filter, NSString *sourceKey, NSString **outExceptionString)
 {
     if (!parsePopulateTabs(options, populate, sourceKey, outExceptionString))
@@ -362,7 +377,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
     return true;
 }
 
-static bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **outExceptionString)
+bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **outExceptionString)
 {
     if (UNLIKELY(!isValid(identifier))) {
         if (isNone(identifier))

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -37,6 +37,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 struct WebExtensionTabParameters;
+struct WebExtensionTabQueryParameters;
 
 class WebExtensionAPITabs : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITabs, tabs);
@@ -81,6 +82,10 @@ public:
     WebExtensionAPIEvent& onUpdated();
 
 private:
+    static bool parseTabCreateOptions(NSDictionary *, WebExtensionTabParameters&, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseTabUpdateOptions(NSDictionary *, WebExtensionTabParameters&, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseTabQueryOptions(NSDictionary *, WebExtensionTabQueryParameters&, NSString *sourceKey, NSString **outExceptionString);
+
     RefPtr<WebExtensionAPIEvent> m_onActivated;
     RefPtr<WebExtensionAPIEvent> m_onAttached;
     RefPtr<WebExtensionAPIEvent> m_onCreated;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
@@ -68,10 +68,12 @@ public:
     WebExtensionAPIWindowsEvent& onFocusChanged();
 
 private:
+    friend class WebExtensionAPITabs;
     friend class WebExtensionAPIWindowsEvent;
 
     static bool parsePopulateTabs(NSDictionary *, PopulateTabs&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseWindowTypesFilter(NSDictionary *, OptionSet<WindowTypeFilter>&, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseWindowTypeFilter(NSString *, OptionSet<WindowTypeFilter>&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseWindowGetOptions(NSDictionary *, PopulateTabs&, OptionSet<WindowTypeFilter>&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseWindowCreateOptions(NSDictionary *, WebExtensionWindowParameters&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseWindowUpdateOptions(NSDictionary *, WebExtensionWindowParameters&, NSString *sourceKey, NSString **outExceptionString);
@@ -81,6 +83,8 @@ private:
     RefPtr<WebExtensionAPIWindowsEvent> m_onFocusChanged;
 #endif
 };
+
+bool isValid(std::optional<WebExtensionWindowIdentifier>, NSString **outExceptionString);
 
 } // namespace WebKit
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -292,6 +292,7 @@ Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
 Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
 Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
 Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
 Tests/WebKitCocoa/WKWebExtensionContext.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2107,6 +2107,7 @@
 		1CF59ADF21E68925006E37EC /* ForceLightAppearanceInBundle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ForceLightAppearanceInBundle.mm; sourceTree = "<group>"; };
 		1CF59AE021E68925006E37EC /* ForceLightAppearanceInBundle_Bundle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ForceLightAppearanceInBundle_Bundle.mm; sourceTree = "<group>"; };
 		1CF59AE421E696FB006E37EC /* dark-mode.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "dark-mode.html"; sourceTree = "<group>"; };
+		1CF7FFA72AA7C302003609F0 /* WKWebExtensionAPITabs.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPITabs.mm; sourceTree = "<group>"; };
 		1CFAA40828947999009F894D /* WKWebExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtension.mm; sourceTree = "<group>"; };
 		1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionMatchPattern.mm; sourceTree = "<group>"; };
 		1CFD5D3E2851B62100A0E30B /* EnumeratedArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumeratedArray.cpp; sourceTree = "<group>"; };
@@ -4211,6 +4212,7 @@
 				330E135E2943C92000367438 /* WKWebExtensionAPINamespace.mm */,
 				B61EB1642994734A0048DFC0 /* WKWebExtensionAPIPermissions.mm */,
 				1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */,
+				1CF7FFA72AA7C302003609F0 /* WKWebExtensionAPITabs.mm */,
 				3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */,
 				1C9A2E182A9FB6F400D1B4A5 /* WKWebExtensionAPIWindows.mm */,
 				1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestWebExtensionsDelegate.h"
+#import "WebExtensionUtilities.h"
+#import <WebKit/_WKWebExtensionWindowCreationOptions.h>
+
+namespace TestWebKitAPI {
+
+static auto *tabsManifest = @{
+    @"manifest_version": @3,
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+};
+
+TEST(WKWebExtensionAPITabs, Errors)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertThrows(() => browser.tabs.get('bad'), /'tabID' value is invalid, because a number is expected/i)",
+        @"browser.test.assertThrows(() => browser.tabs.get(-3), /'tabID' value is invalid, because it is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.duplicate('bad'), /'tabID' value is invalid, because a number is expected/i)",
+        @"browser.test.assertThrows(() => browser.tabs.remove('bad'), /'tabIDs' value is invalid, because a number value or an array of number values is expected, but a string value was provided/i)",
+        @"browser.test.assertThrows(() => browser.tabs.reload('bad'), /an unknown argument was provided/i)",
+        @"browser.test.assertThrows(() => browser.tabs.goBack('bad'), /'tabID' value is invalid, because it is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.goForward('bad'), /'tabID' value is invalid, because it is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.getZoom('bad'), /'tabID' value is invalid, because it is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.detectLanguage('bad'), /'tabID' value is invalid, because it is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.toggleReaderMode('bad'), /'tabID' value is invalid, because it is not a tab identifier/i)",
+
+        @"browser.test.assertThrows(() => browser.tabs.setZoom('bad'), /'zoomFactor' value is invalid, because a number is expected/i)",
+        @"browser.test.assertThrows(() => browser.tabs.setZoom(1, 'bad'), /'zoomFactor' value is invalid, because a number is expected/i)",
+
+        @"browser.test.assertThrows(() => browser.tabs.update('bad'), /'properties' value is invalid, because an object is expected/i)",
+        @"browser.test.assertThrows(() => browser.tabs.update(1, 'bad'), /'properties' value is invalid, because an object is expected/i)",
+
+        @"browser.test.assertThrows(() => browser.tabs.update(1, { 'openerTabId': true }), /'openerTabId' is expected to be a number value, but a boolean value was provided/i)",
+        @"browser.test.assertThrows(() => browser.tabs.update(1, { 'openerTabId': 4.2 }), /'openerTabId' value is invalid, because '4.2' is not a tab identifier/i)",
+
+        @"browser.test.assertThrows(() => browser.tabs.create({ 'url': 1234 }), /'url' is expected to be a string value/i)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:tabsManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### cbed4bc921fd108d498644804120bb96798f2a69
<pre>
Add argument parsing and error handling for the tabs Web Extension APIs.
<a href="https://webkit.org/b/260994">https://webkit.org/b/260994</a>
rdar://problem/114787376

Reviewed by Brian Weinstein.

Add all arguments and type processing for the base tabs APIs.

* Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in: Added WebExtensionTabQueryParameters.
* Source/WebKit/Shared/Extensions/WebExtensionTabQueryParameters.h: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::toWebAPI): Added.
(WebKit::WebExtensionAPITabs::parseTabCreateOptions): Added.
(WebKit::WebExtensionAPITabs::parseTabUpdateOptions): Added.
(WebKit::WebExtensionAPITabs::parseTabQueryOptions): Added.
(WebKit::isValid): Added.
(WebKit::WebExtensionAPITabs::isPropertyAllowed):
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::query):
(WebKit::WebExtensionAPITabs::get):
(WebKit::WebExtensionAPITabs::getCurrent):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::duplicate):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::remove):
(WebKit::WebExtensionAPITabs::reload):
(WebKit::WebExtensionAPITabs::goBack):
(WebKit::WebExtensionAPITabs::goForward):
(WebKit::WebExtensionAPITabs::getZoom):
(WebKit::WebExtensionAPITabs::setZoom):
(WebKit::WebExtensionAPITabs::detectLanguage):
(WebKit::WebExtensionAPITabs::toggleReaderMode):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowTypeFilter): Added.
(WebKit::isValid): Removed inline to use in WebExtensionAPITabs.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt: Added WKWebExtensionAPITabs.mm.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267709@main">https://commits.webkit.org/267709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fcc3618b1c9f268f31e3e788dabcc3650f2219b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17933 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17671 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/17990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20074 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15893 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20366 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/15776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2139 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->