### PR TITLE
[web-animations] color-scheme should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/animation/color-scheme-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/animation/color-scheme-no-interpolation-expected.txt
@@ -16,15 +16,15 @@ PASS CSS Transitions with transition: all: property <color-scheme> from [initial
 PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (-0.3) should be [initial]
 PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (0) should be [initial]
 PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (0.3) should be [initial]
-FAIL CSS Animations: property <color-scheme> from [initial] to [dark] at (0.5) should be [dark] assert_equals: expected "dark " but got "normal "
-FAIL CSS Animations: property <color-scheme> from [initial] to [dark] at (0.6) should be [dark] assert_equals: expected "dark " but got "normal "
-FAIL CSS Animations: property <color-scheme> from [initial] to [dark] at (1) should be [dark] assert_equals: expected "dark " but got "normal "
-FAIL CSS Animations: property <color-scheme> from [initial] to [dark] at (1.5) should be [dark] assert_equals: expected "dark " but got "normal "
+PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (0.5) should be [dark]
+PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (0.6) should be [dark]
+PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (1) should be [dark]
+PASS CSS Animations: property <color-scheme> from [initial] to [dark] at (1.5) should be [dark]
 PASS Web Animations: property <color-scheme> from [initial] to [dark] at (-0.3) should be [initial]
 PASS Web Animations: property <color-scheme> from [initial] to [dark] at (0) should be [initial]
 PASS Web Animations: property <color-scheme> from [initial] to [dark] at (0.3) should be [initial]
-FAIL Web Animations: property <color-scheme> from [initial] to [dark] at (0.5) should be [dark] assert_equals: expected "dark " but got "normal "
-FAIL Web Animations: property <color-scheme> from [initial] to [dark] at (0.6) should be [dark] assert_equals: expected "dark " but got "normal "
-FAIL Web Animations: property <color-scheme> from [initial] to [dark] at (1) should be [dark] assert_equals: expected "dark " but got "normal "
-FAIL Web Animations: property <color-scheme> from [initial] to [dark] at (1.5) should be [dark] assert_equals: expected "dark " but got "normal "
+PASS Web Animations: property <color-scheme> from [initial] to [dark] at (0.5) should be [dark]
+PASS Web Animations: property <color-scheme> from [initial] to [dark] at (0.6) should be [dark]
+PASS Web Animations: property <color-scheme> from [initial] to [dark] at (1) should be [dark]
+PASS Web Animations: property <color-scheme> from [initial] to [dark] at (1.5) should be [dark]
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3842,6 +3842,9 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<BlendMode>(CSSPropertyMixBlendMode, &RenderStyle::blendMode, &RenderStyle::setBlendMode),
         new DiscretePropertyWrapper<BlendMode>(CSSPropertyBackgroundBlendMode, &RenderStyle::backgroundBlendMode, &RenderStyle::setBackgroundBlendMode),
 #endif
+#if ENABLE(DARK_MODE_CSS)
+        new DiscretePropertyWrapper<StyleColorScheme>(CSSPropertyColorScheme, &RenderStyle::colorScheme, &RenderStyle::setColorScheme),
+#endif
         new PropertyWrapperAspectRatio,
         new DiscretePropertyWrapper<FontPalette>(CSSPropertyFontPalette, &RenderStyle::fontPalette, &RenderStyle::setFontPalette),
 
@@ -3977,9 +3980,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         // When adding a new property, you should make sure it belongs in this list
         // or provide a wrapper for it above. If you are adding to this list but the
         // property should be animatable, make sure to file a bug.
-#if ENABLE(DARK_MODE_CSS)
-        case CSSPropertyColorScheme:
-#endif
         case CSSPropertyDirection:
         case CSSPropertyDisplay:
 #if ENABLE(VARIATION_FONTS)

--- a/Source/WebCore/rendering/style/StyleColorScheme.h
+++ b/Source/WebCore/rendering/style/StyleColorScheme.h
@@ -29,6 +29,7 @@
 
 #include "RenderStyleConstants.h"
 #include <wtf/OptionSet.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -58,6 +59,13 @@ private:
     OptionSet<ColorScheme> m_colorScheme;
     bool m_allowsTransformations { true };
 };
+
+inline WTF::TextStream& operator<<(WTF::TextStream& ts, const StyleColorScheme& styleColorScheme)
+{
+    ts.dumpProperty("color-scheme", styleColorScheme.colorScheme());
+    ts.dumpProperty("allows-transformations", styleColorScheme.allowsTransformations());
+    return ts;
+}
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 8d8787bcabc26b663d65c2306a76374ed5a9a771
<pre>
[web-animations] color-scheme should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=241179">https://bugs.webkit.org/show_bug.cgi?id=241179</a>
rdar://94615599

Reviewed by Tim Nguyen.

The `color-scheme` property should support discrete animation, per
<a href="https://drafts.csswg.org/css-color-adjust/#color-scheme-prop.">https://drafts.csswg.org/css-color-adjust/#color-scheme-prop.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/animation/color-scheme-no-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/StyleColorScheme.h:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/267750@main">https://commits.webkit.org/267750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5892d6c9aae9a0a3730c6bcba5d98d4471c142ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18056 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20229 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22613 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20465 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14188 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15873 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4189 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->