### PR TITLE
Cache resolved variable references

### DIFF
--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -48,6 +48,7 @@ CSSVariableReferenceValue::CSSVariableReferenceValue(Ref<CSSVariableData>&& data
     : CSSValue(VariableReferenceClass)
     , m_data(WTFMove(data))
 {
+    cacheSimpleReference();
 }
 
 Ref<CSSVariableReferenceValue> CSSVariableReferenceValue::create(const CSSParserTokenRange& range, const CSSParserContext& context)
@@ -107,6 +108,17 @@ auto CSSVariableReferenceValue::resolveVariableFallback(const AtomString& variab
     return { FallbackResult::Valid, WTFMove(*tokens) };
 }
 
+static const CSSCustomPropertyValue* propertyValueForVariableName(const AtomString& variableName, CSSValueID functionId, Style::BuilderState& builderState)
+{
+    if (functionId == CSSValueEnv)
+        return builderState.document().constantProperties().values().get(variableName);
+
+    // Apply this variable first, in case it is still unresolved
+    builderState.builder().applyCustomProperty(variableName);
+
+    return builderState.style().customPropertyValue(variableName);
+}
+
 bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, Style::BuilderState& builderState) const
 {
     ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
@@ -115,20 +127,12 @@ bool CSSVariableReferenceValue::resolveVariableReference(CSSParserTokenRange ran
     ASSERT(range.peek().type() == IdentToken);
     auto variableName = range.consumeIncludingWhitespace().value().toAtomString();
 
-    // Apply this variable first, in case it is still unresolved
-    builderState.builder().applyCustomProperty(variableName);
-
     // Fallback has to be resolved even when not used to detect cycles and invalid syntax.
     auto [fallbackResult, fallbackTokens] = resolveVariableFallback(variableName, range, functionId, builderState);
     if (fallbackResult == FallbackResult::Invalid)
         return false;
 
-    auto* property = [&]() -> const CSSCustomPropertyValue* {
-        if (functionId == CSSValueEnv)
-            return builderState.document().constantProperties().values().get(variableName);
-
-        return builderState.style().customPropertyValue(variableName);
-    }();
+    auto* property = propertyValueForVariableName(variableName, functionId, builderState);
 
     if (!property || property->isInvalid()) {
         if (fallbackTokens.size() > maxSubstitutionTokens)
@@ -168,13 +172,106 @@ std::optional<Vector<CSSParserToken>> CSSVariableReferenceValue::resolveTokenRan
     return tokens;
 }
 
+void CSSVariableReferenceValue::cacheSimpleReference()
+{
+    ASSERT(!m_simpleReference);
+
+    auto range = m_data->tokenRange();
+    auto functionId = range.peek().functionId();
+    if (functionId != CSSValueVar && functionId != CSSValueEnv)
+        return;
+
+    auto variableRange = range.consumeBlock();
+    if (!range.atEnd())
+        return;
+
+    variableRange.consumeWhitespace();
+
+    auto variableName = variableRange.consumeIncludingWhitespace().value().toAtomString();
+
+    // No fallback support on this path.
+    if (!variableRange.atEnd())
+        return;
+
+    m_simpleReference = SimpleReference { variableName, functionId };
+}
+
+RefPtr<CSSVariableData> CSSVariableReferenceValue::tryResolveSimpleReference(Style::BuilderState& builderState) const
+{
+    if (!m_simpleReference)
+        return nullptr;
+
+    // Shortcut for the simple common case of property:var(--foo)
+
+    auto* property = propertyValueForVariableName(m_simpleReference->name, m_simpleReference->functionId, builderState);
+    if (!property || property->isInvalid())
+        return nullptr;
+
+    if (!std::holds_alternative<Ref<CSSVariableData>>(property->value()))
+        return nullptr;
+
+    return std::get<Ref<CSSVariableData>>(property->value()).ptr();
+}
+
 RefPtr<CSSVariableData> CSSVariableReferenceValue::resolveVariableReferences(Style::BuilderState& builderState) const 
 {
+    if (auto data = tryResolveSimpleReference(builderState))
+        return data;
+
     auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builderState);
     if (!resolvedTokens)
         return nullptr;
 
     return CSSVariableData::create(*resolvedTokens, context());
+}
+
+template<typename ParseFunction>
+RefPtr<CSSValue> CSSVariableReferenceValue::resolveAndCacheValue(Style::BuilderState& builderState, CSSPropertyID propertyID, CSSPropertyID shorthandID, ParseFunction&& parseFunction) const
+{
+    if (auto data = tryResolveSimpleReference(builderState)) {
+        // FIXME: Also cache the complex case.
+        auto hasValidCachedValue = m_cachedResolvedValue
+            && arePointingToEqualData(m_cachedResolvedValue->dependencyData, data)
+            && m_cachedResolvedValue->propertyID == propertyID
+            && m_cachedResolvedValue->shorthandID == shorthandID;
+
+        if (hasValidCachedValue) {
+            // Update in case the object changed but data stayed the same.
+            m_cachedResolvedValue->dependencyData = data;
+        } else {
+            auto value = parseFunction(data->tokenRange());
+            m_cachedResolvedValue = makeUnique<ResolvedValue>(ResolvedValue { value, propertyID, shorthandID, data });
+        }
+        return m_cachedResolvedValue->value;
+    }
+
+    auto resolvedTokens = resolveTokenRange(m_data->tokenRange(), builderState);
+    if (!resolvedTokens)
+        return nullptr;
+
+    return parseFunction(CSSParserTokenRange { *resolvedTokens });
+}
+
+RefPtr<CSSValue> CSSVariableReferenceValue::resolveSingleValue(Style::BuilderState& builderState, CSSPropertyID propertyID) const
+{
+    return resolveAndCacheValue(builderState, propertyID, CSSPropertyInvalid, [&](auto tokens) -> RefPtr<CSSValue> {
+        return CSSPropertyParser::parseSingleValue(propertyID, tokens, context());
+    });
+}
+
+RefPtr<CSSValue> CSSVariableReferenceValue::resolveSubstitutionValue(Style::BuilderState& builderState, CSSPropertyID propertyID, CSSPropertyID shorthandID) const
+{
+    return resolveAndCacheValue(builderState, propertyID, shorthandID, [&](auto tokens) -> RefPtr<CSSValue> {
+        ParsedPropertyVector parsedProperties;
+        if (!CSSPropertyParser::parseValue(shorthandID, false, tokens, context(), parsedProperties, StyleRuleType::Style))
+            return nullptr;
+
+        for (auto& property : parsedProperties) {
+            if (property.id() == propertyID)
+                return property.value();
+        }
+        return nullptr;
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -363,30 +363,11 @@ Ref<CSSValue> Builder::resolveVariableReferences(CSSPropertyID propertyID, CSSVa
     auto variableValue = [&]() -> RefPtr<CSSValue> {
         if (is<CSSPendingSubstitutionValue>(value)) {
             auto& substitution = downcast<CSSPendingSubstitutionValue>(value);
-            auto shorthandID = substitution.shorthandPropertyId();
-
-            auto resolvedData = substitution.shorthandValue().resolveVariableReferences(m_state);
-            if (!resolvedData)
-                return nullptr;
-
-            ParsedPropertyVector parsedProperties;
-            if (!CSSPropertyParser::parseValue(shorthandID, false, resolvedData->tokens(), substitution.shorthandValue().context(), parsedProperties, StyleRuleType::Style))
-                return nullptr;
-
-            for (auto& property : parsedProperties) {
-                if (property.id() == propertyID)
-                    return property.value();
-            }
-
-            return nullptr;
+            return substitution.shorthandValue().resolveSubstitutionValue(m_state, propertyID, substitution.shorthandPropertyId());
         }
 
         auto& variableReferenceValue = downcast<CSSVariableReferenceValue>(value);
-        auto resolvedData = variableReferenceValue.resolveVariableReferences(m_state);
-        if (!resolvedData)
-            return nullptr;
-
-        return CSSPropertyParser::parseSingleValue(propertyID, resolvedData->tokens(), variableReferenceValue.context());
+        return variableReferenceValue.resolveSingleValue(m_state, propertyID);
     }();
 
     // https://drafts.csswg.org/css-variables-2/#invalid-variables


### PR DESCRIPTION
#### 954e3afcfb437134cbc829c3168496bb15f6aa42
<pre>
Cache resolved variable references
<a href="https://bugs.webkit.org/show_bug.cgi?id=261265">https://bugs.webkit.org/show_bug.cgi?id=261265</a>
rdar://115104109

Reviewed by Alan Baradlay.

If the pointed-to variable doesn&apos;t change then the final result will be unchanged.
Also add a fast path for resolving simple var(--foo) reference. Currently the cache
is only used on this path.

* Source/WebCore/css/CSSVariableReferenceValue.cpp:
(WebCore::CSSVariableReferenceValue::CSSVariableReferenceValue):
(WebCore::propertyValueForVariableName):
(WebCore::CSSVariableReferenceValue::resolveVariableReference const):
(WebCore::CSSVariableReferenceValue::cacheSimpleReference):

Detect the simple reference case and cache it.

(WebCore::CSSVariableReferenceValue::tryResolveSimpleReference const):

In the simple case we just grab the underlying value and return it without doing any token manipulation.

(WebCore::CSSVariableReferenceValue::resolveVariableReferences const):

Use the fast path if possible.

(WebCore::CSSVariableReferenceValue::resolveAndCacheValue const):

In case we are depenent of only a single variable data object, check if it is equal to the cache entry
and if so, return the cached final value.

(WebCore::CSSVariableReferenceValue::resolveSingleValue const):
(WebCore::CSSVariableReferenceValue::resolveSubstitutionValue const):

Handle the normal and substitution (shorthand) case using a template.

* Source/WebCore/css/CSSVariableReferenceValue.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveVariableReferences):

Canonical link: <a href="https://commits.webkit.org/267742@main">https://commits.webkit.org/267742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da74f1e3911985a9cff2a5d1ad1a34aff920d265

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15246 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20221 "Failed to checkout and rebase branch from PR 17535") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15983 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22597 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20449 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14170 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15849 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->