### PR TITLE
REGRESSION (265576@main): Wrong paint order of positioned and in-flow content inside overflow:scroll

### DIFF
--- a/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 7
+      (children 8
         (GraphicsLayer
           (position 23.00 105.00)
           (bounds 402.00 352.00)
@@ -21,7 +21,6 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 385.00 832.00)
-                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (position 20.00 110.00)
@@ -58,6 +57,22 @@
                       )
                     )
                   )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 24.00 106.00)
+          (bounds 385.00 350.00)
+          (clips 1)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 80.00)
+                  (contentsOpaque 1)
                 )
               )
             )

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap-expected.txt
@@ -1,0 +1,62 @@
+header
+content
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 793.00 598.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 793.00 598.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (bounds 785.00 585.00)
+          (children 1
+            (GraphicsLayer
+              (bounds 785.00 585.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 785.00 585.00)
+                  (children 2
+                    (GraphicsLayer
+                      (bounds 770.00 585.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 770.00 2000.00)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                    (GraphicsLayer
+                      (bounds 785.00 585.00)
+                      (children 1
+                        (GraphicsLayer
+                          (position 770.00 0.00)
+                          (bounds 15.00 585.00)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (bounds 785.00 585.00)
+          (children 1
+            (GraphicsLayer
+              (bounds 785.00 50.00)
+              (contentsOpaque 1)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<head>
+    <meta name="viewport" content="initial-scale=1.0">
+        <style>
+            .page {
+                position: absolute;
+                height: 100%;
+                width: 100%;
+                overflow: auto;
+            }
+            
+            .container {
+                height: 100%;
+                width: 100%;
+                overflow: auto;
+            }
+            
+            .header {
+                position: absolute;
+                top: 0;
+                background: lightblue;
+                height: 50px;
+                width: 100%;
+            }
+            
+            .content {
+                height: 2000px;
+                background: lightcoral;
+                box-sizing: border-box;
+            }
+        </style>
+        <script>
+            if (window.testRunner)
+                testRunner.dumpAsText();
+
+            window.addEventListener('load', () => {
+                if (window.testRunner)
+                    document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+            }, false);
+        </script>
+</head>
+<body>
+  <div class="page">
+    <div class="container">
+      <div class="header">header</div>
+      <div class="content">content</div>
+    </div>
+  </div>
+<pre id="layers">Layer tree goes here</pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 6
+      (children 7
         (GraphicsLayer
           (position 23.00 105.00)
           (bounds 402.00 352.00)
@@ -21,7 +21,6 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 400.00 832.00)
-                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (position 20.00 110.00)
@@ -46,6 +45,22 @@
                       )
                     )
                   )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 24.00 106.00)
+          (bounds 400.00 350.00)
+          (clips 1)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 80.00)
+                  (contentsOpaque 1)
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap-expected.txt
@@ -1,0 +1,52 @@
+header
+content
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 808.00 613.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 808.00 613.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 600.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 800.00 600.00)
+                      (children 1
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 800.00 2000.00)
+                          (drawsContent 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (bounds 800.00 600.00)
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 50.00)
+              (contentsOpaque 1)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
#### fff1fa9717176e16d188ae593a0e01e83ec5900c
<pre>
REGRESSION (265576@main): Wrong paint order of positioned and in-flow content inside overflow:scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=261302">https://bugs.webkit.org/show_bug.cgi?id=261302</a>
rdar://115144982

Reviewed by NOBODY (OOPS!).

We end up having multiple backing store providers that overlap each other.

* LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap-expected.txt: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap.html: Added.
* LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/backing-sharing-multiple-overlap-expected.txt: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::canUseMultipleProviders const):

Move the overlap test to canUseMultipleProviders so it is done after descendant traversal for each new provider candidate.

(WebCore::RenderLayerCompositor::BackingSharingState::updateBeforeDescendantTraversal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fff1fa9717176e16d188ae593a0e01e83ec5900c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20397 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22705 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14288 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/15976 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4375 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20352 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->