### PR TITLE
check-webkit-style assertion failure in Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4069,8 +4069,8 @@ def check_identifier_name_in_declaration(filename, line_number, line, file_state
                   the state of things in the file.
       error: The function to call with any errors found.
     """
-    # We don't check a return statement.
-    if match(r'\s*(return|delete)\b', line):
+    # We don't check return, case or delete statements.
+    if match(r'\s*(return|case|delete)\b', line):
         return
 
     # Make sure Ref/RefPtrs used as protectors are named correctly, and do this before we start stripping things off the input.

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -2553,6 +2553,9 @@ class CppStyleTest(CppStyleTestBase):
                          'Extra space before last semicolon. If this should be an '
                          'empty statement, use { } instead.'
                          '  [whitespace/semicolon] [5]')
+        self.assert_lint('case DAV1D_TASK_TYPE_FG_APPLY:;',
+                         'Semicolon defining empty statement. Use { } instead.'
+                         '  [whitespace/semicolon] [5]')
         self.assert_lint('default:;',
                          'Semicolon defining empty statement. Use { } instead.'
                          '  [whitespace/semicolon] [5]')


### PR DESCRIPTION
#### 18c176998114e1ca89b5c213a21f74dd57b9c316
<pre>
check-webkit-style assertion failure in Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c
<a href="https://bugs.webkit.org/show_bug.cgi?id=261309">https://bugs.webkit.org/show_bug.cgi?id=261309</a>
&lt;rdar://115150139&gt;

Reviewed by Jonathan Bedard.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_identifier_name_in_declaration):
- Don&apos;t attempt to check variable names in &apos;case&apos; statements since this
  code was not designed to do that. A stray semi-colon after a
  &apos;case XYZ:;&apos; statement caused &apos;XYZ:&apos; to be treated as a variable.

* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
- Add a unit test.

Canonical link: <a href="https://commits.webkit.org/267833@main">https://commits.webkit.org/267833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a6746b1198eb4811af5c488bac0885affa7dad9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18595 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20318 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17797 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22662 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14241 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15930 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20296 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2187 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->