### PR TITLE
[visionOS] Under thermal throttling Safari webpage went blank when navigating

### DIFF
--- a/Source/WebCore/platform/ThermalMitigationNotifier.cpp
+++ b/Source/WebCore/platform/ThermalMitigationNotifier.cpp
@@ -41,6 +41,11 @@ bool ThermalMitigationNotifier::thermalMitigationEnabled() const
     return false;
 }
 
+bool ThermalMitigationNotifier::isThermalMitigationEnabled()
+{
+    return false;
+}
+
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ThermalMitigationNotifier.h
+++ b/Source/WebCore/platform/ThermalMitigationNotifier.h
@@ -43,6 +43,7 @@ public:
     WEBCORE_EXPORT ~ThermalMitigationNotifier();
 
     WEBCORE_EXPORT bool thermalMitigationEnabled() const;
+    WEBCORE_EXPORT static bool isThermalMitigationEnabled();
 
 private:
 #if HAVE(APPLE_THERMAL_MITIGATION_SUPPORT)

--- a/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
+++ b/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
@@ -32,6 +32,13 @@
 #import <Foundation/NSProcessInfo.h>
 #import <wtf/MainThread.h>
 
+namespace WebCore {
+static bool isThermalMitigationEnabled()
+{
+    return NSProcessInfo.processInfo.thermalState >= NSProcessInfoThermalStateSerious;
+}
+}
+
 @interface WebThermalMitigationObserver : NSObject
 @property (nonatomic) WeakPtr<WebCore::ThermalMitigationNotifier> notifier;
 @property (nonatomic, readonly) BOOL thermalMitigationEnabled;
@@ -66,7 +73,7 @@
 
 - (BOOL)thermalMitigationEnabled
 {
-    return NSProcessInfo.processInfo.thermalState >= NSProcessInfoThermalStateSerious;
+    return WebCore::isThermalMitigationEnabled();
 }
 
 @end
@@ -87,6 +94,11 @@ ThermalMitigationNotifier::~ThermalMitigationNotifier()
 bool ThermalMitigationNotifier::thermalMitigationEnabled() const
 {
     return [m_observer thermalMitigationEnabled];
+}
+
+bool ThermalMitigationNotifier::isThermalMitigationEnabled()
+{
+    return WebCore::isThermalMitigationEnabled();
 }
 
 void ThermalMitigationNotifier::notifyThermalMitigationChanged(bool enabled)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -45,10 +45,23 @@
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #endif
 
+#if PLATFORM(VISION)
+#import <WebCore/ThermalMitigationNotifier.h>
+#endif
+
 namespace WebKit {
 
+static Seconds adjustedTimeoutForThermalState(Seconds timeout)
+{
+#if PLATFORM(VISION)
+    return WebCore::ThermalMitigationNotifier::isThermalMitigationEnabled() ? (timeout * 20) : timeout;
+#else
+    return timeout;
+#endif
+}
+
 AuxiliaryProcessProxy::AuxiliaryProcessProxy(bool alwaysRunsAtBackgroundPriority, Seconds responsivenessTimeout)
-    : m_responsivenessTimer(*this, responsivenessTimeout)
+    : m_responsivenessTimer(*this, adjustedTimeoutForThermalState(responsivenessTimeout))
     , m_alwaysRunsAtBackgroundPriority(alwaysRunsAtBackgroundPriority)
 #if USE(RUNNINGBOARD)
     , m_timedActivityForIPC(3_s)


### PR DESCRIPTION
#### bd0c3f38c2e8a609fe52a4c87e2fd4ee2e6fe06b
<pre>
[visionOS] Under thermal throttling Safari webpage went blank when navigating
<a href="https://bugs.webkit.org/show_bug.cgi?id=261374">https://bugs.webkit.org/show_bug.cgi?id=261374</a>
&lt;radar://113230434&gt;

Reviewed by Dean Jackson.

When the system is throttled due to thermal pressure, we can easily hit process
timeouts and then web pages will fail to load.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::adjustedTimeoutForThermalState):
(WebKit::AuxiliaryProcessProxy::AuxiliaryProcessProxy):
Query if thermal mitigation is enabled and increase process timeout if so.

* Source/WebCore/platform/ThermalMitigationNotifier.cpp:
(WebCore::ThermalMitigationNotifier::isThermalMitigationEnabled):
Default implementation.

* Source/WebCore/platform/ThermalMitigationNotifier.h:
* Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm:
(WebCore::isThermalMitigationEnabled):
(-[WebThermalMitigationObserver thermalMitigationEnabled]):
(WebCore::ThermalMitigationNotifier::isThermalMitigationEnabled):
Add static member function to query if thermal mitigation is enabled
as we don&apos;t need an instance function in AuxiliaryProcessProxy

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Make ThermalMitigationNotifier.h a private header.

Canonical link: <a href="https://commits.webkit.org/268149@main">https://commits.webkit.org/268149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69fce90f19b1574829ae9a6e68b1e6b33fb31503

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21610 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17191 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21537 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17951 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17018 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4477 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21384 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->