### PR TITLE
[build.webkit.org] Remove unused imports in steps.py

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2017-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from buildbot.plugins import steps, util
-from buildbot.process import buildstep, factory, logobserver, properties
+from buildbot.process import buildstep, logobserver, properties
 from buildbot.process.results import Results, SUCCESS, FAILURE, WARNINGS, SKIPPED, EXCEPTION, RETRY
 from buildbot.steps import master, shell, transfer, trigger
 from buildbot.steps.source import git
@@ -32,8 +32,6 @@ import os
 import re
 import socket
 import sys
-import urllib
-from pathlib import Path
 
 if sys.version_info < (3, 5):
     print('ERROR: Please use Python 3. This code is not compatible with Python 2.')


### PR DESCRIPTION
#### b25c98be626a3295a5205025e975a7385366edb9
<pre>
[build.webkit.org] Remove unused imports in steps.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=261334">https://bugs.webkit.org/show_bug.cgi?id=261334</a>

Reviewed by Alexey Proskuryakov and Jonathan Bedard.

* Tools/CISupport/build-webkit-org/steps.py:

Canonical link: <a href="https://commits.webkit.org/267794@main">https://commits.webkit.org/267794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c0a50dadb70e2cdd6b7ab9dc3c25299641df993

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17719 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/18049 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/18585 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/19544 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16575 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/17914 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/21340 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/18198 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/19544 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/17932 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/21340 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/18585 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20406 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/21340 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/18585 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/20406 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/21340 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/18585 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20406 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/16882 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/18198 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/17567 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15997 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/18585 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20361 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2171 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/16727 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
<!--EWS-Status-Bubble-End-->