### PR TITLE
Use 'ScrollSetting' enum in 'VTTRegion.idl' align with IDL Spec

### DIFF
--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -127,19 +127,9 @@ static const AtomString& upKeyword()
     return upKeyword;
 }
 
-const AtomString& VTTRegion::scroll() const
+void VTTRegion::setScroll(const ScrollSetting value)
 {
-    return m_scroll ? upKeyword() : emptyAtom();
-}
-
-void VTTRegion::setScroll(const AtomString& value)
-{
-    if (value.isEmpty()) {
-        m_scroll = false;
-    }
-    if (value == upKeyword()) {
-        m_scroll = true;
-    }
+    m_scroll = value;
 }
 
 void VTTRegion::updateParametersFromRegion(const VTTRegion& other)
@@ -243,7 +233,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
     }
     case Scroll:
         if (input.scanRun(valueRun, upKeyword()))
-            m_scroll = true;
+            m_scroll = ScrollSetting::Up;
         else
             LOG(Media, "VTTRegion::parseSettingValue, invalid Scroll");
         break;
@@ -281,7 +271,7 @@ void VTTRegion::displayLastTextTrackCueBox()
         return;
 
     // If it's a scrolling region, add the scrolling class.
-    if (isScrollingRegion())
+    if (scroll() == ScrollSetting::Up)
         m_cueContainer->classList().add(textTrackCueContainerScrollingClass());
 
     float regionBottom = m_regionDisplayTree->boundingClientRect().maxY();
@@ -386,7 +376,7 @@ void VTTRegion::startTimer()
     if (m_scrollTimer.isActive())
         return;
 
-    Seconds duration = isScrollingRegion() ? scrollTime : 0_s;
+    Seconds duration = scroll() == ScrollSetting::Up ? scrollTime : 0_s;
     m_scrollTimer.startOneShot(duration);
 }
 

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -77,15 +77,14 @@ public:
     double viewportAnchorY() const { return m_viewportAnchor.y(); }
     ExceptionOr<void> setViewportAnchorY(double);
 
-    const AtomString& scroll() const;
-    void setScroll(const AtomString&);
+    enum class ScrollSetting : bool { EmptyString, Up };
+    ScrollSetting scroll() const { return m_scroll; }
+    void setScroll(const ScrollSetting);
 
     void updateParametersFromRegion(const VTTRegion&);
 
     const String& regionSettings() const { return m_settings; }
     void setRegionSettings(const String&);
-
-    bool isScrollingRegion() { return m_scroll; }
 
     HTMLDivElement& getDisplayTree();
     
@@ -130,7 +129,7 @@ private:
     FloatPoint m_regionAnchor { 0, 100 };
     FloatPoint m_viewportAnchor { 0, 100 };
 
-    bool m_scroll { false };
+    ScrollSetting m_scroll { ScrollSetting::EmptyString };
 
     // The cue container is the container that is scrolled up to obtain the
     // effect of scrolling cues when this is enabled for the regions.

--- a/Source/WebCore/html/track/VTTRegion.idl
+++ b/Source/WebCore/html/track/VTTRegion.idl
@@ -24,9 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
- // https://www.w3.org/TR/webvtt1/#the-vttregion-interface
+// https://w3c.github.io/webvtt/#the-vttregion-interface
 
- // FIXME: Add 'enum' for 'ScrollSetting' to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260766
+enum ScrollSetting { "" /* none */, "up" };
 
 [
     Conditional=VIDEO,
@@ -42,7 +42,8 @@
     attribute double regionAnchorY;
     attribute double viewportAnchorX;
     attribute double viewportAnchorY;
-    // FIXME: Use 'enum' 'ScrollSetting' for 'scroll'. See: https://bugs.webkit.org/show_bug.cgi?id=260766
-    attribute [AtomString] DOMString scroll;
+    attribute ScrollSetting scroll;
+    
+    // FIXME: non-standard?
     readonly attribute TextTrack track;
 };


### PR DESCRIPTION
#### 48210b2e0db44cf7b44187d06d30c805389b34a7
<pre>
Use &apos;ScrollSetting&apos; enum in &apos;VTTRegion.idl&apos; align with IDL Spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=260766">https://bugs.webkit.org/show_bug.cgi?id=260766</a>
rdar://114859668

Reviewed by Eric Carlson.

Implement the scroll IDL attribute using a ScrollSetting enum as
suggested by the WebVTT standard. And because m_scroll is now of that
type we can also remove isScrollingRegion().

There should be no behavioral changes so no tests.

* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setScroll):
(WebCore::VTTRegion::parseSettingValue):
(WebCore::VTTRegion::displayLastTextTrackCueBox):
(WebCore::VTTRegion::startTimer):
(WebCore::VTTRegion::scroll const): Deleted.
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/html/track/VTTRegion.idl:

Canonical link: <a href="https://commits.webkit.org/267842@main">https://commits.webkit.org/267842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13b2c1793650ede261e86b2ec8be92051f51e00b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18701 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20536 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20661 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14380 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16093 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4250 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->