### PR TITLE
canvas-as-container-005.html & canvas-as-container-006.html fail

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/canvas-as-container-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/canvas-as-container-005-expected.txt
@@ -1,6 +1,6 @@
 Test passes if there is a filled green square.
 
 
-FAIL Initially display:none, not focusable assert_not_equals: got disallowed value Element node <div id="target" tabindex="1"></div>
+PASS Initially display:none, not focusable
 PASS Focusable after container size change
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/canvas-as-container-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/canvas-as-container-006-expected.txt
@@ -1,6 +1,6 @@
 Test passes if there is a filled green square.
 
 
-FAIL Initially display:none, not focusable assert_not_equals: got disallowed value Element node <div id="target" tabindex="1"></div>
+PASS Initially display:none, not focusable
 PASS Focusable after container size change
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2339,6 +2339,12 @@ std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets
     ASSERT(pseudoElementSpecifier == PseudoId::None || parentStyle);
     ASSERT(Style::postResolutionCallbacksAreSuspended());
 
+    std::optional<RenderStyle> updatedDocumentStyle;
+    if (!parentStyle && m_needsFullStyleRebuild) {
+        updatedDocumentStyle.emplace(Style::resolveForDocument(*this));
+        parentStyle = &*updatedDocumentStyle;
+    }
+
     SetForScope change(m_ignorePendingStylesheets, true);
     auto& resolver = element.styleResolver();
 


### PR DESCRIPTION
#### 514d0acadd369b1e25caa9d1705af22448feabc5
<pre>
canvas-as-container-005.html &amp; canvas-as-container-006.html fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=253936">https://bugs.webkit.org/show_bug.cgi?id=253936</a>
rdar://106739131

Reviewed by Alan Baradlay.

When resolving computed style in a non-rendered subtree we fail to take container queries into account.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/canvas-as-container-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/canvas-as-container-006-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::styleForElementIgnoringPendingStylesheets):

Take care to have updated document style if it is not clean and we are resolving the root element.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveComputedStyle):

- Ensure the style scope is flushed so stylesheet data is current.
- Don&apos;t bail out when encountering display:none subtree, the ancestors may still affect its style.
- Fall back to a full style update if we encounter a query container with invalid style in the ancestor chain.

Canonical link: <a href="https://commits.webkit.org/267786@main">https://commits.webkit.org/267786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0aba3c5bbb8ed1c4ca5b2c17aa354982b6a88ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18164 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20367 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22683 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20542 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14265 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15965 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4215 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->