### PR TITLE
REGRESSION(267658@main): Crash in CSSValue::cssText() when showing web inspector

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle-font-variant-shorthand-crash-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle-font-variant-shorthand-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/getComputedStyle-font-variant-shorthand-crash.html
+++ b/LayoutTests/fast/css/getComputedStyle-font-variant-shorthand-crash.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ CSSFontVariantEmojiEnabled=false ] -->
+<script>
+    function test() {
+        if (window.testRunner)
+            testRunner.dumpAsText();
+        document.body.dataset.fontVariant = getComputedStyle(document.body)["font-variant"];
+    };
+</script>
+<body onload="test()">
+    PASS if no crash.
+</body>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2203,7 +2203,8 @@ Ref<CSSValue> ComputedStyleExtractor::fontVariantShorthandValue() const
     CSSValueListBuilder list;
     for (auto longhand : fontVariantShorthand()) {
         auto value = propertyValue(longhand, UpdateLayout::No);
-        if (isValueID(value, CSSValueNormal))
+        // We may not have a value if the longhand is disabled.
+        if (!value || isValueID(value, CSSValueNormal))
             continue;
         list.append(value.releaseNonNull());
     }


### PR DESCRIPTION
#### 0ca3d955d80a15db42ca63e9240a4cbf2cef64c7
<pre>
REGRESSION(267658@main): Crash in CSSValue::cssText() when showing web inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=261322">https://bugs.webkit.org/show_bug.cgi?id=261322</a>
rdar://115124068

Reviewed by Antti Koivisto.

Avoid a nullptr deref by skipping properties that are disabled (including font-variant-emoji).

* LayoutTests/fast/css/getComputedStyle-font-variant-shorthand-crash-expected.txt: Added.
* LayoutTests/fast/css/getComputedStyle-font-variant-shorthand-crash.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::fontVariantShorthandValue const):

Canonical link: <a href="https://commits.webkit.org/267787@main">https://commits.webkit.org/267787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54dc99881b946ef79e992b6c194714e0da461db1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18163 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20365 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22684 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20544 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16848 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14266 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15949 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4217 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20327 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2170 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->