### PR TITLE
Optimize the CSSVariableData constructor

### DIFF
--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -41,17 +41,15 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSVariableData);
 
-template<typename CharacterType> void CSSVariableData::updateTokens(const CSSParserTokenRange& range)
+template<typename CharacterType> void CSSVariableData::updateBackingStringsInTokens()
 {
-    const CharacterType* currentOffset = m_backingString.characters<CharacterType>();
-    for (const CSSParserToken& token : range) {
-        if (token.hasStringBacking()) {
-            unsigned length = token.value().length();
-            StringView string(currentOffset, length);
-            m_tokens.append(token.copyWithUpdatedString(string));
-            currentOffset += length;
-        } else
-            m_tokens.append(token);
+    auto* currentOffset = m_backingString.characters<CharacterType>();
+    for (auto& token : m_tokens) {
+        if (!token.hasStringBacking())
+            continue;
+        unsigned length = token.value().length();
+        token.updateCharacters(currentOffset, length);
+        currentOffset += length;
     }
     ASSERT(currentOffset == m_backingString.characters<CharacterType>() + m_backingString.length());
 }
@@ -65,17 +63,19 @@ CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSPars
     : m_context(context)
 {
     StringBuilder stringBuilder;
+    m_tokens.reserveInitialCapacity(range.end() - range.begin());
     for (auto& token : range) {
+        m_tokens.uncheckedAppend(token);
         if (token.hasStringBacking())
             stringBuilder.append(token.value());
     }
-    m_backingString = stringBuilder.toString();
-    if (m_backingString.is8Bit())
-        updateTokens<LChar>(range);
-    else
-        updateTokens<UChar>(range);
-
-    m_tokens.shrinkToFit();
+    if (!stringBuilder.isEmpty()) {
+        m_backingString = stringBuilder.toString();
+        if (m_backingString.is8Bit())
+            updateBackingStringsInTokens<LChar>();
+        else
+            updateBackingStringsInTokens<UChar>();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -37,7 +37,6 @@ namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSVariableData);
 class CSSVariableData : public RefCounted<CSSVariableData> {
-    WTF_MAKE_NONCOPYABLE(CSSVariableData);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CSSVariableData);
 public:
     static Ref<CSSVariableData> create(const CSSParserTokenRange& range, const CSSParserContext& context = strictCSSParserContext())
@@ -54,7 +53,7 @@ public:
 
 private:
     CSSVariableData(const CSSParserTokenRange&, const CSSParserContext&);
-    template<typename CharacterType> void updateTokens(const CSSParserTokenRange&);
+    template<typename CharacterType> void updateBackingStringsInTokens();
 
     String m_backingString;
     Vector<CSSParserToken> m_tokens;

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -142,6 +142,9 @@ public:
 
     void serialize(StringBuilder&, const CSSParserToken* nextToken = nullptr) const;
 
+    template<typename CharacterType>
+    void updateCharacters(const CharacterType* characters, unsigned length);
+
     CSSParserToken copyWithUpdatedString(StringView) const;
 
 private:
@@ -171,5 +174,13 @@ private:
         mutable int m_id;
     };
 };
+
+template<typename CharacterType>
+inline void CSSParserToken::updateCharacters(const CharacterType* characters, unsigned length)
+{
+    m_valueLength = length;
+    m_valueIs8Bit = (sizeof(CharacterType) == 1);
+    m_valueDataCharRaw = characters;
+}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 641608e9630336fbbd011dc072655ee83bdf7b03
<pre>
Optimize the CSSVariableData constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=261285">https://bugs.webkit.org/show_bug.cgi?id=261285</a>

Reviewed by Ryosuke Niwa.

Optimize the CSSVariableData constructor by:
1. Using Vector&apos;s reserveInitialCapacity() / uncheckedAppend() for m_tokens
   since we know how many tokens are present in the range.
2. Populate the m_tokens vector as we traverse the token range to append to
   the StringBuilder, instead of doing it later on.
3. Stop relying on CSSParserToken::copyWithUpdatedString() instead instead
   update characters in place in the pre-populated vector using the new
   CSSParserToken::updateCharacters(). CSSParserToken::updateCharacters()
   also takes the characters as LChar/UChar instead of StringView to avoid
   a redundant `is8Bit()` check.

* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::updateBackingStringsInTokens):
(WebCore::CSSVariableData::CSSVariableData):
(WebCore::CSSVariableData::updateTokens): Deleted.
* Source/WebCore/css/CSSVariableData.h:
* Source/WebCore/css/parser/CSSParserToken.h:
(WebCore::CSSParserToken::updateCharacters):

Canonical link: <a href="https://commits.webkit.org/267753@main">https://commits.webkit.org/267753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50fa2452fa082336e1224cfbb6f9c99cedbe4c59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16460 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18073 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20251 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22626 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20482 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15885 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4191 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->