### PR TITLE
Implement a Ed25519 key pair check during the JWK import

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt
@@ -195,6 +195,6 @@ PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt
@@ -195,6 +195,6 @@ PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, true, [verify, verify])
 PASS Missing JWK 'crv' parameter: importKey(jwk (public) , {name: Ed25519}, false, [verify, verify])
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
-FAIL Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign]) assert_equals: Operation succeeded, but should not have. expected (undefined) undefined but got (object) object "[object CryptoKey]"
+PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign])
+PASS Invalid key pair: importKey(jwk(private), {name: Ed25519}, true, [sign, sign])
 

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC7748.cpp
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC7748.cpp
@@ -103,5 +103,4 @@ std::optional<Vector<uint8_t>> X25519(const Vector<uint8_t>& kArg, const Vector<
     return xImpl<X25519Impl>(kArg, uArg);
 }
 
-
 } // namespace WebCore

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC8032.cpp
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC8032.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GCryptRFC8032.h"
+
+namespace WebCore {
+
+bool validateEd25519KeyPair(const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
+{
+    if (privateKey.size() != 32 || publicKey.size() != 32)
+        return false;
+
+    gcry_error_t error = GPG_ERR_NO_ERROR;
+
+    std::array<uint8_t, 32> hddata;
+    {
+        std::array<uint8_t, 32> ddata;
+        memcpy(ddata.data(), privateKey.data(), 32);
+
+        std::array<uint8_t, 64> digest;
+        gcry_md_hash_buffer(GCRY_MD_SHA512, digest.data(), ddata.data(), ddata.size());
+
+        memcpy(hddata.data(), digest.data(), 32);
+        std::reverse(hddata.begin(), hddata.end());
+    }
+
+    PAL::GCrypt::Handle<gcry_mpi_t> hdmpi;
+    {
+        error = gcry_mpi_scan(&hdmpi, GCRYMPI_FMT_USG, hddata.data(), hddata.size(), nullptr);
+        if (error != GPG_ERR_NO_ERROR)
+            return false;
+
+        gcry_mpi_clear_bit(hdmpi, 0);
+        gcry_mpi_clear_bit(hdmpi, 1);
+        gcry_mpi_clear_bit(hdmpi, 2);
+        gcry_mpi_set_bit(hdmpi, 254);
+        gcry_mpi_clear_bit(hdmpi, 255);
+    }
+
+    PAL::GCrypt::Handle<gcry_ctx_t> context;
+    error = gcry_mpi_ec_new(&context, nullptr, "Ed25519");
+    if (error != GPG_ERR_NO_ERROR)
+        return false;
+
+    std::array<uint8_t, 32> qdata;
+    {
+        PAL::GCrypt::Handle<gcry_mpi_point_t> G(gcry_mpi_ec_get_point("g", context, 1));
+        PAL::GCrypt::Handle<gcry_mpi_point_t> Q(gcry_mpi_point_new(0));
+
+        gcry_mpi_ec_mul(Q, hdmpi, G, context);
+        PAL::GCrypt::Handle<gcry_mpi_t> xmpi(gcry_mpi_new(0));
+        PAL::GCrypt::Handle<gcry_mpi_t> ympi(gcry_mpi_new(0));
+        int ret = gcry_mpi_ec_get_affine(xmpi, ympi, Q, context);
+
+        Vector<uint8_t> result;
+        if (!ret) {
+            if (gcry_mpi_test_bit(xmpi, 0))
+                gcry_mpi_set_bit(ympi, 255);
+            else
+                gcry_mpi_clear_bit(ympi, 255);
+
+            size_t ylength = 0;
+            error = gcry_mpi_print(GCRYMPI_FMT_USG, nullptr, 0, &ylength, ympi);
+            if (error != GPG_ERR_NO_ERROR)
+                return false;
+
+            result = Vector<uint8_t>(ylength, uint8_t(0));
+            error = gcry_mpi_print(GCRYMPI_FMT_USG, result.data(), result.size(), nullptr, ympi);
+            if (error != GPG_ERR_NO_ERROR)
+                return false;
+        } else
+            result = Vector<uint8_t>(32, uint8_t(0));
+
+        std::reverse(result.begin(), result.end());
+        if (result.size() > 32)
+            result.resize(32);
+        while (result.size() < 32)
+            result.append(0x00);
+        ASSERT(result.size() == 32);
+
+        memcpy(qdata.data(), result.data(), 32);
+    }
+
+    return !memcmp(qdata.begin(), publicKey.data(), 32);
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC8032.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC8032.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+static bool validateEd25519KeyPair(const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/SourcesGCrypt.txt
+++ b/Source/WebCore/platform/SourcesGCrypt.txt
@@ -42,5 +42,6 @@ crypto/gcrypt/CryptoKeyECGCrypt.cpp
 crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
 crypto/gcrypt/CryptoKeyRSAGCrypt.cpp
 crypto/gcrypt/GCryptRFC7748.cpp
+crypto/gcrypt/GCryptRFC8032.cpp
 crypto/gcrypt/GCryptUtilities.cpp
 crypto/gcrypt/SerializedCryptoKeyWrapGCrypt.cpp


### PR DESCRIPTION
#### 6940fc8a24d037525d6a83c817016ad79489e2a2
<pre>
Implement a Ed25519 key pair check during the JWK import
<a href="https://bugs.webkit.org/show_bug.cgi?id=261323">https://bugs.webkit.org/show_bug.cgi?id=261323</a>

Reviewed by Žan Doberšek.

This change implemenets the logic to ensure they private and public
keys imported using JWK format are actually compatible, according to
the RFC8032 specification.

There are similar checks for the X25519, already implemented in both
the Mac and Gtk+ ports. The implementation of this check is also present
in the Mac port.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker-expected.txt:
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
* Source/WebCore/crypto/gcrypt/GCryptRFC7748.cpp:
* Source/WebCore/crypto/gcrypt/GCryptRFC8032.cpp: Added.
(WebCore::validateEd25519KeyPair):
* Source/WebCore/crypto/gcrypt/GCryptRFC8032.h: Added.
* Source/WebCore/platform/SourcesGCrypt.txt:

Canonical link: <a href="https://commits.webkit.org/267957@main">https://commits.webkit.org/267957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73b45711ff118453cd8c1492b4853a3ad798b739

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20874 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23074 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20957 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14655 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16392 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4328 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->