### PR TITLE
[css-grid] Last baseline aligned grid items should use the start of the last track they span for their alignment context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt
@@ -12,17 +12,13 @@ line1
 line2
 
 PASS #target > div 1
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 140
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 161
+PASS #target > div 2
+PASS #target > div 3
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 0
+offsetLeft expected 35 but got 15
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 7
+offsetLeft expected 42 but got 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt
@@ -12,17 +12,13 @@ line1
 line2
 
 PASS #target > div 1
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 140
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 161
+PASS #target > div 2
+PASS #target > div 3
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 0
+offsetLeft expected 35 but got 15
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 7
+offsetLeft expected 42 but got 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -16,15 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 0
+offsetLeft expected 105 but got 35
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 7
+offsetLeft expected 126 but got 42
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 0
+offsetLeft expected 35 but got 15
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 7
+offsetLeft expected 42 but got 22
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -961,6 +961,14 @@ bool GridTrackSizingAlgorithm::participateInBaselineAlignment(const RenderBox& c
     return baselineAxis == GridColumnAxis ? m_columnBaselineItemsMap.get(&child) : m_rowBaselineItemsMap.get(&child);
 }
 
+static unsigned alignmentContextForBaselineAlignment(const GridSpan& span, const ItemPosition& alignment)
+{
+    ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
+    if (alignment == ItemPosition::Baseline)
+        return span.startLine();
+    return span.endLine() - 1;
+}
+
 void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& child, GridAxis baselineAxis)
 {
     ASSERT(wasSetup());
@@ -968,8 +976,8 @@ void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& c
 
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
-    auto spanForBaselineAlignment = align == ItemPosition::Baseline ? span.startLine() : span.endLine();
-    m_baselineAlignment.updateBaselineAlignmentContext(align, spanForBaselineAlignment, child, baselineAxis);
+    auto alignmentContext = alignmentContextForBaselineAlignment(span, align);
+    m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, child, baselineAxis);
 }
 
 LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& child, GridAxis baselineAxis) const
@@ -984,8 +992,8 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& chi
 
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
-    auto spanForBaselineAlignment = align == ItemPosition::Baseline ? span.startLine() : span.endLine();
-    return m_baselineAlignment.baselineOffsetForChild(align, spanForBaselineAlignment, child, baselineAxis);
+    auto alignmentContext = alignmentContextForBaselineAlignment(span, align);
+    return m_baselineAlignment.baselineOffsetForChild(align, alignmentContext, child, baselineAxis);
 }
 
 void GridTrackSizingAlgorithm::clearBaselineItemsCache()


### PR DESCRIPTION
#### caab01d5e748531c1ff7fbcdab9b2da36801d73e
<pre>
[css-grid] Last baseline aligned grid items should use the start of the last track they span for their alignment context
<a href="https://bugs.webkit.org/show_bug.cgi?id=261244">https://bugs.webkit.org/show_bug.cgi?id=261244</a>
rdar://115083708

Reviewed by Matt Woodrow.

Instead of using span.endLine() for a last baseline aligned grid item&apos;s
alignment context, we should use span.endLine() - 1. This will allow
them to be in the same alignment context and potentially the same
baseline sharing group as first baseline aligned items in the same
track. For example, both items in the following grid should be in
the same baseline sharing group and should be aligned together as a
result:

&lt;style&gt;
  display: grid;
  grid-auto-flow: column;
  align-items: last baseline;
  width: 200px;
  writing-mode: vertical-lr;
}
  background: lime;
  margin-right: 20px;
  padding-right: 20px;
  font-size: 20px;
  line-height: 20px;
  align-self: first baseline;
  writing-mode: vertical-rl;
}
  background: hotpink;
  font-size: 30px;
  line-height: 30px;
  writing-mode: vertical-lr;
}
&lt;/style&gt;
&lt;div id=&quot;grid&quot;&gt;
  &lt;div&gt;line1&lt;br&gt;line2&lt;/div&gt;
  &lt;div&gt;line1&lt;br&gt;line2&lt;/div&gt;
&lt;div&gt;

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::alignmentContextForBaselineAlignment):
(WebCore::GridTrackSizingAlgorithm::updateBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForChild const):

Canonical link: <a href="https://commits.webkit.org/267922@main">https://commits.webkit.org/267922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fa1c1ffbdfbc7e592e38cd98efdfa5d09c3da45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18679 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20486 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22767 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20632 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14349 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16057 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4303 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->