### PR TITLE
Add support for tabs.get(), tabs.getCurrent(), tabs.getSelected(), and tabs.query() APIs.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -424,6 +424,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::WCLayerTreeHostIdentifier',
         'WebKit::WebExtensionEventListenerType',
         'WebKit::WebExtensionTabParameters',
+        'WebKit::WebExtensionTabQueryParameters',
         'WebKit::WebExtensionWindowParameters',
         'WebKit::XRDeviceIdentifier',
     ] + serialized_identifiers() + types_that_must_be_moved())

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -110,7 +110,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the selected state of the tab is needed.
  @param context The context in which the web extension is running.
  @return `YES` if the tab is selected, `NO` otherwise.
- @discussion Defaults to `NO` if not implemented.
+ @discussion Defaults to `YES` for the active tab and `NO` for other tabs if not implemented.
  */
 - (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WKWebViewInternal.h"
+#import "WebExtensionContextProxy.h"
+#import "WebExtensionContextProxyMessages.h"
+#import "WebExtensionTabIdentifier.h"
+#import "WebExtensionUtilities.h"
+#import "WebExtensionWindowIdentifier.h"
+#import "WebPageProxy.h"
+#import "_WKWebExtensionTabCreationOptionsInternal.h"
+
+namespace WebKit {
+
+void WebExtensionContext::tabsGet(WebExtensionTabIdentifier tabIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&& completionHandler)
+{
+    auto tab = getTab(tabIdentifier);
+    if (!tab) {
+        completionHandler(std::nullopt, toErrorString(@"tabs.get()", nil, @"tab not found"));
+        return;
+    }
+
+    completionHandler(tab->parameters(), std::nullopt);
+}
+
+void WebExtensionContext::tabsGetCurrent(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&& completionHandler)
+{
+    for (auto& tab : openTabs()) {
+        for (WKWebView *webView in tab->webViews()) {
+            if (webView._page->identifier() == webPageProxyIdentifier) {
+                completionHandler(tab->parameters(), std::nullopt);
+                return;
+            }
+        }
+    }
+
+    // No error is reported when the page isn't a tab (e.g. the background page).
+    completionHandler(std::nullopt, std::nullopt);
+}
+
+void WebExtensionContext::tabsQuery(WebPageProxyIdentifier webPageProxyIdentifier, const WebExtensionTabQueryParameters& queryParameters, CompletionHandler<void(Vector<WebExtensionTabParameters>, WebExtensionTab::Error)>&& completionHandler)
+{
+    Vector<WebExtensionTabParameters> result;
+
+    for (auto& window : openWindows()) {
+        if (!window->matches(queryParameters, webPageProxyIdentifier))
+            continue;
+
+        for (auto& tab : window->tabs()) {
+            if (tab->matches(queryParameters, WebExtensionTab::AssumeWindowMatches::Yes, webPageProxyIdentifier))
+                result.append(tab->parameters());
+        }
+    }
+
+    completionHandler(WTFMove(result), std::nullopt);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -42,18 +42,7 @@
 
 namespace WebKit {
 
-static inline bool matchesFilter(const WebExtensionWindow& window, OptionSet<WebExtensionWindow::TypeFilter> filter)
-{
-    switch (window.type()) {
-    case WebExtensionWindow::Type::Normal:
-        return filter.contains(WebExtensionWindow::TypeFilter::Normal);
-
-    case WebExtensionWindow::Type::Popup:
-        return filter.contains(WebExtensionWindow::TypeFilter::Popup);
-    }
-}
-
-void WebExtensionContext::windowsCreate(WebExtensionWindowParameters creationParameters, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
+void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& creationParameters, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&& completionHandler)
 {
     auto delegate = extensionController()->delegate();
     if (![delegate respondsToSelector:@selector(webExtensionController:openNewWindowWithOptions:forExtensionContext:completionHandler:)]) {
@@ -132,7 +121,7 @@ void WebExtensionContext::windowsGet(WebPageProxyIdentifier, WebExtensionWindowI
         return;
     }
 
-    if (!matchesFilter(*window, filter)) {
+    if (!window->matches(filter)) {
         completionHandler(std::nullopt, toErrorString(apiName, nil, @"window does not match requested 'windowTypes'"));
         return;
     }
@@ -150,7 +139,7 @@ void WebExtensionContext::windowsGetLastFocused(OptionSet<WindowTypeFilter> filt
         return;
     }
 
-    if (!matchesFilter(*window, filter)) {
+    if (!window->matches(filter)) {
         completionHandler(std::nullopt, toErrorString(apiName, nil, @"window does not match requested 'windowTypes'"));
         return;
     }
@@ -162,7 +151,7 @@ void WebExtensionContext::windowsGetAll(OptionSet<WindowTypeFilter> filter, Popu
 {
     Vector<WebExtensionWindowParameters> result;
     for (auto& window : openWindows()) {
-        if (!matchesFilter(window, filter))
+        if (!window->matches(filter))
             continue;
 
         result.append(window->parameters(populate));

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -349,8 +349,13 @@ private:
     void permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&&);
     void firePermissionsEventListenerIfNecessary(WebExtensionEventListenerType, const PermissionsSet&, const MatchPatternSet&);
 
+    // Tabs APIs
+    void tabsGet(WebExtensionTabIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
+    void tabsGetCurrent(WebPageProxyIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
+    void tabsQuery(WebPageProxyIdentifier, const WebExtensionTabQueryParameters&, CompletionHandler<void(Vector<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
+
     // Windows APIs
-    void windowsCreate(WebExtensionWindowParameters, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&&);
+    void windowsCreate(const WebExtensionWindowParameters&, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&&);
     void windowsGet(WebPageProxyIdentifier, WebExtensionWindowIdentifier, OptionSet<WindowTypeFilter>, PopulateTabs, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&&);
     void windowsGetLastFocused(OptionSet<WindowTypeFilter>, PopulateTabs, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&&);
     void windowsGetAll(OptionSet<WindowTypeFilter>, PopulateTabs, CompletionHandler<void(Vector<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -50,6 +50,11 @@ messages -> WebExtensionContext {
     PermissionsRequest(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
     PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
 
+    // Tabs APIs
+    TabsGet(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
+    TabsGetCurrent(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
+    TabsQuery(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabQueryParameters queryParameters) -> (Vector<WebKit::WebExtensionTabParameters> tabs, WebKit::WebExtensionWindow::Error error);
+
     // Windows APIs
     WindowsCreate(WebKit::WebExtensionWindowParameters creationParameters) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);
     WindowsGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, OptionSet<WebKit::WebExtensionWindow::TypeFilter> filter, WebKit::WebExtensionWindow::PopulateTabs populate) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "WebExtensionTabIdentifier.h"
+#include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakObjCPtr.h>
 
@@ -41,6 +42,7 @@ namespace WebKit {
 class WebExtensionContext;
 class WebExtensionWindow;
 struct WebExtensionTabParameters;
+struct WebExtensionTabQueryParameters;
 
 class WebExtensionTab : public RefCounted<WebExtensionTab> {
     WTF_MAKE_NONCOPYABLE(WebExtensionTab);
@@ -70,15 +72,21 @@ public:
     };
 
     enum class ExtendSelection : bool { No, Yes };
+    enum class AssumeWindowMatches : bool { No, Yes };
 
     using Error = std::optional<String>;
 
     WebExtensionTabIdentifier identifier() const { return m_identifier; }
     WebExtensionTabParameters parameters() const;
+    WebExtensionTabParameters minimalParameters() const;
 
     WebExtensionContext* extensionContext() const;
 
     bool operator==(const WebExtensionTab&) const;
+
+    bool matches(const WebExtensionTabQueryParameters&, AssumeWindowMatches = AssumeWindowMatches::No, std::optional<WebPageProxyIdentifier> = std::nullopt) const;
+
+    bool extensionHasAccess() const;
 
     RefPtr<WebExtensionWindow> window() const;
     size_t index() const;
@@ -90,6 +98,7 @@ public:
 
     String title() const;
 
+    bool isActive() const;
     bool isSelected() const;
     bool isPinned() const;
     bool isPrivate() const;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "WebExtensionWindowIdentifier.h"
+#include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/WeakObjCPtr.h>
 
@@ -41,6 +42,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 class WebExtensionTab;
+struct WebExtensionTabQueryParameters;
 struct WebExtensionWindowParameters;
 
 class WebExtensionWindow : public RefCounted<WebExtensionWindow> {
@@ -88,6 +90,9 @@ public:
 
     bool operator==(const WebExtensionWindow&) const;
 
+    bool matches(OptionSet<TypeFilter>) const;
+    bool matches(const WebExtensionTabQueryParameters&, std::optional<WebPageProxyIdentifier> = std::nullopt) const;
+
     TabVector tabs() const;
     RefPtr<WebExtensionTab> activeTab() const;
 
@@ -97,6 +102,7 @@ public:
     void setState(State, CompletionHandler<void(Error)>&&);
 
     bool isFocused() const;
+    bool isFrontmost() const;
     void focus(CompletionHandler<void(Error)>&&);
 
     bool isPrivate() const;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */; };
 		1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE971288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C1D9C872AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C20936022318CB000026A39 /* NSAttributedString.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C20935E22318CB000026A39 /* NSAttributedString.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1C2184022233872800BAC700 /* NSAttributedStringPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3390,6 +3391,7 @@
 		1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMatchPatternInternal.h; sourceTree = "<group>"; };
 		1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMatchPatternPrivate.h; sourceTree = "<group>"; };
 		1C1CE971288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMatchPattern.h; sourceTree = "<group>"; };
+		1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPITabsCocoa.mm; sourceTree = "<group>"; };
 		1C20935E22318CB000026A39 /* NSAttributedString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSAttributedString.h; sourceTree = "<group>"; };
 		1C20935F22318CB000026A39 /* NSAttributedString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSAttributedString.mm; sourceTree = "<group>"; };
 		1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSAttributedStringPrivate.h; sourceTree = "<group>"; };
@@ -8561,6 +8563,7 @@
 				1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */,
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
 				B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */,
+				1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */,
 				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
 				1C49579A2A9813AA007D0B64 /* WebExtensionContextAPIWindowsCocoa.mm */,
 			);
@@ -17480,6 +17483,7 @@
 				1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
 				B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */,
+				1C1D9C872AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm in Sources */,
 				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
 				1C49579B2A9813AA007D0B64 /* WebExtensionContextAPIWindowsCocoa.mm in Sources */,
 				1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-bool WebExtensionAPIExtension::isPropertyAllowed(String name, WebPage*)
+bool WebExtensionAPIExtension::isPropertyAllowed(ASCIILiteral name, WebPage*)
 {
     // This method was removed in manifest version 3.
     if (name == "getURL"_s)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -36,7 +36,7 @@
 
 namespace WebKit {
 
-bool WebExtensionAPINamespace::isPropertyAllowed(String name, WebPage*)
+bool WebExtensionAPINamespace::isPropertyAllowed(ASCIILiteral name, WebPage*)
 {
     // This property is only allowed in testing contexts.
     if (name == "test"_s)
@@ -44,7 +44,7 @@ bool WebExtensionAPINamespace::isPropertyAllowed(String name, WebPage*)
 
     // FIXME: https://webkit.org/b/259914 This should be a hasPermission: call to extensionContext() and updated with actually granted permissions from the UI process.
     auto *permissions = objectForKey<NSArray>(extensionContext().manifest(), @"permissions", true, NSString.class);
-    return [permissions containsObject:static_cast<NSString *>(name)];
+    return [permissions containsObject:name.createNSString().get()];
 }
 
 WebExtensionAPIAlarms& WebExtensionAPINamespace::alarms()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -110,6 +110,8 @@ static NSDictionary *toWebAPI(const WebExtensionWindowParameters& parameters)
     ASSERT(parameters.focused);
     ASSERT(parameters.privateBrowsing);
 
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window
+
     NSMutableDictionary *result = [@{
         idKey: @(toWebAPI(parameters.identifier.value())),
         stateKey: toWebAPI(parameters.state.value()),
@@ -392,14 +394,14 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
     return true;
 }
 
-bool WebExtensionAPIWindows::isPropertyAllowed(String propertyName, WebPage*)
+bool WebExtensionAPIWindows::isPropertyAllowed(ASCIILiteral name, WebPage*)
 {
 #if PLATFORM(MAC)
     return true;
 #else
-    // Opening, closing, and updating a window in not supported on iOS or visionOS.
-    static NSSet<NSString *> *unsupportedWindowProperties = [NSSet setWithObjects:@"create", @"remove", @"update", nil];
-    return ![unsupportedWindowProperties containsObject:(NSString *)propertyName];
+    // Opening, closing, and updating a window in not supported on iOS, iPadOS, or visionOS.
+    static NeverDestroyed<HashSet<AtomString>> unsupported { HashSet { AtomString("create"_s), AtomString("remove"_s), AtomString("update"_s) } };
+    return !unsupported.get().contains(name);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
@@ -42,7 +42,7 @@ class WebExtensionAPIExtension : public WebExtensionAPIObject, public JSWebExten
 
 public:
 #if PLATFORM(COCOA)
-    bool isPropertyAllowed(String propertyName, WebPage*);
+    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
     NSURL *getURL(NSString *resourcePath, NSString **errorString);
 #endif

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -49,7 +49,7 @@ class WebExtensionAPINamespace : public WebExtensionAPIObject, public JSWebExten
 
 public:
 #if PLATFORM(COCOA)
-    bool isPropertyAllowed(String propertyName, WebPage*);
+    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
     WebExtensionAPIAlarms& alarms();
     WebExtensionAPIExtension& extension();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -30,6 +30,7 @@
 #include "JSWebExtensionAPITabs.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebExtensionTab.h"
 
 OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
@@ -44,15 +45,15 @@ class WebExtensionAPITabs : public WebExtensionAPIObject, public JSWebExtensionW
 
 public:
 #if PLATFORM(COCOA)
-    bool isPropertyAllowed(String propertyName, WebPage*);
+    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
     void createTab(NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void query(NSDictionary *queryInfo, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void query(WebPage*, NSDictionary *queryInfo, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void get(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getCurrent(Ref<WebExtensionCallbackHandler>&&);
-    void getSelected(double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getCurrent(WebPage*, Ref<WebExtensionCallbackHandler>&&);
+    void getSelected(WebPage*, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void duplicate(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void update(double tabID, NSDictionary *updateProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
@@ -48,7 +48,7 @@ public:
     using PopulateTabs = WebExtensionWindow::PopulateTabs;
     using WindowTypeFilter = WebExtensionWindow::TypeFilter;
 
-    bool isPropertyAllowed(String propertyName, WebPage*);
+    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
     void createWindow(NSDictionary *data, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -31,11 +31,11 @@
 
     [RaisesException, ImplementedAs=createTab] void create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void query([NSDictionary] any info, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void query([NSDictionary] any info, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void get(double tabID, [Optional, CallbackHandler] function callback);
-    void getCurrent([Optional, CallbackHandler] function callback);
-    [RaisesException, Dynamic] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
+    [NeedsPage] void getCurrent([Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPage] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void duplicate(double tabID, [Optional, CallbackHandler] function callback);
     [RaisesException] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -56,6 +56,12 @@
 @end
 
 @interface TestWebExtensionTab : NSObject <_WKWebExtensionTab>
+
+- (instancetype)initWithWindow:(id<_WKWebExtensionWindow>)window extensionController:(_WKWebExtensionController *)extensionController;
+
+@property (nonatomic, weak) id<_WKWebExtensionWindow> window;
+@property (nonatomic, strong) WKWebView *mainWebView;
+
 @end
 
 @interface TestWebExtensionWindow : NSObject <_WKWebExtensionWindow>

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionUtilities.h"
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 
 @interface TestWebExtensionManager () <_WKWebExtensionControllerDelegatePrivate>
 @end
@@ -137,6 +138,31 @@
 
 @implementation TestWebExtensionTab
 
+- (instancetype)initWithWindow:(id<_WKWebExtensionWindow>)window extensionController:(_WKWebExtensionController *)extensionController
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _window = window;
+
+    WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
+    configuration._webExtensionController = extensionController;
+
+    _mainWebView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
+
+    return self;
+}
+
+- (id<_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _window;
+}
+
+- (WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _mainWebView;
+}
+
 @end
 
 @implementation TestWebExtensionWindow {
@@ -164,6 +190,12 @@
     _previousFrame = CGRectNull;
 
     return self;
+}
+
+- (void)setTabs:(NSArray<id<_WKWebExtensionTab>> *)tabs
+{
+    _tabs = [tabs copy];
+    _activeTab = _tabs.firstObject;
 }
 
 - (NSArray<id<_WKWebExtensionTab>> *)tabsForWebExtensionContext:(_WKWebExtensionContext *)context


### PR DESCRIPTION
#### 012da625f11e5611b377597a0a9cc187e8638922
<pre>
Add support for tabs.get(), tabs.getCurrent(), tabs.getSelected(), and tabs.query() APIs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261342">https://bugs.webkit.org/show_bug.cgi?id=261342</a>
rdar://problem/115180170

Reviewed by Brian Weinstein.

* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared): Added WebExtensionTabQueryParameters.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm: Added.
(WebKit::WebExtensionContext::tabsGet):
(WebKit::WebExtensionContext::tabsGetCurrent):
(WebKit::WebExtensionContext::tabsQuery):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate): Use matches() on the window object.
(WebKit::WebExtensionContext::windowsGet): Ditto.
(WebKit::WebExtensionContext::windowsGetLastFocused): Ditto.
(WebKit::WebExtensionContext::windowsGetAll): Ditto.
(WebKit::matchesFilter): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::parameters const):
(WebKit::WebExtensionTab::minimalParameters const): Added.
(WebKit::WebExtensionTab::matches const): Added.
(WebKit::WebExtensionTab::extensionHasAccess const): Added.
(WebKit::WebExtensionTab::isActive const): Added.
(WebKit::WebExtensionTab::isSelected const): Default to isActive().
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::parameters const):
(WebKit::WebExtensionWindow::matches const): Added.
(WebKit::WebExtensionWindow::isFrontmost const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed): Changed to use ASCIILiteral.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Changed to use ASCIILiteral.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPITabs::parseTabQueryOptions): Added.
(WebKit::WebExtensionAPITabs::isPropertyAllowed): Implemented.
(WebKit::WebExtensionAPITabs::query): Implemented.
(WebKit::WebExtensionAPITabs::get): Implemented.
(WebKit::WebExtensionAPITabs::getCurrent): Implemented.
(WebKit::WebExtensionAPITabs::getSelected): Implemented.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIWindows::isPropertyAllowed): Changed to use ASCIILiteral and HashSet.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab initWithWindow:extensionController:]): Added.
(-[TestWebExtensionTab windowForWebExtensionContext:]): Added.
(-[TestWebExtensionTab mainWebViewForWebExtensionContext:]): Added.
(-[TestWebExtensionWindow setTabs:]): Added. Set active tab too.

Canonical link: <a href="https://commits.webkit.org/267864@main">https://commits.webkit.org/267864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da5a75a453e5e2d07fd97bfa01e4993e664ebfb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17752 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16605 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18657 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20440 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/17900 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22739 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20390 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2198 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->