### PR TITLE
[GStreamer] http/wpt/webcodecs/hevc-encoder-config.https.any.html fails

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.js
+++ b/LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.js
@@ -41,13 +41,6 @@ validButUnsupportedConfigs.forEach(entry => {
           })
         });
         codec.configure(entry.config);
-        codec.flush()
-            .then(t.unreached_func('flush succeeded unexpectedly'))
-            .catch(t.step_func(e => {
-              assert_true(e instanceof DOMException);
-              assert_equals(e.name, 'InvalidStateError');
-              assert_equals(codec.state, 'closed', 'state');
-            }));
       },
       'Test that VideoEncoder.configure() doesn\'t support config: ' +
           entry.comment);

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1143,7 +1143,6 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_hevc [ Pass ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_annexb [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_hevc [ Pass ]
-http/wpt/webcodecs/hevc-encoder-config.https.any.html [ Failure ]
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 

--- a/LayoutTests/platform/glib/media/media-can-play-h265-video-expected.txt
+++ b/LayoutTests/platform/glib/media/media-can-play-h265-video-expected.txt
@@ -1,0 +1,10 @@
+
+Test HTMLMediaElement canPlayType() method with multiple video mpeg4 MIME types with H265 codecs.
+
+These tests may be expected to fail if the WebKit port does not support the format.
+
+EXPECTED (video.canPlayType('video/mp4') == 'maybe') OK
+EXPECTED (video.canPlayType('video/mp4; Codecs="hvc1.2.20000000.l123.b0"') == 'probably'), OBSERVED '' FAIL
+EXPECTED (video.canPlayType(' Video/MP4 ; CODECS="hev1.1.6.L150.B0"') == 'probably') OK
+END OF TEST
+

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -97,7 +97,7 @@ public:
     MediaPlayerEnums::SupportsType isContentTypeSupported(Configuration, const ContentType&, const Vector<ContentType>& contentTypesRequiringHardwareSupport) const;
     bool areAllCodecsSupported(Configuration, const Vector<String>& codecs, bool shouldCheckForHardwareUse = false) const;
 
-    CodecLookupResult areCapsSupported(Configuration, const GRefPtr<GstCaps>&, bool shouldCheckForHardwareUse);
+    CodecLookupResult areCapsSupported(Configuration, const GRefPtr<GstCaps>&, bool shouldCheckForHardwareUse) const;
 
 #if USE(GSTREAMER_WEBRTC)
     RTCRtpCapabilities audioRtpCapabilities(Configuration);
@@ -159,9 +159,10 @@ protected:
     };
     void fillMimeTypeSetFromCapsMapping(const ElementFactories&, const Vector<GstCapsWebKitMapping>&);
 
-    CodecLookupResult isAVC1CodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
-
 private:
+    CodecLookupResult isAVC1CodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
+    CodecLookupResult isHEVCCodecSupported(Configuration, const String& codec, bool shouldCheckForHardwareUse) const;
+
     const char* configurationNameForLogging(Configuration) const;
     bool supportsFeatures(const String& features) const;
 


### PR DESCRIPTION
#### 8a21dcdda524903b19b086f9a136b360480547e0
<pre>
[GStreamer] http/wpt/webcodecs/hevc-encoder-config.https.any.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=261267">https://bugs.webkit.org/show_bug.cgi?id=261267</a>

Reviewed by Youenn Fablet and Xabier Rodriguez-Calvar.

The GStreamer registry scanner now checks the validity of HEVC codec strings before looking-up an
encoder or decoder for it.

The test was also flaky, calling flush after the asynchronous configuration can lead to flakyness
where the exception caught during flush would be the one raised during configuration. So remove the
flush part.

* LayoutTests/http/wpt/webcodecs/hevc-encoder-config.https.any.js:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isCapsSupported const):
(WebCore::GStreamerRegistryScanner::isHEVCCodecSupported const):
(WebCore::GStreamerRegistryScanner::isCodecSupported const):
(WebCore::GStreamerRegistryScanner::isAVC1CodecSupported const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:

Canonical link: <a href="https://commits.webkit.org/267781@main">https://commits.webkit.org/267781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/563e7a588a18bea1a9f0258f2aa1a796b571a293

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16544 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18195 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20369 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16112 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20546 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16851 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15967 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4210 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->