### PR TITLE
Switch webpushd over to using generated IPC encoder/decoder

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -337,6 +337,8 @@ set(WebKit_MESSAGES_IN_FILES
     WebProcess/WebStorage/StorageAreaMap
 
     WebProcess/XR/PlatformXRSystemProxy
+
+    webpushd/PushClientConnection
 )
 
 set(WebKit_SERIALIZATION_IN_FILES

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -474,6 +474,7 @@ $(PROJECT_DIR)/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
 $(PROJECT_DIR)/WebProcess/cocoa/UserMediaCaptureManager.messages.in
 $(PROJECT_DIR)/WebProcess/cocoa/VideoFullscreenManager.messages.in
 $(PROJECT_DIR)/WebProcess/com.apple.WebProcess.sb.in
+$(PROJECT_DIR)/webpushd/PushClientConnection.messages.in
 $(PROJECT_DIR)/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
 $(PROJECT_DIR)/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/ActivityState.serialization.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -466,6 +466,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessPoolMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessPoolMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessProxyMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PushClientConnectionMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PushClientConnectionMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebRTCMonitorMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebRTCMonitorMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebRTCResolverMessageReceiver.cpp

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -104,6 +104,7 @@ VPATH = \
     $(WebKit2)/UIProcess/WebAuthentication \
     $(WebKit2)/UIProcess/mac \
     $(WebKit2)/UIProcess/ios \
+    $(WebKit2)/webpushd \
     $(WebKit2)/webpushd/mac \
     $(WEBKITADDITIONS_HEADER_SEARCH_PATHS) \
 #
@@ -316,6 +317,7 @@ MESSAGE_RECEIVERS = \
 	GPUProcess/media/RemoteMediaSourceProxy \
 	GPUProcess/media/RemoteRemoteCommandListenerProxy \
 	GPUProcess/media/RemoteSourceBufferProxy \
+	webpushd/PushClientConnection \
 #
 
 GENERATE_MESSAGE_RECEIVER_SCRIPT = $(WebKit2)/Scripts/generate-message-receiver.py

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -28,23 +28,15 @@
 
 #if PLATFORM(COCOA) && ENABLE(BUILT_IN_NOTIFICATIONS)
 
-#import "DaemonDecoder.h"
-#import "DaemonEncoder.h"
 #import "DaemonUtilities.h"
+#import "Decoder.h"
 #import "HandleMessage.h"
+#import "MessageSenderInlines.h"
+#import "PushClientConnectionMessages.h"
 #import "WebPushDaemonConstants.h"
 #import <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit::WebPushD { 
-
-using Daemon::EncodedMessage;
-
-static void addVersionAndEncodedMessageToDictionary(Vector<uint8_t>&& message, xpc_object_t dictionary)
-{
-    ASSERT(xpc_get_type(dictionary) == XPC_TYPE_DICTIONARY);
-    xpc_dictionary_set_uint64(dictionary, WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
-    xpc_dictionary_set_value(dictionary, WebPushD::protocolEncodedMessageKey, vectorToXPCData(WTFMove(message)).get());
-}
 
 void Connection::newConnectionWasInitialized() const
 {
@@ -52,66 +44,49 @@ void Connection::newConnectionWasInitialized() const
     if (networkSession().sessionID().isEphemeral())
         return;
 
-    Daemon::Encoder encoder;
-    encoder.encode(m_configuration);
-    Daemon::Connection::send(dictionaryFromMessage(WebPushD::MessageType::UpdateConnectionConfiguration, encoder.takeBuffer()).get());
+    sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(m_configuration));
 }
 
-namespace MessageInfo {
-
-#define FUNCTION(mf) struct mf { static constexpr auto MemberFunction = &WebKit::WebPushD::Connection::mf;
-#define ARGUMENTS(...) using ArgsTuple = std::tuple<__VA_ARGS__>;
-#define END };
-
-FUNCTION(debugMessage)
-ARGUMENTS(String)
-END
-
-} // namespace MessageInfo
-
-template<typename Info>
-void handleWebPushDaemonMessage(WebKit::WebPushD::Connection* connection, std::span<const uint8_t> encodedMessage)
+static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
-    WebKit::Daemon::Decoder decoder(encodedMessage);
+    auto xpcData = encoderToXPCData(WTFMove(encoder));
+    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    xpc_dictionary_set_uint64(dictionary.get(), WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
+    xpc_dictionary_set_value(dictionary.get(), WebPushD::protocolEncodedMessageKey, xpcData.get());
 
-    std::optional<typename Info::ArgsTuple> arguments;
-    decoder >> arguments;
-    if (UNLIKELY(!arguments))
-        return;
-
-    IPC::callMemberFunction(connection, Info::MemberFunction, WTFMove(*arguments));
-}
-
-void Connection::connectionReceivedEvent(xpc_object_t request)
-{
-    if (xpc_get_type(request) != XPC_TYPE_DICTIONARY)
-        return;
-
-    if (xpc_dictionary_get_uint64(request, protocolVersionKey) != protocolVersionValue) {
-        RELEASE_LOG(Push, "Received request that was not the current protocol version");
-        return;
-    }
-
-    auto messageType { static_cast<DaemonMessageType>(xpc_dictionary_get_uint64(request, protocolMessageTypeKey)) };
-    size_t dataSize { 0 };
-    const void* data = xpc_dictionary_get_data(request, protocolEncodedMessageKey, &dataSize);
-    std::span<const uint8_t> encodedMessage { static_cast<const uint8_t*>(data), dataSize };
-
-    ASSERT(!daemonMessageTypeSendsReply(messageType));
-
-    switch (messageType) {
-    case DaemonMessageType::DebugMessage:
-        handleWebPushDaemonMessage<MessageInfo::debugMessage>(this, encodedMessage);
-        break;
-    };
-}
-
-RetainPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
-{
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
-    addVersionAndEncodedMessageToDictionary(WTFMove(message), dictionary.get());
-    xpc_dictionary_set_uint64(dictionary.get(), protocolMessageTypeKey, static_cast<uint64_t>(messageType));
     return dictionary;
+}
+
+bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder) const
+{
+    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    Daemon::Connection::send(dictionary.get());
+
+    return true;
+}
+
+bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Decoder*)>&& completionHandler) const
+{
+    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    Daemon::Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+        if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY) {
+            ASSERT_NOT_REACHED();
+            return completionHandler(nullptr);
+        }
+        if (xpc_dictionary_get_uint64(reply, WebPushD::protocolVersionKey) != WebPushD::protocolVersionValue) {
+            ASSERT_NOT_REACHED();
+            return completionHandler(nullptr);
+        }
+
+        size_t dataSize { 0 };
+        const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebPushD::protocolEncodedMessageKey, &dataSize));
+        auto decoder = IPC::Decoder::create(data, dataSize, { });
+        ASSERT(decoder);
+
+        completionHandler(decoder.get());
+    });
+
+    return true;
 }
 
 } // namespace WebKit::WebPushD

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -78,11 +78,6 @@ private:
 
     NetworkSession& m_networkSession;
     std::unique_ptr<WebPushD::Connection> m_connection;
-
-    template<WebPushD::MessageType messageType, typename... Args>
-    void sendMessage(Args&&...) const;
-    template<WebPushD::MessageType messageType, typename... Args, typename... ReplyArgs>
-    void sendMessageWithReply(CompletionHandler<void(ReplyArgs...)>&&, Args&&...) const;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -29,7 +29,6 @@
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
 #include "PushMessageForTesting.h"
-#include "WebPushDaemonConnectionConfiguration.h"
 #include "WebPushMessage.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/ExceptionData.h>
@@ -351,16 +350,6 @@ std::optional<WebCore::PCM::AttributionTriggerData> Coder<WebCore::PCM::Attribut
         WTFMove(*destinationSite),
         // destinationUnlinkableToken and destinationSecretToken are not serialized.
     } };
-}
-
-void Coder<WebPushD::WebPushDaemonConnectionConfiguration, void>::encode(Encoder& encoder, const WebPushD::WebPushDaemonConnectionConfiguration& instance)
-{
-    instance.encode(encoder);
-}
-
-std::optional<WebPushD::WebPushDaemonConnectionConfiguration> Coder<WebPushD::WebPushDaemonConnectionConfiguration, void>::decode(Decoder& decoder)
-{
-    return WebPushD::WebPushDaemonConnectionConfiguration::decode(decoder);
 }
 
 void Coder<WebPushMessage, void>::encode(Encoder& encoder, const WebPushMessage& instance)

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -48,13 +48,13 @@ bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, Asyn
     return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions) == Error::NoError;
 }
 
-bool MessageSender::performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&)
+bool MessageSender::performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&) const
 {
     // Senders that use sendWithoutUsingIPCConnection(T&& message) must also override this.
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-bool MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>)
+bool MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>&&) const
 {
     // Senders that use sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler) must also override this.
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -70,11 +70,11 @@ public:
     template<typename T, typename C, typename U, typename V> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V> destinationID);
     template<typename T, typename C, typename U, typename V> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V> destinationID, OptionSet<SendOption>);
 
-    template<typename T> inline bool sendWithoutUsingIPCConnection(T&& message);
-    virtual bool performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&);
+    template<typename T> inline bool sendWithoutUsingIPCConnection(T&& message) const;
+    virtual bool performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&) const;
 
-    template<typename T, typename C> inline bool sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler);
-    virtual bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>);
+    template<typename T, typename C> inline bool sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler) const;
+    virtual bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>&&) const;
 
     virtual bool sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption>);
 

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -58,7 +58,7 @@ template<typename MessageType, typename C> inline AsyncReplyID MessageSender::se
     return { };
 }
 
-template<typename MessageType> inline bool MessageSender::sendWithoutUsingIPCConnection(MessageType&& message)
+template<typename MessageType> inline bool MessageSender::sendWithoutUsingIPCConnection(MessageType&& message) const
 {
     static_assert(!MessageType::isSync);
     auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), messageSenderDestinationID());
@@ -67,7 +67,7 @@ template<typename MessageType> inline bool MessageSender::sendWithoutUsingIPCCon
     return performSendWithoutUsingIPCConnection(WTFMove(encoder));
 }
 
-template<typename MessageType, typename C> inline bool MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection(MessageType&& message, C&& completionHandler)
+template<typename MessageType, typename C> inline bool MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection(MessageType&& message, C&& completionHandler) const
 {
     static_assert(!MessageType::isSync);
     auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), messageSenderDestinationID());

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -982,6 +982,8 @@ def headers_for_type(type):
         'WebKit::WebGPU::VertexBufferLayout': ['"WebGPUVertexBufferLayout.h"'],
         'WebKit::WebGPU::VertexState': ['"WebGPUVertexState.h"'],
         'WebKit::WebGPU::WebCodecsVideoFrameIdentifier': ['"WebGPUExternalTextureDescriptor.h"'],
+        'WebKit::WebPushD::PushMessageForTesting': ['"PushMessageForTesting.h"'],
+        'WebKit::WebPushD::WebPushDaemonConnectionConfiguration': ['"WebPushDaemonConnectionConfiguration.h"'],
         'WebKit::WebScriptMessageHandlerData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserScriptData': ['"WebUserContentControllerDataTypes.h"'],
         'WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
@@ -1158,10 +1160,11 @@ def generate_message_handler(receiver):
             if not receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE):
                 result.append('    UNUSED_PARAM(connection);\n')
             result.append('    UNUSED_PARAM(decoder);\n')
-            result.append('#if ENABLE(IPC_TESTING_API)\n')
-            result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
-            result.append('        return;\n')
-            result.append('#endif // ENABLE(IPC_TESTING_API)\n')
+            if not receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE):
+                result.append('#if ENABLE(IPC_TESTING_API)\n')
+                result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
+                result.append('        return;\n')
+                result.append('#endif // ENABLE(IPC_TESTING_API)\n')
             result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());\n')
         result.append('}\n')
 
@@ -1178,10 +1181,12 @@ def generate_message_handler(receiver):
         result.append('    UNUSED_PARAM(connection);\n')
         result.append('    UNUSED_PARAM(decoder);\n')
         result.append('    UNUSED_PARAM(replyEncoder);\n')
-        result.append('#if ENABLE(IPC_TESTING_API)\n')
-        result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
-        result.append('        return false;\n')
-        result.append('#endif // ENABLE(IPC_TESTING_API)\n')
+
+        if not receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE):
+            result.append('#if ENABLE(IPC_TESTING_API)\n')
+            result.append('    if (connection.ignoreInvalidMessageForTesting())\n')
+            result.append('        return false;\n')
+            result.append('#endif // ENABLE(IPC_TESTING_API)\n')
         result.append('    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());\n')
         result.append('    return false;\n')
         result.append('}\n')

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -53,10 +53,6 @@ void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decod
     if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
         return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
     UNUSED_PARAM(decoder);
-#if ENABLE(IPC_TESTING_API)
-    if (connection.ignoreInvalidMessageForTesting())
-        return;
-#endif // ENABLE(IPC_TESTING_API)
     ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
 }
 

--- a/Source/WebKit/Shared/API/Cocoa/WKMain.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKMain.mm
@@ -43,10 +43,18 @@ int WKAdAttributionDaemonMain(int argc, const char** argv)
 
 int WKWebPushDaemonMain(int argc, char** argv)
 {
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
     return WebKit::WebPushDaemonMain(argc, argv);
+#else
+    return -1;
+#endif
 }
 
 int WKWebPushToolMain(int argc, char** argv)
 {
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
     return WebKit::WebPushToolMain(argc, argv);
+#else
+    return -1;
+#endif
 }

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.h
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.h
@@ -25,13 +25,19 @@
 
 #pragma once
 
+#include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/spi/darwin/XPCSPI.h>
+
+namespace IPC {
+class Encoder;
+}
 
 namespace WebKit {
 
 void startListeningForMachServiceConnections(const char* serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t));
 RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
+OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -47,7 +47,7 @@ header: <wtf/text/AtomString.h>
     String string()
 }
 
-class WTF::UUID {
+[WebKitPlatform] class WTF::UUID {
     uint64_t high();
     [Validator='((static_cast<UInt128>(*high) << 64) | *low) != WTF::UUID::deletedValue'] uint64_t low();
 }

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -32,50 +32,10 @@
 namespace WebKit::WebPushD {
 
 struct WebPushDaemonConnectionConfiguration {
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<WebPushDaemonConnectionConfiguration> decode(Decoder&);
-
     bool useMockBundlesForTesting { false };
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;
 };
-
-template<class Encoder>
-void WebPushDaemonConnectionConfiguration::encode(Encoder& encoder) const
-{
-    encoder << useMockBundlesForTesting << hostAppAuditTokenData << pushPartitionString << dataStoreIdentifier;
-}
-
-template<class Decoder>
-std::optional<WebPushDaemonConnectionConfiguration> WebPushDaemonConnectionConfiguration::decode(Decoder& decoder)
-{
-    std::optional<bool> useMockBundlesForTesting;
-    decoder >> useMockBundlesForTesting;
-    if (!useMockBundlesForTesting)
-        return std::nullopt;
-
-    std::optional<std::optional<Vector<uint8_t>>> hostAppAuditTokenData;
-    decoder >> hostAppAuditTokenData;
-    if (!hostAppAuditTokenData)
-        return std::nullopt;
-
-    std::optional<String> pushPartitionString;
-    decoder >> pushPartitionString;
-    if (!pushPartitionString)
-        return std::nullopt;
-
-    std::optional<std::optional<WTF::UUID>> dataStoreIdentifier;
-    decoder >> dataStoreIdentifier;
-    if (!dataStoreIdentifier)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*useMockBundlesForTesting),
-        WTFMove(*hostAppAuditTokenData),
-        WTFMove(*pushPartitionString),
-        WTFMove(*dataStoreIdentifier)
-    } };
-}
 
 } // namespace WebKit::WebPushD

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -20,8 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-header: "WebPushDaemonConnectionConfiguration.h"
-[CustomHeader] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
+webkit_platform_headers: "ArgumentCoders.h" "WebPushDaemonConnectionConfiguration.h"
+
+[CustomHeader, WebKitPlatform] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
     bool useMockBundlesForTesting;
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
     String pushPartitionString;

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -33,80 +33,15 @@ namespace WebKit::WebPushD {
 constexpr unsigned maxSilentPushCount = 3;
 
 constexpr const char* protocolVersionKey = "protocol version";
-constexpr uint64_t protocolVersionValue = 2;
+constexpr uint64_t protocolVersionValue = 3;
 constexpr const char* protocolEncodedMessageKey = "encoded message";
-
 constexpr const char* protocolDebugMessageKey { "debug message" };
-constexpr const char* protocolDebugMessageLevelKey { "debug message level" };
 
-constexpr const char* protocolMessageTypeKey { "message type" };
-
+// FIXME: ConnectionToMachService traits requires we have a message type, so keep this placeholder here
+// until we can remove that requirement.
 enum class MessageType : uint8_t {
-    EchoTwice = 1,
-    RequestSystemNotificationPermission_UNUSED,
-    DeletePushAndNotificationRegistration,
-    GetOriginsWithPushAndNotificationPermissions_UNUSED,
-    SetDebugModeIsEnabled,
-    UpdateConnectionConfiguration,
-    InjectPushMessageForTesting,
-    InjectEncryptedPushMessageForTesting,
-    GetPendingPushMessages,
-    SubscribeToPushService,
-    UnsubscribeFromPushService,
-    GetPushSubscription,
-    GetPushPermissionState,
-    IncrementSilentPushCount,
-    RemoveAllPushSubscriptions,
-    RemovePushSubscriptionsForOrigin,
-    SetPublicTokenForTesting,
-    SetPushAndNotificationsEnabledForOrigin,
+    EchoTwice
 };
-
-enum class RawXPCMessageType : uint8_t {
-    GetPushTopicsForTesting = 192,
-};
-
-inline bool messageTypeSendsReply(MessageType messageType)
-{
-    switch (messageType) {
-    case MessageType::EchoTwice:
-    case MessageType::RequestSystemNotificationPermission_UNUSED:
-    case MessageType::DeletePushAndNotificationRegistration:
-    case MessageType::GetOriginsWithPushAndNotificationPermissions_UNUSED:
-    case MessageType::GetPendingPushMessages:
-    case MessageType::InjectPushMessageForTesting:
-    case MessageType::InjectEncryptedPushMessageForTesting:
-    case MessageType::SubscribeToPushService:
-    case MessageType::UnsubscribeFromPushService:
-    case MessageType::GetPushSubscription:
-    case MessageType::GetPushPermissionState:
-    case MessageType::IncrementSilentPushCount:
-    case MessageType::RemoveAllPushSubscriptions:
-    case MessageType::RemovePushSubscriptionsForOrigin:
-    case MessageType::SetPublicTokenForTesting:
-    case MessageType::SetPushAndNotificationsEnabledForOrigin:
-        return true;
-    case MessageType::SetDebugModeIsEnabled:
-    case MessageType::UpdateConnectionConfiguration:
-        return false;
-    }
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
-enum class DaemonMessageType : uint8_t {
-    DebugMessage = 1,
-};
-
-inline bool daemonMessageTypeSendsReply(DaemonMessageType messageType)
-{
-    switch (messageType) {
-    case DaemonMessageType::DebugMessage:
-        return false;
-    }
-    ASSERT_NOT_REACHED();
-    return false;
-}
 
 } // namespace WebKit::WebPushD
 

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -876,6 +876,7 @@ RemoteGraphicsContextGLMessageReceiver.cpp
 RemoteGraphicsContextGLProxyMessageReceiver.cpp
 PlatformXRSystemMessageReceiver.cpp
 PlatformXRSystemProxyMessageReceiver.cpp
+PushClientConnectionMessageReceiver.cpp
 RemoteAdapterMessageReceiver.cpp
 RemoteBarcodeDetectorMessageReceiver.cpp
 RemoteBindGroupMessageReceiver.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1104,7 +1104,6 @@
 		517A52D91F43A9DA00DCDC0A /* WebSWServerConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 517A52D61F43A9B600DCDC0A /* WebSWServerConnectionMessages.h */; };
 		517A530F1F47A86200DCDC0A /* WebSWClientConnectionMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 517A530E1F47A84300DCDC0A /* WebSWClientConnectionMessageReceiver.cpp */; };
 		517A53101F47A86200DCDC0A /* WebSWClientConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 517A530D1F47A84300DCDC0A /* WebSWClientConnectionMessages.h */; };
-		517B5F2E2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 517B5F2D2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h */; };
 		517B5F73275E9609002DC22D /* WebPushDaemonMain.h in Headers */ = {isa = PBXBuildFile; fileRef = 517B5F72275E9609002DC22D /* WebPushDaemonMain.h */; };
 		517B5F78275E9795002DC22D /* webpushd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F77275E9795002DC22D /* webpushd.cpp */; };
 		517B5F79275E97A1002DC22D /* WebPushDaemonMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C157A0B2717CA1C00ED5280 /* WebPushDaemonMain.mm */; };
@@ -1155,8 +1154,10 @@
 		51DD9F2816367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51DD9F2616367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp */; };
 		51DD9F2916367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51DD9F2716367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h */; };
 		51E351CB180F2CCC00E53BE9 /* IDBUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E351C9180F2CCC00E53BE9 /* IDBUtilities.h */; };
+		51E481052AAA8F0A0069B158 /* WebPushDaemonConnectionConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 517B5F2D2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h */; };
 		51E9049A27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E9049827BCB9D100929E7E /* LaunchServicesSPI.h */; };
 		51E9049B27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E9049827BCB9D100929E7E /* LaunchServicesSPI.h */; };
+		51EE7B5B2A95B5820016FF78 /* PushClientConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EE7B5A2A95B5820016FF78 /* PushClientConnectionMessages.h */; };
 		51EFC1CF1524E62500C9A938 /* WKBundleDOMWindowExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FA2D541521118600C1BA0B /* WKBundleDOMWindowExtension.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51F060E01654317F00F3281B /* WebResourceLoaderMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51F060DE1654317500F3281B /* WebResourceLoaderMessages.h */; };
 		51F060E11654318500F3281B /* WebResourceLoaderMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51F060DD1654317500F3281B /* WebResourceLoaderMessageReceiver.cpp */; };
@@ -5087,6 +5088,8 @@
 		51E8B68D1E712873001B7132 /* WebURLSchemeTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebURLSchemeTask.cpp; sourceTree = "<group>"; };
 		51E9049827BCB9D100929E7E /* LaunchServicesSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LaunchServicesSPI.h; sourceTree = "<group>"; };
 		51E949961D761CC700EC9EB9 /* UIGamepadProviderIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UIGamepadProviderIOS.mm; sourceTree = "<group>"; };
+		51EE7B592A9542B70016FF78 /* PushClientConnection.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PushClientConnection.messages.in; sourceTree = "<group>"; };
+		51EE7B5A2A95B5820016FF78 /* PushClientConnectionMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushClientConnectionMessages.h; sourceTree = "<group>"; };
 		51F060DD1654317500F3281B /* WebResourceLoaderMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebResourceLoaderMessageReceiver.cpp; sourceTree = "<group>"; };
 		51F060DD1654317500F3281C /* LibWebRTCNetworkMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LibWebRTCNetworkMessageReceiver.cpp; sourceTree = "<group>"; };
 		51F060DD1654317500F3281E /* NetworkRTCMonitorMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkRTCMonitorMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -11350,6 +11353,7 @@
 				EBA8D3AD27A5E33E00CB7900 /* MockPushServiceConnection.h */,
 				EBA8D3B027A5E33F00CB7900 /* MockPushServiceConnection.mm */,
 				51F7BB792744C50700C45A72 /* PushClientConnection.h */,
+				51EE7B592A9542B70016FF78 /* PushClientConnection.messages.in */,
 				51F7BB7A2744C50700C45A72 /* PushClientConnection.mm */,
 				EB36B16627A7B4500050E00D /* PushService.h */,
 				EB36B16727A7B4500050E00D /* PushService.mm */,
@@ -13424,6 +13428,7 @@
 				CDA29A251CBEB67A00901CCF /* PlaybackSessionManagerMessages.h */,
 				CDA29A261CBEB67A00901CCF /* PlaybackSessionManagerProxyMessageReceiver.cpp */,
 				CDA29A271CBEB67A00901CCF /* PlaybackSessionManagerProxyMessages.h */,
+				51EE7B5A2A95B5820016FF78 /* PushClientConnectionMessages.h */,
 				1C55A593275457C900EB7E95 /* RemoteAdapterMessageReceiver.cpp */,
 				1C55A5B1275457CD00EB7E95 /* RemoteAdapterMessages.h */,
 				CD20CE7725CD2B9D0069B542 /* RemoteAudioHardwareListenerMessageReceiver.cpp */,
@@ -14697,6 +14702,7 @@
 				83048AE61ACA45DC0082C832 /* ProcessThrottlerClient.h in Headers */,
 				2D279E1926955768004B3EEB /* PrototypeToolsSPI.h in Headers */,
 				517B5F7D275E97B6002DC22D /* PushClientConnection.h in Headers */,
+				51EE7B5B2A95B5820016FF78 /* PushClientConnectionMessages.h in Headers */,
 				517B5F95275EBA63002DC22D /* PushMessageForTesting.h in Headers */,
 				EB36B16827A7B4500050E00D /* PushService.h in Headers */,
 				EBA8D3B527A5E33F00CB7900 /* PushServiceConnection.h in Headers */,
@@ -15120,7 +15126,7 @@
 				512F589D12A8838800629530 /* WebProtectionSpace.h in Headers */,
 				517B5F7F275E97B6002DC22D /* WebPushDaemon.h in Headers */,
 				512CD6982721EFC800F7F8EC /* WebPushDaemonConnection.h in Headers */,
-				517B5F2E2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h in Headers */,
+				51E481052AAA8F0A0069B158 /* WebPushDaemonConnectionConfiguration.h in Headers */,
 				512CD69A2721F0A900F7F8EC /* WebPushDaemonConstants.h in Headers */,
 				517B5F73275E9609002DC22D /* WebPushDaemonMain.h in Headers */,
 				517B5F97275EC5E5002DC22D /* WebPushMessage.h in Headers */,

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -25,7 +25,15 @@
 
 #pragma once
 
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+
+#include "MessageReceiver.h"
+#include "PushMessageForTesting.h"
+#include "WebPushMessage.h"
+#include <WebCore/ExceptionData.h>
+#include <WebCore/PushSubscriptionData.h>
 #include <WebCore/PushSubscriptionIdentifier.h>
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/Identified.h>
@@ -36,6 +44,10 @@
 #include <wtf/spi/darwin/XPCSPI.h>
 #include <wtf/text/WTFString.h>
 
+namespace WebCore {
+class SecurityOriginData;
+}
+
 namespace WebKit {
 namespace WebPushD {
 enum class DaemonMessageType : uint8_t;
@@ -44,22 +56,21 @@ struct WebPushDaemonConnectionConfiguration;
 }
 
 using WebKit::WebPushD::DaemonMessageType;
+using WebKit::WebPushD::PushMessageForTesting;
 using WebKit::WebPushD::WebPushDaemonConnectionConfiguration;
 
 namespace WebPushD {
 
-class PushClientConnection : public RefCounted<PushClientConnection>, public CanMakeWeakPtr<PushClientConnection>, public Identified<PushClientConnection> {
+class PushClientConnection : public RefCounted<PushClientConnection>, public Identified<PushClientConnection>, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<PushClientConnection> create(xpc_connection_t);
 
-    void updateConnectionConfiguration(const WebPushDaemonConnectionConfiguration&);
-
     bool hasHostAppAuditToken() const { return !!m_hostAppAuditToken; }
 
     WebCore::PushSubscriptionSetIdentifier subscriptionSetIdentifier();
-
     const String& hostAppCodeSigningIdentifier();
+
     bool hostAppHasPushEntitlement();
     bool hostAppHasPushInjectEntitlement();
 
@@ -76,16 +87,30 @@ public:
     void broadcastDebugMessage(const String&);
     void sendDebugMessage(const String&);
 
+    void didReceiveMessageWithReplyHandler(IPC::Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&) override;
+
 private:
     PushClientConnection(xpc_connection_t);
 
+    // PushClientConnectionMessages
+    void setPushAndNotificationsEnabledForOrigin(const String& originString, bool, CompletionHandler<void()>&& replySender);
+    void deletePushAndNotificationRegistration(const String& originString, CompletionHandler<void(const String&)>&& replySender);
+    void injectPushMessageForTesting(PushMessageForTesting&&, CompletionHandler<void(bool)>&&);
+    void injectEncryptedPushMessageForTesting(const String&, CompletionHandler<void(bool)>&&);
+    void getPendingPushMessages(CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
+    void subscribeToPushService(URL&& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
+    void unsubscribeFromPushService(URL&& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
+    void getPushSubscription(URL&& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
+    void incrementSilentPushCount(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
+    void removeAllPushSubscriptions(CompletionHandler<void(unsigned)>&&);
+    void removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
+    void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
+    void updateConnectionConfiguration(WebPushDaemonConnectionConfiguration&&);
+    void getPushPermissionState(URL&& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
-
+    void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
     String bundleIdentifierFromAuditToken(audit_token_t);
     bool hostHasEntitlement(ASCIILiteral);
-
-    template<DaemonMessageType messageType, typename... Args>
-    void sendDaemonMessage(Args&&...) const;
 
     OSObjectPtr<xpc_connection_t> m_xpcConnection;
 
@@ -101,3 +126,5 @@ private:
 };
 
 } // namespace WebPushD
+
+#endif // ENABLE(BUILT_IN_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -1,0 +1,44 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+
+messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
+    SetPushAndNotificationsEnabledForOrigin(String originString, bool enabled) -> ()
+    DeletePushAndNotificationRegistration(String registrationURL) -> (String unusedResult)
+    GetPendingPushMessages() -> (Vector<WebKit::WebPushMessage> messages)
+    SetDebugModeIsEnabled(bool enabled)
+    UpdateConnectionConfiguration(WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration)
+    InjectPushMessageForTesting(WebKit::WebPushD::PushMessageForTesting message) -> (bool injected)
+    InjectEncryptedPushMessageForTesting(String encryptedMessage) -> (bool injected)
+    SubscribeToPushService(URL scopeURL, Vector<uint8_t> vapidPublicKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)
+    UnsubscribeFromPushService(URL scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> identifier) -> (Expected<bool, WebCore::ExceptionData> result)
+    GetPushSubscription(URL scopeURL) -> (Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData> result)
+    GetPushPermissionState(URL scopeURL) -> (Expected<uint8_t, WebCore::ExceptionData> result)
+    IncrementSilentPushCount(WebCore::SecurityOriginData origin) -> (unsigned newCount)
+    RemoveAllPushSubscriptions()  -> (unsigned removed)
+    RemovePushSubscriptionsForOrigin(WebCore::SecurityOriginData origin) -> (unsigned removed)
+    SetPublicTokenForTesting(String token) -> ()
+    GetPushTopicsForTesting() -> (Vector<String> enabled, Vector<String> ignored)
+}
+
+#endif // ENABLE(BUILT_IN_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+
 #include "PushClientConnection.h"
 #include "PushMessageForTesting.h"
 #include "PushService.h"
@@ -72,33 +74,25 @@ public:
     void handleIncomingPush(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
 
     // Message handlers
-    void echoTwice(PushClientConnection*, const String&, CompletionHandler<void(const String&)>&& replySender);
-    void setPushAndNotificationsEnabledForOrigin(PushClientConnection*, const String& originString, bool, CompletionHandler<void()>&& replySender);
-    void deletePushAndNotificationRegistration(PushClientConnection*, const String& originString, CompletionHandler<void(const String&)>&& replySender);
-    void setDebugModeIsEnabled(PushClientConnection*, bool);
-    void updateConnectionConfiguration(PushClientConnection*, const WebPushDaemonConnectionConfiguration&);
-    void injectPushMessageForTesting(PushClientConnection*, const PushMessageForTesting&, CompletionHandler<void(bool)>&&);
-    void injectEncryptedPushMessageForTesting(PushClientConnection*, const String&, CompletionHandler<void(bool)>&&);
-    void getPendingPushMessages(PushClientConnection*, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
-    void getPushTopicsForTesting(OSObjectPtr<xpc_object_t>&&);
-    void subscribeToPushService(PushClientConnection*, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
-    void unsubscribeFromPushService(PushClientConnection*, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
-    void getPushSubscription(PushClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
-    void getPushPermissionState(PushClientConnection*, const URL& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender);
-    void incrementSilentPushCount(PushClientConnection*, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
-    void removeAllPushSubscriptions(PushClientConnection*, CompletionHandler<void(unsigned)>&&);
-    void removePushSubscriptionsForOrigin(PushClientConnection*, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
-    void setPublicTokenForTesting(PushClientConnection*, const String& publicToken, CompletionHandler<void()>&&);
+    void setPushAndNotificationsEnabledForOrigin(PushClientConnection&, const String& originString, bool, CompletionHandler<void()>&& replySender);
+    void deletePushAndNotificationRegistration(PushClientConnection&, const String& originString, CompletionHandler<void(const String&)>&& replySender);
+    void injectPushMessageForTesting(PushClientConnection&, const PushMessageForTesting&, CompletionHandler<void(bool)>&&);
+    void injectEncryptedPushMessageForTesting(PushClientConnection&, const String&, CompletionHandler<void(bool)>&&);
+    void getPendingPushMessages(PushClientConnection&, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
+    void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
+    void subscribeToPushService(PushClientConnection&, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
+    void unsubscribeFromPushService(PushClientConnection&, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
+    void getPushSubscription(PushClientConnection&, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
+    void incrementSilentPushCount(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
+    void removeAllPushSubscriptions(PushClientConnection&, CompletionHandler<void(unsigned)>&&);
+    void removePushSubscriptionsForOrigin(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
+    void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
 
     void broadcastDebugMessage(const String&);
     void broadcastAllConnectionIdentities();
 
 private:
     WebPushDaemon();
-
-    CompletionHandler<void(EncodedMessage&&)> createReplySender(WebKit::WebPushD::MessageType, OSObjectPtr<xpc_object_t>&& request);
-    void decodeAndHandleRawXPCMessage(WebKit::WebPushD::RawXPCMessageType, OSObjectPtr<xpc_object_t>&&);
-    void decodeAndHandleMessage(xpc_connection_t, WebKit::WebPushD::MessageType, std::span<const uint8_t> encodedMessage, CompletionHandler<void(EncodedMessage&&)>&&);
 
     bool canRegisterForNotifications(PushClientConnection&);
 
@@ -128,3 +122,6 @@ private:
 };
 
 } // namespace WebPushD
+
+#endif // ENABLE(BUILT_IN_NOTIFICATIONS)
+

--- a/Source/WebKit/webpushd/WebPushDaemonMain.h
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.h
@@ -25,8 +25,13 @@
 
 #pragma once
 
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+
 namespace WebKit {
 
 int WebPushDaemonMain(int, char**);
 
 } // namespace WebKit
+
+#endif // ENABLE(BUILT_IN_NOTIFICATIONS)
+

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -24,6 +24,8 @@
  */
 
 #import "config.h"
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+
 #import "WebPushDaemonMain.h"
 
 #import "AuxiliaryProcess.h"
@@ -171,3 +173,6 @@ int WebPushDaemonMain(int argc, char** argv)
 }
 
 } // namespace WebKit
+
+#endif // ENABLE(BUILT_IN_NOTIFICATIONS)
+

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "MessageSenderInlines.h"
 #include "PushMessageForTesting.h"
 #include <memory>
 #include <wtf/RetainPtr.h>
@@ -55,11 +56,12 @@ enum class WaitForServiceToExist : bool {
     Yes,
 };
 
-class Connection : public CanMakeWeakPtr<Connection> {
+class Connection : public CanMakeWeakPtr<Connection>, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static std::unique_ptr<Connection> create(std::optional<Action>, PreferTestService, Reconnect);
     Connection(std::optional<Action>, PreferTestService, Reconnect);
+    ~Connection() final { }
 
     void connectToService(WaitForServiceToExist);
 
@@ -74,6 +76,11 @@ private:
     void sendPushMessage();
 
     void sendAuditToken();
+
+    bool performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&) const final;
+    bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&, CompletionHandler<void(IPC::Decoder*)>&&) const final;
+    IPC::Connection* messageSenderConnection() const final { return nullptr; }
+    uint64_t messageSenderDestinationID() const final { return 0; }
 
     std::optional<Action> m_action;
     bool m_reconnect { false };

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -24,15 +24,18 @@
  */
 
 #import "config.h"
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
 #import "WebPushToolConnection.h"
 
 #import "DaemonEncoder.h"
 #import "DaemonUtilities.h"
+#import "PushClientConnectionMessages.h"
 #import "WebPushDaemonConnectionConfiguration.h"
 #import "WebPushDaemonConstants.h"
 #import <mach/mach_init.h>
 #import <mach/task.h>
 #import <pal/spi/cocoa/ServersSPI.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
 
@@ -136,20 +139,10 @@ void Connection::sendPushMessage()
 {
     ASSERT(m_pushMessage);
 
-    WebKit::Daemon::Encoder encoder;
-    encoder << *m_pushMessage;
-
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
-    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
-    xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, WebKit::vectorToXPCData(encoder.takeBuffer()).get());
-    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolMessageTypeKey, static_cast<uint64_t>(WebKit::WebPushD::MessageType::InjectPushMessageForTesting));
-
     printf("Injecting push message\n");
 
-    // If we have no action for this invocation (such as streaming debug messages) then we can exit after the push injection completes
-    __block bool shouldExitAfterInject = !m_action;
-    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), dispatch_get_main_queue(), ^(xpc_object_t resultMessage) {
-        printf("Push message injected\n");
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(*m_pushMessage), [shouldExitAfterInject = !m_action] (bool injected) {
+        printf("Push message injected - %i\n", injected);
         if (shouldExitAfterInject)
             CFRunLoopStop(CFRunLoopGetMain());
     });
@@ -157,14 +150,7 @@ void Connection::sendPushMessage()
 
 void Connection::startDebugStreamAction()
 {
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
-    std::array<uint8_t, 1> encodedMessage { 1 };
-    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
-    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolMessageTypeKey, static_cast<uint64_t>(WebKit::WebPushD::MessageType::SetDebugModeIsEnabled));
-    xpc_dictionary_set_data(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, encodedMessage.data(), encodedMessage.size());
-
-    xpc_connection_send_message(m_connection.get(), dictionary.get());
-
+    sendWithoutUsingIPCConnection(Messages::PushClientConnection::SetDebugModeIsEnabled(true));
     printf("Now streaming debug messages\n");
 }
 
@@ -186,14 +172,7 @@ void Connection::sendAuditToken()
     memcpy(tokenVector.data(), &token, sizeof(token));
     configuration.hostAppAuditTokenData = WTFMove(tokenVector);
 
-    WebKit::Daemon::Encoder encoder;
-    configuration.encode(encoder);
-
-    auto dictionary = adoptNS(xpc_dictionary_create(nullptr, nullptr, 0));
-    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
-    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolMessageTypeKey, static_cast<uint64_t>(WebKit::WebPushD::MessageType::UpdateConnectionConfiguration));
-    xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, WebKit::vectorToXPCData(encoder.takeBuffer()).get());
-    xpc_connection_send_message(m_connection.get(), dictionary.get());
+    sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(WTFMove(configuration)));
 }
 
 void Connection::connectionDropped()
@@ -219,4 +198,50 @@ void Connection::messageReceived(xpc_object_t message)
     printf("%s\n", debugMessage);
 }
 
+static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+{
+    auto xpcData = WebKit::encoderToXPCData(WTFMove(encoder));
+    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
+    xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, xpcData.get());
+
+    return dictionary;
+}
+
+bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder) const
+{
+    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    xpc_connection_send_message(m_connection.get(), dictionary.get());
+
+    return true;
+}
+
+bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Decoder*)>&& completionHandler) const
+{
+    auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
+    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), dispatch_get_main_queue(), makeBlockPtr([completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+        if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY) {
+            ASSERT_NOT_REACHED();
+            return completionHandler(nullptr);
+        }
+        if (xpc_dictionary_get_uint64(reply, WebKit::WebPushD::protocolVersionKey) != WebKit::WebPushD::protocolVersionValue) {
+            ASSERT_NOT_REACHED();
+            return completionHandler(nullptr);
+        }
+
+        size_t dataSize { 0 };
+        const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebKit::WebPushD::protocolEncodedMessageKey, &dataSize));
+        auto decoder = IPC::Decoder::create(data, dataSize, { });
+        ASSERT(decoder);
+
+        completionHandler(decoder.get());
+    }).get());
+
+    return true;
+}
+
+
 } // namespace WebPushTool
+
+#endif // ENABLE(BUILT_IN_NOTIFICATIONS)
+

--- a/Tools/TestWebKitAPI/Configurations/TestIPC.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestIPC.xcconfig
@@ -23,7 +23,7 @@
 
 PRODUCT_NAME = TestIPC;
 
-PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform $(SRCROOT)/../../Source/WebKit/Platform/IPC $(SRCROOT)/../../Source/WebKit/Platform/IPC/darwin $(SRCROOT)/../../Source/WebKit/Platform/IPC/cocoa $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit $(inherited);
+PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform $(SRCROOT)/../../Source/WebKit/Platform/IPC $(SRCROOT)/../../Source/WebKit/Platform/IPC/darwin $(SRCROOT)/../../Source/WebKit/Platform/IPC/cocoa $(SRCROOT)/../../Source/WebKit/Shared $(SRCROOT)/../../Source/WebKit/Shared/API/C $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit $(inherited);
 
 CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING = $(CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING_$(ENABLE_LLVM_PROFILE_GENERATION));
 CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING_ENABLE_LLVM_PROFILE_GENERATION = YES;

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
@@ -31,6 +31,8 @@ FRAMEWORK_SEARCH_PATHS = $(FRAMEWORK_SEARCH_PATHS_$(WK_COCOA_TOUCH));
 FRAMEWORK_SEARCH_PATHS_ = $(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks $(SYSTEM_LIBRARY_DIR)/Frameworks/WebKit.framework/Versions/A/Frameworks;
 FRAMEWORK_SEARCH_PATHS_cocoatouch = $(inherited);
 
+PROJECT_HEADER_SEARCH_PATHS = $(SRCROOT)/../../Source/WebKit/Platform $(SRCROOT)/../../Source/WebKit/Platform/IPC $(SRCROOT)/../../Source/WebKit/Platform/IPC/darwin $(SRCROOT)/../../Source/WebKit/Platform/IPC/cocoa $(SRCROOT)/../../Source/WebKit/Shared $(SRCROOT)/../../Source/WebKit/Shared/API/C $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit $(inherited);
+
 WK_APPSERVERSUPPORT_LDFLAGS[sdk=iphone*] = -framework AppServerSupport
 
 WK_AUTHKIT_LDFLAGS = $(WK_AUTHKIT_LDFLAGS_$(WK_PLATFORM_NAME));
@@ -96,7 +98,7 @@ WK_WEBCORE_LDFLAGS_watchsimulator = -framework WebCore
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
 OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
 
 // FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 		51CD1C721B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51CD1C711B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html */; };
 		51DB16CE1F085137001FA4C5 /* WebViewIconLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */; };
 		51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E1007129C6D891009CEE99 /* file-with-managedmse.html */; };
+		51E4810D2AAB93800069B158 /* libWebKitPlatform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */; };
 		51E5C7021919C3B200D8B3E1 /* simple2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780361919AFF8001829A2 /* simple2.html */; };
 		51E5C7031919C3B200D8B3E1 /* simple3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780371919AFF8001829A2 /* simple3.html */; };
 		51E6A8961D2F1CA700C004B6 /* LocalStorageClear.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E6A8951D2F1C7700C004B6 /* LocalStorageClear.html */; };
@@ -3691,6 +3692,7 @@
 				CDA3159D1ED5643F009F60D3 /* IOKit.framework in Frameworks */,
 				7B9FC5CB28A52D90007570E7 /* libboringssl.a in Frameworks */,
 				7C83E03F1D0A61A000FEBCF3 /* libicucore.dylib in Frameworks */,
+				51E4810D2AAB93800069B158 /* libWebKitPlatform.a in Frameworks */,
 				578CBD67204FB2C80083B9F2 /* LocalAuthentication.framework in Frameworks */,
 				7A010BCD1D877C0D00EDE72A /* QuartzCore.framework in Frameworks */,
 				574F55D2204D47F0002948C6 /* Security.framework in Frameworks */,


### PR DESCRIPTION
#### 70dba30bd03c14d661efe268d25e418018fdc9d9
<pre>
Switch webpushd over to using generated IPC encoder/decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=261361">https://bugs.webkit.org/show_bug.cgi?id=261361</a>
rdar://114886414

Reviewed by Chris Dumez.

All of these hand rolled and hand maintained messages and related macros and templates are... fragile.
Let&apos;s generate them, greatly improving the ability to hack on webpushd related stuff quickly.

This patch:
- Generates messages/serializers for PushClientConnection stuff
- Removes all of the raw xpc messaging to webpushd
- Exposes these messages and ArgumentCoders to TestWebKitAPI and webpushtool
- Adapts TestWebKitAPI and webpushtool to these changes

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::newConnectionWasInitialized const):
(WebKit::WebPushD::messageDictionaryFromEncoder):
(WebKit::WebPushD::Connection::performSendWithoutUsingIPCConnection const):
(WebKit::WebPushD::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
(WebKit::WebPushD::addVersionAndEncodedMessageToDictionary): Deleted.
(WebKit::WebPushD::handleWebPushDaemonMessage): Deleted.
(WebKit::WebPushD::Connection::connectionReceivedEvent): Deleted.
(WebKit::WebPushD::Connection::dictionaryFromMessage const): Deleted.
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::setPushAndNotificationsEnabledForOrigin):
(WebKit::NetworkNotificationManager::deletePushAndNotificationRegistration):
(WebKit::NetworkNotificationManager::getPendingPushMessages):
(WebKit::NetworkNotificationManager::subscribeToPushService):
(WebKit::NetworkNotificationManager::unsubscribeFromPushService):
(WebKit::NetworkNotificationManager::getPushSubscription):
(WebKit::NetworkNotificationManager::getPushPermissionState):
(WebKit::NetworkNotificationManager::incrementSilentPushCount):
(WebKit::NetworkNotificationManager::removeAllPushSubscriptions):
(WebKit::NetworkNotificationManager::removePushSubscriptionsForOrigin):
(WebKit::NetworkNotificationManager::sendMessage const): Deleted.
(WebKit::ReplyCaller&lt;&gt;::callReply): Deleted.
(WebKit::ReplyCaller&lt;String&gt;::callReply): Deleted.
(): Deleted.
(WebKit::ReplyCaller&lt;bool&gt;::callReply): Deleted.
(WebKit::ReplyCaller&lt;unsigned&gt;::callReply): Deleted.
(WebKit::ReplyCaller&lt;Vector&lt;String&gt;::callReply): Deleted.
(WebKit::ReplyCaller&lt;Vector&lt;WebPushMessage&gt;::callReply): Deleted.
(WebKit::NetworkNotificationManager::sendMessageWithReply const): Deleted.
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::performSendWithoutUsingIPCConnection const):
(IPC::MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
(IPC::MessageSender::performSendWithoutUsingIPCConnection): Deleted.
(IPC::MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection): Deleted.
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithoutUsingIPCConnection const):
(IPC::MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection const):
(IPC::MessageSender::sendWithoutUsingIPCConnection): Deleted.
(IPC::MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
(generate_message_handler):
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp:
(WebKit::TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler):
* Source/WebKit/Shared/Daemon/DaemonUtilities.h:
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::encoderToXPCData):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
(WebKit::WebPushD::WebPushDaemonConnectionConfiguration::encode const): Deleted.
(WebKit::WebPushD::WebPushDaemonConnectionConfiguration::decode): Deleted.
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
(WebKit::WebPushD::messageTypeSendsReply): Deleted.
(WebKit::WebPushD::daemonMessageTypeSendsReply): Deleted.
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in: Added.
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::updateConnectionConfiguration):
(WebPushD::PushClientConnection::getPushTopicsForTesting):
(WebPushD::PushClientConnection::sendDebugMessage):
(WebPushD::PushClientConnection::setPushAndNotificationsEnabledForOrigin):
(WebPushD::PushClientConnection::deletePushAndNotificationRegistration):
(WebPushD::PushClientConnection::injectPushMessageForTesting):
(WebPushD::PushClientConnection::injectEncryptedPushMessageForTesting):
(WebPushD::PushClientConnection::getPendingPushMessages):
(WebPushD::PushClientConnection::subscribeToPushService):
(WebPushD::PushClientConnection::unsubscribeFromPushService):
(WebPushD::PushClientConnection::getPushSubscription):
(WebPushD::PushClientConnection::incrementSilentPushCount):
(WebPushD::PushClientConnection::removeAllPushSubscriptions):
(WebPushD::PushClientConnection::removePushSubscriptionsForOrigin):
(WebPushD::PushClientConnection::setPublicTokenForTesting):
(WebPushD::PushClientConnection::getPushPermissionState):
(WebPushD::PushClientConnection::sendDaemonMessage const): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::tryCloseRequestConnection):
(WebPushD::WebPushDaemon::connectionEventHandler):
(WebPushD::WebPushDaemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::WebPushDaemon::deletePushAndNotificationRegistration):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::getPushTopicsForTesting):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::unsubscribeFromPushService):
(WebPushD::WebPushDaemon::getPushSubscription):
(WebPushD::WebPushDaemon::incrementSilentPushCount):
(WebPushD::WebPushDaemon::removeAllPushSubscriptions):
(WebPushD::WebPushDaemon::removePushSubscriptionsForOrigin):
(WebPushD::WebPushDaemon::setPublicTokenForTesting):
(WebPushD::WebPushDaemon::canRegisterForNotifications):
(WebPushD::MessageInfo::echoTwice::encodeReply): Deleted.
(WebPushD::MessageInfo::deletePushAndNotificationRegistration::encodeReply): Deleted.
(WebPushD::MessageInfo::injectPushMessageForTesting::encodeReply): Deleted.
(WebPushD::MessageInfo::injectEncryptedPushMessageForTesting::encodeReply): Deleted.
(WebPushD::MessageInfo::getPendingPushMessages::encodeReply): Deleted.
(WebPushD::MessageInfo::subscribeToPushService::encodeReply): Deleted.
(WebPushD::MessageInfo::unsubscribeFromPushService::encodeReply): Deleted.
(WebPushD::MessageInfo::getPushSubscription::encodeReply): Deleted.
(WebPushD::MessageInfo::getPushPermissionState::encodeReply): Deleted.
(WebPushD::MessageInfo::incrementSilentPushCount::encodeReply): Deleted.
(WebPushD::MessageInfo::removeAllPushSubscriptions::encodeReply): Deleted.
(WebPushD::MessageInfo::removePushSubscriptionsForOrigin::encodeReply): Deleted.
(WebPushD::handleWebPushDMessageWithReply): Deleted.
(WebPushD::handleWebPushDMessage): Deleted.
(WebPushD::CompletionHandler&lt;void): Deleted.
(WebPushD::WebPushDaemon::decodeAndHandleRawXPCMessage): Deleted.
(WebPushD::WebPushDaemon::decodeAndHandleMessage): Deleted.
(WebPushD::WebPushDaemon::echoTwice): Deleted.
(WebPushD::WebPushDaemon::setDebugModeIsEnabled): Deleted.
(WebPushD::WebPushDaemon::updateConnectionConfiguration): Deleted.
(WebPushD::toXPCArray): Deleted.
(WebPushD::WebPushDaemon::getPushPermissionState): Deleted.
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::sendPushMessage):
(WebPushTool::Connection::startDebugStreamAction):
(WebPushTool::Connection::sendAuditToken):
(WebPushTool::messageDictionaryFromEncoder):
(WebPushTool::Connection::performSendWithoutUsingIPCConnection const):
(WebPushTool::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/TestWebKitAPI/Configurations/TestIPC.xcconfig:
* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::WebPushXPCConnectionMessageSender):
(TestWebKitAPI::WebPushXPCConnectionMessageSender::incrementProtocolVersionForTesting):
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
(TestWebKitAPI::WebPushXPCConnectionMessageSender::performSendWithoutUsingIPCConnection const):
(TestWebKitAPI::WebPushXPCConnectionMessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
(TestWebKitAPI::sendConfigurationWithAuditToken):
(TestWebKitAPI::TEST):
(TestWebKitAPI::addMessageHeaders): Deleted.
(TestWebKitAPI::sendMessageToDaemon): Deleted.
(TestWebKitAPI::sendMessageToDaemonWithReplySync): Deleted.
(TestWebKitAPI::sendRawMessageToDaemonWithReplySync): Deleted.
(TestWebKitAPI::toStringVector): Deleted.
(TestWebKitAPI::encodeString): Deleted.

Canonical link: <a href="https://commits.webkit.org/267851@main">https://commits.webkit.org/267851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e917c5d3d766bd7640edef5afc87b5b6c5cdcb27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18362 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20577 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18031 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16298 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16467 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17031 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16133 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->