### PR TITLE
[GStreamer] WebCodecs rebaseline after 267403@main

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -12,7 +12,8 @@ PASS Test that VideoEncoder.configure() rejects invalid config: Height is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
@@ -20,13 +21,16 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd size
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
 FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
           codec.configure(entry.config);
-        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -12,7 +12,8 @@ PASS Test that VideoEncoder.configure() rejects invalid config: Height is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayWidth is 0
 PASS Test that VideoEncoder.configure() rejects invalid config: displayHeight is 0
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Invalid scalability mode
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec promise_test: Unhandled rejection with value: object "TypeError: Config is not valid"
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Codec with bad casing
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Width is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height is too large
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
@@ -20,13 +21,16 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd size
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
 FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
           codec.configure(entry.config);
-        }" threw object "TypeError: Config is invalid" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+        }" did not throw
+FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
 FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
           codec.configure(entry.config);
         }" did not throw


### PR DESCRIPTION
#### e8891e7f3da958f3f23ea6aaef728c42ae69060c
<pre>
[GStreamer] WebCodecs rebaseline after 267403@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=261324">https://bugs.webkit.org/show_bug.cgi?id=261324</a>

Unreviewed, update GLib baselines.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/267778@main">https://commits.webkit.org/267778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/609e52a6215c18798f22465095cf5f802ec46905

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17689 "Failed to checkout and rebase branch from PR 17581") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18552 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/19513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16545 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18167 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/19513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/17902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/18196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/16114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/20370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/16440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20331 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2168 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->