### PR TITLE
Add a basic heuristic to trigger eden GC during opportunistic tasks

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1392,7 +1392,8 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
         m_opaqueRoots.clear();
         m_collectorSlotVisitor->clearMarkStacks();
         m_mutatorMarkStack->clear();
-    }
+    } else
+        m_bytesAllocatedBeforeLastEdenCollect = m_bytesAllocatedThisCycle;
 
     RELEASE_ASSERT(m_raceMarkStack->isEmpty());
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -758,6 +758,7 @@ private:
     MutatorState m_mutatorState { MutatorState::Running };
     const size_t m_ramSize;
     const size_t m_minBytesPerCycle;
+    size_t m_bytesAllocatedBeforeLastEdenCollect { 0 };
     size_t m_sizeAfterLastCollect { 0 };
     size_t m_sizeAfterLastFullCollect { 0 };
     size_t m_sizeBeforeLastFullCollect { 0 };

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -416,7 +416,10 @@ public:
         m_entryScopeServices.add(service);
     }
 
-    JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+    enum class SchedulerOptions : uint8_t {
+        HasImminentlyScheduledWork = 1 << 0,
+    };
+    JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(MonotonicTime deadline, OptionSet<SchedulerOptions>);
 
 private:
     VMIdentifier m_identifier;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4545,7 +4545,10 @@ void Page::opportunisticallyRunIdleCallbacks()
 
 void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
 {
-    commonVM().performOpportunisticallyScheduledTasks(deadline);
+    OptionSet<JSC::VM::SchedulerOptions> options;
+    if (m_opportunisticTaskScheduler->hasImminentlyScheduledWork())
+        options.add(JSC::VM::SchedulerOptions::HasImminentlyScheduledWork);
+    commonVM().performOpportunisticallyScheduledTasks(deadline, options);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7213ee0ad4e7bcab13c4e24665520040e7429130
<pre>
Add a basic heuristic to trigger eden GC during opportunistic tasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=261358">https://bugs.webkit.org/show_bug.cgi?id=261358</a>
rdar://115193873

Reviewed by Yusuke Suzuki and Mark Lam.

Extend opportunistically scheduled work to sometimes trigger an eden GC, as long as:
1. There are no imminently scheduled tasks (e.g. zero-delay timers, rAF).
2. The estimated time required to perform the eden GC fits well within the task deadline.

See below for more details.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runBeginPhase):

Keep track of the prior value of `m_bytesAllocatedThisCycle`, right before embarking on the last
eden GC. We use this in `VM` to help estimate the cost of subsequent eden GC.

* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::performOpportunisticallyScheduledTasks):

If there aren&apos;t any imminently scheduled tasks, use `m_bytesAllocatedBeforeLastEdenCollect` to
estimate the duration of the next eden GC; if this estimate is less than the time remaining until
the opportunistic task deadline (by at least 1 ms), then immediately perform an eden GC during this
opportunistic task.

For now, we get a rough estimate by computing the &quot;time-per-byte&quot; rate from the last eden GC, and
then compute the time needed for the next eden GC based on the current `m_bytesAllocatedThisCycle`.

* Source/JavaScriptCore/runtime/VM.h:
* Source/WebCore/page/Page.cpp:

Augment `Page` to forward some context from the opportunistic task scheduler to JSC, when performing
opportunistic work. For now, we only pass in whether or not there are imminently scheduled tasks,
but in the future, we can extend this with additional options to provide `VM`/`Heap` with the
information needed to make more granular decisions.

(WebCore::Page::performOpportunisticallyScheduledTasks):

Canonical link: <a href="https://commits.webkit.org/267893@main">https://commits.webkit.org/267893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a496d74ec43dce29737f464cd25bbaf118336707

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18725 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20564 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22822 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15458 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20686 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17114 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14411 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21214 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16120 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5220 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4281 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20478 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22447 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16866 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5067 "Passed tests") | 
<!--EWS-Status-Bubble-End-->