### PR TITLE
Associate a purpose for each GraphicsContextState in the context state stack

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -62,22 +62,22 @@ const DestinationColorSpace& BifurcatedGraphicsContext::colorSpace() const
     return m_primaryContext.colorSpace();
 }
 
-void BifurcatedGraphicsContext::save()
+void BifurcatedGraphicsContext::save(GraphicsContextState::Purpose purpose)
 {
     // FIXME: Consider not using the BifurcatedGraphicsContext's state stack at all,
     // and making all of the state getters and setters virtual.
-    GraphicsContext::save();
-    m_primaryContext.save();
-    m_secondaryContext.save();
+    GraphicsContext::save(purpose);
+    m_primaryContext.save(purpose);
+    m_secondaryContext.save(purpose);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::restore()
+void BifurcatedGraphicsContext::restore(GraphicsContextState::Purpose purpose)
 {
-    GraphicsContext::restore();
-    m_primaryContext.restore();
-    m_secondaryContext.restore();
+    GraphicsContext::restore(purpose);
+    m_primaryContext.restore(purpose);
+    m_secondaryContext.restore(purpose);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }
@@ -154,8 +154,7 @@ void BifurcatedGraphicsContext::beginTransparencyLayer(float opacity)
     m_primaryContext.beginTransparencyLayer(opacity);
     m_secondaryContext.beginTransparencyLayer(opacity);
 
-    GraphicsContext::save();
-    m_state.didBeginTransparencyLayer();
+    GraphicsContext::save(GraphicsContextState::Purpose::TransparencyLayer);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }
@@ -166,7 +165,7 @@ void BifurcatedGraphicsContext::endTransparencyLayer()
     m_primaryContext.endTransparencyLayer();
     m_secondaryContext.endTransparencyLayer();
 
-    GraphicsContext::restore();
+    GraphicsContext::restore(GraphicsContextState::Purpose::TransparencyLayer);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -45,8 +45,8 @@ public:
 
     const DestinationColorSpace& colorSpace() const final;
 
-    void save() final;
-    void restore() final;
+    void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
+    void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
 
     void drawRect(const FloatRect&, float borderThickness = 1) final;
     void drawLine(const FloatPoint&, const FloatPoint&) final;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -194,7 +194,7 @@ std::unique_ptr<DisplayList::DisplayList> FontCascade::displayListForTextRun(Gra
         return nullptr;
 
     std::unique_ptr<DisplayList::DisplayList> displayList = makeUnique<DisplayList::DisplayList>();
-    DisplayList::RecorderImpl recordingContext(*displayList, context.state().cloneForRecording(), { },
+    DisplayList::RecorderImpl recordingContext(*displayList, context.state().clone(GraphicsContextState::Purpose::Initial), { },
         context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), context.colorSpace(),
         DisplayList::Recorder::DrawGlyphsMode::DeconstructUsingDrawDecomposedGlyphsCommands);
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -61,17 +61,22 @@ GraphicsContext::~GraphicsContext()
     ASSERT(!m_transparencyLayerCount);
 }
 
-void GraphicsContext::save()
+void GraphicsContext::save(GraphicsContextState::Purpose purpose)
 {
+    ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore || purpose == GraphicsContextState::Purpose::TransparencyLayer);
     m_stack.append(m_state);
+    m_state.repurpose(purpose);
 }
 
-void GraphicsContext::restore()
+void GraphicsContext::restore(GraphicsContextState::Purpose purpose)
 {
     if (m_stack.isEmpty()) {
         LOG_ERROR("ERROR void GraphicsContext::restore() stack is empty");
         return;
     }
+
+    ASSERT_UNUSED(purpose, purpose == m_state.purpose());
+    ASSERT_UNUSED(purpose, purpose == GraphicsContextState::Purpose::SaveRestore || purpose == GraphicsContextState::Purpose::TransparencyLayer);
 
     m_state = m_stack.last();
     m_stack.removeLast();

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -172,9 +172,9 @@ public:
     // to the platform context's state.
     virtual void didUpdateState(GraphicsContextState&) = 0;
 
-    WEBCORE_EXPORT virtual void save();
-    WEBCORE_EXPORT virtual void restore();
-    
+    WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
+    WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
+
     unsigned stackSize() const { return m_stack.size(); }
 
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -65,12 +65,19 @@ public:
     static constexpr ChangeFlags basicChangeFlags { Change::StrokeThickness, Change::StrokeBrush, Change::FillBrush };
     static constexpr ChangeFlags strokeChangeFlags { Change::StrokeThickness, Change::StrokeBrush };
 
+    enum class Purpose : uint8_t {
+        Initial,
+        SaveRestore,
+        TransparencyLayer
+    };
+
     WEBCORE_EXPORT GraphicsContextState(const ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
+
+    void repurpose(Purpose);
+    GraphicsContextState clone(Purpose) const;
 
     ChangeFlags changes() const { return m_changeFlags; }
     void didApplyChanges() { m_changeFlags = { }; }
-
-    GraphicsContextState cloneForRecording() const;
 
     SourceBrush& fillBrush() { return m_fillBrush; }
     const SourceBrush& fillBrush() const { return m_fillBrush; }
@@ -137,7 +144,7 @@ public:
     void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
     void mergeAllChanges(const GraphicsContextState&);
 
-    void didBeginTransparencyLayer();
+    Purpose purpose() const { return m_purpose; }
 
     WTF::TextStream& dump(WTF::TextStream&) const;
 
@@ -191,6 +198,8 @@ private:
 #if HAVE(OS_DARK_MODE_SUPPORT)
     bool m_useDarkAppearance { false };
 #endif
+
+    Purpose m_purpose { Purpose::Initial };
 };
 
 template<class Encoder>

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -100,8 +100,8 @@ private:
     void resetClip() final { }
     void clip(const FloatRect&) final { }
     void clipOut(const FloatRect&) final { }
-    void save() final { }
-    void restore() final { }
+    void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final { }
+    void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final { }
 
     void drawRaisedEllipse(const FloatRect&, const Color&, const Color&) final { }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -98,9 +98,9 @@ GraphicsContextCairo* GraphicsContextCairo::platformContext() const
     return const_cast<GraphicsContextCairo*>(this);
 }
 
-void GraphicsContextCairo::save()
+void GraphicsContextCairo::save(GraphicsContextState::Purpose purpose)
 {
-    GraphicsContext::save();
+    GraphicsContext::save(purpose);
 
     m_cairoStateStack.append(CairoState());
     m_cairoState = &m_cairoStateStack.last();
@@ -108,12 +108,12 @@ void GraphicsContextCairo::save()
     cairo_save(m_cr.get());
 }
 
-void GraphicsContextCairo::restore()
+void GraphicsContextCairo::restore(GraphicsContextState::Purpose purpose)
 {
     if (!stackSize())
         return;
 
-    GraphicsContext::restore();
+    GraphicsContext::restore(purpose);
 
     if (m_cairoStateStack.isEmpty())
         return;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -80,8 +80,8 @@ public:
     void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
     void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;
 
-    void save() final;
-    void restore() final;
+    void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
+    void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
 
     void translate(float, float) final;
     void rotate(float) final;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -251,18 +251,18 @@ const DestinationColorSpace& GraphicsContextCG::colorSpace() const
     return *m_colorSpace;
 }
 
-void GraphicsContextCG::save()
+void GraphicsContextCG::save(GraphicsContextState::Purpose purpose)
 {
-    GraphicsContext::save();
+    GraphicsContext::save(purpose);
     CGContextSaveGState(contextForState());
 }
 
-void GraphicsContextCG::restore()
+void GraphicsContextCG::restore(GraphicsContextState::Purpose purpose)
 {
     if (!stackSize())
         return;
 
-    GraphicsContext::restore();
+    GraphicsContext::restore(purpose);
     CGContextRestoreGState(contextForState());
     m_userToDeviceTransformKnownToBeIdentity = false;
 }
@@ -1054,13 +1054,12 @@ void GraphicsContextCG::beginTransparencyLayer(float opacity)
 {
     GraphicsContext::beginTransparencyLayer(opacity);
 
-    save();
+    save(GraphicsContextState::Purpose::TransparencyLayer);
 
     CGContextRef context = platformContext();
     CGContextSetAlpha(context, opacity);
     CGContextBeginTransparencyLayer(context, 0);
     
-    m_state.didBeginTransparencyLayer();
     m_userToDeviceTransformKnownToBeIdentity = false;
 }
 
@@ -1071,7 +1070,7 @@ void GraphicsContextCG::endTransparencyLayer()
     CGContextRef context = platformContext();
     CGContextEndTransparencyLayer(context);
 
-    restore();
+    restore(GraphicsContextState::Purpose::TransparencyLayer);
 }
 
 static void applyShadowOffsetWorkaroundIfNeeded(CGContextRef context, CGFloat& xOffset, CGFloat& yOffset)

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -49,8 +49,8 @@ public:
 
     const DestinationColorSpace& colorSpace() const final;
 
-    void save() final;
-    void restore() final;
+    void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
+    void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final;
 
     void drawRect(const FloatRect&, float borderThickness = 1) final;
     void drawLine(const FloatPoint&, const FloatPoint&) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -279,18 +279,22 @@ void Recorder::drawPattern(ImageBuffer& imageBuffer, const FloatRect& destRect, 
     recordDrawPattern(imageBuffer.renderingResourceIdentifier(), destRect, tileRect, patternTransform, phase, spacing, options);
 }
 
-void Recorder::save()
+void Recorder::save(GraphicsContextState::Purpose purpose)
 {
+    ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore);
+
     appendStateChangeItemIfNecessary();
-    GraphicsContext::save();
+    GraphicsContext::save(purpose);
     recordSave();
     m_stateStack.append(m_stateStack.last());
 }
 
-void Recorder::restore()
+void Recorder::restore(GraphicsContextState::Purpose purpose)
 {
+    ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore);
+
     appendStateChangeItemIfNecessary();
-    GraphicsContext::restore();
+    GraphicsContext::restore(purpose);
 
     if (!m_stateStack.size())
         return;
@@ -350,10 +354,8 @@ void Recorder::beginTransparencyLayer(float opacity)
     appendStateChangeItemIfNecessary();
     recordBeginTransparencyLayer(opacity);
 
-    GraphicsContext::save();
+    GraphicsContext::save(GraphicsContextState::Purpose::TransparencyLayer);
     m_stateStack.append(m_stateStack.last().cloneForTransparencyLayer());
-    
-    m_state.didBeginTransparencyLayer();
 }
 
 void Recorder::endTransparencyLayer()
@@ -364,7 +366,7 @@ void Recorder::endTransparencyLayer()
     recordEndTransparencyLayer();
 
     m_stateStack.removeLast();
-    GraphicsContext::restore();
+    GraphicsContext::restore(GraphicsContextState::Purpose::TransparencyLayer);
 }
 
 void Recorder::drawRect(const FloatRect& rect, float borderThickness)

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
@@ -809,14 +809,14 @@ void CairoOperationRecorder::drawFocusRing(const Vector<FloatRect>& rects, float
     UNUSED_PARAM(outlineOffset);
 }
 
-void CairoOperationRecorder::save()
+void CairoOperationRecorder::save(GraphicsContextState::Purpose purpose)
 {
-    struct Save final : PaintingOperation, OperationData<> {
+    struct Save final : PaintingOperation, OperationData<GraphicsContextState::Purpose> {
         virtual ~Save() = default;
 
         void execute(PaintingOperationReplay& replayer) override
         {
-            contextForReplay(replayer).save();
+            contextForReplay(replayer).save(arg<0>());
         }
 
         void dump(TextStream& ts) override
@@ -825,21 +825,21 @@ void CairoOperationRecorder::save()
         }
     };
 
-    GraphicsContext::save();
+    GraphicsContext::save(purpose);
 
-    append(createCommand<Save>());
+    append(createCommand<Save>(purpose));
 
     m_stateStack.append(m_stateStack.last());
 }
 
-void CairoOperationRecorder::restore()
+void CairoOperationRecorder::restore(GraphicsContextState::Purpose purpose)
 {
-    struct Restore final : PaintingOperation, OperationData<> {
+    struct Restore final : PaintingOperation, OperationData<GraphicsContextState::Purpose> {
         virtual ~Restore() = default;
 
         void execute(PaintingOperationReplay& replayer) override
         {
-            contextForReplay(replayer).restore();
+            contextForReplay(replayer).restore(arg<0>());
         }
 
         void dump(TextStream& ts) override
@@ -851,12 +851,12 @@ void CairoOperationRecorder::restore()
     if (!stackSize())
         return;
 
-    GraphicsContext::restore();
+    GraphicsContext::restore(purpose);
 
     if (m_stateStack.isEmpty())
         return;
 
-    append(createCommand<Restore>());
+    append(createCommand<Restore>(purpose));
 
     m_stateStack.removeLast();
     if (m_stateStack.isEmpty())

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
@@ -80,8 +80,8 @@ private:
     void drawFocusRing(const WebCore::Path&, float outlineWidth, const WebCore::Color&) override;
     void drawFocusRing(const Vector<WebCore::FloatRect>&, float outlineOffset, float outlineWidth, const WebCore::Color&) override;
 
-    void save() override;
-    void restore() override;
+    void save(WebCore::GraphicsContextState::Purpose = WebCore::GraphicsContextState::Purpose::SaveRestore) override;
+    void restore(WebCore::GraphicsContextState::Purpose = WebCore::GraphicsContextState::Purpose::SaveRestore) override;
 
     void translate(float, float) override;
     void rotate(float angleInRadians) override;


### PR DESCRIPTION
#### 7d3126b3705a8d90653f9efad3c6d7246307bd09
<pre>
Associate a purpose for each GraphicsContextState in the context state stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=261296">https://bugs.webkit.org/show_bug.cgi?id=261296</a>
rdar://115138846

Reviewed by Simon Fraser.

We internally call GraphicsContext::save() when we begin a transparency layer and
we call GraphicsContext::restore() when we end the transparency layer.

Differentiating when this happens from normal save/restore will make it easy to
unwind the stack of the GraphicsContextState and the transparency layers in the
right order.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::save):
(WebCore::BifurcatedGraphicsContext::restore):
(WebCore::BifurcatedGraphicsContext::beginTransparencyLayer):
(WebCore::BifurcatedGraphicsContext::endTransparencyLayer):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::displayListForTextRun const):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::save):
(WebCore::GraphicsContext::restore):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::repurpose):
(WebCore::GraphicsContextState::clone const):
(WebCore::GraphicsContextState::cloneForRecording const): Deleted.
(WebCore::GraphicsContextState::didBeginTransparencyLayer): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::purpose const):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::save):
(WebCore::GraphicsContextCairo::restore):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::save):
(WebCore::GraphicsContextCG::restore):
(WebCore::GraphicsContextCG::beginTransparencyLayer):
(WebCore::GraphicsContextCG::endTransparencyLayer):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::save):
(WebCore::DisplayList::Recorder::restore):
(WebCore::DisplayList::Recorder::beginTransparencyLayer):
(WebCore::DisplayList::Recorder::endTransparencyLayer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::ContextState::cloneForTransparencyLayer const):
(WebCore::DisplayList::Recorder::ContextState::ContextState): Deleted.
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp:
(Nicosia::CairoOperationRecorder::save):
(Nicosia::CairoOperationRecorder::restore):
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h:

Canonical link: <a href="https://commits.webkit.org/267790@main">https://commits.webkit.org/267790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b01f2670be637b5936287732b7c98c056cec01e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20331 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22677 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20527 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15941 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->