### PR TITLE
Prevent :has(:scope ...) from breaking the :has scope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/has-argument-with-explicit-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/has-argument-with-explicit-scope-expected.txt
@@ -1,6 +1,6 @@
 
 PASS :has(:scope) matches expected elements on scope1
-FAIL :has(:scope .c) matches expected elements on scope1 assert_equals: expected "" but got "d02"
+PASS :has(:scope .c) matches expected elements on scope1
 PASS :has(.a :scope) matches expected elements on scope1
 FAIL .a:has(:scope) .c matches expected elements on scope1 assert_equals: expected "d02,d03" but got ""
 FAIL .a:has(:scope) .c and :is(.a :scope .c) returns same elements on scope1 assert_equals: expected "d02,d03" but got ""

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -157,7 +157,7 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector)
         case CSSSelector::PseudoClassType::NthLastChild:
         case CSSSelector::PseudoClassType::Host:
             return SelectorSpecificityIncrement::ClassB + maxSpecificity(simpleSelector.selectorList());
-        case CSSSelector::PseudoClassType::RelativeScope:
+        case CSSSelector::PseudoClassType::HasScope:
             return 0;
         default:
             return SelectorSpecificityIncrement::ClassB;
@@ -680,7 +680,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             case CSSSelector::PseudoClassType::Scope:
                 builder.append(":scope");
                 break;
-            case CSSSelector::PseudoClassType::RelativeScope:
+            case CSSSelector::PseudoClassType::HasScope:
                 // Remove the space from the start to generate a relative selector string like in ":has(> foo)".
                 return makeString(separator.substring(1), rightSide);
             case CSSSelector::PseudoClassType::SingleButton:

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -149,7 +149,7 @@ struct PossiblyQuotedIdentifier {
             Not,
             Root,
             Scope,
-            RelativeScope, // Like :scope but for internal use with relative selectors like :has(> foo).
+            HasScope, // for internal use, matches the :has() scope
             WindowInactive,
             CornerPresent,
             Decrement,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1083,14 +1083,15 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             return matchesVolumeLockedPseudoClass(element);
 #endif
 
-        case CSSSelector::PseudoClassType::Scope:
-        case CSSSelector::PseudoClassType::RelativeScope: {
+        case CSSSelector::PseudoClassType::Scope: {
             const Node* contextualReferenceNode = !checkingContext.scope ? element.document().documentElement() : checkingContext.scope;
+            return &element == contextualReferenceNode;
+        }
+        case CSSSelector::PseudoClassType::HasScope: {
+            bool matches = &element == checkingContext.hasScope || checkingContext.matchesAllHasScopes;
 
-            bool matches = &element == contextualReferenceNode || checkingContext.matchesAllScopes;
-
-            if (!matches && checkingContext.scope) {
-                if (element.isDescendantOf(*checkingContext.scope))
+            if (!matches && checkingContext.hasScope) {
+                if (element.isDescendantOf(*checkingContext.hasScope))
                     checkingContext.matchedInsideScope = true;
             }
 
@@ -1318,7 +1319,7 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     }
 
     CheckingContext hasCheckingContext(SelectorChecker::Mode::ResolvingStyle);
-    hasCheckingContext.scope = &element;
+    hasCheckingContext.hasScope = &element;
 
     bool matchedInsideScope = false;
 

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -95,7 +95,8 @@ public:
         std::optional<StyleScrollbarState> scrollbarState;
         AtomString nameForHightlightPseudoElement;
         const ContainerNode* scope { nullptr };
-        bool matchesAllScopes { false };
+        const Element* hasScope { nullptr };
+        bool matchesAllHasScopes { false };
         Style::ScopeOrdinal styleScopeOrdinal { Style::ScopeOrdinal::Element };
         Style::SelectorMatchingState* selectorMatchingState { nullptr };
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -389,28 +389,16 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelect
     if (!selector)
         return nullptr;
 
-    auto hasScopePseudoClass = [](auto& selector) {
-        return selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClassType() == CSSSelector::PseudoClassType::Scope;
-    };
-
-    bool hasExplicitScope = hasScopePseudoClass(*selector);
-
     auto* end = selector.get();
-    while (end->tagHistory()) {
+    while (end->tagHistory())
         end = end->tagHistory();
-        if (hasScopePseudoClass(*end))
-            hasExplicitScope = true;
-    }
 
-    // If the selector doesn't have an explicit :scope on the left, add an implicit one.
-    if (!hasExplicitScope || scopeCombinator != CSSSelector::RelationType::DescendantSpace) {
-        auto scopeSelector = makeUnique<CSSParserSelector>();
-        scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
-        scopeSelector->setPseudoClassType(CSSSelector::PseudoClassType::RelativeScope);
+    auto scopeSelector = makeUnique<CSSParserSelector>();
+    scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
+    scopeSelector->setPseudoClassType(CSSSelector::PseudoClassType::HasScope);
 
-        end->setRelation(scopeCombinator);
-        end->setTagHistory(WTFMove(scopeSelector));
-    }
+    end->setRelation(scopeCombinator);
+    end->setTagHistory(WTFMove(scopeSelector));
 
     return selector;
 }

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1230,7 +1230,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClassType::NthLastOfType:
     case CSSSelector::PseudoClassType::Drag:
     case CSSSelector::PseudoClassType::Has:
-    case CSSSelector::PseudoClassType::RelativeScope:
+    case CSSSelector::PseudoClassType::HasScope:
         return FunctionType::CannotCompile;
 
     // Optimized pseudo selectors.

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -66,7 +66,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
     auto hasMatchingInvalidationSelector = [&](auto& invalidationRuleSet) {
         SelectorChecker selectorChecker(changedElement.document());
         SelectorChecker::CheckingContext checkingContext(SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements);
-        checkingContext.matchesAllScopes = true;
+        checkingContext.matchesAllHasScopes = true;
 
         for (auto* selector : invalidationRuleSet.invalidationSelectors) {
             if (isFirst) {


### PR DESCRIPTION
#### ae0d407eae254cf17867edb5b9d66e77b03a521b
<pre>
Prevent :has(:scope ...) from breaking the :has scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=261320">https://bugs.webkit.org/show_bug.cgi?id=261320</a>
rdar://problem/115158183

Reviewed by Antti Koivisto.

This content:

&lt;div id=x&gt;&lt;span&gt;&lt;/span&gt;&lt;/div&gt;
&lt;script&gt;
alert(x.matches(&quot;:has(:scope span)&quot;));
&lt;/script&gt;

currently alerts &quot;true&quot;, but it should show &quot;false&quot;.

We treat :scope as something that can match the :has() scope, but that
is not supported by the spec. Instead it should only match against the
scope induced by the matches() call.

We also need to unconditionally insert the implicit pseudo-class at the
start of the :has() selector argument that matches the :has scope.
Currently we skip this if :scope is present in the select argument
(irrelevant) or if the :has relation is DescendantSpace. But we still
need to check for the :has scope element in these cases.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/has-argument-with-explicit-scope-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::matchHasPseudoClass const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):

Canonical link: <a href="https://commits.webkit.org/267809@main">https://commits.webkit.org/267809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e4d653492063cacefc1cb3a8f9517f3dcc465c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18611 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20382 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22698 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20557 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14262 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20323 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2179 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->