### PR TITLE
Remove debug-only asserts added in 266304@main

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -418,7 +418,6 @@ void VideoFullscreenManager::exitVideoFullscreenForVideoElement(HTMLVideoElement
     LOG(Fullscreen, "VideoFullscreenManager::exitVideoFullscreenForVideoElement(%p)", this);
 
     ASSERT(m_page);
-    ASSERT(m_videoElements.contains(videoElement));
 
     if (!m_videoElements.contains(videoElement)) {
         completionHandler(false);
@@ -453,7 +452,6 @@ void VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVideo
     INFO_LOG(LOGIDENTIFIER);
 
     ASSERT(m_page);
-    ASSERT(m_videoElements.contains(videoElement));
 
     if (!m_videoElements.contains(videoElement))
         return;


### PR DESCRIPTION
#### d0ef72caf9de05f7e1a710aa63d947e140b5492c
<pre>
Remove debug-only asserts added in 266304@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=261343">https://bugs.webkit.org/show_bug.cgi?id=261343</a>
rdar://113674840

Reviewed by Jer Noble.

The asserts added in <a href="https://commits.webkit.org/266304@main">https://commits.webkit.org/266304@main</a> test a condition that sometimes
happens because we fire the end fullscreen event *before* exiting fullscreen to allow the
page to restore the video element size/position so the exit fullscreen animation looks
correct. The condition isn&apos;t a problem because already we call the completion handler and
return early when it is true.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):

Canonical link: <a href="https://commits.webkit.org/267807@main">https://commits.webkit.org/267807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adde50b5c3251a7aadd183b159288f12170f3d0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19568 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16597 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18224 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15417 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15483 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22733 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20592 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16905 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16019 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4230 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->