### PR TITLE
Don't allow form-feed (U+000C) as a WebVTT signature separator

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/signature-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/signature-invalid-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL signature, empty assert_unreached: track should fail to load Reached unreachable code
-FAIL signature, formfeed assert_unreached: track should fail to load Reached unreachable code
+PASS signature, formfeed
 PASS signature, invalid whitespace
 PASS signature, invalid
 PASS signature, lowercase

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -250,7 +250,7 @@ bool WebVTTParser::hasRequiredFileIdentifier(const String& line)
     // and any number of characters that are not line terminators ...
     if (!line.startsWith(fileIdentifier))
         return false;
-    if (line.length() > fileIdentifierLength && !isASCIIWhitespace(line[fileIdentifierLength]))
+    if (line.length() > fileIdentifierLength && !isTabOrSpace(line[fileIdentifierLength]))
         return false;
     return true;
 }


### PR DESCRIPTION
#### f98a7bee4cc3cd9f75b1e4e2f99d7414117c23d3
<pre>
Don&apos;t allow form-feed (U+000C) as a WebVTT signature separator
<a href="https://bugs.webkit.org/show_bug.cgi?id=260390">https://bugs.webkit.org/show_bug.cgi?id=260390</a>
rdar://114118340

Reviewed by Eric Carlson.

As U+000A and U+000D are already taken care of by BufferedLineReader
we can switch this isASCIIWhitespace to isTabOrSpace and thereby avoid
ignoring an incorrect U+000C.

(Note that other identifiers in WebVTT, such as &quot;STYLE&quot;, do allow a
trailing U+000C, so we are not changing those, even though they are also
redundantly checking for U+000A and U+000D.)

* LayoutTests/imported/w3c/web-platform-tests/webvtt/parsing/file-parsing/signature-invalid-expected.txt:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::hasRequiredFileIdentifier):

Canonical link: <a href="https://commits.webkit.org/269619@main">https://commits.webkit.org/269619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/apple/WebKit/commit/82c54e41f8fe6dda74fdd7e1ef27198bd36ef89d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22112 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23174 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/513 "Found 39 new test failures: accessibility/ios-simulator/inline-prediction-attributed-string.html, editing/caret/ios/absolute-caret-position-after-scroll.html, editing/caret/ios/caret-color-after-refocusing-input.html, editing/caret/ios/caret-color-auto.html, editing/caret/ios/caret-color-currentcolor.html, editing/caret/ios/caret-color-in-nested-editable-containers.html, editing/caret/ios/caret-in-overflow-area.html, editing/selection/character-granularity-rect.html, editing/selection/ios/absolute-selection-after-scroll.html, editing/selection/ios/become-first-responder-after-relinquishing-focus.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25701 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26969 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24831 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/878 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2932 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->