### PR TITLE
IPC::Semaphore waits don't terminate if the remote process crashes and can cause hangs.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -165,11 +165,17 @@ void RemoteImageBuffer::transformToColorSpace(const WebCore::DestinationColorSpa
     m_imageBuffer->transformToColorSpace(colorSpace);
 }
 
-void RemoteImageBuffer::flushContext(IPC::Semaphore&& semaphore)
+void RemoteImageBuffer::setFlushSignal(IPC::Signal&& signal)
 {
+    m_flushSignal = WTFMove(signal);
+}
+
+void RemoteImageBuffer::flushContext()
+{
+    RELEASE_ASSERT(m_flushSignal);
     assertIsCurrent(workQueue());
     m_imageBuffer->flushDrawingContext();
-    semaphore.signal();
+    m_flushSignal->signal();
 }
 
 void RemoteImageBuffer::flushContextSync(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "IPCEvent.h"
 #include "ScopedRenderingResourcesRequest.h"
 #include "ShareableBitmap.h"
 #include "StreamMessageReceiver.h"
@@ -64,12 +65,14 @@ private:
     void getFilteredImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();
     void transformToColorSpace(const WebCore::DestinationColorSpace&);
-    void flushContext(IPC::Semaphore&&);
+    void setFlushSignal(IPC::Signal&&);
+    void flushContext();
     void flushContextSync(CompletionHandler<void()>&&);
 
     RefPtr<RemoteRenderingBackend> m_backend;
     Ref<WebCore::ImageBuffer> m_imageBuffer;
     ScopedRenderingResourcesRequest m_renderingResourcesRequest { ScopedRenderingResourcesRequest::acquire() };
+    std::optional<IPC::Signal> m_flushSignal;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -31,7 +31,8 @@ messages -> RemoteImageBuffer NotRefCounted Stream {
     GetFilteredImage(Ref<WebCore::Filter> filter) -> (std::optional<WebKit::ShareableBitmap::Handle> handle) Synchronous NotStreamEncodableReply
     ConvertToLuminanceMask()
     TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)
-    FlushContext(IPC::Semaphore semaphore) NotStreamEncodable
+    SetFlushSignal(IPC::Signal signal) NotStreamEncodable
+    FlushContext()
     FlushContextSync() -> () Synchronous
 }
 

--- a/Source/WebKit/Platform/IPC/IPCEvent.h
+++ b/Source/WebKit/Platform/IPC/IPCEvent.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IPCSemaphore.h"
+
+namespace IPC {
+
+struct EventSignalPair;
+std::optional<EventSignalPair> createEventSignalPair();
+
+// A waitable Event object (and corresponding Signal object), where the
+// Signal object can be serialized across IPC.
+// The wait operation will be interrupted if the Signal instance is
+// destroyed (including if the remote process that owns it crashes or is
+// killed).
+// FIXME: Write proper interruptible implementations for non-COCOA platforms.
+class Signal {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(Signal);
+public:
+    Signal(Signal&& other) = default;
+    Signal& operator=(Signal&& other) = default;
+
+#if PLATFORM(COCOA)
+    void signal();
+    void encode(Encoder&) &&;
+    static std::optional<Signal> decode(Decoder&);
+#else
+    void signal()
+    {
+        m_semaphore.signal();
+    }
+
+    void encode(Encoder& encoder) &&
+    {
+        m_semaphore.encode(encoder);
+    }
+
+    static std::optional<Signal> decode(Decoder& decoder)
+    {
+        std::optional<Semaphore> semaphore = Semaphore::decode(decoder);
+        if (!semaphore)
+            return std::nullopt;
+
+        return Signal(WTFMove(*semaphore));
+    }
+#endif
+
+private:
+    friend std::optional<EventSignalPair> createEventSignalPair();
+
+#if PLATFORM(COCOA)
+    Signal(MachSendRight&& sendRight)
+        : m_sendRight(WTFMove(sendRight))
+    { }
+#else
+    Signal(Semaphore&& semaphore)
+        : m_semaphore(WTFMove(semaphore))
+    { }
+#endif
+
+#if PLATFORM(COCOA)
+    MachSendRight m_sendRight;
+#else
+    Semaphore m_semaphore;
+#endif
+};
+
+class Event {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(Event);
+public:
+#if PLATFORM(COCOA)
+    ~Event();
+    Event(Event&& other)
+        : m_receiveRight(WTFMove(other.m_receiveRight))
+    {
+        other.m_receiveRight = MACH_PORT_NULL;
+    }
+
+    Event& operator=(Event&& other)
+    {
+        m_receiveRight = WTFMove(other.m_receiveRight);
+        other.m_receiveRight = MACH_PORT_NULL;
+        return *this;
+    }
+
+    bool wait();
+    bool waitFor(Timeout);
+#else
+    Event(Event&& other) = default;
+    Event& operator=(Event&& other) = default;
+
+    bool wait()
+    {
+        return m_semaphore.wait();
+    }
+
+    bool waitFor(Timeout timeout)
+    {
+        return m_semaphore.waitFor(timeout);
+    }
+#endif
+
+private:
+    friend std::optional<EventSignalPair> createEventSignalPair();
+
+#if PLATFORM(COCOA)
+    Event(mach_port_t port)
+        : m_receiveRight(port)
+    { }
+#else
+    Event(Semaphore&& semaphore)
+        : m_semaphore(WTFMove(semaphore))
+    { }
+#endif
+
+#if PLATFORM(COCOA)
+    mach_port_t m_receiveRight;
+#else
+    Semaphore m_semaphore;
+#endif
+};
+
+struct EventSignalPair {
+    Event event;
+    Signal signal;
+};
+
+#if !PLATFORM(COCOA)
+inline std::optional<EventSignalPair> createEventSignalPair()
+{
+    Semaphore event;
+#if PLATFORM(WIN)
+    Semaphore signal(Win32Handle { event.m_semaphoreHandle });
+#else
+    Semaphore signal(event.m_fd.duplicate());
+#endif
+    return EventSignalPair { Event { WTFMove(event) }, Signal { WTFMove(signal) } };
+}
+#endif
+
+} // namespace IPC

--- a/Source/WebKit/Platform/IPC/IPCSemaphore.h
+++ b/Source/WebKit/Platform/IPC/IPCSemaphore.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Timeout.h"
+#include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
 
@@ -42,7 +43,16 @@ namespace IPC {
 
 class Decoder;
 class Encoder;
+struct EventSignalPair;
 
+std::optional<EventSignalPair> createEventSignalPair();
+
+// A semaphore implementation that can be duplicated across IPC.
+// The cocoa implementation of this only interrupts wait calls upon the
+// remote process terminating if the Semaphore was created by the remote
+// process.
+// It is generally preferred to start using IPC::Event/Signal instead
+// to avoid this.
 class Semaphore {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(Semaphore);
@@ -74,6 +84,7 @@ public:
 #endif
 
 private:
+    friend std::optional<EventSignalPair> createEventSignalPair();
     void destroy();
 #if PLATFORM(COCOA)
     MachSendRight m_sendRight;

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -637,4 +637,5 @@ std::optional<Connection::ConnectionIdentifierPair> Connection::createConnection
     mach_port_insert_right(mach_task_self(), listeningPort, listeningPort, MACH_MSG_TYPE_MAKE_SEND);
     return ConnectionIdentifierPair { Identifier { listeningPort, nullptr }, MachSendRight::adopt(listeningPort) };
 }
+
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IPCEvent.h"
+
+#include "Logging.h"
+#include "MachUtilities.h"
+#include <mach/mach_init.h>
+#include <mach/mach_port.h>
+#include <mach/message.h>
+
+namespace IPC {
+
+// Arbitrary message IDs that do not collide with Mach notification messages.
+constexpr mach_msg_id_t inlineBodyMessageID = 0xdba0dba;
+
+static void requestNoSenderNotifications(mach_port_t port, mach_port_t notify)
+{
+    mach_port_t previousNotificationPort = MACH_PORT_NULL;
+    auto kr = mach_port_request_notification(mach_task_self(), port, MACH_NOTIFY_NO_SENDERS, 0, notify, MACH_MSG_TYPE_MAKE_SEND_ONCE, &previousNotificationPort);
+    ASSERT(kr == KERN_SUCCESS);
+    if (kr != KERN_SUCCESS) {
+        // If mach_port_request_notification fails, 'previousNotificationPort' will be uninitialized.
+        LOG_ERROR("mach_port_request_notification failed: (%x) %s", kr, mach_error_string(kr));
+    } else
+        deallocateSendRightSafely(previousNotificationPort);
+}
+
+static void requestNoSenderNotifications(mach_port_t port)
+{
+    requestNoSenderNotifications(port, port);
+}
+
+static void clearNoSenderNotifications(mach_port_t port)
+{
+    requestNoSenderNotifications(port, MACH_PORT_NULL);
+}
+
+void Signal::signal()
+{
+    mach_msg_header_t message;
+    memset(&message, 0, sizeof(message));
+    message.msgh_remote_port = m_sendRight.sendRight();
+    message.msgh_local_port = MACH_PORT_NULL;
+    message.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0);
+    message.msgh_id = inlineBodyMessageID;
+
+    auto ret = mach_msg(&message, MACH_SEND_MSG, sizeof(message), 0, MACH_PORT_NULL, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+    if (ret != KERN_SUCCESS)
+        RELEASE_LOG_ERROR(Process, "IPC::Signal::signal Could not send mach message, error %x", ret);
+}
+
+void Signal::encode(Encoder& encoder) &&
+{
+    encoder << WTFMove(m_sendRight);
+}
+
+std::optional<Signal> Signal::decode(Decoder& decoder)
+{
+    std::optional<MachSendRight> sendRight;
+    decoder >> sendRight;
+    if (!sendRight)
+        return std::nullopt;
+
+    return Signal(WTFMove(*sendRight));
+}
+
+std::optional<EventSignalPair> createEventSignalPair()
+{
+    // Create the listening port.
+    mach_port_t listeningPort = MACH_PORT_NULL;
+    auto kr = mach_port_allocate(mach_task_self(), MACH_PORT_RIGHT_RECEIVE, &listeningPort);
+    if (kr != KERN_SUCCESS) {
+        RELEASE_LOG_ERROR(Process, "createEventSignalPair: Could not allocate mach port, error %x", kr);
+        return std::nullopt;
+    }
+    if (!MACH_PORT_VALID(listeningPort)) {
+        RELEASE_LOG_ERROR(Process, "createEventSignalPair: Could not allocate mach port, returned port was invalid");
+        return std::nullopt;
+    }
+
+    setMachPortQueueLength(listeningPort, 1);
+    mach_port_insert_right(mach_task_self(), listeningPort, listeningPort, MACH_MSG_TYPE_MAKE_SEND);
+    requestNoSenderNotifications(listeningPort);
+
+    return EventSignalPair { Event { listeningPort }, Signal { MachSendRight::adopt(listeningPort) } };
+}
+
+Event::~Event()
+{
+    if (m_receiveRight != MACH_PORT_NULL) {
+        clearNoSenderNotifications(m_receiveRight);
+        mach_port_mod_refs(mach_task_self(), m_receiveRight, MACH_PORT_RIGHT_RECEIVE, -1);
+    }
+}
+
+typedef struct {
+    mach_msg_header_t header;
+    mach_msg_trailer_t trailer;
+} ReceiveMessage;
+
+bool Event::wait()
+{
+    ReceiveMessage receiveMessage;
+    memset(&receiveMessage, 0, sizeof(receiveMessage));
+    mach_msg_return_t ret = mach_msg(&receiveMessage.header, MACH_RCV_MSG, 0, sizeof(receiveMessage), m_receiveRight, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+    if (ret != MACH_MSG_SUCCESS)
+        return false;
+    if (receiveMessage.header.msgh_id != inlineBodyMessageID)
+        return false;
+    return true;
+}
+
+bool Event::waitFor(Timeout timeout)
+{
+    ReceiveMessage receiveMessage;
+    memset(&receiveMessage, 0, sizeof(receiveMessage));
+    mach_msg_return_t ret = mach_msg(&receiveMessage.header, MACH_RCV_MSG | MACH_RCV_TIMEOUT, 0, sizeof(receiveMessage), m_receiveRight, timeout.secondsUntilDeadline().milliseconds(), MACH_PORT_NULL);
+    if (ret != MACH_MSG_SUCCESS)
+        return false;
+    if (receiveMessage.header.msgh_id != inlineBodyMessageID)
+        return false;
+    return true;
+}
+
+} // namespace IPC
+

--- a/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
@@ -106,7 +106,6 @@ std::optional<Semaphore> Semaphore::decode(Decoder& decoder)
     return std::optional<Semaphore> { std::in_place, WTFMove(sendRight) };
 }
 
-
 void Semaphore::destroy()
 {
     if (m_sendRight) {

--- a/Source/WebKit/Platform/SourcesCocoa.txt
+++ b/Source/WebKit/Platform/SourcesCocoa.txt
@@ -17,6 +17,7 @@ Platform/IPC/cocoa/DaemonConnectionCocoa.mm
 Platform/IPC/cocoa/MachMessage.cpp
 
 Platform/IPC/darwin/ArgumentCodersDarwin.mm
+Platform/IPC/darwin/IPCEventDarwin.cpp
 Platform/IPC/darwin/IPCSemaphoreDarwin.cpp
 
 Platform/mac/MachUtilities.cpp

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -138,6 +138,7 @@ def surround_in_condition(string, condition):
 def types_that_must_be_moved():
     return [
         'IPC::Connection::Handle',
+        'IPC::Signal',
         'IPC::StreamServerConnection::Handle',
         'MachSendRight',
         'Vector<WebKit::SharedMemory::Handle>',
@@ -365,6 +366,7 @@ def types_that_cannot_be_forward_declared():
         'CVPixelBufferRef',
         'GCGLint',
         'IPC::AsyncReplyID',
+        'IPC::Signal',
         'IPC::DataReference',
         'IPC::FontReference',
         'IPC::Semaphore',
@@ -651,6 +653,7 @@ def argument_coder_headers_for_type(type):
 
     special_cases = {
         'IPC::Connection::Handle': '"Connection.h"',
+        'IPC::Signal': '"IPCEvent.h"',
         'String': '"ArgumentCoders.h"',
         'MachSendRight': '"ArgumentCodersDarwin.h"',
         'WebKit::ScriptMessageHandlerHandle': '"WebScriptMessageHandler.h"',
@@ -684,6 +687,7 @@ def headers_for_type(type):
         'Inspector::FrontendChannel::ConnectionType': ['<JavaScriptCore/InspectorFrontendChannel.h>'],
         'Inspector::InspectorTargetType': ['<JavaScriptCore/InspectorTarget.h>'],
         'IPC::AsyncReplyID': ['"Connection.h"'],
+        'IPC::Signal': ['"IPCEvent.h"'],
         'IPC::Semaphore': ['"IPCSemaphore.h"'],
         'JSC::MessageLevel': ['<JavaScriptCore/ConsoleTypes.h>'],
         'JSC::MessageSource': ['<JavaScriptCore/ConsoleTypes.h>'],

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1779,6 +1779,7 @@
 		A5E391FD2183C1F800C8FB31 /* InspectorTargetProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E391FC2183C1E900C8FB31 /* InspectorTargetProxy.h */; };
 		A5EC6AD42151BD7B00677D17 /* WebPageDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EC6AD32151BD6900677D17 /* WebPageDebuggable.h */; };
 		A5EFD38C16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = A73E66BC2AB107BB005FC327 /* IPCEvent.h */; };
 		A7A3D555289395E2008D683D /* WebWorkerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A3D553289395E2008D683D /* WebWorkerClient.h */; };
 		A7D792D81767CCA300881CBE /* ActivityAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D792D41767CB0900881CBE /* ActivityAssertion.h */; };
 		AAB145E6223F931200E489D8 /* PrefetchCache.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB145E4223F931200E489D8 /* PrefetchCache.h */; };
@@ -6379,6 +6380,8 @@
 		A5EC6AD32151BD6900677D17 /* WebPageDebuggable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageDebuggable.h; sourceTree = "<group>"; };
 		A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageVisibilityTypes.h; sourceTree = "<group>"; };
 		A72D5D7F1236CBA800A88B15 /* APISerializedScriptValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APISerializedScriptValue.h; sourceTree = "<group>"; };
+		A73E66BC2AB107BB005FC327 /* IPCEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPCEvent.h; sourceTree = "<group>"; };
+		A73E66BE2AB10958005FC327 /* IPCEventDarwin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPCEventDarwin.cpp; sourceTree = "<group>"; };
 		A78CCDD8193AC9E3005ECC25 /* com.apple.WebKit.Networking.sb.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = com.apple.WebKit.Networking.sb.in; sourceTree = "<group>"; };
 		A7A3D552289395E2008D683D /* WebWorkerClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebWorkerClient.cpp; sourceTree = "<group>"; };
 		A7A3D553289395E2008D683D /* WebWorkerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebWorkerClient.h; sourceTree = "<group>"; };
@@ -8506,6 +8509,7 @@
 				BC032DA010F437D10058C15A /* Encoder.h */,
 				4151E5C31FBB90A900E47E2D /* FormDataReference.h */,
 				C0CE72AC1247E78D00BC0EC4 /* HandleMessage.h */,
+				A73E66BC2AB107BB005FC327 /* IPCEvent.h */,
 				A31F60A225CC7DB800AF14F4 /* IPCSemaphore.h */,
 				7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */,
 				7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */,
@@ -11522,6 +11526,7 @@
 			children = (
 				7B9FC5E128A54BCC007570E7 /* ArgumentCodersDarwin.h */,
 				7B9FC5E228A54BCC007570E7 /* ArgumentCodersDarwin.mm */,
+				A73E66BE2AB10958005FC327 /* IPCEventDarwin.cpp */,
 				A31F60A625CC7DCF00AF14F4 /* IPCSemaphoreDarwin.cpp */,
 			);
 			path = darwin;
@@ -14524,6 +14529,7 @@
 				2D4D2C811DF60BF3002EB10C /* InteractionInformationRequest.h in Headers */,
 				7BBA63E0280E93D600B04823 /* IPCConnectionTester.h in Headers */,
 				7BBA63DF280E93D200B04823 /* IPCConnectionTesterIdentifier.h in Headers */,
+				A73E66BD2AB107C3005FC327 /* IPCEvent.h in Headers */,
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
+class Signal;
 class Semaphore;
 class StreamClientConnection;
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -936,6 +936,7 @@
 		A57D54F91F3397B400A97AA7 /* LifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F71F3397B400A97AA7 /* LifecycleLogger.cpp */; };
 		A5B149DE1F5A19EA00C6DAFF /* MIMETypeRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */; };
 		A5E2027515B21F6E00C13E14 /* WindowlessWebViewWithMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A5E2027015B2180600C13E14 /* WindowlessWebViewWithMedia.html */; };
+		A73E66C42AB29574005FC327 /* EventTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A73E66C32AB29574005FC327 /* EventTests.cpp */; };
 		AA96CAB621C7DB5000FD2F97 /* ParsedContentType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */; };
 		AD57AC201DA7465000FF1BDE /* DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD57AC1E1DA7464D00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp */; };
 		AD57AC211DA7465B00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD57AC1F1DA7464D00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache.cpp */; };
@@ -3104,6 +3105,7 @@
 		A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MIMETypeRegistry.cpp; sourceTree = "<group>"; };
 		A5E2027015B2180600C13E14 /* WindowlessWebViewWithMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = WindowlessWebViewWithMedia.html; sourceTree = "<group>"; };
 		A5E2027215B2181900C13E14 /* WindowlessWebViewWithMedia.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WindowlessWebViewWithMedia.mm; sourceTree = "<group>"; };
+		A73E66C32AB29574005FC327 /* EventTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventTests.cpp; sourceTree = "<group>"; };
 		A7A966DA140ECCC8005EF9B4 /* CheckedArithmeticOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CheckedArithmeticOperations.cpp; sourceTree = "<group>"; };
 		AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParsedContentType.cpp; sourceTree = "<group>"; };
 		ABF510632A19B8AC7EC40E17 /* AbortableTaskQueue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AbortableTaskQueue.cpp; sourceTree = "<group>"; };
@@ -4544,6 +4546,7 @@
 			children = (
 				2D83D08A29194B0100C5C051 /* ArgumentCoderTests.cpp */,
 				7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */,
+				A73E66C32AB29574005FC327 /* EventTests.cpp */,
 				7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */,
 				7B7392EA28F849F3007297FC /* IPCTestUtilities.h */,
 				7B7392E128F849EC007297FC /* MessageSenderTests.cpp */,
@@ -6147,6 +6150,7 @@
 			files = (
 				2D83D08B29194B0100C5C051 /* ArgumentCoderTests.cpp in Sources */,
 				7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */,
+				A73E66C42AB29574005FC327 /* EventTests.cpp in Sources */,
 				7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */,
 				7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */,
 				7B9FC3A028A26137007570E7 /* mainMac.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "IPCEvent.h"
+#include "IPCTestUtilities.h"
+#include "Test.h"
+
+namespace TestWebKitAPI {
+
+struct MockTestMessageWithSignal {
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
+    auto&& arguments() { return WTFMove(m_arguments); }
+    MockTestMessageWithSignal(IPC::Signal&& signal)
+        : m_arguments(WTFMove(signal))
+    {
+    }
+    std::tuple<IPC::Signal&&> m_arguments;
+};
+
+class EventTestABBA : public testing::TestWithParam<std::tuple<ConnectionTestDirection>>, protected ConnectionTestBase {
+public:
+    bool serverIsA() const { return std::get<0>(GetParam()) == ConnectionTestDirection::ServerIsA; }
+
+    void SetUp() override
+    {
+        setupBase();
+        if (!serverIsA())
+            std::swap(m_connections[0].connection, m_connections[1].connection);
+    }
+
+    void TearDown() override
+    {
+        teardownBase();
+    }
+
+    Ref<RunLoop> createRunLoop(const char* name)
+    {
+        auto runLoop = RunLoop::create(name, ThreadType::Unknown);
+        m_runLoops.append(runLoop);
+        return runLoop;
+    }
+
+protected:
+    Vector<Ref<RunLoop>> m_runLoops;
+};
+
+#define LOCAL_STRINGIFY(x) #x
+#define RUN_LOOP_NAME "RunLoop at EventTests.cpp:" LOCAL_STRINGIFY(__LINE__)
+
+TEST_P(EventTestABBA, SerializeAndSignal)
+{
+    ASSERT_TRUE(openA());
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+
+        bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+            decoder.decode<uint64_t>();
+            auto signal = decoder.decode<IPC::Signal>();
+            signal->signal();
+
+            b()->invalidate();
+            return true;
+        });
+    });
+
+    auto pair = IPC::createEventSignalPair();
+    ASSERT_TRUE(pair);
+    a()->send(MockTestMessageWithSignal { WTFMove(pair->signal) }, 77);
+
+    pair->event.wait();
+}
+
+TEST_P(EventTestABBA, InterruptOnDestruct)
+{
+    ASSERT_TRUE(openA());
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+
+        bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+            decoder.decode<uint64_t>();
+            {
+                auto signal = decoder.decode<IPC::Signal>();
+            }
+
+            b()->invalidate();
+            return true;
+        });
+    });
+
+    auto pair = IPC::createEventSignalPair();
+    ASSERT_TRUE(pair);
+    a()->send(MockTestMessageWithSignal { WTFMove(pair->signal) }, 77);
+
+    pair->event.wait();
+}
+
+#undef RUN_LOOP_NAME
+#undef LOCAL_STRINGIFY
+
+INSTANTIATE_TEST_SUITE_P(EventTest,
+    EventTestABBA,
+    testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
+    TestParametersToStringFormatter());
+
+
+}


### PR DESCRIPTION
#### f2796edab1163daa5bb37135f7fee0dbe58f577e
<pre>
IPC::Semaphore waits don&apos;t terminate if the remote process crashes and can cause hangs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260690">https://bugs.webkit.org/show_bug.cgi?id=260690</a>
&lt;rdar://114591255&gt;

Reviewed by Kimmo Kinnunen.

This introduces new IPC::Event and Signal classes (implemented properly for cocoa
only so far) that can detect crashes (by the &apos;Signal&apos; instance being destroyed).
It reimplements a semaphore using a mach_port_t, and uses no sender notifications to
detect when the last MachSendRight (owned by the Signal component) is released.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setFlushSignal):
(WebKit::RemoteDisplayListRecorder::flushContext):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/Platform/IPC/IPCEvent.h: Added.
(IPC::Signal::signal):
(IPC::Signal::encode):
(IPC::Signal::decode):
(IPC::Signal::Signal):
(IPC::Event::Event):
(IPC::Event::operator=):
(IPC::Event::wait):
(IPC::Event::waitFor):
(IPC::createEventSignalPair):
* Source/WebKit/Platform/IPC/IPCSemaphore.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
* Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp: Added.
(IPC::requestNoSenderNotifications):
(IPC::clearNoSenderNotifications):
(IPC::Signal::signal):
(IPC::Signal::encode):
(IPC::Signal::decode):
(IPC::createEventSignalPair):
(IPC::Event::~Event):
(IPC::Event::wait):
(IPC::Event::waitFor):
* Source/WebKit/Platform/IPC/darwin/IPCSemaphoreDarwin.cpp:
* Source/WebKit/Platform/SourcesCocoa.txt:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
(types_that_cannot_be_forward_declared):
(argument_coder_headers_for_type):
(headers_for_type):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::setFlushSignal):
(WebKit::RemoteDisplayListRecorderProxy::flushContext):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxyFlushFence::create):
(WebKit::RemoteImageBufferProxyFlushFence::waitFor):
(WebKit::RemoteImageBufferProxyFlushFence::tryTakeEvent):
(WebKit::RemoteImageBufferProxyFlushFence::RemoteImageBufferProxyFlushFence):
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
(WebKit::RemoteImageBufferProxyFlushFence::tryTakeSemaphore): Deleted.

Canonical link: <a href="https://commits.webkit.org/268093@main">https://commits.webkit.org/268093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d575b669e7923cf875738655188f325fd1862b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18604 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19260 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21341 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18771 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21299 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15025 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16779 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4436 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->