### PR TITLE
Invalidate scope-breaking :has(:is(...)) selectors more thoroughly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/is-pseudo-containing-complex-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/is-pseudo-containing-complex-in-has-expected.txt
@@ -68,37 +68,37 @@ PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #has_scope.classL
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.add('c_has_scope') : check matches (true)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.add('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.remove('c_has_scope') : check matches (false)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.remove('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (insertion) check matches (true)
-FAIL [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (removal) check matches (false)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #previous.classList.add('c_has_scope') : check matches (true)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #previous.classList.add('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (insertion) check matches (false)
-FAIL [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (removal) check matches (true)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #previous.classList.remove('c_has_scope') : check matches (false)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #previous.classList.remove('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (insertion) check matches (true)
-FAIL [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (removal) check matches (false)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.add('c_has_scope') : check matches (true)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.add('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (insertion) check matches (false)
-FAIL [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (removal) check matches (true)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.remove('c_has_scope') : check matches (false)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.remove('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (insertion) check matches (true)
-FAIL [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (removal) check matches (false)
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:is(.p + .c_has_scope ~ .d .e)) ] #has_scope.classList.remove('green') : check matches (false)
@@ -108,37 +108,37 @@ PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ]
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.add('c_descendant') : check matches (true)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.add('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(144, 238, 144)"
+PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.remove('c_descendant') : check matches (false)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.remove('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (insertion) check matches (true)
-FAIL [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(144, 238, 144)" but got "rgb(128, 128, 128)"
+PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (removal) check matches (false)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.add('c_descendant') : check matches (true)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.add('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (insertion) check matches (false)
-FAIL [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(144, 238, 144)"
+PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (removal) check matches (true)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.remove('c_descendant') : check matches (false)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.remove('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (insertion) check matches (true)
-FAIL [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(144, 238, 144)" but got "rgb(128, 128, 128)"
+PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (removal) check matches (false)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.add('c_descendant') : check matches (true)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.add('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (insertion) check matches (false)
-FAIL [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(144, 238, 144)"
+PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (removal) check matches (true)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.remove('c_descendant') : check matches (false)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.remove('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (insertion) check matches (true)
-FAIL [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (insertion) check #descendant color assert_equals: expected "rgb(144, 238, 144)" but got "rgb(128, 128, 128)"
+PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (removal) check matches (false)
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:is(.p + .c_descendant ~ .d .e)) #descendant ] #has_scope.classList.remove('lightgreen') : check matches (false)
@@ -148,13 +148,13 @@ PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.add('c_indirect_next') : check matches (true)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.add('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 100, 0)"
+PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.remove('c_indirect_next') : check matches (false)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.remove('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (insertion) check matches (true)
-FAIL [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(0, 100, 0)" but got "rgb(128, 128, 128)"
+PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (removal) check matches (false)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #previous.classList.add('c_indirect_next') : check matches (true)
@@ -172,13 +172,13 @@ PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.add('c_indirect_next') : check matches (true)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.add('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (insertion) check matches (false)
-FAIL [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 100, 0)"
+PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (removal) check matches (true)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.remove('c_indirect_next') : check matches (false)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.remove('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (insertion) check matches (true)
-FAIL [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(0, 100, 0)" but got "rgb(128, 128, 128)"
+PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (removal) check matches (false)
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:is(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #has_scope.classList.remove('darkgreen') : check matches (false)
@@ -188,13 +188,13 @@ PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('c_indirect_next_child') : check matches (true)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(154, 205, 50)"
+PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('c_indirect_next_child') : check matches (false)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (insertion) check matches (true)
-FAIL [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(154, 205, 50)" but got "rgb(128, 128, 128)"
+PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (removal) check matches (false)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #previous.classList.add('c_indirect_next_child') : check matches (true)
@@ -212,13 +212,13 @@ PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.add('c_indirect_next_child') : check matches (true)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.add('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (insertion) check matches (false)
-FAIL [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(154, 205, 50)"
+PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (removal) check matches (true)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.remove('c_indirect_next_child') : check matches (false)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.remove('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (insertion) check matches (true)
-FAIL [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(154, 205, 50)" but got "rgb(128, 128, 128)"
+PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (removal) check matches (false)
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:is(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #has_scope.classList.remove('yellowgreen') : check matches (false)
@@ -228,13 +228,13 @@ PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #has_scope.class
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #previous.classList.add('f_has_scope') : check matches (true)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #previous.classList.add('f_has_scope') : check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #previous) : (insertion) check matches (false)
-FAIL [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 0, 255)"
+PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #previous) : (insertion) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #previous) : (removal) check matches (true)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #previous) : (removal) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #previous.classList.remove('f_has_scope') : check matches (false)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #previous.classList.remove('f_has_scope') : check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (insertion) check matches (true)
-FAIL [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
+PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (insertion) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (removal) check matches (false)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (removal) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #has_scope.classList.add('f_has_scope') : check matches (true)
@@ -244,13 +244,13 @@ PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #has_scope.class
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #direct_next.classList.add('f_has_scope') : check matches (true)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #direct_next.classList.add('f_has_scope') : check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #direct_next) : (insertion) check matches (false)
-FAIL [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #direct_next) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 0, 255)"
+PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #direct_next) : (insertion) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #direct_next) : (removal) check matches (true)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .invalid before #direct_next) : (removal) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #direct_next.classList.remove('f_has_scope') : check matches (false)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #direct_next.classList.remove('f_has_scope') : check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (insertion) check matches (true)
-FAIL [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(128, 128, 128)"
+PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (insertion) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (removal) check matches (false)
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (removal) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:is(.p + .f_has_scope ~ .g)) ] #has_scope.classList.remove('blue') : check matches (false)
@@ -260,13 +260,13 @@ PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] 
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #previous.classList.add('f_descendant') : check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #previous.classList.add('f_descendant') : check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #previous) : (insertion) check matches (false)
-FAIL [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(135, 206, 235)"
+PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #previous) : (insertion) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #previous) : (removal) check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #previous) : (removal) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #previous.classList.remove('f_descendant') : check matches (false)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #previous.classList.remove('f_descendant') : check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (insertion) check matches (true)
-FAIL [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(135, 206, 235)" but got "rgb(128, 128, 128)"
+PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (insertion) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (removal) check matches (false)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (removal) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #has_scope.classList.add('f_descendant') : check matches (true)
@@ -276,13 +276,13 @@ PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] 
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #direct_next.classList.add('f_descendant') : check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #direct_next.classList.add('f_descendant') : check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #direct_next) : (insertion) check matches (false)
-FAIL [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #direct_next) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(135, 206, 235)"
+PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #direct_next) : (insertion) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #direct_next) : (removal) check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .invalid before #direct_next) : (removal) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #direct_next.classList.remove('f_descendant') : check matches (false)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #direct_next.classList.remove('f_descendant') : check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (insertion) check matches (true)
-FAIL [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (insertion) check #descendant color assert_equals: expected "rgb(135, 206, 235)" but got "rgb(128, 128, 128)"
+PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (insertion) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (removal) check matches (false)
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (removal) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:is(.p + .f_descendant ~ .g)) #descendant ] #has_scope.classList.remove('skyblue') : check matches (false)
@@ -388,13 +388,13 @@ PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] #has_scope.
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.add('j_has_scope') : check matches (true)
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.add('j_has_scope') : check #has_scope color
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(128, 0, 128)"
+PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (removal) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.remove('j_has_scope') : check matches (false)
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.remove('j_has_scope') : check #has_scope color
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (insertion) check matches (true)
-FAIL [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 0, 128)" but got "rgb(128, 128, 128)"
+PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (insertion) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (removal) check matches (false)
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (removal) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:is(.p + .j_has_scope ~ .k .l)) ] #has_scope.classList.remove('purple') : check matches (false)
@@ -404,13 +404,13 @@ PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant 
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.add('j_descendant') : check matches (true)
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.add('j_descendant') : check #descendant color
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(238, 130, 238)"
+PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check #descendant color
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.remove('j_descendant') : check matches (false)
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.remove('j_descendant') : check #descendant color
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (insertion) check matches (true)
-FAIL [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(238, 130, 238)" but got "rgb(128, 128, 128)"
+PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (insertion) check #descendant color
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (removal) check matches (false)
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (removal) check #descendant color
 PASS [ .violet:has(~ #indirect_next:is(.p + .j_descendant ~ .k .l)) #descendant ] #has_scope.classList.remove('violet') : check matches (false)
@@ -420,13 +420,13 @@ PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indire
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.add('j_indirect_next') : check matches (true)
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.add('j_indirect_next') : check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(218, 112, 214)"
+PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.remove('j_indirect_next') : check matches (false)
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.remove('j_indirect_next') : check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (insertion) check matches (true)
-FAIL [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(218, 112, 214)" but got "rgb(128, 128, 128)"
+PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (removal) check matches (false)
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (removal) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:is(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #has_scope.classList.remove('orchid') : check matches (false)
@@ -436,13 +436,13 @@ PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #in
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('j_indirect_next_child') : check matches (true)
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('j_indirect_next_child') : check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check matches (false)
-FAIL [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(221, 160, 221)"
+PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check matches (true)
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('j_indirect_next_child') : check matches (false)
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('j_indirect_next_child') : check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (insertion) check matches (true)
-FAIL [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(221, 160, 221)" but got "rgb(128, 128, 128)"
+PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (removal) check matches (false)
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:is(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #has_scope.classList.remove('plum') : check matches (false)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/not-pseudo-containing-complex-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/not-pseudo-containing-complex-in-has-expected.txt
@@ -68,37 +68,37 @@ PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #has_scope.class
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.add('c_has_scope') : check matches (false)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.add('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #parent_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.remove('c_has_scope') : check matches (true)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #parent_previous.classList.remove('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (insertion) check matches (false)
-FAIL [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (removal) check matches (true)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #parent_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #previous.classList.add('c_has_scope') : check matches (false)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #previous.classList.add('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (insertion) check matches (true)
-FAIL [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (removal) check matches (false)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #previous.classList.remove('c_has_scope') : check matches (true)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #previous.classList.remove('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (insertion) check matches (false)
-FAIL [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (removal) check matches (true)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.add('c_has_scope') : check matches (false)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.add('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (insertion) check matches (true)
-FAIL [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(128, 128, 128)"
+PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (removal) check matches (false)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .invalid before #child_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.remove('c_has_scope') : check matches (true)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #child_previous.classList.remove('c_has_scope') : check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (insertion) check matches (false)
-FAIL [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 128, 0)"
+PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (insertion) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (removal) check matches (true)
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] insert/remove .c_has_scope before #child_previous) : (removal) check #has_scope color
 PASS [ .green:has(#descendant:not(.p + .c_has_scope ~ .d .e)) ] #has_scope.classList.remove('green') : check matches (false)
@@ -108,37 +108,37 @@ PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant 
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.add('c_descendant') : check matches (false)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.add('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(144, 238, 144)" but got "rgb(128, 128, 128)"
+PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.remove('c_descendant') : check matches (true)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #parent_previous.classList.remove('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (insertion) check matches (false)
-FAIL [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(144, 238, 144)"
+PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (removal) check matches (true)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #parent_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.add('c_descendant') : check matches (false)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.add('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (insertion) check matches (true)
-FAIL [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(144, 238, 144)" but got "rgb(128, 128, 128)"
+PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (removal) check matches (false)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.remove('c_descendant') : check matches (true)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #previous.classList.remove('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (insertion) check matches (false)
-FAIL [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(144, 238, 144)"
+PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (removal) check matches (true)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.add('c_descendant') : check matches (false)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.add('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (insertion) check matches (true)
-FAIL [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (insertion) check #descendant color assert_equals: expected "rgb(144, 238, 144)" but got "rgb(128, 128, 128)"
+PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (removal) check matches (false)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .invalid before #child_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.remove('c_descendant') : check matches (true)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #child_previous.classList.remove('c_descendant') : check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (insertion) check matches (false)
-FAIL [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(144, 238, 144)"
+PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (insertion) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (removal) check matches (true)
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] insert/remove .c_descendant before #child_previous) : (removal) check #descendant color
 PASS [ .lightgreen:has(#descendant:not(.p + .c_descendant ~ .d .e)) #descendant ] #has_scope.classList.remove('lightgreen') : check matches (false)
@@ -148,13 +148,13 @@ PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirec
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.add('c_indirect_next') : check matches (false)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.add('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(0, 100, 0)" but got "rgb(128, 128, 128)"
+PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.remove('c_indirect_next') : check matches (true)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #parent_previous.classList.remove('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (insertion) check matches (false)
-FAIL [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 100, 0)"
+PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (removal) check matches (true)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #parent_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #previous.classList.add('c_indirect_next') : check matches (false)
@@ -172,13 +172,13 @@ PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirec
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.add('c_indirect_next') : check matches (false)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.add('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (insertion) check matches (true)
-FAIL [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(0, 100, 0)" but got "rgb(128, 128, 128)"
+PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (removal) check matches (false)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .invalid before #child_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.remove('c_indirect_next') : check matches (true)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #child_previous.classList.remove('c_indirect_next') : check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (insertion) check matches (false)
-FAIL [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 100, 0)"
+PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (insertion) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (removal) check matches (true)
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] insert/remove .c_indirect_next before #child_previous) : (removal) check #indirect_next color
 PASS [ .darkgreen:has(#descendant:not(.p + .c_indirect_next ~ .d .e)) ~ #indirect_next ] #has_scope.classList.remove('darkgreen') : check matches (false)
@@ -188,13 +188,13 @@ PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ 
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('c_indirect_next_child') : check matches (false)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(154, 205, 50)" but got "rgb(128, 128, 128)"
+PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('c_indirect_next_child') : check matches (true)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (insertion) check matches (false)
-FAIL [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(154, 205, 50)"
+PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (removal) check matches (true)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #previous.classList.add('c_indirect_next_child') : check matches (false)
@@ -212,13 +212,13 @@ PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ 
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.add('c_indirect_next_child') : check matches (false)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.add('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (insertion) check matches (true)
-FAIL [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(154, 205, 50)" but got "rgb(128, 128, 128)"
+PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (removal) check matches (false)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #child_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.remove('c_indirect_next_child') : check matches (true)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #child_previous.classList.remove('c_indirect_next_child') : check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (insertion) check matches (false)
-FAIL [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(154, 205, 50)"
+PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (insertion) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (removal) check matches (true)
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] insert/remove .c_indirect_next_child before #child_previous) : (removal) check #indirect_next_child color
 PASS [ .yellowgreen:has(#descendant:not(.p + .c_indirect_next_child ~ .d .e)) ~ #indirect_next #indirect_next_child ] #has_scope.classList.remove('yellowgreen') : check matches (false)
@@ -230,7 +230,7 @@ PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #previous.class
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #previous.classList.remove('f_has_scope') : check matches (true)
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #previous.classList.remove('f_has_scope') : check #has_scope color
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (insertion) check matches (false)
-FAIL [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 0, 255)"
+PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (insertion) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (removal) check matches (true)
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #previous) : (removal) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #has_scope.classList.add('f_has_scope') : check matches (false)
@@ -242,7 +242,7 @@ PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #direct_next.cl
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #direct_next.classList.remove('f_has_scope') : check matches (true)
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #direct_next.classList.remove('f_has_scope') : check #has_scope color
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (insertion) check matches (false)
-FAIL [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(0, 0, 255)"
+PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (insertion) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (removal) check matches (true)
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] insert/remove .f_has_scope before #direct_next) : (removal) check #has_scope color
 PASS [ .blue:has(~ #indirect_next:not(.p + .f_has_scope ~ .g)) ] #has_scope.classList.remove('blue') : check matches (false)
@@ -254,7 +254,7 @@ PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ]
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] #previous.classList.remove('f_descendant') : check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] #previous.classList.remove('f_descendant') : check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (insertion) check matches (false)
-FAIL [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(135, 206, 235)"
+PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (insertion) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (removal) check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #previous) : (removal) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] #has_scope.classList.add('f_descendant') : check matches (false)
@@ -266,7 +266,7 @@ PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ]
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] #direct_next.classList.remove('f_descendant') : check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] #direct_next.classList.remove('f_descendant') : check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (insertion) check matches (false)
-FAIL [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(135, 206, 235)"
+PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (insertion) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (removal) check matches (true)
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] insert/remove .f_descendant before #direct_next) : (removal) check #descendant color
 PASS [ .skyblue:has(~ #indirect_next:not(.p + .f_descendant ~ .g)) #descendant ] #has_scope.classList.remove('skyblue') : check matches (false)
@@ -372,13 +372,13 @@ PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] #has_scope
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.add('j_has_scope') : check matches (false)
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.add('j_has_scope') : check #has_scope color
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 0, 128)" but got "rgb(128, 128, 128)"
+PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (insertion) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .invalid before #parent_previous) : (removal) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.remove('j_has_scope') : check matches (true)
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] #parent_previous.classList.remove('j_has_scope') : check #has_scope color
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (insertion) check matches (false)
-FAIL [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (insertion) check #has_scope color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(128, 0, 128)"
+PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (insertion) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (removal) check matches (true)
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] insert/remove .j_has_scope before #parent_previous) : (removal) check #has_scope color
 PASS [ .purple:has(~ #indirect_next:not(.p + .j_has_scope ~ .k .l)) ] #has_scope.classList.remove('purple') : check matches (false)
@@ -388,13 +388,13 @@ PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.add('j_descendant') : check matches (false)
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.add('j_descendant') : check #descendant color
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(238, 130, 238)" but got "rgb(128, 128, 128)"
+PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (insertion) check #descendant color
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .invalid before #parent_previous) : (removal) check #descendant color
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.remove('j_descendant') : check matches (true)
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] #parent_previous.classList.remove('j_descendant') : check #descendant color
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (insertion) check matches (false)
-FAIL [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (insertion) check #descendant color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(238, 130, 238)"
+PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (insertion) check #descendant color
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (removal) check matches (true)
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] insert/remove .j_descendant before #parent_previous) : (removal) check #descendant color
 PASS [ .violet:has(~ #indirect_next:not(.p + .j_descendant ~ .k .l)) #descendant ] #has_scope.classList.remove('violet') : check matches (false)
@@ -404,13 +404,13 @@ PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indir
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.add('j_indirect_next') : check matches (false)
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.add('j_indirect_next') : check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(218, 112, 214)" but got "rgb(128, 128, 128)"
+PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.remove('j_indirect_next') : check matches (true)
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #parent_previous.classList.remove('j_indirect_next') : check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (insertion) check matches (false)
-FAIL [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (insertion) check #indirect_next color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(218, 112, 214)"
+PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (insertion) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (removal) check matches (true)
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] insert/remove .j_indirect_next before #parent_previous) : (removal) check #indirect_next color
 PASS [ .orchid:has(~ #indirect_next:not(.p + .j_indirect_next ~ .k .l)) ~ #indirect_next ] #has_scope.classList.remove('orchid') : check matches (false)
@@ -420,13 +420,13 @@ PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #i
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('j_indirect_next_child') : check matches (false)
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.add('j_indirect_next_child') : check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check matches (true)
-FAIL [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(221, 160, 221)" but got "rgb(128, 128, 128)"
+PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check matches (false)
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .invalid before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('j_indirect_next_child') : check matches (true)
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #parent_previous.classList.remove('j_indirect_next_child') : check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (insertion) check matches (false)
-FAIL [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color assert_equals: expected "rgb(128, 128, 128)" but got "rgb(221, 160, 221)"
+PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (insertion) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (removal) check matches (true)
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] insert/remove .j_indirect_next_child before #parent_previous) : (removal) check #indirect_next_child color
 PASS [ .plum:has(~ #indirect_next:not(.p + .j_indirect_next_child ~ .k .l)) ~ #indirect_next #indirect_next_child ] #has_scope.classList.remove('plum') : check matches (false)

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -48,6 +48,7 @@ private:
     using MatchingHasSelectors = HashSet<const CSSSelector*>;
     enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
     void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
+    void invalidateForChangeOutsideHasScope();
 
     template<typename Function> void traverseRemovedElements(Function&&);
     template<typename Function> void traverseAddedElements(Function&&);

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -120,7 +120,8 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
         case MatchElement::ParentAnySibling:
         case MatchElement::AncestorAnySibling:
         case MatchElement::HasAnySibling:
-        case MatchElement::HasNonSubjectOrScopeBreaking:
+        case MatchElement::HasNonSubject:
+        case MatchElement::HasScopeBreaking:
             return true;
         case MatchElement::Subject:
         case MatchElement::Parent:

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -57,7 +57,8 @@ static bool isSiblingOrSubject(MatchElement matchElement)
     case MatchElement::HasChild:
     case MatchElement::HasDescendant:
     case MatchElement::HasSiblingDescendant:
-    case MatchElement::HasNonSubjectOrScopeBreaking:
+    case MatchElement::HasNonSubject:
+    case MatchElement::HasScopeBreaking:
         return false;
     }
     ASSERT_NOT_REACHED();
@@ -72,11 +73,41 @@ bool isHasPseudoClassMatchElement(MatchElement matchElement)
     case MatchElement::HasSibling:
     case MatchElement::HasSiblingDescendant:
     case MatchElement::HasAnySibling:
-    case MatchElement::HasNonSubjectOrScopeBreaking:
+    case MatchElement::HasNonSubject:
+    case MatchElement::HasScopeBreaking:
         return true;
     default:
         return false;
     }
+}
+
+static bool isScopeBreaking(MatchElement matchElement)
+{
+    switch (matchElement) {
+    case MatchElement::HasAnySibling:
+    case MatchElement::HasScopeBreaking:
+        return true;
+    case MatchElement::Subject:
+    case MatchElement::IndirectSibling:
+    case MatchElement::DirectSibling:
+    case MatchElement::AnySibling:
+    case MatchElement::HasSibling:
+    case MatchElement::Host:
+    case MatchElement::HostChild:
+    case MatchElement::Parent:
+    case MatchElement::Ancestor:
+    case MatchElement::ParentSibling:
+    case MatchElement::AncestorSibling:
+    case MatchElement::ParentAnySibling:
+    case MatchElement::AncestorAnySibling:
+    case MatchElement::HasChild:
+    case MatchElement::HasDescendant:
+    case MatchElement::HasSiblingDescendant:
+    case MatchElement::HasNonSubject:
+        return false;
+    }
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 RuleAndSelector::RuleAndSelector(const RuleData& ruleData)
@@ -155,13 +186,19 @@ static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElem
     if (canBreakScope == CanBreakScope::No)
         return matchElement;
 
-    // :has(:is(foo bar)) can be affected by changes outside the :has scope.
+    // `:has(:is(foo bar))` can be affected by changes outside the :has scope.
     if (relation == CSSSelector::RelationType::DescendantSpace || relation == CSSSelector::RelationType::Child)
-        return MatchElement::HasNonSubjectOrScopeBreaking;
+        return MatchElement::HasScopeBreaking;
 
-    // :has(~ :is(.x ~ .y)) must look at previous siblings of the :scope scope too.
-    if (matchElement == MatchElement::HasSibling && (relation == CSSSelector::RelationType::IndirectAdjacent || relation == CSSSelector::RelationType::DirectAdjacent))
-        return MatchElement::HasAnySibling;
+    if (relation == CSSSelector::RelationType::IndirectAdjacent || relation == CSSSelector::RelationType::DirectAdjacent) {
+        // `:has(~ :is(.x ~ .y))` must look at previous siblings of the :scope scope too.
+        if (matchElement == MatchElement::HasSibling)
+            return MatchElement::HasAnySibling;
+
+        // `:has(~ :is(.x ~ .y)) .z` must be treated as scope breaking, rather than HasAnySibling like the previous case.
+        if (matchElement == MatchElement::HasNonSubject)
+            return MatchElement::HasScopeBreaking;
+    }
 
     return matchElement;
 }
@@ -192,7 +229,8 @@ MatchElement computeHasPseudoClassMatchElement(const CSSSelector& hasSelector)
     case MatchElement::HasSibling:
     case MatchElement::HasSiblingDescendant:
     case MatchElement::HasAnySibling:
-    case MatchElement::HasNonSubjectOrScopeBreaking:
+    case MatchElement::HasNonSubject:
+    case MatchElement::HasScopeBreaking:
     case MatchElement::Host:
     case MatchElement::HostChild:
         ASSERT_NOT_REACHED();
@@ -220,7 +258,7 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
 
         if (type == CSSSelector::PseudoClassType::Has) {
             if (matchElement != MatchElement::Subject)
-                return MatchElement::HasNonSubjectOrScopeBreaking;
+                return MatchElement::HasNonSubject;
             return computeHasPseudoClassMatchElement(childSelector);
         }
 
@@ -232,9 +270,9 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
     }
 
     return matchElement;
-};
+}
 
-void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& firstSelector, MatchElement matchElement, IsNegation isNegation, CanBreakScope canBreakScope)
+DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& firstSelector, MatchElement matchElement, IsNegation isNegation, CanBreakScope canBreakScope)
 {
     const CSSSelector* selector = &firstSelector;
     do {
@@ -278,12 +316,10 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
 
             for (const CSSSelector* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
                 auto subSelectorMatchElement = computeSubSelectorMatchElement(matchElement, *selector, *subSelector);
-                if (!selectorFeatures.hasSiblingSelector && selector->isSiblingSelector())
-                    selectorFeatures.hasSiblingSelector = true;
-                recursivelyCollectFeaturesFromSelector(selectorFeatures, *subSelector, subSelectorMatchElement, subSelectorIsNegation, canBreakScope);
+                auto doesBreakScope = recursivelyCollectFeaturesFromSelector(selectorFeatures, *subSelector, subSelectorMatchElement, subSelectorIsNegation, canBreakScope);
 
                 if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassType::Has)
-                    selectorFeatures.hasPseudoClasses.append({ subSelector, subSelectorMatchElement, isNegation });
+                    selectorFeatures.hasPseudoClasses.append({ subSelector, subSelectorMatchElement, isNegation, doesBreakScope });
             }
         }
 
@@ -295,6 +331,8 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
 
         selector = selector->tagHistory();
     } while (selector);
+
+    return isScopeBreaking(matchElement) ? DoesBreakScope::Yes : DoesBreakScope::No;
 }
 
 PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::PseudoClassType pseudoClass, InvalidationKeyType keyType, const AtomString& keyString)
@@ -387,11 +425,14 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData)
     }
 
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
-        auto& [selector, matchElement, isNegation] = entry;
+        auto& [selector, matchElement, isNegation, doesBreakScope] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
         hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClassType::Has, *selector), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
         }).iterator->value->append({ ruleData, matchElement, isNegation, selector });
+
+        if (doesBreakScope == DoesBreakScope::Yes)
+            scopeBreakingHasPseudoClassRules.append({ ruleData });
 
         setUsesMatchElement(matchElement);
     }
@@ -428,6 +469,7 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     pseudoClassTypes.add(other.pseudoClassTypes.begin(), other.pseudoClassTypes.end());
 
     addMap(hasPseudoClassRules, other.hasPseudoClassRules);
+    scopeBreakingHasPseudoClassRules.appendVector(other.scopeBreakingHasPseudoClassRules);
 
     for (size_t i = 0; i < usedMatchElements.size(); ++i)
         usedMatchElements[i] = usedMatchElements[i] || other.usedMatchElements[i];
@@ -455,6 +497,7 @@ void RuleFeatureSet::clear()
     idRules.clear();
     classRules.clear();
     hasPseudoClassRules.clear();
+    scopeBreakingHasPseudoClassRules.clear();
     classesAffectingHost.clear();
     attributeRules.clear();
     attributesAffectingHost.clear();
@@ -469,6 +512,7 @@ void RuleFeatureSet::shrinkToFit()
 {
     siblingRules.shrinkToFit();
     uncommonAttributeRules.shrinkToFit();
+    scopeBreakingHasPseudoClassRules.shrinkToFit();
     for (auto& rules : idRules.values())
         rules->shrinkToFit();
     for (auto& rules : classRules.values())

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -378,7 +378,8 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         }
         break;
     }
-    case MatchElement::HasNonSubjectOrScopeBreaking: {
+    case MatchElement::HasNonSubject:
+    case MatchElement::HasScopeBreaking: {
         SelectorMatchingState selectorMatchingState;
         invalidateStyleForDescendants(*element.document().documentElement(), &selectorMatchingState);
         break;
@@ -468,6 +469,13 @@ void Invalidator::invalidateWithMatchElementRuleSets(Element& element, const Mat
         Invalidator invalidator(matchElementAndRuleSet.value);
         invalidator.invalidateStyleWithMatchElement(element, matchElementAndRuleSet.key);
     }
+}
+
+void Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(Element& element, const RuleSet* ruleSet)
+{
+    SetForScope isInvalidating(element.styleResolver().ruleSets().isInvalidatingStyleWithRuleSets(), true);
+    Invalidator invalidator({ ruleSet });
+    invalidator.invalidateStyleWithMatchElement(element, MatchElement::HasScopeBreaking);
 }
 
 void Invalidator::invalidateAllStyle(Scope& scope)

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -68,6 +68,7 @@ public:
     static void invalidateWithMatchElementRuleSets(Element&, const MatchElementRuleSets&);
     static void invalidateAllStyle(Scope&);
     static void invalidateHostAndSlottedStyleIfNeeded(ShadowRoot&);
+    static void invalidateWithScopeBreakingHasPseudoClassRuleSet(Element&, const RuleSet*);
 
 private:
     enum class CheckDescendants : bool { No, Yes };

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -251,6 +251,7 @@ void ScopeRuleSets::collectFeatures() const
 
     m_siblingRuleSet = makeRuleSet(m_features.siblingRules);
     m_uncommonAttributeRuleSet = makeRuleSet(m_features.uncommonAttributeRules);
+    m_scopeBreakingHasPseudoClassInvalidationRuleSet = makeRuleSet(m_features.scopeBreakingHasPseudoClassRules);
 
     m_idInvalidationRuleSets.clear();
     m_classInvalidationRuleSets.clear();

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -67,6 +67,7 @@ public:
     const RuleFeatureSet& features() const;
     RuleSet* sibling() const { return m_siblingRuleSet.get(); }
     RuleSet* uncommonAttribute() const { return m_uncommonAttributeRuleSet.get(); }
+    RuleSet* scopeBreakingHasPseudoClassInvalidationRuleSet() const { return m_scopeBreakingHasPseudoClassInvalidationRuleSet.get(); }
 
     const Vector<InvalidationRuleSet>* idInvalidationRuleSets(const AtomString&) const;
     const Vector<InvalidationRuleSet>* classInvalidationRuleSets(const AtomString&) const;
@@ -108,6 +109,7 @@ private:
     mutable RuleFeatureSet m_features;
     mutable RefPtr<RuleSet> m_siblingRuleSet;
     mutable RefPtr<RuleSet> m_uncommonAttributeRuleSet;
+    mutable RefPtr<RuleSet> m_scopeBreakingHasPseudoClassInvalidationRuleSet;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_idInvalidationRuleSets;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_classInvalidationRuleSets;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_attributeInvalidationRuleSets;


### PR DESCRIPTION
#### 3724105055b3d155fee1da5604623c6200cf1f28
<pre>
Invalidate scope-breaking :has(:is(...)) selectors more thoroughly
<a href="https://bugs.webkit.org/show_bug.cgi?id=253944">https://bugs.webkit.org/show_bug.cgi?id=253944</a>
rdar://106768250

Reviewed by Antti Koivisto.

It&apos;s possible to write :has() selectors with arguments that can match
elements outside of the :has scope, such as

:has(:is(.x .y))

which could match the .x against an ancestor of the :has scope, and

:has(~ :is(.x .y))

which could match the .x against an ancestor of a later sibling of the
:has scope.

We currently handle scope breaking :has() selectors by generating
RuleFeatures based on the nested selectors&apos; features and storing them
with MatchElement::HasNonSubjectOrScopeBreaking, which causes
invalidation to match the inner scope-breaking selector (the :is())
against all elements in the document.

Because we store these in InvalidationRuleSets keyed off the nested
selectors&apos; features, it means that for the above examples, we will
process these document-wide invalidations whenever a class name changes
to or from x or y. But this is not sufficient to invalidate for
selectors like

:has(:is(.x + .y .z))

where if the .x and .y elements are outside the :has scope, an element
insertion or removal between them will not find any relevant
invalidation rule sets, and

:has(~ :is(.x ~ .y))

for similar reasons.

This PR changes how we collect scope breaking :has() rules, so that in
addition to generating entries in m_hasPseudoClassInvalidationRuleSets
on Style::ScopeRuleSet, we also record them in a new
m_scopeBreakingHasPseudoClassInvalidationRuleSet, which we look up for
every element insertion or removal. For simplicity, we do this more
drastic invalidation for both of the above cases.

MatchElement::HasNonSubjectOrScopeBreaking is split into two separate
values -- HasNonSubject and HasScopeBreaking -- where only the latter
causes an entry to be added to
m_scopeBreakingHasPseudoClassInvalidationRuleSet.

This change does not regress the performance of invalidation of :has()
selectors that do not contain logical combination pseudo-classes like
:is() and :not(), or which have do have one but do not have any selector
combinators inside them.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/is-pseudo-containing-complex-in-has-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/not-pseudo-containing-complex-in-has-expected.txt:
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
(WebCore::Style::ChildChangeInvalidation::invalidateForChangeOutsideHasScope):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):
(WebCore::Style::needsDescendantTraversal):
* Source/WebCore/style/ChildChangeInvalidation.h:
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::isSiblingOrSubject):
(WebCore::Style::isHasPseudoClassMatchElement):
(WebCore::Style::isScopeBreaking):
(WebCore::Style::computeNextHasPseudoClassMatchElement):
(WebCore::Style::computeHasPseudoClassMatchElement):
(WebCore::Style::computeSubSelectorMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::clear):
(WebCore::Style::RuleFeatureSet::shrinkToFit):
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeatureSet::usesMatchElement const):
(WebCore::Style::RuleFeatureSet::usesHasPseudoClass const):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):
(WebCore::Style::Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet):
* Source/WebCore/style/StyleInvalidator.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::collectFeatures const):
* Source/WebCore/style/StyleScopeRuleSets.h:
(WebCore::Style::ScopeRuleSets::scopeBreakingHasPseudoClassInvalidationRuleSet const):

Canonical link: <a href="https://commits.webkit.org/268038@main">https://commits.webkit.org/268038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c68cad6d53ee7a0e574725917c4963ad52e4ee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20212 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21092 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23238 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14846 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20943 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2274 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->