### PR TITLE
Update input[type=range]'s step base handling to match spec

### DIFF
--- a/LayoutTests/fast/forms/range/range-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/range/range-stepup-stepdown-expected.txt
@@ -133,6 +133,12 @@ PASS stepDownExplicitBounds(null, null, "foo", "1") is "0"
 PASS stepDownExplicitBounds(null, null, "0", "2") is "1"
 PASS stepDownExplicitBounds(null, null, "-1", "3") is "2"
 
+Step bases
+PASS createInputWithContentAttributes(0, 100, "20", "50"); input.value is "60"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.value is "25"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.value is "75"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.stepDown(1); input.value is "25"
+
 Step=any
 PASS stepUpExplicitBounds(null, null, "any", "1") threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDownExplicitBounds(null, null, "any", "1") threw exception InvalidStateError: The object is in an invalid state..

--- a/LayoutTests/fast/forms/range/range-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/range/range-stepup-stepdown.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -9,13 +9,29 @@
 <script>
 description('Check stepUp() and stepDown() bahevior for range type.');
 
-var input = document.createElement('input');
+var input;
+function createRangeElement() {
+    input = document.createElement('input');
+    input.type = 'range';
+}
 
 function setInputAttributes(min, max, step, value) {
     input.min = min;
     input.max = max;
     input.step = step;
     input.value = value;
+}
+
+function createInputWithContentAttributes(min, max, step, value) {
+    createRangeElement();
+    function setIfNonNull(attribute, value) {
+        if (typeof value !== "null")
+	    input.setAttribute(attribute, value);
+    }
+    setIfNonNull("min", min);
+    setIfNonNull("max", max);
+    setIfNonNull("step", step);
+    setIfNonNull("value", value);
 }
 
 function stepUp(value, step, max, optionalStepCount) {
@@ -57,30 +73,29 @@ function stepDownExplicitBounds(min, max, step, value, stepCount) {
     return input.value;
 }
 
-input.type = 'range';
+createRangeElement();
 debug('function arguments are (min, max, step, value, [stepCount])');
 debug('Using the default values');
-shouldBe('stepUpExplicitBounds(null, null, null, "")', '"51"');
-shouldBe('stepDownExplicitBounds(null, null, null, "")', '"49"');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "")', '51');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "")', '49');
 
 debug('');
 debug('Non-number arguments (stepCount)');
-shouldBe('stepUpExplicitBounds(null, null, null, "0", "0")', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, null, "0", "0")', '"0"');
-shouldBe('stepUpExplicitBounds(null, null, null, "0", "foo")', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, null, "0", "foo")', '"0"');
-shouldBe('stepUpExplicitBounds(null, null, null, "0", null)', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, null, "0", null)', '"0"');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0", "0")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "0", "0")', '0');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0", "foo")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "0", "foo")', '0');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0", null)', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "0", null)', '0');
 
 debug('');
 debug('Normal cases');
-shouldBe('stepUpExplicitBounds(null, null, null, "0")', '"1"');
-shouldBe('stepUpExplicitBounds(null, null, null, "1", 2)', '"3"');
-shouldBe('stepUpExplicitBounds(null, null, null, "3", -1)', '"2"');
-shouldBe('stepDownExplicitBounds("-100", null, null, "2")', '"1"');
-shouldBe('stepDownExplicitBounds("-100", null, null, "1", 2)', '"-1"');
-shouldBe('stepDownExplicitBounds("-100", null, null, "-1", -1)', '"0"');
-
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0")', '1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "1", 2)', '3');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "3", -1)', '2');
+shouldBeEqualToString('stepDownExplicitBounds("-100", null, null, "2")', '1');
+shouldBeEqualToString('stepDownExplicitBounds("-100", null, null, "1", 2)', '-1');
+shouldBeEqualToString('stepDownExplicitBounds("-100", null, null, "-1", -1)', '0');
 debug('');
 debug('Fractional cases')
 // "When the element is suffering from a step mismatch, the user agent must
@@ -209,18 +224,30 @@ shouldBe('stepDownExplicitBounds(-10, 10, .1, "-2.")', '"-2.1"');
 
 debug('');
 debug('Extra arguments');
-shouldBe('setInputAttributes(null, null, null, "0"); input.stepUp(1,2); input.value', '"1"');
-shouldBe('setInputAttributes(null, null, null, "1"); input.stepDown(1,3); input.value', '"0"');
+shouldBeEqualToString('setInputAttributes(null, null, null, "0"); input.stepUp(1,2); input.value', '1');
+shouldBeEqualToString('setInputAttributes(null, null, null, "1"); input.stepDown(1,3); input.value', '0');
 
 debug('');
 debug('Invalid step value');
-shouldBe('stepUpExplicitBounds(null, null, "foo", "0")', '"1"');
-shouldBe('stepUpExplicitBounds(null, null, "0", "1")', '"2"');
-shouldBe('stepUpExplicitBounds(null, null, "-1", "2")', '"3"');
-shouldBe('stepDownExplicitBounds(null, null, "foo", "1")', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, "0", "2")', '"1"');
-shouldBe('stepDownExplicitBounds(null, null, "-1", "3")', '"2"');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "foo", "0")', '1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "0", "1")', '2');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "-1", "2")', '3');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "foo", "1")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "0", "2")', '1');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "-1", "3")', '2');
 
+debug('');
+debug('Step bases');
+shouldBeEqualToString('createInputWithContentAttributes(0, 100, "20", "50"); input.value', '60');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.value', '25');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.value', '75');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.stepDown(1); input.value', '25');
+// FIXME: these shouldn't throw according to the spec; commented-out version give its expected outcomes.
+// shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(2); input.stepDown(2); input.value', '25');
+// shouldBeEqualToString('createInputWithContentAttributes(null, null, "7", "22"); input.stepUp(40); input.value', '99');
+
+// Reset 'input' for follow-on tests.
+createRangeElement();
 debug('');
 debug('Step=any');
 shouldThrowErrorName('stepUpExplicitBounds(null, null, "any", "1")', "InvalidStateError");
@@ -228,29 +255,29 @@ shouldThrowErrorName('stepDownExplicitBounds(null, null, "any", "1")', "InvalidS
 
 debug('');
 debug('Overflow/underflow');
-shouldBe('stepUpExplicitBounds(null, "100", "1", "99")', '"100"');
+shouldBeEqualToString('stepUpExplicitBounds(null, "100", "1", "99")', '100');
 shouldBe('stepUpExplicitBounds(null, "100", "1", "100")', '"100"');
-shouldBe('input.value', '"100"');
+shouldBeEqualToString('input.value', '100');
 shouldBe('stepUpExplicitBounds(null, "100", "1", "99", "2")', '"100"');
-shouldBe('input.value', '"100"');
-shouldBe('stepDownExplicitBounds("0", null, "1", "1")', '"0"');
+shouldBeEqualToString('input.value', '100');
+shouldBeEqualToString('stepDownExplicitBounds("0", null, "1", "1")', '0');
 shouldBe('stepDownExplicitBounds("0", null, "1", "0")', '"0"');
-shouldBe('input.value', '"0"');
+shouldBeEqualToString('input.value', '0');
 shouldBe('stepDownExplicitBounds("0", null, "1", "1", "2")', '"0"');
-shouldBe('input.value', '"0"');
+shouldBeEqualToString('input.value', '0');
 shouldBe('stepDownExplicitBounds(null, null, "3.40282346e+38", "1", "2")', '"0"');
-shouldBe('stepUpExplicitBounds(-100, 0, 1, -1)', '"0"');
+shouldBeEqualToString('stepUpExplicitBounds(-100, 0, 1, -1)', '0');
 shouldBe('stepUpExplicitBounds(null, 0, 1, 0)', '"0"');
 shouldBe('stepUpExplicitBounds(-100, 0, 1, -1, 2)', '"0"');
-shouldBe('input.value', '"0"');
+shouldBeEqualToString('input.value', '0');
 shouldBe('stepUpExplicitBounds(null, null, "3.40282346e+38", "1", "2")', '"0"');
 
 debug('');
 debug('stepDown()/stepUp() for stepMismatch values');
-shouldBe('stepUpExplicitBounds(null, null, 2, 1)', '"4"');
-shouldBe('input.stepDown(); input.value', '"2"');
-shouldBe('stepUpExplicitBounds(0, null, 10, 9, 9)', '"100"');
-shouldBe('stepDownExplicitBounds(0, null, 10, 19)', '"10"');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 2, 1)', '4');
+shouldBeEqualToString('input.stepDown(); input.value', '2');
+shouldBeEqualToString('stepUpExplicitBounds(0, null, 10, 9, 9)', '100');
+shouldBeEqualToString('stepDownExplicitBounds(0, null, 10, 19)', '10');
 
 debug('');
 debug('value + step is <= max, but rounded result would be > max.');
@@ -258,23 +285,22 @@ shouldBe('stepUpExplicitBounds(null, 99, 10, 89)', '"90"');
 
 debug('');
 debug('Huge value and small step');
-shouldBe('stepUpExplicitBounds(0, 1e38, 1, 1e38, 999999)', '"1e+38"');
-shouldBe('stepDownExplicitBounds(0, 1e38, 1, 1e38, 999999)', '"1e+38"');
+shouldBeEqualToString('stepUpExplicitBounds(0, 1e38, 1, 1e38, 999999)', '1e+38');
+shouldBeEqualToString('stepDownExplicitBounds(0, 1e38, 1, 1e38, 999999)', '1e+38');
 
 debug('');
 debug('Fractional numbers');
-shouldBe('stepUpExplicitBounds(null, null, 0.33333333333333333, 0, 3)', '"1"');
-shouldBe('stepUpExplicitBounds(null, null, 0.1, 1)', '"1.1"');
-shouldBe('stepUpExplicitBounds(null, null, 0.1, 1, 8)', '"1.8"');
-shouldBe('stepUpExplicitBounds(null, null, 0.1, 1, 10)', '"2"');
-shouldBe('input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.value', '"3"');
-shouldBe('stepUpExplicitBounds(0, 1, 0.003921568627450980, 0, 255)', '"1"');
-shouldBe('for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, 0.1, 1, 8)', '"0.2"');
-shouldBe('stepDownExplicitBounds(null, null, 0.1, 1)', '"0.9"');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.33333333333333333, 0, 3)', '1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.1, 1)', '1.1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.1, 1, 8)', '1.8');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.1, 1, 10)', '2');
+shouldBeEqualToString('input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.value', '3');
+shouldBeEqualToString('stepUpExplicitBounds(0, 1, 0.003921568627450980, 0, 255)', '1');
+shouldBeEqualToString('for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, 0.1, 1, 8)', '0.2');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, 0.1, 1)', '0.9');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -1042,7 +1042,7 @@ ExceptionOr<void> InputType::applyStep(int count, AnyStepHandling anyStepHandlin
 
     newValue = newValue + stepRange.step() * Decimal::fromDouble(count);
     const AtomString& stepString = element()->getAttribute(HTMLNames::stepAttr);
-    if (!equalLettersIgnoringASCIICase(stepString, "any"_s))
+    if (!equalLettersIgnoringASCIICase(stepString, "any"_s) && stepRange.stepMismatch(current))
         newValue = stepRange.alignValueForStep(current, newValue);
 
     // 8. If the element has a minimum, and value is less than that minimum, then set value to the smallest value that, when subtracted from the step
@@ -1222,6 +1222,14 @@ void InputType::createShadowSubtreeIfNeeded()
     element()->ensureUserAgentShadowRoot();
     m_hasCreatedShadowSubtree = true;
     createShadowSubtree();
+}
+
+Decimal InputType::findStepBase(const Decimal& defaultValue) const
+{
+    Decimal stepBase = parseToNumberOrNaN(element()->attributeWithoutSynchronization(minAttr));
+    if (!stepBase.isFinite())
+        stepBase = parseToNumber(element()->attributeWithoutSynchronization(valueAttr), defaultValue);
+    return stepBase;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -248,6 +248,7 @@ public:
     virtual float decorationWidth() const;
     bool stepMismatch(const String&) const;
     virtual bool getAllowedValueStep(Decimal*) const;
+    Decimal findStepBase(const Decimal&) const;
     virtual StepRange createStepRange(AnyStepHandling) const;
     virtual ExceptionOr<void> stepUp(int);
     virtual void stepUpFromRenderer(int);

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -119,11 +119,12 @@ bool RangeInputType::supportsRequired() const
 StepRange RangeInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
+    const Decimal stepBase = findStepBase(rangeDefaultStepBase);
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), rangeDefaultMinimum);
     const Decimal maximum = ensureMaximum(parseToNumber(element()->attributeWithoutSynchronization(maxAttr), rangeDefaultMaximum), minimum);
 
     const Decimal step = StepRange::parseStep(anyStepHandling, rangeStepDescription, element()->attributeWithoutSynchronization(stepAttr));
-    return StepRange(minimum, RangeLimitations::Valid, minimum, maximum, step, rangeStepDescription);
+    return StepRange(stepBase, RangeLimitations::Valid, minimum, maximum, step, rangeStepDescription);
 }
 
 void RangeInputType::handleMouseDownEvent(MouseEvent& event)

--- a/Source/WebCore/html/StepRange.cpp
+++ b/Source/WebCore/html/StepRange.cpp
@@ -87,11 +87,12 @@ Decimal StepRange::clampValue(const Decimal& value) const
     const Decimal inRangeValue = std::max(m_minimum, std::min(value, m_maximum));
     if (!m_hasStep)
         return inRangeValue;
-    // Rounds inRangeValue to minimum + N * step.
-    const Decimal roundedValue = roundByStep(inRangeValue, m_minimum);
-    const Decimal clampedValue = roundedValue > m_maximum ? roundedValue - m_step : roundedValue;
-    ASSERT(clampedValue >= m_minimum);
-    ASSERT(clampedValue <= m_maximum);
+    // Rounds inRangeValue to stepBase + N * step.
+    const Decimal roundedValue = roundByStep(inRangeValue, m_stepBase);
+    const Decimal clampedValue = roundedValue > m_maximum ? roundedValue - m_step : (roundedValue < m_minimum ? roundedValue + m_step : roundedValue);
+    // clampedValue can be outside of [m_minimum, m_maximum] if m_step is huge.
+    if (clampedValue < m_minimum || clampedValue > m_maximum)
+        return inRangeValue;
     return clampedValue;
 }
 


### PR DESCRIPTION
<pre>
Update input[type=range]'s step base handling to match spec 
<a href="https://bugs.webkit.org/show_bug.cgi?id=254761">https://bugs.webkit.org/show_bug.cgi?id=254761</a>
rdar://problem/107721910

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=166367">https://src.chromium.org/viewvc/blink?view=revision&revision=166367</a> &
<a href="https://chromium.googlesource.com/chromium/src.git/+/807ab32fd2e5accda8c5cef2678e0e0af23158b0">https://chromium.googlesource.com/chromium/src.git/+/807ab32fd2e5accda8c5cef2678e0e0af23158b0</a>

The HTML spec recently shifted to using 'value' as the first fallback
option for an input element's "step base" (if no 'min' attribute) [1].

[1] <a href="https://html.spec.whatwg.org/#concept-input-min-zero">https://html.spec.whatwg.org/#concept-input-min-zero</a>

Also bring type=range elements into line with that, including using
that step base when clamping values to the supported range.

According to the specification, we should not resolve step-mismatch if there are
no step-matched values in the range. So, StepRange::clampValue() should return
the minimum value or the maximum value. [2]

[2] <a href="https://html.spec.whatwg.org/multipage/input.html#range-state-(type%3Drange)">https://html.spec.whatwg.org/multipage/input.html#range-state-(type%3Drange)</a>

* Source/WebCore/html/InputType.cpp:
(InputType::applyStep): Add 'stepMismatch' as well
(InputType::findStepBase): Add Helping function
* Source/WebCore/html/InputType.h: Helper function definition
* Source/WebCore/html/RangeInputType.cpp:
(RangeInputType::createStepRange): Use 'stepBase'
* Source/WebCore/html/StepRange.cpp:
(StepRange::clampValue): clampValue but respect 'stepBase'
* LayoutTests/fast/forms/range/range-stepup-stepdown.html: Rebaselined
* LayoutTests/fast/forms/range/range-stepup-stepdown-expected.txt: Rebaselined
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd645873593afa742bd85f0216a8219582736c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18696 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18052 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18319 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20531 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15547 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16245 "4 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22789 "8 flakes 131 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16563 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16414 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14374 "8 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16086 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->