### PR TITLE
[css-scroll-snap] snap-after-relayout/snap-to-different-targets.html fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets.html
@@ -74,16 +74,20 @@ const x_target = document.getElementById("x-axis-target");
 const y_target = document.getElementById("y-axis-target");
 const scroller = document.getElementById("scroller");
 
-test(t => {
+promise_test(async function() {
   // The scroller should be snapped to the two closest points on first layout.
   assert_equals(scroller.scrollTop, 200);
   assert_equals(scroller.scrollLeft, 200);
-  x_target.style.setProperty("left", "1000px");
-  y_target.style.setProperty("top", "1000px");
 
   // The style change makes it impossible for the scroller to snap to both
   // targets, but at least one of the targets should be preserved. The scroller
   // should then re-evaluate the snap point for the other axis.
+  x_target.style.setProperty("left", "1000px");
+
+  await new Promise(resolve => {
+    scroller.addEventListener("scroll", () => step_timeout(resolve, 0));
+    y_target.style.setProperty("top", "1000px");
+   });
   const snapped_to_x = scroller.scrollLeft == 1000 && scroller.scrollTop == 300;
   const snapped_to_y = scroller.scrollTop == 1000 && scroller.scrollLeft == 300;
   assert_true(snapped_to_x || snapped_to_y);

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -204,7 +204,7 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
     auto wasSnappedToMultipleBoxes = previouslySnappedBoxes.size() > 1;
     auto currentlySnappedToMultipleBoxes = m_currentlySnappedBoxes.size() > 1;
     
-    if (wasSnappedToMultipleBoxes && !currentlySnappedToMultipleBoxes) {
+    if ((wasSnappedToMultipleBoxes && !currentlySnappedToMultipleBoxes) || (wasSnappedToMultipleBoxes == currentlySnappedToMultipleBoxes && previouslySnappedBoxes != m_currentlySnappedBoxes)) {
         auto box = chooseBoxToResnapTo(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
         snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, box);
         snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, box);


### PR DESCRIPTION
#### 4b463d0eb8f8375f1cbcb42e20a28f48761c1e7f
<pre>
[css-scroll-snap] snap-after-relayout/snap-to-different-targets.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=261282">https://bugs.webkit.org/show_bug.cgi?id=261282</a>
rdar://115125424

Reviewed by NOBODY (OOPS!).

We should check if we snapped to multiple boxes that are different from the boxes we were
previously snapped to.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/snap-to-different-targets.html:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b463d0eb8f8375f1cbcb42e20a28f48761c1e7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18066 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18557 "18 flakes 167 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15273 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20243 "Failed to checkout and rebase branch from PR 17549") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15341 "4 flakes 6 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16018 "8 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/20243 "Failed to checkout and rebase branch from PR 17549") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16350 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16187 "6 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/20243 "Failed to checkout and rebase branch from PR 17549") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16761 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14195 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15859 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->