### PR TITLE
Skip animation update and resolution in subtrees depending on content-visibility

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/animation-display-lock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/animation-display-lock-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Animation events do not fire for a CSS animation running in a display locked subtree assert_false: Animation events do not fire while the animation is running in a display locked subtree expected false got true
-FAIL The finished promise does not resolve due to the normal passage of time  for a CSS animation in a display locked subtree assert_equals: expected false but got true
-FAIL The finished promise does not resolve due to the normal passage of time  for a CSS transition in a display locked subtree assert_equals: expected false but got true
+PASS Animation events do not fire for a CSS animation running in a display locked subtree
+PASS The finished promise does not resolve due to the normal passage of time  for a CSS animation in a display locked subtree
+PASS The finished promise does not resolve due to the normal passage of time  for a CSS transition in a display locked subtree
 PASS Events and promises are handled normally for animations without an owning element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>Test that scrolling to a content-visibility: auto subtree restarts animations in it</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/">
+
+<style>
+#target {
+  position: relative;
+  background: green;
+  height: 100px;
+  width: 100px;
+  left: 100px;
+}
+</style>
+<body>
+  <div id="container">
+    <div id="target"></div>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Test that scrolling to a content-visibility: auto subtree restarts animations in it</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/">
+<link rel="match" href="content-visibility-animation-becomes-visible-ref.html">
+<meta name="assert" content="animations in content-visibility: auto subtree should restart when scrolled to">
+
+<script src="/common/reftest-wait.js"></script>
+<script src="../resources/utils.js"></script>
+
+<style>
+#container {
+  content-visibility: auto;
+  contain-intrinsic-size: 100px 100px;
+}
+@keyframes unfade {
+  from { opacity: 0; transform: none; }
+  to { opacity: 1; transform: translate(100px); }
+}
+#target {
+  background: green;
+  height: 100px;
+  width: 100px;
+}
+.animate {
+  animation: unfade 1s linear 1 alternate;
+  animation-fill-mode: forwards;
+}
+#spacer {
+  height: 300vh;
+}
+</style>
+<body>
+  <div id="spacer"></div>
+  <div id="container"></div>
+</body>
+
+<script>
+function createAnimatingElement(name) {
+  const container = document.getElementById('container');
+  const target = document.createElement('div');
+  container.appendChild(target);
+  target.id = 'target';
+  target.className = name;
+  return target;
+}
+
+function runTest() {
+  const container = document.getElementById('container');
+  const target = createAnimatingElement('animate');
+  container.scrollIntoView(true /* alignToTop */);
+  const listener = (e) => {
+    spacer.style.height = "0px";
+    takeScreenshot();
+  };
+
+  target.addEventListener("animationend", listener);
+}
+window.onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-becomes-visible-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-becomes-visible-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<title>Test that making a content-visibility: hidden subtree visible restarts animations in it</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/">
+
+<style>
+#target {
+  position: relative;
+  background: green;
+  height: 100px;
+  width: 100px;
+  left: 100px;
+}
+</style>
+<body>
+  <div id="target"</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-becomes-visible.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-becomes-visible.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>Test that making a content-visibility: hidden subtree visible restarts animations in it</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/">
+<link rel="match" href="content-visibility-animation-becomes-visible-ref.html">
+<meta name="assert" content="animations in content-visibility: hidden subtree should restart once visible">
+
+<script src="/common/reftest-wait.js"></script>
+<script src="../resources/utils.js"></script>
+
+<style>
+#container {
+  content-visibility: hidden;
+}
+@keyframes fade {
+  from { opacity: 0; transform: none; }
+  to { opacity: 1; transform: translate(100px); }
+}
+#target {
+  background: green;
+  height: 100px;
+  width: 100px;
+}
+.animate {
+  animation: fade 1s linear 1 alternate;
+  animation-fill-mode: forwards;
+}
+</style>
+<body>
+  <div id="container"></div>
+</body>
+
+<script>
+function createAnimatingElement(name) {
+  const container = document.getElementById('container');
+  const target = document.createElement('div');
+  container.appendChild(target);
+  target.id = 'target';
+  target.className = name;
+  return target;
+}
+
+function runTest() {
+  const container = document.getElementById('container');
+  const target = createAnimatingElement('animate');
+  container.style.contentVisibility = "visible";
+  const listener = (e) => {
+    takeScreenshot();
+  };
+
+  target.addEventListener("animationend", listener);
+}
+window.onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Animation events do not fire for a CSS animation running in a content visibility subtree
+PASS The finished promise does not resolve due to the normal passage of time  for a CSS animation in a content visibility subtree
+PASS The finished promise does not resolve due to the normal passage of time  for a CSS transition in a content visibility subtree
+PASS Events and promises are handled normally for animations without an owning element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<meta charset=utf8>
+<title>Test getComputedStyle on a CSS animation in a content visibility subtree using content-visibility: auto</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-2/">
+<script src="/web-animations/testcommon.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#container {
+  content-visibility: auto;
+}
+@keyframes fade {
+  from { opacity: 1; }
+  to { opacity: 0;  }
+}
+#target {
+  background: 'green';
+  height: 100px;
+  width: 100px;
+}
+.animate {
+  animation: fade 1s linear 2 alternate;
+}
+.transition {
+  transition: opacity 1s linear;
+}
+</style>
+<body>
+  <div id="spacer"></div>
+  <div id="container"></div>
+</body>
+<script>
+"use strict";
+
+function reset() {
+  const container = document.getElementById('container');
+  const target = document.getElementById('target');
+  container.style = '';
+  container.removeChild(target);
+}
+
+function createAnimatingElement(test, name) {
+  const container = document.getElementById('container');
+  const target = document.createElement('div');
+  container.appendChild(target);
+  target.id = 'target';
+  target.className = name;
+  test.add_cleanup(() => {
+    reset();
+  });
+  return target;
+}
+
+promise_test(async t => {
+  const container = document.getElementById('container');
+  const target = createAnimatingElement(t, 'animate');
+  let animationIterationEvent = false;
+  const animation = target.getAnimations()[0];
+  await animation.ready;
+  await waitForAnimationFrames(1);
+  document.getElementById("spacer").style.height = "300vh";
+  await waitForAnimationFrames(1);
+  target.addEventListener('animationiteration', () => {
+    animationIterationEvent = true;
+  });
+  animation.currentTime = 1500;
+  assert_approx_equals(
+      parseFloat(getComputedStyle(target).opacity), 0.5, 1e-6,
+      'Computed style is updated even when the animation is running in a ' +
+      'content visibility subtree');
+  await waitForAnimationFrames(2);
+  assert_false(animationIterationEvent,
+               'Animation events do not fire while the animation is ' +
+               'running in a content visibility subtree');
+  document.getElementById("spacer").style.height = "0vh";
+  await waitForAnimationFrames(2);
+  assert_true(animationIterationEvent,
+              'The animationiteration event fires once the animation is ' +
+              'no longer content visibility');
+}, 'Animation events do not fire for a CSS animation running in a content ' +
+   'visibility subtree');
+
+promise_test(async t => {
+  const container = document.getElementById('container');
+  const target = createAnimatingElement(t, 'animate');
+  const animation = target.getAnimations()[0];
+  await animation.ready;
+  let finishedWhileDisplayLocked = false;
+  animation.finished.then(() => {
+    finishedWhileDisplayLocked =
+        getComputedStyle(target).height == '0px';
+  });
+  await waitForAnimationFrames(1);
+  document.getElementById("spacer").style.height = "300vh";
+  // Advance to just shy of the effect end.
+  animation.currentTime = 1999;
+  assert_approx_equals(
+      parseFloat(getComputedStyle(target).opacity), 0.999, 1e-6,
+                'Computed style is updated even when the animation is ' +
+                'running in a content visibility subtree');
+  // Advancing frames should not resolve the finished promise.
+  await waitForAnimationFrames(3);
+  document.getElementById("spacer").style.height = "0vh";
+  // Now we can resolve the finished promise.
+  await animation.finished;
+  assert_equals(finishedWhileDisplayLocked, false);
+}, 'The finished promise does not resolve due to the normal passage of time  ' +
+   'for a CSS animation in a content visibility subtree');
+
+promise_test(async t => {
+  const container = document.getElementById('container');
+  await waitForAnimationFrames(1);
+  const target = createAnimatingElement(t, 'transition');
+  await waitForAnimationFrames(1);
+  target.style.opacity = 0;
+  const animation = target.getAnimations()[0];
+  await animation.ready;
+  let finishedWhileDisplayLocked = false;
+  animation.finished.then(() => {
+    finishedWhileDisplayLocked =
+        getComputedStyle(target).height == '0px';
+  });
+  await waitForAnimationFrames(1);
+  document.getElementById("spacer").style.height = "300vh";
+  // Advance to just shy of the effect end.
+  animation.currentTime = 999;
+  assert_approx_equals(
+      parseFloat(getComputedStyle(target).opacity), 0.001, 1e-6,
+                'Computed style is updated even when the animation is ' +
+                'running in a content visibility subtree');
+  // Advancing frames should not resolve the finished promise.
+  await waitForAnimationFrames(3);
+  document.getElementById("spacer").style.height = "0vh";
+  // Now we can resolve the finished promise.
+  await animation.finished;
+  assert_equals(finishedWhileDisplayLocked, false);
+}, 'The finished promise does not resolve due to the normal passage of time  ' +
+   'for a CSS transition in a content visibility subtree');
+
+promise_test(async t => {
+  const container = document.getElementById('container');
+  const target = createAnimatingElement(t, 'animate');
+  const animation = target.getAnimations()[0];
+  target.className = '';
+  document.getElementById("spacer").style.height = "300vh";
+  assert_equals(target.getAnimations().length, 0);
+
+  // Though originally a CSS animation, it is no longer associated with
+  // CSS rules and no longer has an owning element. It now behaves like a
+  // programmatic web animation. Animation playback events (but not CSS
+  // animation events) should be dispatched and promises resolved despite
+  // being in a content visibility subtree.
+
+  let cssAnimationEndEvent = false;
+  target.addEventListener('animationend', () => {
+    cssAnimationEndEvent = true;
+  });
+
+  let animationFinishEvent = false;
+  animation.addEventListener('finish', () => {
+    animationFinishEvent = true;
+  });
+
+  let animationFinished = false;
+  animation.finished.then(() => {
+    animationFinished = true;
+  });
+
+  animation.play();
+  assert_equals(target.getAnimations().length, 1);
+
+  animation.currentTime = 1999;
+  await animation.ready;
+  await waitForAnimationFrames(2);
+
+  assert_true(animationFinishEvent,
+              'Animation event not blocked on content visibility subtree if ' +
+              'no owning element');
+  assert_true(animationFinished,
+              'Finished promise not blocked on content visibility subtree if ' +
+              'no owning element');
+  assert_false(cssAnimationEndEvent,
+              'CSS animation events should not be dispatched if there is no ' +
+              'owning element');
+}, 'Events and promises are handled normally for animations without an ' +
+   'owning element');
+
+</script>

--- a/Source/WebCore/animation/DocumentTimelinesController.cpp
+++ b/Source/WebCore/animation/DocumentTimelinesController.cpp
@@ -118,6 +118,9 @@ void DocumentTimelinesController::updateAnimationsAndSendEvents(ReducedResolutio
         timelinesToUpdate.append(timeline.copyRef());
 
         for (auto& animation : copyToVector(timeline->relevantAnimations())) {
+            if (animation->isSkippedContentAnimation())
+                continue;
+
             if (animation->timeline() != timeline.ptr()) {
                 ASSERT(!animation->timeline());
                 continue;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1662,4 +1662,13 @@ std::optional<Seconds> WebAnimation::convertAnimationTimeToTimelineTime(Seconds 
     return animationTime * (1 / m_playbackRate) + *m_startTime;
 }
 
+bool WebAnimation::isSkippedContentAnimation() const
+{
+    if (auto animation = dynamicDowncast<DeclarativeAnimation>(this)) {
+        if (auto element = animation->owningElement())
+            return element->element.renderer() && element->element.renderer()->isSkippedContent();
+    }
+    return false;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -68,6 +68,8 @@ public:
     virtual bool isCSSAnimation() const { return false; }
     virtual bool isCSSTransition() const { return false; }
 
+    bool isSkippedContentAnimation() const;
+
     const String& id() const { return m_id; }
     void setId(String&&);
 

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.h
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.h
@@ -54,6 +54,8 @@ public:
 
     void updateViewportProximity(const Element&, ViewportProximity);
 
+    static void skippedContentStateDidChange(const Element&, bool wasSkipped, bool becameUnskipped);
+
 private:
     bool checkRelevancyOfContentVisibilityElement(Element&, OptionSet<ContentRelevancy>) const;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -814,6 +814,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
         if (contentVisibilityChanged) {
             if (oldStyle->contentVisibility() == ContentVisibility::Auto)
                 ContentVisibilityDocumentState::unobserve(*element());
+            ContentVisibilityDocumentState::skippedContentStateDidChange(*element(), oldStyle->contentVisibility() == ContentVisibility::Hidden, newStyle.contentVisibility() == ContentVisibility::Visible);
         }
         if ((contentVisibilityChanged || !oldStyle) && newStyle.contentVisibility() == ContentVisibility::Auto)
             ContentVisibilityDocumentState::observe(*element());


### PR DESCRIPTION
#### 37f52f4720baa187a5eb8454ff878840911e6925
<pre>
Skip animation update and resolution in subtrees depending on content-visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=223930">https://bugs.webkit.org/show_bug.cgi?id=223930</a>

Reviewed by Tim Nguyen.

This change has two parts:
- skip updating and sending events for animation in hidden content-visibility subtrees
- restart the animation once the subtree becomes visible/unskipped

A test is added for the behaviour of content-visibility: auto and animations, one when using scrollIntoView and
a reftest is included testing animations are restarted once a hidden content-visibility subtree becomes visible.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/animation-display-lock-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-and-scroll.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-becomes-visible-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-becomes-visible.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html: Added.
* Source/WebCore/animation/DocumentTimelinesController.cpp:
(WebCore::DocumentTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::isSkippedContentAnimation const):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const):
(WebCore::ContentVisibilityDocumentState::skippedContentStateDidChange):
* Source/WebCore/dom/ContentVisibilityDocumentState.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):

Canonical link: <a href="https://commits.webkit.org/268312@main">https://commits.webkit.org/268312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaae203103efeed469473e338cbb362c02e7ee26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22052 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23897 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21862 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15515 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->