### PR TITLE
[visionOS] Audio does not spatialize correctly with multiple windows after switching tabs

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
@@ -469,4 +469,11 @@ NS_ASSUME_NONNULL_END
 @interface AVSampleBufferVideoRenderer (AVSampleBufferVideoRendererWebKitPrivate)
 @property (nonatomic, copy, nullable, getter=_STSLabel) NSString *STSLabel SPI_AVAILABLE(ios(15.0)) API_UNAVAILABLE(macos, tvos, watchos);
 @end
+@interface AVAudioSession (SpatialPreferenceWebKitPrivate)
+@property (readonly, nullable) NSString* spatialTrackingLabel SPI_AVAILABLE(xros(1.0)) API_UNAVAILABLE(ios, watchos, tvos, macos);
+@end
 #endif
+
+@interface NSObject (AVSampleBufferRenderSynchronizer_PrivateWebKitStaged_114060722)
+- (void)resetRendererTrackedBySTS SPI_AVAILABLE(ios(15.0)) API_UNAVAILABLE(macos, tvos, watchos);
+@end

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -432,8 +432,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
     if (!visible) {
         AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
         [m_sampleBufferDisplayLayer sampleBufferRenderer].STSLabel = session.spatialTrackingLabel;
-    } else
+    } else {
         [m_sampleBufferDisplayLayer sampleBufferRenderer].STSLabel = nil;
+        if ([m_synchronizer respondsToSelector:@selector(resetRendererTrackedBySTS)])
+            [m_synchronizer resetRendererTrackedBySTS];
+    }
 #endif
 }
 


### PR DESCRIPTION
#### 74964c1946b6cd7d6b4277a53d8fc21dd8dad6c7
<pre>
[visionOS] Audio does not spatialize correctly with multiple windows after switching tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=261367">https://bugs.webkit.org/show_bug.cgi?id=261367</a>
&lt;radar://114060695&gt;

Reviewed by NOBODY (OOPS!).

When we made spatial audio work for backgrounded tabs playing audio it broke the multi-window
spatial audio since the identifier is attached to the scene and not the window.

It would seem preferable to use an identifier attached to the window, but until we have such an
identifier, we can fix the regression by adapting the SPI to reset the behavior so AVSampleBufferRenderSynchronizer
clients can re-elect to use the renderer tracked by STS.

* Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h:
Stage SPI.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible):
Reset the renderer after setting the identifier to nil.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74964c1946b6cd7d6b4277a53d8fc21dd8dad6c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18687 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20516 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22779 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20644 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->