### PR TITLE
[JHBuild] Make libsoup3 default

### DIFF
--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -55,6 +55,7 @@ PACKAGES=(
     libkate-dev
     liblcms2-dev
     $(aptIfExists libmanette-0.2-dev)
+    libnghttp2-dev
     libopenjp2-7-dev
     libpng-dev
     libseccomp-dev

--- a/Tools/gtk/jhbuild.modules
+++ b/Tools/gtk/jhbuild.modules
@@ -32,6 +32,7 @@
       <dep package="shared-mime-info"/>
       <dep package="wpebackend-fdo"/>
       <dep package="webkit-gstreamer-testing-dependencies"/>
+      <dep package="libsoup"/>
       <if condition-set="linux">
           <dep package="xdg-dbus-proxy"/>
           <dep package="xserver"/>
@@ -42,9 +43,6 @@
       </if>
       <if condition-set="macos">
           <dep package="gsettings-desktop-schemas"/>
-      </if>
-      <if condition-unset="USE_SOUP2">
-        <dep package="libsoup3"/>
       </if>
     </dependencies>
   </metamodule>
@@ -251,21 +249,19 @@
             hash="sha256:f8fd0aeb66252dfcc638f14d9be1e2362fdaf2ca86bde0444ff4d5cc961b560f"/>
   </autotools>
 
-  <if condition-unset="USE_SOUP2">
-    <meson id="libsoup3" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
-      <pkg-config>libsoup-3.0.pc</pkg-config>
-      <dependencies>
-        <dep package="glib"/>
-        <dep package="glib-networking"/>
-        <dep package="libpsl"/>
-      </dependencies>
-      <branch module="/sources/libsoup/3.2/libsoup-${version}.tar.xz"
-              version="3.2.2"
-              repo="download.gnome.org"
-              hash="sha256:83673c685b910fb7d39f1f28eee5afbefb71c05798fc350ac3bf1b885e1efaa1">
-      </branch>
-    </meson>
-  </if>
+  <meson id="libsoup" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
+    <pkg-config>libsoup-3.0.pc</pkg-config>
+    <dependencies>
+      <dep package="glib"/>
+      <dep package="glib-networking"/>
+      <dep package="libpsl"/>
+    </dependencies>
+    <branch module="/sources/libsoup/3.0/libsoup-${version}.tar.xz"
+            version="3.0.7"
+            repo="download.gnome.org"
+            hash="sha256:ebdf90cf3599c11acbb6818a9d9e3fc9d2c68e56eb829b93962972683e1bf7c8">
+    </branch>
+  </meson>
 
   <autotools id="fontconfig"
              autogenargs="--enable-libxml2 --disable-docs"

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -16,9 +16,7 @@
       <dep package="glib-networking"/>
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
-      <if condition-unset="USE_SOUP2">
-        <dep package="libsoup3"/>
-      </if>
+      <dep package="libsoup"/>
     </dependencies>
   </metamodule>
 
@@ -33,9 +31,7 @@
       <dep package="glib-networking"/>
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
-      <if condition-unset="USE_SOUP2">
-        <dep package="libsoup3"/>
-      </if>
+      <dep package="libsoup"/>
     </dependencies>
   </metamodule>
 
@@ -108,21 +104,19 @@
     </branch>
   </autotools>
 
-  <if condition-unset="USE_SOUP2">
-    <meson id="libsoup3" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
-      <pkg-config>libsoup-3.0.pc</pkg-config>
-      <dependencies>
-        <dep package="glib"/>
-        <dep package="glib-networking"/>
-        <dep package="libpsl"/>
-      </dependencies>
-      <branch module="/sources/libsoup/3.2/libsoup-${version}.tar.xz"
-              version="3.2.2"
-              repo="download.gnome.org"
-              hash="sha256:83673c685b910fb7d39f1f28eee5afbefb71c05798fc350ac3bf1b885e1efaa1">
-      </branch>
-    </meson>
-  </if>
+  <meson id="libsoup" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
+    <pkg-config>libsoup-3.0.pc</pkg-config>
+    <dependencies>
+      <dep package="glib"/>
+      <dep package="glib-networking"/>
+      <dep package="libpsl"/>
+    </dependencies>
+    <branch module="/sources/libsoup/3.0/libsoup-${version}.tar.xz"
+            version="3.0.7"
+            repo="download.gnome.org"
+            hash="sha256:ebdf90cf3599c11acbb6818a9d9e3fc9d2c68e56eb829b93962972683e1bf7c8">
+    </branch>
+  </meson>
 
   <autotools id="libpsl" autogenargs="--enable-runtime=libicu --enable-builtin=libicu">
     <pkg-config>libpsl.pc</pkg-config>

--- a/Tools/jhbuild/jhbuildrc_common.py
+++ b/Tools/jhbuild/jhbuildrc_common.py
@@ -100,8 +100,3 @@ def init(jhbuildrc_globals, jhbuild_platform):
         jhbuild_enable_thunder = os.environ['JHBUILD_ENABLE_THUNDER'].lower()
         if jhbuild_enable_thunder == 'yes' or jhbuild_enable_thunder == '1' or jhbuild_enable_thunder == 'true':
             jhbuildrc_globals['conditions'].add('Thunder')
-
-    if 'JHBUILD_USE_SOUP2' in os.environ:
-        jhbuild_use_soup2 = os.environ['JHBUILD_USE_SOUP2'].lower()
-        if jhbuild_use_soup2 in ('true', 'on', 'yes', '1'):
-            jhbuildrc_globals['conditions'].add('USE_SOUP2')

--- a/Tools/wpe/jhbuild.modules
+++ b/Tools/wpe/jhbuild.modules
@@ -28,9 +28,7 @@
       <dep package="wpebackend-fdo"/>
       <dep package="xdg-dbus-proxy"/>
       <dep package="webkit-gstreamer-testing-dependencies"/>
-      <if condition-unset="USE_SOUP2">
-        <dep package="libsoup3"/>
-      </if>
+      <dep package="libsoup"/>
     </dependencies>
   </metamodule>
 
@@ -96,7 +94,19 @@
             hash="sha256:f8fd0aeb66252dfcc638f14d9be1e2362fdaf2ca86bde0444ff4d5cc961b560f"/>
   </autotools>
 
-
+  <meson id="libsoup" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
+    <pkg-config>libsoup-3.0.pc</pkg-config>
+    <dependencies>
+      <dep package="glib"/>
+      <dep package="glib-networking"/>
+      <dep package="libpsl"/>
+    </dependencies>
+    <branch module="/sources/libsoup/3.0/libsoup-${version}.tar.xz"
+            version="3.0.7"
+            repo="download.gnome.org"
+            hash="sha256:ebdf90cf3599c11acbb6818a9d9e3fc9d2c68e56eb829b93962972683e1bf7c8">
+    </branch>
+  </meson>
 
   <autotools id="dicts" supports-non-srcdir-builds="no"
              skip-autogen="true">
@@ -109,22 +119,6 @@
             repo="savannah.gnu.org"
             hash="sha256:db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d"/>
   </autotools>
-
-  <if condition-unset="USE_SOUP2">
-    <meson id="libsoup3" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
-      <pkg-config>libsoup-3.0.pc</pkg-config>
-      <dependencies>
-        <dep package="glib"/>
-        <dep package="glib-networking"/>
-        <dep package="libpsl"/>
-      </dependencies>
-      <branch module="/sources/libsoup/3.2/libsoup-${version}.tar.xz"
-              version="3.2.2"
-              repo="download.gnome.org"
-              hash="sha256:83673c685b910fb7d39f1f28eee5afbefb71c05798fc350ac3bf1b885e1efaa1">
-      </branch>
-    </meson>
-  </if>
 
   <autotools id="fontconfig" autogen-sh="configure"
              autogenargs="--disable-docs"


### PR DESCRIPTION
#### 7a86572720b39d1e7a61275b6aaca22b392df177
<pre>
[JHBuild] Make libsoup3 default
<a href="https://bugs.webkit.org/show_bug.cgi?id=261192">https://bugs.webkit.org/show_bug.cgi?id=261192</a>

Reviewed by Carlos Garcia Campos.

Libsoup3 is the default networking library in Flatpak SDK.

Right now the oldest distribution officially supported is Debian 11,
which satisfies all system dependencies necessary to build libsoup3.

* Tools/glib/dependencies/apt: Add &apos;libnghttp2-dev&apos;.
* Tools/gtk/jhbuild.modules: Update libsoup to 3.0.7.
* Tools/jhbuild/jhbuild-minimal.modules: Update libsoup to 3.0.7.
* Tools/jhbuild/jhbuildrc_common.py:
(init): Remove support in JHBuild to build using libsoup2.
* Tools/wpe/jhbuild.modules: Update libsoup to 3.0.7.

Canonical link: <a href="https://commits.webkit.org/267852@main">https://commits.webkit.org/267852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e20b847e6a013ea8528fb4d11ab9769f415196e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18587 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20307 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22656 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15921 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4256 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->