### PR TITLE
Reland 267718@main with fixes.

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2750,6 +2750,8 @@ WEBKIT_COMPUTE_SOURCES(WebCore)
 target_precompile_headers(WebCore PRIVATE WebCorePrefix.h)
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+    Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+
     page/ActivityState.serialization.in
     page/DragActions.serialization.in
     page/LayoutMilestones.serialization.in
@@ -2757,14 +2759,22 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/PlatformEvent.serialization.in
     platform/PlatformScreen.serialization.in
+    platform/PlatformWheelEvent.serialization.in
+    platform/ScrollTypes.serialization.in
 
     platform/audio/PlatformMediaSession.serialization.in
+
+    platform/cocoa/PlaybackSessionModel.serialization.in
 
     platform/graphics/cocoa/MediaPlaybackTargetContext.serialization.in
 
     platform/graphics/InbandTextTrackPrivate.serialization.in
 
     platform/mediastream/MDNSRegisterError.serialization.in
+
+    platform/network/ProtectionSpaceBase.serialization.in
+
+    platform/network/soup/SoupNetworkProxySettings.serialization.in
 )
 
 WEBKIT_COPY_FILES(WebCore_CopyPrivateHeaders

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeFormatInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeFormatInterface.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::ShapeDetection {
 
@@ -49,26 +48,3 @@ enum class BarcodeFormat : uint8_t {
 
 } // namespace WebCore::ShapeDetection
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ShapeDetection::BarcodeFormat> {
-    using values = EnumValues<
-        WebCore::ShapeDetection::BarcodeFormat,
-        WebCore::ShapeDetection::BarcodeFormat::Aztec,
-        WebCore::ShapeDetection::BarcodeFormat::Code_128,
-        WebCore::ShapeDetection::BarcodeFormat::Code_39,
-        WebCore::ShapeDetection::BarcodeFormat::Code_93,
-        WebCore::ShapeDetection::BarcodeFormat::Codabar,
-        WebCore::ShapeDetection::BarcodeFormat::Data_matrix,
-        WebCore::ShapeDetection::BarcodeFormat::Ean_13,
-        WebCore::ShapeDetection::BarcodeFormat::Ean_8,
-        WebCore::ShapeDetection::BarcodeFormat::Itf,
-        WebCore::ShapeDetection::BarcodeFormat::Pdf417,
-        WebCore::ShapeDetection::BarcodeFormat::Qr_code,
-        WebCore::ShapeDetection::BarcodeFormat::Unknown,
-        WebCore::ShapeDetection::BarcodeFormat::Upc_a,
-        WebCore::ShapeDetection::BarcodeFormat::Upc_e
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -1,0 +1,45 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/WebGPUErrorFilter.h>
+enum class WebCore::WebGPU::ErrorFilter : uint8_t {
+    OutOfMemory,
+    Validation,
+    Internal
+};
+
+header: <WebCore/WebGPUIndexFormat.h>
+enum class WebCore::WebGPU::IndexFormat : uint8_t {
+    Uint16,
+    Uint32,
+};
+
+header: <WebCore/WebGPUMapMode.h>
+[OptionSet] enum class WebCore::WebGPU::MapMode : uint8_t {
+    Read,
+    Write,
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::WebGPU::MapMode : uint8_t {
+    Read,
+    Write,
+};

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUErrorFilter.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUErrorFilter.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -38,15 +37,3 @@ enum class ErrorFilter : uint8_t {
 
 } // namespace WebCore::WebGPU
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::ErrorFilter> {
-    using values = EnumValues<
-        WebCore::WebGPU::ErrorFilter,
-        WebCore::WebGPU::ErrorFilter::OutOfMemory,
-        WebCore::WebGPU::ErrorFilter::Validation,
-        WebCore::WebGPU::ErrorFilter::Internal
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUIndexFormat.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUIndexFormat.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class IndexFormat : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::IndexFormat> {
-    using values = EnumValues<
-        WebCore::WebGPU::IndexFormat,
-        WebCore::WebGPU::IndexFormat::Uint16,
-        WebCore::WebGPU::IndexFormat::Uint32
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUMapMode.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUMapMode.h
@@ -27,7 +27,6 @@
 
 #include "WebGPUIntegralTypes.h"
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore::WebGPU {
@@ -39,16 +38,4 @@ enum class MapMode : uint8_t {
 using MapModeFlags = OptionSet<MapMode>;
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::MapMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::MapMode,
-        WebCore::WebGPU::MapMode::Read,
-        WebCore::WebGPU::MapMode::Write
-    >;
-};
-
-} // namespace WTF
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1242,7 +1242,7 @@ void Element::scrollByUnits(int units, ScrollGranularity granularity)
     if (!renderer->hasNonVisibleOverflow())
         return;
 
-    auto direction = units < 0 ? ScrollUp : ScrollDown;
+    auto direction = units < 0 ? ScrollDirection::ScrollUp : ScrollDirection::ScrollDown;
     auto* stopElement = this;
     downcast<RenderBox>(*renderer).scroll(direction, granularity, std::abs(units), &stopElement);
 }

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1036,12 +1036,12 @@ static bool executeScrollPageForward(LocalFrame& frame, Event*, EditorCommandSou
 
 static bool executeScrollLineUp(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    return frame.eventHandler().scrollRecursively(ScrollUp, ScrollGranularity::Line);
+    return frame.eventHandler().scrollRecursively(ScrollDirection::ScrollUp, ScrollGranularity::Line);
 }
 
 static bool executeScrollLineDown(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    return frame.eventHandler().scrollRecursively(ScrollDown, ScrollGranularity::Line);
+    return frame.eventHandler().scrollRecursively(ScrollDirection::ScrollDown, ScrollGranularity::Line);
 }
 
 static bool executeScrollToBeginningOfDocument(LocalFrame& frame, Event*, EditorCommandSource, const String&)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3161,10 +3161,10 @@ static bool scrollViaNonPlatformEvent(ScrollableArea& scrollableArea, const Whee
     ScrollGranularity scrollGranularity = wheelGranularityToScrollGranularity(wheelEvent.deltaMode());
     bool didHandleWheelEvent = false;
     if (float absoluteDelta = std::abs(filteredDelta.width()))
-        didHandleWheelEvent |= scrollableArea.scroll(filteredDelta.width() > 0 ? ScrollRight : ScrollLeft, scrollGranularity, absoluteDelta);
+        didHandleWheelEvent |= scrollableArea.scroll(filteredDelta.width() > 0 ? ScrollDirection::ScrollRight : ScrollDirection::ScrollLeft, scrollGranularity, absoluteDelta);
 
     if (float absoluteDelta = std::abs(filteredDelta.height()))
-        didHandleWheelEvent |= scrollableArea.scroll(filteredDelta.height() > 0 ? ScrollDown : ScrollUp, scrollGranularity, absoluteDelta);
+        didHandleWheelEvent |= scrollableArea.scroll(filteredDelta.height() > 0 ? ScrollDirection::ScrollDown : ScrollDirection::ScrollUp, scrollGranularity, absoluteDelta);
     return didHandleWheelEvent;
 }
 

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -284,22 +284,3 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformWheelEventP
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformWheelEventPhase> {
-    using values = EnumValues<
-        WebCore::PlatformWheelEventPhase,
-        WebCore::PlatformWheelEventPhase::None
-#if ENABLE(KINETIC_SCROLLING)
-        ,
-        WebCore::PlatformWheelEventPhase::Began,
-        WebCore::PlatformWheelEventPhase::Stationary,
-        WebCore::PlatformWheelEventPhase::Changed,
-        WebCore::PlatformWheelEventPhase::Ended,
-        WebCore::PlatformWheelEventPhase::Cancelled,
-        WebCore::PlatformWheelEventPhase::MayBegin
-#endif
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/PlatformWheelEvent.serialization.in
+++ b/Source/WebCore/platform/PlatformWheelEvent.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+enum class WebCore::PlatformWheelEventPhase : uint8_t {
+    None,
+#if ENABLE(KINETIC_SCROLLING)
+    Began,
+    Stationary,
+    Changed,
+    Ended,
+    Cancelled,
+    MayBegin,
+#endif
+};

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -54,7 +54,7 @@ enum class OverscrollBehavior : uint8_t {
     None
 };
 
-enum ScrollDirection : uint8_t {
+enum class ScrollDirection : uint8_t {
     ScrollUp,
     ScrollDown,
     ScrollLeft,
@@ -86,53 +86,53 @@ inline ScrollDirection logicalToPhysical(ScrollLogicalDirection direction, bool 
     case ScrollBlockDirectionBackward: {
         if (isVertical) {
             if (!isFlipped)
-                return ScrollUp;
-            return ScrollDown;
+                return ScrollDirection::ScrollUp;
+            return ScrollDirection::ScrollDown;
         } else {
             if (!isFlipped)
-                return ScrollLeft;
-            return ScrollRight;
+                return ScrollDirection::ScrollLeft;
+            return ScrollDirection::ScrollRight;
         }
         break;
     }
     case ScrollBlockDirectionForward: {
         if (isVertical) {
             if (!isFlipped)
-                return ScrollDown;
-            return ScrollUp;
+                return ScrollDirection::ScrollDown;
+            return ScrollDirection::ScrollUp;
         } else {
             if (!isFlipped)
-                return ScrollRight;
-            return ScrollLeft;
+                return ScrollDirection::ScrollRight;
+            return ScrollDirection::ScrollLeft;
         }
         break;
     }
     case ScrollInlineDirectionBackward: {
         if (isVertical) {
             if (!isFlipped)
-                return ScrollLeft;
-            return ScrollRight;
+                return ScrollDirection::ScrollLeft;
+            return ScrollDirection::ScrollRight;
         } else {
             if (!isFlipped)
-                return ScrollUp;
-            return ScrollDown;
+                return ScrollDirection::ScrollUp;
+            return ScrollDirection::ScrollDown;
         }
         break;
     }
     case ScrollInlineDirectionForward: {
         if (isVertical) {
             if (!isFlipped)
-                return ScrollRight;
-            return ScrollLeft;
+                return ScrollDirection::ScrollRight;
+            return ScrollDirection::ScrollLeft;
         } else {
             if (!isFlipped)
-                return ScrollDown;
-            return ScrollUp;
+                return ScrollDirection::ScrollDown;
+            return ScrollDirection::ScrollUp;
         }
         break;
     }
     }
-    return ScrollUp;
+    return ScrollDirection::ScrollUp;
 }
 
 enum class ScrollGranularity : uint8_t {
@@ -184,10 +184,10 @@ enum class ScrollEventAxis : uint8_t {
 inline constexpr ScrollEventAxis axisFromDirection(ScrollDirection direction)
 {
     switch (direction) {
-    case ScrollUp: return ScrollEventAxis::Vertical;
-    case ScrollDown: return ScrollEventAxis::Vertical;
-    case ScrollLeft: return ScrollEventAxis::Horizontal;
-    case ScrollRight: return ScrollEventAxis::Horizontal;
+    case ScrollDirection::ScrollUp: return ScrollEventAxis::Vertical;
+    case ScrollDirection::ScrollDown: return ScrollEventAxis::Vertical;
+    case ScrollDirection::ScrollLeft: return ScrollEventAxis::Horizontal;
+    case ScrollDirection::ScrollRight: return ScrollEventAxis::Horizontal;
     }
     ASSERT_NOT_REACHED();
     return ScrollEventAxis::Vertical;
@@ -388,32 +388,3 @@ WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarWidth);
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ScrollDirection> {
-    using values = EnumValues<
-        WebCore::ScrollDirection,
-        WebCore::ScrollDirection::ScrollUp,
-        WebCore::ScrollDirection::ScrollDown,
-        WebCore::ScrollDirection::ScrollLeft,
-        WebCore::ScrollDirection::ScrollRight
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollbarOrientation> {
-    using values = EnumValues<
-        WebCore::ScrollbarOrientation,
-        WebCore::ScrollbarOrientation::Horizontal,
-        WebCore::ScrollbarOrientation::Vertical
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollbarWidth> {
-    using values = EnumValues<
-        WebCore::ScrollbarWidth,
-        WebCore::ScrollbarWidth::Auto,
-        WebCore::ScrollbarWidth::Thin,
-        WebCore::ScrollbarWidth::None
-    >;
-};
-} // namespace WTF

--- a/Source/WebCore/platform/ScrollTypes.serialization.in
+++ b/Source/WebCore/platform/ScrollTypes.serialization.in
@@ -1,0 +1,40 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/ScrollTypes.h>
+enum class WebCore::ScrollDirection : uint8_t {
+    ScrollUp,
+    ScrollDown,
+    ScrollLeft,
+    ScrollRight,
+};
+
+enum class WebCore::ScrollbarOrientation : uint8_t {
+    Horizontal,
+    Vertical,
+};
+
+enum class WebCore::ScrollbarWidth : uint8_t {
+    Auto,
+    Thin,
+    None,
+};

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -144,7 +144,7 @@ bool ScrollableArea::scroll(ScrollDirection direction, ScrollGranularity granula
 
     auto scrollDelta = step * stepCount;
     
-    if (direction == ScrollUp || direction == ScrollLeft)
+    if (direction == ScrollDirection::ScrollUp || direction == ScrollDirection::ScrollLeft)
         scrollDelta = -scrollDelta;
 
     return scrollAnimator().singleAxisScroll(axis, scrollDelta, ScrollAnimator::ScrollBehavior::RespectScrollSnap);

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -244,11 +244,11 @@ public:
     Scrollbar* scrollbarForDirection(ScrollDirection direction) const
     {
         switch (direction) {
-        case ScrollUp:
-        case ScrollDown:
+        case ScrollDirection::ScrollUp:
+        case ScrollDirection::ScrollDown:
             return verticalScrollbar();
-        case ScrollLeft:
-        case ScrollRight:
+        case ScrollDirection::ScrollLeft:
+        case ScrollDirection::ScrollRight:
             return horizontalScrollbar();
         }
         return nullptr;

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -227,7 +227,7 @@ void Scrollbar::startTimerIfNeeded(Seconds delay)
 
     // We can't scroll if we've hit the beginning or end.
     ScrollDirection dir = pressedPartScrollDirection();
-    if (dir == ScrollUp || dir == ScrollLeft) {
+    if (dir == ScrollDirection::ScrollUp || dir == ScrollDirection::ScrollLeft) {
         if (m_currentPos == 0)
             return;
     } else {
@@ -248,12 +248,12 @@ ScrollDirection Scrollbar::pressedPartScrollDirection()
 {
     if (m_orientation == ScrollbarOrientation::Horizontal) {
         if (m_pressedPart == BackButtonStartPart || m_pressedPart == BackButtonEndPart || m_pressedPart == BackTrackPart)
-            return ScrollLeft;
-        return ScrollRight;
+            return ScrollDirection::ScrollLeft;
+        return ScrollDirection::ScrollRight;
     } else {
         if (m_pressedPart == BackButtonStartPart || m_pressedPart == BackButtonEndPart || m_pressedPart == BackTrackPart)
-            return ScrollUp;
-        return ScrollDown;
+            return ScrollDirection::ScrollUp;
+        return ScrollDirection::ScrollDown;
     }
 }
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -39,6 +39,17 @@ class TimeRanges;
 class PlaybackSessionModelClient;
 struct MediaSelectionOption;
 
+enum class PlaybackSessionModelExternalPlaybackTargetType : uint8_t {
+    TargetTypeNone,
+    TargetTypeAirPlay,
+    TargetTypeTVOut
+};
+
+enum class PlaybackSessionModelPlaybackState : uint8_t {
+    Playing = 1 << 0,
+    Stalled = 1 << 1,
+};
+
 class PlaybackSessionModel : public CanMakeWeakPtr<PlaybackSessionModel> {
 public:
     virtual ~PlaybackSessionModel() { };
@@ -66,17 +77,15 @@ public:
     virtual void setPlayingOnSecondScreen(bool) = 0;
     virtual void sendRemoteCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) { };
 
-    enum class ExternalPlaybackTargetType { TargetTypeNone, TargetTypeAirPlay, TargetTypeTVOut };
+    using ExternalPlaybackTargetType = PlaybackSessionModelExternalPlaybackTargetType;
 
     virtual double playbackStartedTime() const = 0;
     virtual double duration() const = 0;
     virtual double currentTime() const = 0;
     virtual double bufferedTime() const = 0;
 
-    enum class PlaybackState {
-        Playing = 1 << 0,
-        Stalled = 1 << 1,
-    };
+    using PlaybackState = PlaybackSessionModelPlaybackState;
+
     virtual bool isPlaying() const = 0;
     virtual bool isStalled() const = 0;
     virtual bool isScrubbing() const = 0;
@@ -130,26 +139,5 @@ public:
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlaybackSessionModel::ExternalPlaybackTargetType> {
-    using values = EnumValues<
-        WebCore::PlaybackSessionModel::ExternalPlaybackTargetType,
-        WebCore::PlaybackSessionModel::ExternalPlaybackTargetType::TargetTypeNone,
-        WebCore::PlaybackSessionModel::ExternalPlaybackTargetType::TargetTypeAirPlay,
-        WebCore::PlaybackSessionModel::ExternalPlaybackTargetType::TargetTypeTVOut
-    >;
-};
-
-template<> struct EnumTraits<WebCore::PlaybackSessionModel::PlaybackState> {
-    using values = EnumValues<
-        WebCore::PlaybackSessionModel::PlaybackState,
-        WebCore::PlaybackSessionModel::PlaybackState::Playing,
-        WebCore::PlaybackSessionModel::PlaybackState::Stalled
-    >;
-};
-
-} // namespace WTF
 
 #endif // PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.serialization.in
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.serialization.in
@@ -1,0 +1,37 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
+
+header: <WebCore/PlaybackSessionModel.h>
+enum class WebCore::PlaybackSessionModelExternalPlaybackTargetType : uint8_t {
+    TargetTypeNone,
+    TargetTypeAirPlay,
+    TargetTypeTVOut,
+};
+
+[OptionSet] enum class WebCore::PlaybackSessionModelPlaybackState : uint8_t {
+    Playing,
+    Stalled,
+};
+
+#endif // PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -139,13 +139,13 @@ bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)
     // Horizontal
     if (m_touchScrollAxisLatch != AxisLatchVertical) {
         int delta = touchDelta.width();
-        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollLeft : ScrollRight, ScrollGranularity::Pixel, std::abs(delta));
+        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollDirection::ScrollLeft : ScrollDirection::ScrollRight, ScrollGranularity::Pixel, std::abs(delta));
     }
     
     // Vertical
     if (m_touchScrollAxisLatch != AxisLatchHorizontal) {
         int delta = touchDelta.height();
-        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollUp : ScrollDown, ScrollGranularity::Pixel, std::abs(delta));
+        handled |= m_scrollableAreaForTouchSequence->scroll(delta < 0 ? ScrollDirection::ScrollUp : ScrollDirection::ScrollDown, ScrollGranularity::Pixel, std::abs(delta));
     }
     
     // Return false until we manage to scroll at all, and then keep returning true until the gesture ends.

--- a/Source/WebCore/platform/network/ProtectionSpaceBase.h
+++ b/Source/WebCore/platform/network/ProtectionSpaceBase.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -102,36 +101,3 @@ inline bool operator==(const ProtectionSpace& a, const ProtectionSpace& b) { ret
     
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ProtectionSpaceBase::AuthenticationScheme> {
-    using values = EnumValues<
-        WebCore::ProtectionSpaceBase::AuthenticationScheme,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::Default,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::HTTPBasic,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::HTTPDigest,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::HTMLForm,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::NTLM,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::Negotiate,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::ClientCertificateRequested,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::ServerTrustEvaluationRequested,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::OAuth,
-        WebCore::ProtectionSpaceBase::AuthenticationScheme::Unknown
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ProtectionSpaceBase::ServerType> {
-    using values = EnumValues<
-        WebCore::ProtectionSpaceBase::ServerType,
-        WebCore::ProtectionSpaceBase::ServerType::HTTP,
-        WebCore::ProtectionSpaceBase::ServerType::HTTPS,
-        WebCore::ProtectionSpaceBase::ServerType::FTP,
-        WebCore::ProtectionSpaceBase::ServerType::FTPS,
-        WebCore::ProtectionSpaceBase::ServerType::ProxyHTTP,
-        WebCore::ProtectionSpaceBase::ServerType::ProxyHTTPS,
-        WebCore::ProtectionSpaceBase::ServerType::ProxyFTP,
-        WebCore::ProtectionSpaceBase::ServerType::ProxySOCKS
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/network/ProtectionSpaceBase.serialization.in
+++ b/Source/WebCore/platform/network/ProtectionSpaceBase.serialization.in
@@ -1,0 +1,48 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[Nested] enum class WebCore::ProtectionSpace::ServerType : uint8_t {
+    HTTP,
+    HTTPS,
+    FTP,
+    FTPS,
+    ProxyHTTP,
+    ProxyHTTPS,
+    ProxyFTP,
+    ProxySOCKS,
+};
+
+[Nested] enum class WebCore::ProtectionSpace::AuthenticationScheme : uint8_t {
+    Default,
+    HTTPBasic,
+    HTTPDigest,
+    HTMLForm,
+    NTLM,
+    Negotiate,
+    ClientCertificateRequested,
+    ServerTrustEvaluationRequested,
+    OAuth,
+#if USE(GLIB)
+    ClientCertificatePINRequested,
+#endif
+    Unknown,
+};

--- a/Source/WebCore/platform/network/soup/SoupNetworkProxySettings.h
+++ b/Source/WebCore/platform/network/soup/SoupNetworkProxySettings.h
@@ -25,15 +25,21 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/HashMap.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {
 
+enum class SoupNetworkProxySettingsMode : uint8_t {
+    Default,
+    NoProxy,
+    Custom,
+    Auto
+};
+
 struct SoupNetworkProxySettings {
-    enum class Mode { Default, NoProxy, Custom, Auto };
+    using Mode = SoupNetworkProxySettingsMode;
 
     SoupNetworkProxySettings() = default;
 
@@ -80,17 +86,3 @@ struct SoupNetworkProxySettings {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SoupNetworkProxySettings::Mode> {
-    using values = EnumValues<
-        WebCore::SoupNetworkProxySettings::Mode,
-        WebCore::SoupNetworkProxySettings::Mode::Default,
-        WebCore::SoupNetworkProxySettings::Mode::NoProxy,
-        WebCore::SoupNetworkProxySettings::Mode::Custom,
-        WebCore::SoupNetworkProxySettings::Mode::Auto
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/network/soup/SoupNetworkProxySettings.serialization.in
+++ b/Source/WebCore/platform/network/soup/SoupNetworkProxySettings.serialization.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(SOUP)
+
+enum class WebCore::SoupNetworkProxySettingsMode : uint8_t {
+    Default,
+    NoProxy,
+    Custom,
+    Auto
+};
+
+#endif // USE(SOUP)

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -518,6 +518,11 @@ set(WebCore_SERIALIZATION_IN_FILES
     PlatformEvent.serialization.in
     PlatformMediaSession.serialization.in
     PlatformScreen.serialization.in
+    PlatformWheelEvent.serialization.in
+    PlaybackSessionModel.serialization.in
+    ProtectionSpaceBase.serialization.in
+    ScrollTypes.serialization.in
+    WebGPU.serialization.in
 )
 
 set(WebKit_FRAMEWORKS

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -491,4 +491,9 @@ $(WEBCORE_PRIVATE_HEADERS_DIR)/MediaProducer.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformEvent.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformMediaSession.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformScreen.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformWheelEvent.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/PlaybackSessionModel.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/ProtectionSpaceBase.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/ScrollTypes.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/WebGPU.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/generate-bindings.pl

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -645,6 +645,11 @@ WEBCORE_SERIALIZATION_DESCRIPTION_FILES = \
 	PlatformEvent.serialization.in \
 	PlatformMediaSession.serialization.in \
 	PlatformScreen.serialization.in \
+	PlatformWheelEvent.serialization.in \
+	PlaybackSessionModel.serialization.in \
+	ProtectionSpaceBase.serialization.in \
+	ScrollTypes.serialization.in \
+	WebGPU.serialization.in \
 #
 
 WEBCORE_SERIALIZATION_DESCRIPTION_FILES_FULLPATH := $(foreach I,$(WEBCORE_SERIALIZATION_DESCRIPTION_FILES),$(WebCorePrivateHeaders)/$I)

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -62,6 +62,8 @@ list(APPEND WebKit_MESSAGES_IN_FILES
     WebProcess/gtk/GtkSettingsManagerProxy
 )
 
+list(APPEND WebCore_SERIALIZATION_IN_FILES SoupNetworkProxySettings.serialization.in)
+
 list(APPEND WebKit_DERIVED_SOURCES
     ${WebKitGTK_DERIVED_SOURCES_DIR}/InspectorGResourceBundle.c
     ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -89,6 +89,8 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
     "SourcesWPE.txt"
 )
 
+list(APPEND WebCore_SERIALIZATION_IN_FILES SoupNetworkProxySettings.serialization.in)
+
 list(APPEND WebKit_DERIVED_SOURCES
     ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c
     ${WebKit_DERIVED_SOURCES_DIR}/WebKitDirectoryInputStreamData.cpp

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -790,6 +790,7 @@ def headers_for_type(type):
         'WebCore::RouteSharingPolicy': ['<WebCore/AudioSession.h>'],
         'WebCore::SameSiteStrictEnforcementEnabled': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::ScriptExecutionContextIdentifier': ['<WebCore/ProcessQualified.h>', '<WebCore/ScriptExecutionContextIdentifier.h>', '<wtf/ObjectIdentifier.h>'],
+        'WebCore::ScrollDirection': ['<WebCore/ScrollTypes.h>'],
         'WebCore::ScrollGranularity': ['<WebCore/ScrollTypes.h>'],
         'WebCore::ScrollPinningBehavior': ['<WebCore/ScrollTypes.h>'],
         'WebCore::ScrollbarOrientation': ['<WebCore/ScrollTypes.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2387,13 +2387,6 @@ header: <WebCore/ScrollTypes.h>
     ReplacedByCustomScrollbar
 };
 
-header: <WebCore/ScrollTypes.h>
-[CustomHeader] enum class WebCore::ScrollbarWidth : uint8_t {
-    Auto,
-    Thin,
-    None
-};
-
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] struct WebCore::ScrollableAreaParameters {
     WebCore::ScrollElasticity horizontalScrollElasticity;
@@ -5502,33 +5495,6 @@ header: <WebCore/CaretAnimator.h>
     Dictation,
 };
 #endif
-
-[Nested] enum class WebCore::ProtectionSpace::ServerType : uint8_t {
-    HTTP,
-    HTTPS,
-    FTP,
-    FTPS,
-    ProxyHTTP,
-    ProxyHTTPS,
-    ProxyFTP,
-    ProxySOCKS
-};
-
-[Nested] enum class WebCore::ProtectionSpace::AuthenticationScheme : uint8_t {
-    Default,
-    HTTPBasic,
-    HTTPDigest,
-    HTMLForm,
-    NTLM,
-    Negotiate,
-    ClientCertificateRequested,
-    ServerTrustEvaluationRequested,
-    OAuth,
-#if USE(GLIB)
-    ClientCertificatePINRequested,
-#endif
-    Unknown
-};
 
 class WebCore::ProtectionSpace {
     String host();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -129,7 +129,7 @@ class ValidationBubble;
 
 enum class LayoutMilestone : uint16_t;
 enum PaginationMode : uint8_t;
-enum ScrollDirection : uint8_t;
+enum class ScrollDirection : uint8_t;
 enum ScrollbarOverlayStyle : uint8_t;
 
 enum class ActivityState : uint16_t;

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -750,7 +750,7 @@ LRESULT WebPopupMenuProxyWin::onMouseWheel(HWND hWnd, UINT message, WPARAM wPara
             --i;
     }
 
-    ScrollableArea::scroll(i > 0 ? ScrollUp : ScrollDown, ScrollGranularity::Line, std::abs(i));
+    ScrollableArea::scroll(i > 0 ? ScrollDirection::ScrollUp : ScrollDirection::ScrollDown, ScrollGranularity::Line, std::abs(i));
     return 0;
 }
 

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -391,19 +391,19 @@ LRESULT WebView::onHorizontalScroll(HWND hWnd, UINT message, WPARAM wParam, LPAR
     switch (LOWORD(wParam)) {
     case SB_LINELEFT:
         granularity = ScrollGranularity::Line;
-        direction = ScrollLeft;
+        direction = ScrollDirection::ScrollLeft;
         break;
     case SB_LINERIGHT:
         granularity = ScrollGranularity::Line;
-        direction = ScrollRight;
+        direction = ScrollDirection::ScrollRight;
         break;
     case SB_PAGELEFT:
         granularity = ScrollGranularity::Document;
-        direction = ScrollLeft;
+        direction = ScrollDirection::ScrollLeft;
         break;
     case SB_PAGERIGHT:
         granularity = ScrollGranularity::Document;
-        direction = ScrollRight;
+        direction = ScrollDirection::ScrollRight;
         break;
     default:
         handled = false;
@@ -423,19 +423,19 @@ LRESULT WebView::onVerticalScroll(HWND hWnd, UINT message, WPARAM wParam, LPARAM
     switch (LOWORD(wParam)) {
     case SB_LINEDOWN:
         granularity = ScrollGranularity::Line;
-        direction = ScrollDown;
+        direction = ScrollDirection::ScrollDown;
         break;
     case SB_LINEUP:
         granularity = ScrollGranularity::Line;
-        direction = ScrollUp;
+        direction = ScrollDirection::ScrollUp;
         break;
     case SB_PAGEDOWN:
         granularity = ScrollGranularity::Document;
-        direction = ScrollDown;
+        direction = ScrollDirection::ScrollDown;
         break;
     case SB_PAGEUP:
         granularity = ScrollGranularity::Document;
-        direction = ScrollUp;
+        direction = ScrollDirection::ScrollUp;
         break;
     default:
         handled = false;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3720,7 +3720,7 @@ bool WebPage::logicalScroll(Page* page, ScrollLogicalDirection direction, Scroll
     return Ref(page->focusController().focusedOrMainFrame())->eventHandler().logicalScrollRecursively(direction, granularity);
 }
 
-bool WebPage::scrollBy(uint32_t scrollDirection, WebCore::ScrollGranularity scrollGranularity)
+bool WebPage::scrollBy(WebCore::ScrollDirection scrollDirection, WebCore::ScrollGranularity scrollGranularity)
 {
     return scroll(m_page.get(), static_cast<ScrollDirection>(scrollDirection), static_cast<ScrollGranularity>(scrollGranularity));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -438,7 +438,7 @@ public:
 
     void scrollMainFrameIfNotAtMaxScrollPosition(const WebCore::IntSize& scrollOffset);
 
-    bool scrollBy(uint32_t scrollDirection, WebCore::ScrollGranularity);
+    bool scrollBy(WebCore::ScrollDirection, WebCore::ScrollGranularity);
 
     void centerSelectionInVisibleArea();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -179,7 +179,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidEndDateTimePicker();
 #endif
 
-    ScrollBy(uint32_t scrollDirection, enum:uint8_t WebCore::ScrollGranularity scrollGranularity)
+    ScrollBy(enum:uint8_t WebCore::ScrollDirection scrollDirection, enum:uint8_t WebCore::ScrollGranularity scrollGranularity)
     CenterSelectionInVisibleArea()
 
     GoToBackForwardItem(struct WebKit::GoToBackForwardItemParameters parameters)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -453,27 +453,27 @@ bool WebPage::performNonEditingBehaviorForSelector(const String& selector, Keybo
     
     if (!frame->eventHandler().shouldUseSmoothKeyboardScrollingForFocusedScrollableArea()) {
         if (selector == "moveUp:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollUp, ScrollGranularity::Line);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollUp, ScrollGranularity::Line);
         else if (selector == "moveToBeginningOfParagraph:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollUp, ScrollGranularity::Page);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollUp, ScrollGranularity::Page);
         else if (selector == "moveToBeginningOfDocument:"_s) {
-            didPerformAction = scroll(m_page.get(), ScrollUp, ScrollGranularity::Document);
-            didPerformAction |= scroll(m_page.get(), ScrollLeft, ScrollGranularity::Document);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollUp, ScrollGranularity::Document);
+            didPerformAction |= scroll(m_page.get(), ScrollDirection::ScrollLeft, ScrollGranularity::Document);
         } else if (selector == "moveDown:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollDown, ScrollGranularity::Line);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollDown, ScrollGranularity::Line);
         else if (selector == "moveToEndOfParagraph:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollDown, ScrollGranularity::Page);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollDown, ScrollGranularity::Page);
         else if (selector == "moveToEndOfDocument:"_s) {
-            didPerformAction = scroll(m_page.get(), ScrollDown, ScrollGranularity::Document);
-            didPerformAction |= scroll(m_page.get(), ScrollLeft, ScrollGranularity::Document);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollDown, ScrollGranularity::Document);
+            didPerformAction |= scroll(m_page.get(), ScrollDirection::ScrollLeft, ScrollGranularity::Document);
         } else if (selector == "moveLeft:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollLeft, ScrollGranularity::Line);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollLeft, ScrollGranularity::Line);
         else if (selector == "moveWordLeft:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollLeft, ScrollGranularity::Page);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollLeft, ScrollGranularity::Page);
         else if (selector == "moveRight:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollRight, ScrollGranularity::Line);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollRight, ScrollGranularity::Line);
         else if (selector == "moveWordRight:"_s)
-            didPerformAction = scroll(m_page.get(), ScrollRight, ScrollGranularity::Page);
+            didPerformAction = scroll(m_page.get(), ScrollDirection::ScrollRight, ScrollGranularity::Page);
     }
 
     if (selector == "moveToLeftEndOfLine:"_s)

--- a/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
@@ -628,7 +628,7 @@ enum {
 
 - (BOOL)_scrollToBeginningOfDocument
 {
-    if ([self _scrollOverflowInDirection:WebCore::ScrollUp granularity:WebCore::ScrollGranularity::Document])
+    if ([self _scrollOverflowInDirection:WebCore::ScrollDirection::ScrollUp granularity:WebCore::ScrollGranularity::Document])
         return YES;
     if (![self _isScrollable])
         return NO;
@@ -640,7 +640,7 @@ enum {
 
 - (BOOL)_scrollToEndOfDocument
 {
-    if ([self _scrollOverflowInDirection:WebCore::ScrollDown granularity:WebCore::ScrollGranularity::Document])
+    if ([self _scrollOverflowInDirection:WebCore::ScrollDirection::ScrollDown granularity:WebCore::ScrollGranularity::Document])
         return YES;
     if (![self _isScrollable])
         return NO;
@@ -737,7 +737,7 @@ enum {
 
 - (BOOL)_pageVertically:(BOOL)up
 {
-    if ([self _scrollOverflowInDirection:up ? WebCore::ScrollUp : WebCore::ScrollDown granularity:WebCore::ScrollGranularity::Page])
+    if ([self _scrollOverflowInDirection:up ? WebCore::ScrollDirection::ScrollUp : WebCore::ScrollDirection::ScrollDown granularity:WebCore::ScrollGranularity::Page])
         return YES;
     
     if (![self _isScrollable])
@@ -749,7 +749,7 @@ enum {
 
 - (BOOL)_pageHorizontally:(BOOL)left
 {
-    if ([self _scrollOverflowInDirection:left ? WebCore::ScrollLeft : WebCore::ScrollRight granularity:WebCore::ScrollGranularity::Page])
+    if ([self _scrollOverflowInDirection:left ? WebCore::ScrollDirection::ScrollLeft : WebCore::ScrollDirection::ScrollRight granularity:WebCore::ScrollGranularity::Page])
         return YES;
 
     if (![self _isScrollable])
@@ -771,7 +771,7 @@ enum {
 
 - (BOOL)_scrollLineVertically:(BOOL)up
 {
-    if ([self _scrollOverflowInDirection:up ? WebCore::ScrollUp : WebCore::ScrollDown granularity:WebCore::ScrollGranularity::Line])
+    if ([self _scrollOverflowInDirection:up ? WebCore::ScrollDirection::ScrollUp : WebCore::ScrollDirection::ScrollDown granularity:WebCore::ScrollGranularity::Line])
         return YES;
 
     if (![self _isScrollable])
@@ -783,7 +783,7 @@ enum {
 
 - (BOOL)_scrollLineHorizontally:(BOOL)left
 {
-    if ([self _scrollOverflowInDirection:left ? WebCore::ScrollLeft : WebCore::ScrollRight granularity:WebCore::ScrollGranularity::Line])
+    if ([self _scrollOverflowInDirection:left ? WebCore::ScrollDirection::ScrollLeft : WebCore::ScrollDirection::ScrollRight granularity:WebCore::ScrollGranularity::Line])
         return YES;
 
     if (![self _isScrollable])


### PR DESCRIPTION
#### 5c073cc4a558bf6cd1d88cbfd123a202a27bb792
<pre>
Reland 267718@main with fixes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261051">https://bugs.webkit.org/show_bug.cgi?id=261051</a>
rdar://114846429

Reviewed by Don Olmstead and Alex Christensen.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeFormatInterface.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in: Added.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUErrorFilter.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUIndexFormat.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUMapMode.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollByUnits):
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeScrollLineUp):
(WebCore::executeScrollLineDown):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::scrollViaNonPlatformEvent):
* Source/WebCore/platform/PlatformWheelEvent.h:
* Source/WebCore/platform/PlatformWheelEvent.serialization.in: Added.
* Source/WebCore/platform/ScrollTypes.h:
(WebCore::logicalToPhysical):
(WebCore::axisFromDirection):
* Source/WebCore/platform/ScrollTypes.serialization.in: Added.
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scroll):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::scrollbarForDirection const):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::startTimerIfNeeded):
(WebCore::Scrollbar::pressedPartScrollDirection):
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.serialization.in: Added.
* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:
(WebCore::ScrollAnimatorIOS::handleTouchEvent):
* Source/WebCore/platform/network/ProtectionSpaceBase.h:
* Source/WebCore/platform/network/ProtectionSpaceBase.serialization.in: Added.
* Source/WebCore/platform/network/soup/SoupNetworkProxySettings.h:
* Source/WebCore/platform/network/soup/SoupNetworkProxySettings.serialization.in: Added.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
(WebKit::WebPopupMenuProxyWin::onMouseWheel):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::onHorizontalScroll):
(WebKit::WebView::onVerticalScroll):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::scrollBy):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performNonEditingBehaviorForSelector):
* Source/WebKitLegacy/mac/WebView/WebFrameView.mm:
(-[WebFrameView _scrollToBeginningOfDocument]):
(-[WebFrameView _scrollToEndOfDocument]):
(-[WebFrameView _pageVertically:]):
(-[WebFrameView _pageHorizontally:]):
(-[WebFrameView _scrollLineVertically:]):
(-[WebFrameView _scrollLineHorizontally:]):

Canonical link: <a href="https://commits.webkit.org/267873@main">https://commits.webkit.org/267873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3805712f724cc96ebc390475a52e53d61b52f3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18682 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20499 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17955 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22775 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20640 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14355 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16067 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4270 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->