### PR TITLE
[WGSL] Implement template disambiguation

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -33,7 +33,34 @@
 namespace WGSL {
 
 template <typename T>
-Token Lexer<T>::lex()
+Vector<Token> Lexer<T>::lex()
+{
+    Vector<Token> tokens;
+
+    while (true) {
+        auto token = nextToken();
+        tokens.append(token);
+        switch (token.type) {
+        case TokenType::GtGtEq:
+            tokens.append(makeToken(TokenType::Placeholder));
+            FALLTHROUGH;
+        case TokenType::GtGt:
+        case TokenType::GtEq:
+            tokens.append(makeToken(TokenType::Placeholder));
+            break;
+        default:
+            break;
+        }
+
+        if (token.type == TokenType::EndOfFile || token.type == TokenType::Invalid)
+            break;
+    }
+
+    return tokens;
+}
+
+template <typename T>
+Token Lexer<T>::nextToken()
 {
     if (!skipWhitespaceAndComments())
         return makeToken(TokenType::Invalid);

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -50,11 +50,12 @@ public:
         m_currentPosition = { 1, 0, 0 };
     }
 
-    Token lex();
+    Vector<Token> lex();
     bool isAtEndOfFile() const;
     SourcePosition currentPosition() const { return m_currentPosition; }
 
 private:
+    Token nextToken();
     unsigned currentOffset() const { return m_currentPosition.offset; }
     unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.offset; }
 

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -48,11 +48,15 @@ public:
         : m_shaderModule(shaderModule)
         , m_builder(shaderModule.astBuilder())
         , m_lexer(lexer)
-        , m_current(lexer.lex())
+        , m_tokens(m_lexer.lex())
+        , m_current(m_tokens[0])
     {
     }
 
     Result<void> parseShader();
+
+    void maybeSplitToken(unsigned index);
+    void disambiguateTemplates();
 
     // AST::<type>::Ref whenever it can return multiple types.
     Result<AST::Identifier> parseIdentifier();
@@ -106,6 +110,8 @@ private:
     ShaderModule& m_shaderModule;
     AST::Builder& m_builder;
     Lexer& m_lexer;
+    Vector<Token> m_tokens;
+    unsigned m_currentTokenIndex { 0 };
     Token m_current;
 };
 

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -86,6 +86,7 @@ FOREACH_KEYWORD(KEYWORD_TO_STRING)
         return "="_s;
     case TokenType::EqEq:
         return "=="_s;
+    case TokenType::TemplateArgsRight:
     case TokenType::Gt:
         return ">"_s;
     case TokenType::GtEq:
@@ -94,6 +95,7 @@ FOREACH_KEYWORD(KEYWORD_TO_STRING)
         return ">>"_s;
     case TokenType::GtGtEq:
         return ">>="_s;
+    case TokenType::TemplateArgsLeft:
     case TokenType::Lt:
         return "<"_s;
     case TokenType::LtEq:
@@ -148,6 +150,8 @@ FOREACH_KEYWORD(KEYWORD_TO_STRING)
         return "^"_s;
     case TokenType::XorEq:
         return "^="_s;
+    case TokenType::Placeholder:
+        return "<placeholder>"_s;
     }
 }
 

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -129,6 +129,10 @@ FOREACH_KEYWORD(ENUM_ENTRY)
     Underbar,
     Xor,
     XorEq,
+
+    Placeholder,
+    TemplateArgsLeft,
+    TemplateArgsRight,
     // FIXME: add all the other special tokens
 };
 
@@ -180,6 +184,30 @@ struct Token {
         if (type == TokenType::Identifier)
             ident.~String();
 
+        type = other.type;
+        span = other.span;
+
+        switch (other.type) {
+        case TokenType::Identifier:
+            new (NotNull, &ident) String();
+            ident = other.ident;
+            break;
+        case TokenType::AbstractFloatLiteral:
+        case TokenType::IntegerLiteral:
+        case TokenType::IntegerLiteralSigned:
+        case TokenType::IntegerLiteralUnsigned:
+        case TokenType::FloatLiteral:
+            literalValue = other.literalValue;
+            break;
+        default:
+            break;
+        }
+
+        return *this;
+    }
+
+    Token& operator=(const Token& other)
+    {
         type = other.type;
         span = other.span;
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -902,8 +902,7 @@ TEST(WGSLParserTests, RelationalExpression)
     testBinaryExpressionXY("x != y"_s, WGSL::AST::BinaryOperation::NotEqual,     { "x"_s, "y"_s });
     testBinaryExpressionXY("x > y"_s,  WGSL::AST::BinaryOperation::GreaterThan,  { "x"_s, "y"_s });
     testBinaryExpressionXY("x >= y"_s, WGSL::AST::BinaryOperation::GreaterEqual, { "x"_s, "y"_s });
-    // FIXME: implement template disambiguation
-    // testBinaryExpressionXY("x < y"_s, WGSL::AST::BinaryOperation::LessThan, { "x"_s, "y"_s });
+    testBinaryExpressionXY("x < y"_s, WGSL::AST::BinaryOperation::LessThan, { "x"_s, "y"_s });
     testBinaryExpressionXY("x <= y"_s, WGSL::AST::BinaryOperation::LessEqual,    { "x"_s, "y"_s });
 }
 


### PR DESCRIPTION
#### 26fe72210ffe0d1b5c92ec513730b60e4db5591c
<pre>
[WGSL] Implement template disambiguation
<a href="https://bugs.webkit.org/show_bug.cgi?id=261338">https://bugs.webkit.org/show_bug.cgi?id=261338</a>
rdar://115176925

Reviewed by Mike Wyrzykowski.

Implement the template disambiguation as described in <a href="https://www.w3.org/TR/WGSL/#template-lists-sec">https://www.w3.org/TR/WGSL/#template-lists-sec</a>
and the algorithm described in <a href="https://github.com/gpuweb/gpuweb/issues/3770">https://github.com/gpuweb/gpuweb/issues/3770</a>

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
(WGSL::Lexer&lt;T&gt;::nextToken):
* Source/WebGPU/WGSL/Lexer.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::consumeType):
(WGSL::Parser&lt;Lexer&gt;::consumeTypes):
(WGSL::Parser&lt;Lexer&gt;::consume):
(WGSL::Parser&lt;Lexer&gt;::parseShader):
(WGSL::Parser&lt;Lexer&gt;::maybeSplitToken):
(WGSL::Parser&lt;Lexer&gt;::disambiguateTemplates):
(WGSL::Parser&lt;Lexer&gt;::parseTypeNameAfterIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
* Source/WebGPU/WGSL/ParserPrivate.h:
(WGSL::Parser::Parser):
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
(WGSL::Token::operator=):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TestLexer::TestLexer):
(TestWGSLAPI::TestLexer::lex):
(TestWGSLAPI::checkSingleToken):
(TestWGSLAPI::checkNextTokenIs):
(TestWGSLAPI::checkNextTokenIsIdentifier):
(TestWGSLAPI::checkNextTokenIsLiteral):
(TestWGSLAPI::checkNextTokensAreBuiltinAttr):
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267855@main">https://commits.webkit.org/267855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3236e4bf1fee15b012ca72dca544853b98155feb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18641 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20421 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22725 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20584 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14307 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16009 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4260 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->