### PR TITLE
VTTRegion::setScroll should ignore assignment of an invalid string instead of throwing SyntaxError

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTRegion() initial values
-FAIL VTTRegion() mutations The string did not match the expected pattern.
+PASS VTTRegion() mutations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL VTTRegion.scroll script-created region The string did not match the expected pattern.
+PASS VTTRegion.scroll script-created region
 

--- a/LayoutTests/media/track/regions-webvtt/vtt-region-constructor-expected.txt
+++ b/LayoutTests/media/track/regions-webvtt/vtt-region-constructor-expected.txt
@@ -14,7 +14,6 @@ EXPECTED (region.width == '100') OK
 
 ** Test that incorrect mutation keeps previous valid values. **
 RUN(region.scroll = 'invalid-scroll-value')
-SyntaxError: The string did not match the expected pattern.
 EXPECTED (region.scroll == '') OK
 
 Invalid percentage value: -1

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -132,17 +132,14 @@ const AtomString& VTTRegion::scroll() const
     return m_scroll ? upKeyword() : emptyAtom();
 }
 
-ExceptionOr<void> VTTRegion::setScroll(const AtomString& value)
+void VTTRegion::setScroll(const AtomString& value)
 {
     if (value.isEmpty()) {
         m_scroll = false;
-        return { };
     }
     if (value == upKeyword()) {
         m_scroll = true;
-        return { };
     }
-    return Exception { SyntaxError };
 }
 
 void VTTRegion::updateParametersFromRegion(const VTTRegion& other)

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -78,7 +78,7 @@ public:
     ExceptionOr<void> setViewportAnchorY(double);
 
     const AtomString& scroll() const;
-    ExceptionOr<void> setScroll(const AtomString&);
+    void setScroll(const AtomString&);
 
     void updateParametersFromRegion(const VTTRegion&);
 


### PR DESCRIPTION
#### 8de0edf59961bbcf4e1127ce8b411f680a023fe6
<pre>
VTTRegion::setScroll should ignore assignment of an invalid string instead of throwing SyntaxError
<a href="https://bugs.webkit.org/show_bug.cgi?id=261310">https://bugs.webkit.org/show_bug.cgi?id=261310</a>

Reviewed by Eric Carlson.

The spec that VTTRegion::setScroll throws a SyntaxError in dead code
has been removed at <a href="https://github.com/w3c/webvtt/pull/28">https://github.com/w3c/webvtt/pull/28</a>,
and now it should ignore assignment of an invalid string.

WebKit is failing the corresponding WPT:
<a href="https://wpt.fyi/results/webvtt/api/VTTRegion/scroll.html?label=experimental&amp">https://wpt.fyi/results/webvtt/api/VTTRegion/scroll.html?label=experimental&amp</a>;label=master&amp;aligned&amp;q=webvtt

* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/scroll-expected.txt:
* LayoutTests/media/track/regions-webvtt/vtt-region-constructor-expected.txt:
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setScroll):
* Source/WebCore/html/track/VTTRegion.h:

Canonical link: <a href="https://commits.webkit.org/267828@main">https://commits.webkit.org/267828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ed12fcadb4e385e1ebf9002b8105b48ea961fa7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18626 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20392 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22703 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14284 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15985 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4244 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->