### PR TITLE
Expose GraphicsClient through ScriptExecutionContext

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9510,6 +9510,14 @@ NotificationClient* Document::notificationClient()
 #endif
 }
 
+GraphicsClient* Document::graphicsClient()
+{
+    auto* page = this->page();
+    if (!page)
+        return nullptr;
+    return &page->chrome();
+}
+
 std::optional<PAL::SessionID> Document::sessionID() const
 {
     if (auto* page = this->page())

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -133,6 +133,7 @@ class FormController;
 class FrameSelection;
 class FullscreenManager;
 class GPUCanvasContext;
+class GraphicsClient;
 class HTMLAllCollection;
 class HTMLAttachmentElement;
 class HTMLBodyElement;
@@ -690,6 +691,7 @@ public:
     void suspendActiveDOMObjects(ReasonForSuspension) final;
     void resumeActiveDOMObjects(ReasonForSuspension) final;
     void stopActiveDOMObjects() final;
+    GraphicsClient* graphicsClient() final;
 
     const Settings::Values& settingsValues() const final { return settings().values(); }
 

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -72,6 +72,7 @@ class EventQueue;
 class EventLoopTaskGroup;
 class EventTarget;
 class FontLoadRequest;
+class GraphicsClient;
 class MessagePort;
 class NotificationClient;
 class PublicURLManager;
@@ -128,6 +129,8 @@ public:
     virtual IDBClient::IDBConnectionProxy* idbConnectionProxy() = 0;
 
     virtual SocketProvider* socketProvider() = 0;
+
+    virtual GraphicsClient* graphicsClient() { return nullptr; }
 
     virtual std::optional<uint64_t> noiseInjectionHashSalt() const = 0;
 

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -300,16 +300,6 @@ RefPtr<ImageBuffer> CanvasBase::setImageBuffer(RefPtr<ImageBuffer>&& buffer) con
     return returnBuffer;
 }
 
-GraphicsClient* CanvasBase::graphicsClient() const
-{
-    if (scriptExecutionContext()->isDocument() && downcast<Document>(scriptExecutionContext())->page())
-        return &downcast<Document>(scriptExecutionContext())->page()->chrome();
-    if (is<WorkerGlobalScope>(scriptExecutionContext()))
-        return downcast<WorkerGlobalScope>(scriptExecutionContext())->workerClient();
-
-    return nullptr;
-}
-
 bool CanvasBase::shouldAccelerate(const IntSize& size) const
 {
     auto checkedArea = size.area<RecordOverflow>();
@@ -358,7 +348,7 @@ RefPtr<ImageBuffer> CanvasBase::allocateImageBuffer() const
         pixelFormat = context->pixelFormat();
     }
 
-    return ImageBuffer::create(size(), RenderingPurpose::Canvas, 1, colorSpace, pixelFormat, bufferOptions, graphicsClient());
+    return ImageBuffer::create(size(), RenderingPurpose::Canvas, 1, colorSpace, pixelFormat, bufferOptions, scriptExecutionContext()->graphicsClient());
 }
 
 bool CanvasBase::shouldInjectNoiseBeforeReadback() const

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -42,7 +42,6 @@ class CanvasObserver;
 class CanvasRenderingContext;
 class Element;
 class Event;
-class GraphicsClient;
 class GraphicsContext;
 class GraphicsContextStateSaver;
 class Image;
@@ -113,8 +112,6 @@ public:
 
     virtual GraphicsContext* drawingContext() const;
     virtual GraphicsContext* existingDrawingContext() const;
-
-    GraphicsClient* graphicsClient() const;
 
     void didDraw(const std::optional<FloatRect>& rect) { return didDraw(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }
     virtual void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect);

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -96,17 +96,7 @@ RefPtr<ImageBuffer> ImageBitmap::createImageBuffer(ScriptExecutionContext& scrip
     }
 
     auto bufferOptions = bufferOptionsForRendingMode(renderingMode);
-
-    GraphicsClient* client = nullptr;
-    if (scriptExecutionContext.isDocument()) {
-        auto& document = downcast<Document>(scriptExecutionContext);
-        if (document.view() && document.view()->root()) {
-            client = document.view()->root()->hostWindow();
-        }
-    } else if (scriptExecutionContext.isWorkerGlobalScope())
-        client = downcast<WorkerGlobalScope>(scriptExecutionContext).workerClient();
-
-    return ImageBuffer::create(size, RenderingPurpose::Canvas, resolutionScale, *imageBufferColorSpace, PixelFormat::BGRA8, bufferOptions, client);
+    return ImageBuffer::create(size, RenderingPurpose::Canvas, resolutionScale, *imageBufferColorSpace, PixelFormat::BGRA8, bufferOptions, scriptExecutionContext.graphicsClient());
 }
 
 void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutionContext, ImageBitmap::Source&& source, ImageBitmapOptions&& options, ImageBitmapCompletionHandler&& completionHandler)

--- a/Source/WebCore/html/ImageBitmapBacking.cpp
+++ b/Source/WebCore/html/ImageBitmapBacking.cpp
@@ -88,15 +88,7 @@ void ImageBitmapBacking::connect(ScriptExecutionContext& context)
     ASSERT(!m_bitmapData);
     if (!m_serializedBitmap)
         return;
-
-    if (is<WorkerGlobalScope>(context) && downcast<WorkerGlobalScope>(context).workerClient()) {
-        auto* client = downcast<WorkerGlobalScope>(context).workerClient();
-        m_bitmapData = client->sinkIntoImageBuffer(WTFMove(m_serializedBitmap));
-    } else if (is<Document>(context)) {
-        ASSERT(downcast<Document>(context).page());
-        m_bitmapData = downcast<Document>(context).page()->chrome().sinkIntoImageBuffer(WTFMove(m_serializedBitmap));
-    } else
-        m_bitmapData = SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(m_serializedBitmap));
+    m_bitmapData = SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(m_serializedBitmap), context.graphicsClient());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -573,7 +573,7 @@ std::unique_ptr<WebGLRenderingContextBase> WebGLRenderingContextBase::create(Can
     if (!scriptExecutionContext)
         return nullptr;
 
-    GraphicsClient* graphicsClient = canvas.graphicsClient();
+    GraphicsClient* graphicsClient = scriptExecutionContext->graphicsClient();
 
     auto* canvasElement = dynamicDowncast<HTMLCanvasElement>(canvas);
 
@@ -5636,7 +5636,7 @@ void WebGLRenderingContextBase::maybeRestoreContext()
     if (!scriptExecutionContext->settingsValues().webGLEnabled)
         return;
 
-    GraphicsClient* graphicsClient = canvasBase().graphicsClient();
+    GraphicsClient* graphicsClient = scriptExecutionContext->graphicsClient();
     if (!graphicsClient)
         return;
 

--- a/Source/WebCore/platform/GraphicsClient.h
+++ b/Source/WebCore/platform/GraphicsClient.h
@@ -48,12 +48,19 @@ public:
 
     virtual PlatformDisplayID displayID() const = 0;
 
-    virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidBackendSizeCheck = false) const = 0;
 #if ENABLE(WEBGL)
     virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const = 0;
 #endif
 
+private:
+    // Called by passing GraphicsClient into ImageBuffer functions.
+    virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidBackendSizeCheck = false) const = 0;
+
+    // Called by passing GraphicsClient into SerializedImageBuffer functions.
     virtual RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<WebCore::SerializedImageBuffer>) = 0;
+
+    friend class ImageBuffer;
+    friend class SerializedImageBuffer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -120,8 +120,10 @@ bool ImageBuffer::sizeNeedsClamping(const FloatSize& size)
     return floorf(size.height()) * floorf(size.width()) > MaxClampedArea;
 }
 
-RefPtr<ImageBuffer> SerializedImageBuffer::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> buffer)
+RefPtr<ImageBuffer> SerializedImageBuffer::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> buffer, GraphicsClient* graphicsClient)
 {
+    if (graphicsClient)
+        return graphicsClient->sinkIntoImageBuffer(WTFMove(buffer));
     return buffer->sinkIntoImageBuffer();
 }
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -229,7 +229,7 @@ public:
 
     virtual size_t memoryCost() = 0;
 
-    WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer>);
+    WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer>, GraphicsClient* = nullptr);
 
     virtual bool isRemoteSerializedImageBufferProxy() const { return false; }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -229,6 +229,11 @@ IDBClient::IDBConnectionProxy* WorkerGlobalScope::idbConnectionProxy()
     return m_connectionProxy.get();
 }
 
+GraphicsClient* WorkerGlobalScope::graphicsClient()
+{
+    return workerClient();
+}
+
 void WorkerGlobalScope::stopIndexedDatabase()
 {
     if (m_connectionProxy)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -94,6 +94,8 @@ public:
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
     void suspend() final;
     void resume() final;
+    GraphicsClient* graphicsClient() final;
+
 
     using EventTarget::weakPtrFactory;
     using EventTarget::WeakValueType;


### PR DESCRIPTION
#### a8f55217363bef328ce1a3a61003ce7ce4d4e2e3
<pre>
Expose GraphicsClient through ScriptExecutionContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=261272">https://bugs.webkit.org/show_bug.cgi?id=261272</a>
rdar://115108907

Reviewed by Matt Woodrow.

Expose GraphicsClient through ScriptExecutionContext

All DOM objects that construct graphics objects must do so via a
factory that is able to create graphics objects (either local or
remote). This factory interface is GraphicsClient.

The objects obtain the instance via ScriptExecutionContext, either:
- Document (via Chrome)
- WorkerGlobalScope (via WorkerClient)

Add ScriptExecutionContext::graphicsClient() to avoid doing various
error-prone downcasting sequences.

Make SerializedImageBuffer::sinkIntoImageBuffer() a similar function
to ImageBuffer::create(), where the polymorphism is added with
the GraphicsClient* and in-process variant is invoked if
the instance is nullptr.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::graphicsClient):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::graphicsClient):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::allocateImageBuffer const):
(WebCore::CanvasBase::graphicsClient const): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createImageBuffer):
* Source/WebCore/html/ImageBitmapBacking.cpp:
(WebCore::ImageBitmapBacking::connect):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::DetachedOffscreenCanvas::takeImageBuffer):
(WebCore::OffscreenCanvas::pushBufferToPlaceholder):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::create):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
* Source/WebCore/platform/GraphicsClient.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::SerializedImageBuffer::sinkIntoImageBuffer):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::graphicsClient):
* Source/WebCore/workers/WorkerGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/267938@main">https://commits.webkit.org/267938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd8b27e776799078d70cdb4907f4afb1d9888a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16971 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18623 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20849 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16539 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16710 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14635 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16368 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->