### PR TITLE
Add clear buttons to All Paths To... section of GCHeapInspector UI

### DIFF
--- a/Tools/GCHeapInspector/script/interface.js
+++ b/Tools/GCHeapInspector/script/interface.js
@@ -256,6 +256,16 @@ class HeapSnapshotInspector
         header = document.createElement('h1');
         header.textContent = 'All paths to…'
         this.allPathsContainer.appendChild(header);
+        let clearAllButton = document.createElement('button');
+        clearAllButton.innerText = 'Clear All';
+        clearAllButton.addEventListener("click", () => {
+            let header = this.allPathsContainer.childNodes[0];
+            let clearAllButton = this.allPathsContainer.childNodes[1];
+            DOMUtils.removeAllChildren(this.allPathsContainer);
+            this.allPathsContainer.appendChild(header);
+            this.allPathsContainer.appendChild(clearAllButton);
+        });
+        this.allPathsContainer.appendChild(clearAllButton);
 
         this.containerElement.appendChild(this.pathsToRootsContainer);
         this.containerElement.appendChild(this.allPathsContainer);
@@ -387,6 +397,15 @@ class HeapSnapshotInspector
         this.pathsToRootsContainer.appendChild(detailsContainer);
     }
 
+    addClearButtonToDetailsNode(details)
+    {
+        let summary = details.firstChild;
+        let clearButton = document.createElement('button');
+        clearButton.innerText = 'Clear';
+        clearButton.addEventListener("click", () => this.allPathsContainer.removeChild(details));
+        summary.appendChild(clearButton);
+    }
+
     showAllPathsToNode(node)
     {
         let paths = this.snapshot._gcRootPaths(node.id);
@@ -395,6 +414,7 @@ class HeapSnapshotInspector
         let summary = details.firstChild;
         summary.appendChild(document.createTextNode(`${paths.length} path${paths.length > 1 ? 's' : ''} to `));
         summary.appendChild(HeapInspectorUtils.spanForNode(this, node, false));
+        this.addClearButtonToDetailsNode(details);
 
         let detailsContainer = document.createElement('section')
         detailsContainer.className = 'path';


### PR DESCRIPTION
#### a8d8da847b5febadb0e97875028dee1302ed6331
<pre>
Add clear buttons to All Paths To... section of GCHeapInspector UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=261375">https://bugs.webkit.org/show_bug.cgi?id=261375</a>
rdar://115223418

Reviewed by Simon Fraser.

This adds both a &quot;Clear All&quot; button to the All Paths To... section as
well as individual &quot;Clear&quot; buttons for each object added to this section
of the UI.

In some cases, depending on the heap, we could end up with objects which
have tens of thousands of paths to them in the heap. When this object
is added to the All Paths section we could create well over 16GB of DOM
and Text nodes for all of these paths causing the web process to be
killed in the foreground if these nodes can&apos;t be garbage collected.

These buttons will allow a user to remove sections from the All Paths
section when they&apos;re no longer of interest, giving the GC a chance to
collect all these excess nodes and help improve memory performance for
this tool.

* Tools/GCHeapInspector/script/interface.js:
(HeapSnapshotInspector.prototype.resetUI):
(HeapSnapshotInspector.prototype.addClearButtonToDetailsNode):
(HeapSnapshotInspector.prototype.showAllPathsToNode):
(HeapSnapshotInspector):

Canonical link: <a href="https://commits.webkit.org/267834@main">https://commits.webkit.org/267834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5126a647ecf91e2fc66761e4a48b57787ff02cb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18061 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/18327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20541 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/16256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/16571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16995 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20455 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2188 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->