### PR TITLE
Make `VTTRegion.lines` unsigned long type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL VTTRegion.lines script-created region The index is not in the allowed range.
+PASS VTTRegion.lines script-created region
 

--- a/LayoutTests/media/track/regions-webvtt/vtt-region-constructor-expected.txt
+++ b/LayoutTests/media/track/regions-webvtt/vtt-region-constructor-expected.txt
@@ -102,8 +102,7 @@ RUN(region.width = invalidPercentageValues[index])
 TypeError: The provided value is non-finite
 EXPECTED (region.width == '100') OK
 RUN(region.lines = -1)
-IndexSizeError: The index is not in the allowed range.
-EXPECTED (region.lines == '3') OK
+EXPECTED (region.lines == '4294967295') OK
 
 ** Test that proper mutation keeps assigned value. **
 RUN(region.lines = 130)

--- a/LayoutTests/media/track/regions-webvtt/vtt-region-constructor.html
+++ b/LayoutTests/media/track/regions-webvtt/vtt-region-constructor.html
@@ -50,7 +50,7 @@
                 }
 
                 run("region.lines = -1");
-                testExpected("region.lines", 3);
+                testExpected("region.lines", 4294967295);
 
                 consoleWrite("<br>** Test that proper mutation keeps assigned value. **");
                 run("region.lines = 130");

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -84,12 +84,9 @@ ExceptionOr<void> VTTRegion::setWidth(double value)
     return { };
 }
 
-ExceptionOr<void> VTTRegion::setLines(int value)
+void VTTRegion::setLines(unsigned value)
 {
-    if (value < 0)
-        return Exception { IndexSizeError };
     m_lines = value;
-    return { };
 }
 
 ExceptionOr<void> VTTRegion::setRegionAnchorX(double value)
@@ -224,11 +221,11 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
         break;
     }
     case Lines: {
-        int number;
+        unsigned number;
         if (input.scanDigits(number) && parsedEntireRun(input, valueRun))
             m_lines = number;
         else
-            LOG(Media, "VTTRegion::parseSettingValue, invalid Height");
+            LOG(Media, "VTTRegion::parseSettingValue, invalid Lines");
         break;
     }
     case RegionAnchor: {

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -62,8 +62,8 @@ public:
     double width() const { return m_width; }
     ExceptionOr<void> setWidth(double);
 
-    int lines() const { return m_lines; }
-    ExceptionOr<void> setLines(int);
+    unsigned lines() const { return m_lines; }
+    void setLines(unsigned);
 
     double regionAnchorX() const { return m_regionAnchor.x(); }
     ExceptionOr<void> setRegionAnchorX(double);

--- a/Source/WebCore/html/track/VTTRegion.idl
+++ b/Source/WebCore/html/track/VTTRegion.idl
@@ -37,7 +37,7 @@
 
     attribute DOMString id;
     attribute double width;
-    attribute long lines;
+    attribute unsigned long lines;
     attribute double regionAnchorX;
     attribute double regionAnchorY;
     attribute double viewportAnchorX;

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -117,7 +117,7 @@ String VTTScanner::restOfInputAsString()
     return extractString(rest);
 }
 
-unsigned VTTScanner::scanDigits(int& number)
+unsigned VTTScanner::scanDigits(unsigned& number)
 {
     Run runOfDigits = collectWhile<isASCIIDigit>();
     if (runOfDigits.isEmpty()) {
@@ -132,8 +132,8 @@ unsigned VTTScanner::scanDigits(int& number)
     else
         string = { m_data.characters16, numDigits };
 
-    // Since these are ASCII digits, the only failure mode is overflow, so use the maximum int value.
-    number = parseInteger<int>(string).value_or(std::numeric_limits<int>::max());
+    // Since these are ASCII digits, the only failure mode is overflow, so use the maximum unsigned value.
+    number = parseInteger<unsigned>(string).value_or(std::numeric_limits<unsigned>::max());
 
     // Consume the digits.
     seekTo(runOfDigits.end());

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -121,9 +121,9 @@ public:
 
     // Scan a set of ASCII digits from the input. Return the number of digits
     // scanned, and set |number| to the computed value. If the digits make up a
-    // number that does not fit the 'int' type, |number| is set to INT_MAX.
+    // number that does not fit the 'unsigned' type, |number| is set to UINT_MAX.
     // Note: Does not handle sign.
-    unsigned scanDigits(int& number);
+    unsigned scanDigits(unsigned& number);
 
     // Scan a floating point value on one of the forms: \d+\.? \d+\.\d+ \.\d+
     bool scanFloat(float& number, bool* isNegative = nullptr);

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -584,7 +584,7 @@ bool WebVTTParser::collectTimeStamp(VTTScanner& input, MediaTime& timeStamp)
 
     // Steps 5 - 7 - Collect a sequence of characters that are 0-9.
     // If not 2 characters or value is greater than 59, interpret as hours.
-    int value1;
+    unsigned value1;
     unsigned value1Digits = input.scanDigits(value1);
     if (!value1Digits)
         return false;
@@ -592,12 +592,12 @@ bool WebVTTParser::collectTimeStamp(VTTScanner& input, MediaTime& timeStamp)
         mode = hours;
 
     // Steps 8 - 11 - Collect the next sequence of 0-9 after ':' (must be 2 chars).
-    int value2;
+    unsigned value2;
     if (!input.scan(':') || input.scanDigits(value2) != 2)
         return false;
 
     // Step 12 - Detect whether this timestamp includes hours.
-    int value3;
+    unsigned value3;
     if (mode == hours || input.match(':')) {
         if (!input.scan(':') || input.scanDigits(value3) != 2)
             return false;
@@ -608,7 +608,7 @@ bool WebVTTParser::collectTimeStamp(VTTScanner& input, MediaTime& timeStamp)
     }
 
     // Steps 13 - 17 - Collect next sequence of 0-9 after '.' (must be 3 chars).
-    int value4;
+    unsigned value4;
     if (!input.scan('.') || input.scanDigits(value4) != 3)
         return false;
     if (value2 > 59 || value3 > 59)


### PR DESCRIPTION
#### dc25ee48a22ae9eea1ae639438c2ed20122f23af
<pre>
Make `VTTRegion.lines` unsigned long type
<a href="https://bugs.webkit.org/show_bug.cgi?id=261326">https://bugs.webkit.org/show_bug.cgi?id=261326</a>

Reviewed by Eric Carlson.

The type of VTTRegion.lines is changed to unsigned long in <a href="https://github.com/w3c/webvtt/issues/414">https://github.com/w3c/webvtt/issues/414</a>,
and VTTRegion.lines no longer throws IndexSizeError
when negative value was set due to the change.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTRegion/lines-expected.txt:
* LayoutTests/media/track/regions-webvtt/vtt-region-constructor-expected.txt:
* LayoutTests/media/track/regions-webvtt/vtt-region-constructor.html:
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setLines):
(WebCore::VTTRegion::parseSettingValue):
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/html/track/VTTRegion.idl:
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::scanDigits):
* Source/WebCore/html/track/VTTScanner.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::collectTimeStamp):

Canonical link: <a href="https://commits.webkit.org/267827@main">https://commits.webkit.org/267827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ebc9d4c63aee5131bfcf5186b4d7db36f1ad10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16561 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18184 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18625 "An unexpected error occured. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20391 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22702 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15970 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4245 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->