### PR TITLE
Propagate scope element into :has CheckingContext

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/has-argument-with-explicit-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/has-argument-with-explicit-scope-expected.txt
@@ -2,8 +2,8 @@
 PASS :has(:scope) matches expected elements on scope1
 PASS :has(:scope .c) matches expected elements on scope1
 PASS :has(.a :scope) matches expected elements on scope1
-FAIL .a:has(:scope) .c matches expected elements on scope1 assert_equals: expected "d02,d03" but got ""
-FAIL .a:has(:scope) .c and :is(.a :scope .c) returns same elements on scope1 assert_equals: expected "d02,d03" but got ""
+PASS .a:has(:scope) .c matches expected elements on scope1
+PASS .a:has(:scope) .c and :is(.a :scope .c) returns same elements on scope1
 PASS .a:has(:scope) .c matches expected elements on scope2
 PASS .a:has(:scope) .c and :is(.a :scope .c) returns same elements on scope2
 PASS .c:has(:is(:scope .d)) matches expected elements on scope1

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-closest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-closest-expected.txt
@@ -27,5 +27,5 @@ PASS Element.closest with context node 'test11' and selector ':invalid'
 PASS Element.closest with context node 'test4' and selector ':scope'
 PASS Element.closest with context node 'test4' and selector 'select > :scope'
 PASS Element.closest with context node 'test4' and selector 'div > :scope'
-FAIL Element.closest with context node 'test4' and selector ':has(> :scope)' assert_equals: :has(> :scope) expected "test3" but got ""
+PASS Element.closest with context node 'test4' and selector ':has(> :scope)'
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1319,6 +1319,7 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
     }
 
     CheckingContext hasCheckingContext(SelectorChecker::Mode::ResolvingStyle);
+    hasCheckingContext.scope = checkingContext.scope;
     hasCheckingContext.hasScope = &element;
 
     bool matchedInsideScope = false;


### PR DESCRIPTION
#### 32c83e1e34db9c8cdd92217ee3240daff273e1e4
<pre>
Propagate scope element into :has CheckingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=261378">https://bugs.webkit.org/show_bug.cgi?id=261378</a>
rdar://106524140

Reviewed by Tim Nguyen and Antti Koivisto.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=261320">https://bugs.webkit.org/show_bug.cgi?id=261320</a> we split out
CheckingContext::scope into two separate fields: &quot;scope&quot; for the element
that matches :scope, and &quot;hasScope&quot; for the scope of a :has()
pseudo-class.

We need to propagate scope into the child CheckingContext we create for
:has() pseudo-class matching, otherwise :has(:scope) will never match
anything.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/has-argument-with-explicit-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/Element-closest-expected.txt:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHasPseudoClass const):

Canonical link: <a href="https://commits.webkit.org/267856@main">https://commits.webkit.org/267856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13cecbeb6d1034a007b20699f18779d2b5445af8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16711 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18721 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20560 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17014 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20474 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2194 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->