### PR TITLE
Drop unnecessary operator!=() in WebKit

### DIFF
--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -264,11 +264,6 @@ struct Type {
         return other.kind == kind && other.isNullable() == isNullable() && other.index == index;
     }
 
-    bool operator!=(const Type& other) const
-    {
-        return !(other == *this);
-    }
-
     bool isNullable() const
     {
         return kind == TypeKind::RefNull || kind == TypeKind::Externref || kind == TypeKind::Funcref;

--- a/Source/WebCore/platform/audio/gstreamer/GStreamerAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/gstreamer/GStreamerAudioStreamDescription.h
@@ -94,7 +94,6 @@ public:
     uint32_t sampleWordSize() const final { return GST_AUDIO_INFO_BPS(&m_info); }
 
     bool operator==(const GStreamerAudioStreamDescription& other) { return gst_audio_info_is_equal(&m_info, &other.m_info); }
-    bool operator!=(const GStreamerAudioStreamDescription& other) { return !operator == (other); }
 
     const GRefPtr<GstCaps>& caps()
     {

--- a/Source/WebCore/platform/graphics/freetype/FontSetCache.h
+++ b/Source/WebCore/platform/graphics/freetype/FontSetCache.h
@@ -49,11 +49,6 @@ struct FontSetCacheKey {
         return descriptionKey == other.descriptionKey && preferColoredFont == other.preferColoredFont;
     }
 
-    bool operator!=(const FontSetCacheKey& other) const
-    {
-        return !(*this == other);
-    }
-
     bool isHashTableDeletedValue() const { return descriptionKey.isHashTableDeletedValue(); }
 
     FontDescriptionKey descriptionKey;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -467,7 +467,6 @@ public:
         {
             return m_iter == other.m_iter && m_done == other.m_done;
         }
-        bool operator!=(const iterator& other) const { return !(*this == other); }
 
     private:
         GstIterator* m_iter;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -75,11 +75,6 @@ public:
         {
             return lhs.isSupported == rhs.isSupported && lhs.isUsingHardware == rhs.isUsingHardware;
         }
-
-        friend bool operator!=(const RegistryLookupResult& lhs, const RegistryLookupResult& rhs)
-        {
-            return !(lhs == rhs);
-        }
     };
     RegistryLookupResult isDecodingSupported(MediaConfiguration& mediaConfiguration) const { return isConfigurationSupported(Configuration::Decoding, mediaConfiguration); };
     RegistryLookupResult isEncodingSupported(MediaConfiguration& mediaConfiguration) const { return isConfigurationSupported(Configuration::Encoding, mediaConfiguration); }

--- a/Source/WebCore/platform/network/curl/CertificateInfo.h
+++ b/Source/WebCore/platform/network/curl/CertificateInfo.h
@@ -57,12 +57,7 @@ public:
 
     static Certificate makeCertificate(const uint8_t*, size_t);
 
-    bool operator==(const CertificateInfo& other) const
-    {
-        return verificationError() == other.verificationError()
-            && certificateChain() == other.certificateChain();
-    }
-    bool operator!=(const CertificateInfo& other) const { return !(*this == other); }
+    friend bool operator==(const CertificateInfo&, const CertificateInfo&) = default;
 
 private:
     int m_verificationError { 0 };

--- a/Source/WebCore/platform/network/soup/CertificateInfo.h
+++ b/Source/WebCore/platform/network/soup/CertificateInfo.h
@@ -71,7 +71,6 @@ public:
 
         return m_certificate && other.m_certificate && g_tls_certificate_is_same(m_certificate.get(), other.m_certificate.get());
     }
-    bool operator!=(const CertificateInfo& other) const { return !(*this == other); }
 
 private:
     GRefPtr<GTlsCertificate> m_certificate;


### PR DESCRIPTION
#### e403bc5d9b9c05a3a0f843292a6c65a22fdbaf0c
<pre>
Drop unnecessary operator!=() in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261253">https://bugs.webkit.org/show_bug.cgi?id=261253</a>

Reviewed by Michael Catanzaro.

Drop unnecessary operator!=() in WebKit and let the compiler generate them now
that we support C++20.

* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:
* Source/WebCore/platform/audio/gstreamer/GStreamerAudioStreamDescription.h:
* Source/WebCore/platform/graphics/freetype/FontSetCache.h:
(WebCore::FontSetCacheKey::operator!= const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(GstIteratorAdaptor::iterator::operator== const):
(GstIteratorAdaptor::iterator::operator!= const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
(WebCore::GStreamerRegistryScanner::RegistryLookupResult::operator==):
(WebCore::GStreamerRegistryScanner::RegistryLookupResult::operator!=): Deleted.
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::BidiRange::Iterator::operator==):
(WebCore::BidiRange::Iterator::operator!=): Deleted.
* Source/WebCore/platform/network/curl/CertificateInfo.h:
(WebCore::CertificateInfo::operator== const): Deleted.
(WebCore::CertificateInfo::operator!= const): Deleted.
* Source/WebCore/platform/network/soup/CertificateInfo.h:
(WebCore::CertificateInfo::operator== const):
(WebCore::CertificateInfo::operator!= const): Deleted.

Canonical link: <a href="https://commits.webkit.org/267735@main">https://commits.webkit.org/267735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/775e2e8064c21c1f24bfa658f757aeef329884fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20130 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22561 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20409 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16714 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14135 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/19078 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15807 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4435 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4173 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20175 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/20306 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16524 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4276 "Passed tests") | 
<!--EWS-Status-Bubble-End-->