### PR TITLE
Store correct committed WebPage origin

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5776,8 +5776,7 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
     bool markPageInsecure = hasInsecureContent == HasInsecureContent::Yes;
 
     if (frame->isMainFrame()) {
-        auto frameOrigin = navigation ? navigation->destinationFrameSecurityOrigin() : SecurityOriginData { };
-        internals().pageLoadState.didCommitLoad(transaction, certificateInfo, markPageInsecure, usedLegacyTLS, wasPrivateRelayed, frameOrigin);
+        internals().pageLoadState.didCommitLoad(transaction, certificateInfo, markPageInsecure, usedLegacyTLS, wasPrivateRelayed, frameInfo.securityOrigin);
         m_shouldSuppressNextAutomaticNavigationSnapshot = false;
     } else if (markPageInsecure)
         internals().pageLoadState.didDisplayOrRunInsecureContent(transaction);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -2636,7 +2636,6 @@ TEST(WKDownload, BlobDownload)
         EXPECT_NOT_NULL(value);
         blobURL = adoptNS([[NSURL alloc] initWithString:value]);
         doneEvaluatingJavaScript = true;
-        WTFLogAlways("evaluateJavaScript: blobURL string: %@, blobURL url: %@", value, blobURL.get().absoluteString);
     }];
     Util::run(&doneEvaluatingJavaScript);
 
@@ -2648,7 +2647,6 @@ TEST(WKDownload, BlobDownload)
     };
 
     __block WKDownload *blobDownload = nil;
-    WTFLogAlways("before startDownloadUsingRequest: blobURL: %@", blobURL.get().absoluteString);
     [webView startDownloadUsingRequest:[NSURLRequest requestWithURL:blobURL.get()] completionHandler:^(WKDownload *download) {
         blobDownload = download;
         download.delegate = delegate.get();


### PR DESCRIPTION
#### 99c5b714ebf06956d737ac12c1208852201d9078
<pre>
Store correct committed WebPage origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=261241">https://bugs.webkit.org/show_bug.cgi?id=261241</a>
rdar://problem/115082690

Reviewed by Alex Christensen.

In 266870@main I began caching the committed page&apos;s SecurityOriginData, however
I copied the frame&apos;s origin at the wrong point in time. In that patch, I used
the Navigation&apos;s destinationFrameSecurityOrigin. That captured the frame&apos;s
SecurityOriginData when we began handling the navigation request. We actually
want the frame&apos;s SecurityOriginData at the time we committed the load (&quot;now&quot;).
Therefore we should use the SecurityOriginData from the FrameInfo, instead.

This is still covered by existing tests, but this problem wasn&apos;t noticed until
I began testing enabling a new feature that relies on this informatin being
correct.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:

Canonical link: <a href="https://commits.webkit.org/267739@main">https://commits.webkit.org/267739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2d779e65a3a9d78abadc39ee8c4cdf89ff876f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18481 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20077 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15888 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22534 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20370 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16646 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14111 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15777 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4178 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->