### PR TITLE
[CMake] Support port specific serialization files from WebCore

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -500,6 +500,23 @@ set(WebKit_SERIALIZATION_IN_FILES
     WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in
 )
 
+set(WebCore_GENERATED_SERIALIZATION_IN_FILES
+    HTTPHeaderNames.serialization.in
+)
+
+set(WebCore_SERIALIZATION_IN_FILES
+    ActivityState.serialization.in
+    DragActions.serialization.in
+    InbandTextTrackPrivate.serialization.in
+    LayoutMilestones.serialization.in
+    MDNSRegisterError.serialization.in
+    MediaPlaybackTargetContext.serialization.in
+    MediaProducer.serialization.in
+    PlatformEvent.serialization.in
+    PlatformMediaSession.serialization.in
+    PlatformScreen.serialization.in
+)
+
 set(WebKit_FRAMEWORKS
     JavaScriptCore
     PAL
@@ -671,23 +688,6 @@ macro(GENERATE_MESSAGE_SOURCES _output_source _inputs)
     )
 endmacro()
 GENERATE_MESSAGE_SOURCES(WebKit_DERIVED_SOURCES "${WebKit_MESSAGES_IN_FILES}")
-
-set(WebCore_GENERATED_SERIALIZATION_IN_FILES
-    HTTPHeaderNames.serialization.in
-)
-
-set(WebCore_SERIALIZATION_IN_FILES
-    ActivityState.serialization.in
-    DragActions.serialization.in
-    InbandTextTrackPrivate.serialization.in
-    LayoutMilestones.serialization.in
-    MDNSRegisterError.serialization.in
-    MediaPlaybackTargetContext.serialization.in
-    MediaProducer.serialization.in
-    PlatformEvent.serialization.in
-    PlatformMediaSession.serialization.in
-    PlatformScreen.serialization.in
-)
 
 set(WebKit_SERIALIZATION_DEPENDENCIES ${WebKit_SERIALIZATION_IN_FILES})
 foreach (in_file ${WebCore_GENERATED_SERIALIZATION_IN_FILES})


### PR DESCRIPTION
#### a238722748a07a69056cb7e0565944416640df35
<pre>
[CMake] Support port specific serialization files from WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=261336">https://bugs.webkit.org/show_bug.cgi?id=261336</a>

Reviewed by Michael Catanzaro.

Move the listing before `WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS` so a
port&apos;s CMake can append to the values.

* Source/WebKit/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/267800@main">https://commits.webkit.org/267800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a99b494df3f41ba83ad3acb9be586cb100f55d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19554 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16585 "Failed to checkout and rebase branch from PR 17594") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18209 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18236 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20417 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15470 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16326 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16892 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16007 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2174 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->