### PR TITLE
[ANGLE] Don't lose Metal-backed contexts for non-fatal errors

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -298,7 +298,7 @@ index 2b0ef5ddfe906ba09ad818dadeb41dd444c55f07..5a6d64e0d58fa4e976e16d1fd03b98be
      uint64_t getSerial() const { return mSerial; }
  
 diff --git a/src/libANGLE/renderer/metal/mtl_command_buffer.mm b/src/libANGLE/renderer/metal/mtl_command_buffer.mm
-index 145400aec715ddfadcf33dc941201e1064d33ca0..84b6b2b462ca23fb40722093ec488d7c77787f9c 100644
+index 145400aec715ddfadcf33dc941201e1064d33ca0..8fa9415a6194f3152a681162473dc3e5faae4a4d 100644
 --- a/src/libANGLE/renderer/metal/mtl_command_buffer.mm
 +++ b/src/libANGLE/renderer/metal/mtl_command_buffer.mm
 @@ -373,12 +373,20 @@ inline void SetVisibilityResultModeCmd(id<MTLRenderCommandEncoder> encoder,
@@ -330,14 +330,22 @@ index 145400aec715ddfadcf33dc941201e1064d33ca0..84b6b2b462ca23fb40722093ec488d7c
      [resource ANGLE_MTL_RELEASE];
  }
  
-@@ -606,6 +615,12 @@ void CommandQueue::onCommandBufferCompleted(id<MTLCommandBuffer> buf,
+@@ -606,6 +615,20 @@ void CommandQueue::onCommandBufferCompleted(id<MTLCommandBuffer> buf,
  
      ANGLE_MTL_LOG("Completed MTLCommandBuffer %llu:%p", serial, buf);
  
-+    if ([buf status] != MTLCommandBufferStatusCompleted)
++    MTLCommandBufferStatus status = buf.status;
++    if (status != MTLCommandBufferStatusCompleted)
 +    {
-+        mIsDeviceLost = true;
-+        return;
++        NSError *error = buf.error;
++        // MTLCommandBufferErrorNotPermitted is non-fatal, all other errors
++        // result in device lost.
++        mIsDeviceLost  = !error || error.domain != MTLCommandBufferErrorDomain ||
++                        error.code != MTLCommandBufferErrorNotPermitted;
++        if (mIsDeviceLost)
++        {
++            return;
++        }
 +    }
 +
      if (timeElapsedEntry != 0)


### PR DESCRIPTION
#### e1280c457e8cab275fc3483e816c59d95fd1a2c7
<pre>
[ANGLE] Don&apos;t lose Metal-backed contexts for non-fatal errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=261313">https://bugs.webkit.org/show_bug.cgi?id=261313</a>
rdar://115152037

Reviewed by Kimmo Kinnunen.

Since Bug 257584, Any errors from Metal command buffer submission are treated as
causing a lost device.

MTLCommandBufferErrorNotPermitted is a non-fatal error that is reported when a
page with active WebGL moves to the background on iPhoneOS/iPadOS. This error is
ignored to avoid needlessly losing all WebGL contexts since they can&apos;t be
recovered once lost and need to be recreated.

* Source/ThirdParty/ANGLE/changes.diff:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm:
(rx::mtl::CommandQueue::onCommandBufferCompleted):

Canonical link: <a href="https://commits.webkit.org/267784@main">https://commits.webkit.org/267784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c9075729bdf7f6cfd334ceedbd75e9d5f78157c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16536 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18155 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15354 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20352 "Failed to checkout and rebase branch from PR 17573") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22680 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20539 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15958 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->