### PR TITLE
Use more smart pointers in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentSession.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentSession.cpp
@@ -60,7 +60,7 @@ ExceptionOr<void> PaymentSession::canCreateSession(Document& document)
 
     auto& topDocument = document.topDocument();
     if (&document != &topDocument) {
-        for (auto* ancestorDocument = document.parentDocument(); ancestorDocument != &topDocument; ancestorDocument = ancestorDocument->parentDocument()) {
+        for (RefPtr ancestorDocument = document.parentDocument(); ancestorDocument != &topDocument; ancestorDocument = ancestorDocument->parentDocument()) {
             if (!isSecure(*ancestorDocument->loader()))
                 return Exception { InvalidAccessError, "Trying to start an Apple Pay session from a document with an insecure parent frame."_s };
         }

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -80,7 +80,7 @@ DOMAudioSession::~DOMAudioSession()
 
 ExceptionOr<void> DOMAudioSession::setType(Type type)
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return Exception { InvalidStateError };
 
@@ -100,7 +100,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
 
 DOMAudioSession::Type DOMAudioSession::type() const
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (document && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
         return DOMAudioSession::Type::Auto;
 
@@ -120,7 +120,7 @@ static DOMAudioSession::State computeAudioSessionState()
 
 DOMAudioSession::State DOMAudioSession::state() const
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
         return DOMAudioSession::State::Inactive;
 
@@ -160,7 +160,7 @@ void DOMAudioSession::audioSessionActiveStateChanged()
 
 void DOMAudioSession::scheduleStateChangeEvent()
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (document && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
         return;
 

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -81,11 +81,11 @@ void NavigatorBeacon::logError(const ResourceError& error)
 {
     ASSERT(!error.isNull());
 
-    auto* frame = m_navigator.frame();
+    RefPtr frame = m_navigator.frame();
     if (!frame)
         return;
 
-    auto* document = frame->document();
+    RefPtr document = frame->document();
     if (!document)
         return;
 
@@ -124,7 +124,7 @@ ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& 
     ResourceRequest request(parsedUrl);
     request.setHTTPMethod("POST"_s);
     request.setRequester(ResourceRequestRequester::Beacon);
-    if (auto* documentLoader = document.loader())
+    if (RefPtr documentLoader = document.loader())
         request.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
 
     ResourceLoaderOptions options;

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -55,7 +55,7 @@ DOMCacheStorage::~DOMCacheStorage() = default;
 
 std::optional<ClientOrigin> DOMCacheStorage::origin() const
 {
-    auto* origin = scriptExecutionContext() ? scriptExecutionContext()->securityOrigin() : nullptr;
+    RefPtr origin = scriptExecutionContext() ? scriptExecutionContext()->securityOrigin() : nullptr;
     if (!origin)
         return std::nullopt;
 

--- a/Source/WebCore/Modules/contact-picker/ContactsManager.cpp
+++ b/Source/WebCore/Modules/contact-picker/ContactsManager.cpp
@@ -77,7 +77,7 @@ void ContactsManager::getProperties(Ref<DeferredPromise>&& promise)
 
 void ContactsManager::select(const Vector<ContactProperty>& properties, const ContactsSelectOptions& options, Ref<DeferredPromise>&& promise)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame || !frame->isMainFrame() || !frame->document() || !frame->page()) {
         promise->reject(InvalidStateError);
         return;

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -86,13 +86,13 @@ void CookieStore::get(String&& name, Ref<DeferredPromise>&& promise)
 
 void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context) {
         promise->reject(SecurityError);
         return;
     }
 
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     if (!origin) {
         promise->reject(SecurityError);
         return;
@@ -134,13 +134,13 @@ void CookieStore::getAll(String&& name, Ref<DeferredPromise>&& promise)
 
 void CookieStore::getAll(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context) {
         promise->reject(SecurityError);
         return;
     }
 
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     if (!origin) {
         promise->reject(SecurityError);
         return;
@@ -193,13 +193,13 @@ void CookieStore::set(String&& name, String&& value, Ref<DeferredPromise>&& prom
 
 void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context) {
         promise->reject(SecurityError);
         return;
     }
 
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     if (!origin) {
         promise->reject(SecurityError);
         return;
@@ -292,13 +292,13 @@ void CookieStore::remove(String&& name, Ref<DeferredPromise>&& promise)
 
 void CookieStore::remove(CookieStoreDeleteOptions&& options, Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context) {
         promise->reject(SecurityError);
         return;
     }
 
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     if (!origin) {
         promise->reject(SecurityError);
         return;
@@ -324,7 +324,7 @@ void CookieStore::cookiesAdded(const String& host, const Vector<Cookie>& cookies
     ASSERT_UNUSED(host, host == m_host);
     ASSERT(m_hasChangeEventListener);
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -346,7 +346,7 @@ void CookieStore::cookiesDeleted(const String& host, const Vector<Cookie>& cooki
     ASSERT_UNUSED(host, host == m_host);
     ASSERT(m_hasChangeEventListener);
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -55,7 +55,7 @@ ScopeAndCrossOriginParent CredentialsContainer::scopeAndCrossOriginParent() cons
     auto& origin = m_document->securityOrigin();
     auto& url = m_document->url();
     std::optional<SecurityOriginData> crossOriginParent;
-    for (auto* document = m_document->parentDocument(); document; document = document->parentDocument()) {
+    for (RefPtr document = m_document->parentDocument(); document; document = document->parentDocument()) {
         if (!origin.isSameOriginDomain(document->securityOrigin()) && !areRegistrableDomainsEqual(url, document->url()))
             isSameSite = false;
         if (!crossOriginParent && !origin.isSameOriginAs(document->securityOrigin()))

--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -161,7 +161,7 @@ std::optional<String> CDM::sanitizeSessionId(const String& sessionId)
 
 String CDM::storageDirectory() const
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return emptyString();
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -317,7 +317,7 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
         // FIXME: This needs a global MediaKeySession tracker.
 
         String origin;
-        if (auto* document = downcast<Document>(scriptExecutionContext()))
+        if (RefPtr document = downcast<Document>(scriptExecutionContext()))
             origin = document->securityOrigin().toString();
 
         // 8.4. Let expiration time be NaN.
@@ -747,7 +747,7 @@ void MediaKeySession::sessionIdChanged(const String& sessionId)
 
 PlatformDisplayID MediaKeySession::displayID()
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return 0;
 
@@ -792,7 +792,7 @@ void MediaKeySession::sessionClosed()
 
 String MediaKeySession::mediaKeysStorageDirectory() const
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return emptyString();
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -65,7 +65,7 @@ void provideMediaKeySystemTo(Page& page, MediaKeySystemClient& client)
 
 void MediaKeySystemController::logRequestMediaKeySystemDenial(Document& document)
 {
-    if (auto* window = document.domWindow())
+    if (RefPtr window = document.domWindow())
         window->printErrorMessage(makeString("Not allowed to access MediaKeySystem."));
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -63,13 +63,13 @@ MediaKeySystemRequest::~MediaKeySystemRequest()
 
 SecurityOrigin* MediaKeySystemRequest::topLevelDocumentOrigin() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return context ? &context->topOrigin() : nullptr;
 }
 
 void MediaKeySystemRequest::start()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     ASSERT(context);
     if (!context) {
         deny();

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -232,7 +232,7 @@ void WebKitMediaKeySession::sendError(MediaKeyErrorCode errorCode, uint32_t syst
 
 String WebKitMediaKeySession::mediaKeysStorageDirectory() const
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return emptyString();
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp
@@ -61,7 +61,7 @@ void FileSystemDirectoryEntry::getEntry(ScriptExecutionContext& context, const S
         return;
 
     filesystem().getEntry(context, *this, path, flags, [this, pendingActivity = makePendingActivity(*this), matches = WTFMove(matches), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
-        auto* document = this->document();
+        RefPtr document = this->document();
         if (result.hasException()) {
             if (errorCallback && document) {
                 document->eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), exception = result.releaseException(), pendingActivity = WTFMove(pendingActivity)]() mutable {

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -91,7 +91,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
     callOnMainThread([this, context = Ref { context }, successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), pendingActivity = WTFMove(pendingActivity)]() mutable {
         m_isReading = false;
         m_directory->filesystem().listDirectory(context, m_directory, [this, successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), pendingActivity = WTFMove(pendingActivity)](ExceptionOr<Vector<Ref<FileSystemEntry>>>&& result) mutable {
-            auto* document = this->document();
+            RefPtr document = this->document();
             if (result.hasException()) {
                 m_error = result.releaseException();
                 if (errorCallback && document) {

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -72,7 +72,7 @@ void FileSystemEntry::getParent(ScriptExecutionContext& context, RefPtr<FileSyst
         return;
 
     filesystem().getParent(context, *this, [this, pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
-        auto* document = this->document();
+        RefPtr document = this->document();
         if (!document)
             return;
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp
@@ -51,7 +51,7 @@ FileSystemFileEntry::FileSystemFileEntry(ScriptExecutionContext& context, DOMFil
 void FileSystemFileEntry::file(ScriptExecutionContext& context, Ref<FileCallback>&& successCallback, RefPtr<ErrorCallback>&& errorCallback)
 {
     filesystem().getFile(context, *this, [this, pendingActivity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback)](auto&& result) mutable {
-        auto* document = this->document();
+        RefPtr document = this->document();
         if (!document)
             return;
 

--- a/Source/WebCore/Modules/entriesapi/HTMLInputElementEntriesAPI.cpp
+++ b/Source/WebCore/Modules/entriesapi/HTMLInputElementEntriesAPI.cpp
@@ -42,7 +42,7 @@ Vector<Ref<FileSystemEntry>> HTMLInputElementEntriesAPI::webkitEntries(ScriptExe
     if (input.hasAttributeWithoutSynchronization(webkitdirectoryAttr))
         return { };
 
-    auto* fileList = input.files();
+    RefPtr fileList = input.files();
     if (!fileList)
         return { };
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -222,7 +222,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
 
 static void resolveWithTypeAndData(Ref<DeferredPromise>&& promise, FetchBodyConsumer::Type type, const String& contentType, const unsigned char* data, unsigned length)
 {
-    auto* context = promise->scriptExecutionContext();
+    RefPtr context = promise->scriptExecutionContext();
 
     switch (type) {
     case FetchBodyConsumer::Type::ArrayBuffer:
@@ -240,7 +240,7 @@ static void resolveWithTypeAndData(Ref<DeferredPromise>&& promise, FetchBodyCons
         promise->resolve<IDLDOMString>(TextResourceDecoder::textFromUTF8(data, length));
         return;
     case FetchBodyConsumer::Type::FormData:
-        if (auto formData = FetchBodyConsumer::packageFormData(context, contentType, data, length))
+        if (auto formData = FetchBodyConsumer::packageFormData(context.get(), contentType, data, length))
             promise->resolve<IDLInterface<DOMFormData>>(*formData);
         else
             promise->reject(TypeError);

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -188,7 +188,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone()
 
     // If loading, let's create a stream so that data is teed on both clones.
     if (isLoading() && !m_readableStreamSource) {
-        auto* context = scriptExecutionContext();
+        RefPtr context = scriptExecutionContext();
 
         auto* globalObject = context ? context->globalObject() : nullptr;
         if (!globalObject)

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -74,7 +74,7 @@ static void doFetch(ScriptExecutionContext& scope, FetchRequest::Info&& input, F
 
 void WindowOrWorkerGlobalScopeFetch::fetch(LocalDOMWindow& window, FetchRequest::Info&& input, FetchRequest::Init&& init, Ref<DeferredPromise>&& promise)
 {
-    auto* document = window.document();
+    RefPtr document = window.document();
     if (!document) {
         promise->reject(InvalidStateError);
         return;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -59,7 +59,7 @@ void FileSystemDirectoryHandle::getFileHandle(const String& name, const FileSyst
             return promise.reject(result.releaseException());
 
         auto strongThis = weakThis.get();
-        auto* context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
+        RefPtr context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
         if (!context)
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });
 
@@ -79,7 +79,7 @@ void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, const Fil
             return promise.reject(result.releaseException());
 
         auto strongThis = weakThis.get();
-        auto* context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
+        RefPtr context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
         if (!context)
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });
 
@@ -128,7 +128,7 @@ void FileSystemDirectoryHandle::getHandle(const String& name, CompletionHandler<
 
         auto [identifier, isDirectory] = result.returnValue()->release();
         auto strongThis = weakThis.get();
-        auto* context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
+        RefPtr context = strongThis ? strongThis->scriptExecutionContext() : nullptr;
         if (!context)
             return completionHandler(Exception { InvalidStateError, "Context has stopped"_s });
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
@@ -61,11 +61,11 @@ void FileSystemFileHandle::getFile(DOMPromiseDeferred<IDLInterface<File>>&& prom
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto* context = protectedThis->scriptExecutionContext();
+        RefPtr context = protectedThis->scriptExecutionContext();
         if (!context)
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });
 
-        promise.resolve(File::create(context, result.returnValue(), { }, protectedThis->name()));
+        promise.resolve(File::create(context.get(), result.returnValue(), { }, protectedThis->name()));
     });
 }
 
@@ -82,7 +82,7 @@ void FileSystemFileHandle::createSyncAccessHandle(DOMPromiseDeferred<IDLInterfac
         if (!info.file)
             return promise.reject(Exception { UnknownError, "Invalid platform file handle"_s });
 
-        auto* context = protectedThis->scriptExecutionContext();
+        RefPtr context = protectedThis->scriptExecutionContext();
         if (!context) {
             protectedThis->closeSyncAccessHandle(info.identifier);
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -173,7 +173,7 @@ void GamepadHapticActuator::stop()
 
 void GamepadHapticActuator::visibilityStateChanged()
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document || !document->hidden())
         return;
     stopEffects([] { });

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -76,8 +76,8 @@ Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platf
 
 const Vector<RefPtr<Gamepad>>& NavigatorGamepad::getGamepads(Navigator& navigator)
 {
-    auto* domWindow = navigator.window();
-    Document* document = domWindow ? domWindow->document() : nullptr;
+    RefPtr domWindow = navigator.window();
+    RefPtr document = domWindow ? domWindow->document() : nullptr;
     if (!document) {
         static NeverDestroyed<Vector<RefPtr<Gamepad>>> emptyGamepads;
         return emptyGamepads;

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -57,7 +57,7 @@ static RefPtr<Node> findNodeByPathIndex(const Node& parent, unsigned pathIndex, 
     if (!is<ContainerNode>(parent))
         return nullptr;
 
-    for (auto* child = downcast<ContainerNode>(parent).firstChild(); child; child = child->nextSibling()) {
+    for (RefPtr child = downcast<ContainerNode>(parent).firstChild(); child; child = child->nextSibling()) {
         if (nodeName != child->nodeName())
             continue;
 
@@ -174,7 +174,7 @@ static unsigned computePathIndex(const Node& node)
 {
     String nodeName = node.nodeName();
     unsigned index = 0;
-    for (auto* previousSibling = node.previousSibling(); previousSibling; previousSibling = previousSibling->previousSibling()) {
+    for (RefPtr previousSibling = node.previousSibling(); previousSibling; previousSibling = previousSibling->previousSibling()) {
         if (previousSibling->nodeName() == nodeName)
             index++;
     }

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -329,7 +329,7 @@ bool IDBCursor::setGetResult(IDBRequest& request, const IDBGetResult& getResult,
     LOG(IndexedDB, "IDBCursor::setGetResult - current key %s", getResult.keyData().loggingString().left(100).utf8().data());
     ASSERT(canCurrentThreadAccessThreadLocalData(effectiveObjectStore().transaction().database().originThread()));
 
-    auto* context = request.scriptExecutionContext();
+    RefPtr context = request.scriptExecutionContext();
     if (!context)
         return false;
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -317,7 +317,7 @@ void IDBDatabase::stop()
     removeAllEventListeners();
 
     for (auto& id : copyToVector(m_activeTransactions.keys())) {
-        if (auto* transaction = m_activeTransactions.get(id))
+        if (RefPtr transaction = m_activeTransactions.get(id))
             transaction->stop();
     }
 

--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -46,7 +46,7 @@ Ref<IDBKey> IDBKey::createBinary(const ThreadSafeDataBuffer& buffer)
 
 Ref<IDBKey> IDBKey::createBinary(JSC::JSArrayBuffer& arrayBuffer)
 {
-    auto* buffer = arrayBuffer.impl();
+    RefPtr buffer = arrayBuffer.impl();
     return adoptRef(*new IDBKey(ThreadSafeDataBuffer::copyData(buffer->data(), buffer->byteLength())));
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -365,7 +365,7 @@ void IDBRequest::setResult(const IDBKeyData& keyData)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -379,7 +379,7 @@ void IDBRequest::setResult(const Vector<IDBKeyData>& keyDatas)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -393,7 +393,7 @@ void IDBRequest::setResult(const IDBGetAllResult& result)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -407,7 +407,7 @@ void IDBRequest::setResult(uint64_t number)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -423,7 +423,7 @@ void IDBRequest::setResultToStructuredClone(const IDBGetResult& result)
 
     LOG(IndexedDB, "IDBRequest::setResultToStructuredClone");
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -437,7 +437,7 @@ void IDBRequest::setResultToUndefined()
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
     
@@ -470,7 +470,7 @@ void IDBRequest::willIterateCursor(IDBCursor& cursor)
     m_hasPendingActivity = true;
     m_result = NullResultType::Empty;
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -484,7 +484,7 @@ void IDBRequest::didOpenOrIterateCursor(const IDBResultData& resultData)
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
     ASSERT(m_pendingCursor);
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -541,7 +541,7 @@ void IDBRequest::setResult(Ref<IDBDatabase>&& database)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -554,7 +554,7 @@ void IDBRequest::setResult(Ref<IDBDatabase>&& database)
 
 void IDBRequest::clearWrappers()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
     VM& vm = context->vm();

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -96,7 +96,7 @@ IDBTransaction::IDBTransaction(IDBDatabase& database, const IDBTransactionInfo& 
     } else {
         activate();
 
-        auto* context = scriptExecutionContext();
+        RefPtr context = scriptExecutionContext();
         ASSERT(context);
 
         context->eventLoop().runAtEndOfMicrotaskCheckpoint([protectedThis = Ref { *this }] {
@@ -897,7 +897,7 @@ void IDBTransaction::iterateCursorOnServer(IDBClient::TransactionOperation& oper
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
     ASSERT(operation.idbRequest());
 
-    auto* cursor = operation.idbRequest()->pendingCursor();
+    RefPtr cursor = operation.idbRequest()->pendingCursor();
     ASSERT(cursor);
 
     if (data.keyData.isNull() && data.primaryKeyData.isNull()) {

--- a/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
@@ -90,11 +90,11 @@ DOMWindowIndexedDatabase* DOMWindowIndexedDatabase::from(LocalDOMWindow& window)
 
 IDBFactory* DOMWindowIndexedDatabase::indexedDB()
 {
-    auto* window = this->window();
+    RefPtr window = this->window();
     if (!window)
         return nullptr;
 
-    auto* document = window->document();
+    RefPtr document = window->document();
     if (!document)
         return nullptr;
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -590,7 +590,7 @@ void setMatchingItemsContextSuspended(ScriptExecutionContext& currentContext, Ha
         if (&iterator.value->originThread() != &currentThread)
             continue;
 
-        auto* context = iterator.value->scriptExecutionContext();
+        RefPtr context = iterator.value->scriptExecutionContext();
         if (!context)
             continue;
 

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
@@ -43,7 +43,7 @@ TransactionOperation::TransactionOperation(IDBTransaction& transaction, IDBReque
     m_indexIdentifier = request.sourceIndexIdentifier();
     if (m_indexIdentifier)
         m_indexRecordType = request.requestedIndexRecordType();
-    if (auto* cursor = request.pendingCursor())
+    if (RefPtr cursor = request.pendingCursor())
         m_cursorIdentifier = cursor->info().identifier();
 
     request.setTransactionOperationID(m_operationID);

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -202,8 +202,8 @@ void IDBConnectionToClient::connectionToClientClosed()
     m_isClosed = true;
     auto databaseConnections = m_databaseConnections;
 
-    for (auto* connection : databaseConnections) {
-        ASSERT(m_databaseConnections.contains(connection));
+    for (RefPtr connection : databaseConnections) {
+        ASSERT(m_databaseConnections.contains(connection.get()));
         connection->connectionClosedFromClient();
     }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -147,7 +147,7 @@ MediaSession::MediaSession(Navigator& navigator)
     m_logIdentifier = nextLogIdentifier();
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
-    auto* frame = navigator.frame();
+    RefPtr frame = navigator.frame();
     auto* page = frame ? frame->page() : nullptr;
     if (page && page->mediaSessionCoordinator())
         m_coordinator->setMediaSessionCoordinatorPrivate(*page->mediaSessionCoordinator());
@@ -404,11 +404,11 @@ void MediaSession::notifyActionHandlerObservers()
 
 RefPtr<HTMLMediaElement> MediaSession::activeMediaElement() const
 {
-    auto* doc = document();
-    if (!doc)
+    RefPtr document = this->document();
+    if (!document)
         return nullptr;
 
-    return HTMLMediaElement::bestMediaElementForRemoteControls(MediaElementSession::PlaybackControlsPurpose::MediaSession, doc);
+    return HTMLMediaElement::bestMediaElementForRemoteControls(MediaElementSession::PlaybackControlsPurpose::MediaSession, document.get());
 }
 
 void MediaSession::updateReportedPosition()

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -786,7 +786,7 @@ ExceptionOr<void> MediaSource::removeSourceBuffer(SourceBuffer& buffer)
     ASSERT(scriptExecutionContext());
     if (!scriptExecutionContext()->activeDOMObjectsAreStopped()) {
         // 4. Let SourceBuffer audioTracks list equal the AudioTrackList object returned by sourceBuffer.audioTracks.
-        auto* audioTracks = buffer.audioTracksIfExists();
+        RefPtr audioTracks = buffer.audioTracksIfExists();
 
         // 5. If the SourceBuffer audioTracks list is not empty, then run the following steps:
         if (audioTracks && audioTracks->length()) {
@@ -826,7 +826,7 @@ ExceptionOr<void> MediaSource::removeSourceBuffer(SourceBuffer& buffer)
         }
 
         // 6. Let SourceBuffer videoTracks list equal the VideoTrackList object returned by sourceBuffer.videoTracks.
-        auto* videoTracks = buffer.videoTracksIfExists();
+        RefPtr videoTracks = buffer.videoTracksIfExists();
 
         // 7. If the SourceBuffer videoTracks list is not empty, then run the following steps:
         if (videoTracks && videoTracks->length()) {
@@ -866,7 +866,7 @@ ExceptionOr<void> MediaSource::removeSourceBuffer(SourceBuffer& buffer)
         }
 
         // 8. Let SourceBuffer textTracks list equal the TextTrackList object returned by sourceBuffer.textTracks.
-        auto* textTracks = buffer.textTracksIfExists();
+        RefPtr textTracks = buffer.textTracksIfExists();
 
         // 9. If the SourceBuffer textTracks list is not empty, then run the following steps:
         if (textTracks && textTracks->length()) {

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -654,7 +654,7 @@ uint64_t SourceBuffer::maximumBufferSize() const
     if (isRemoved())
         return 0;
 
-    auto* element = m_source->mediaElement();
+    RefPtr element = m_source->mediaElement();
     if (!element)
         return 0;
 
@@ -751,7 +751,7 @@ void SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment(Initializa
         ASSERT(segment.audioTracks.size() == audioTracks().length());
         for (auto& audioTrackInfo : segment.audioTracks) {
             if (audioTracks().length() == 1) {
-                auto* track = audioTracks().item(0);
+                RefPtr track = audioTracks().item(0);
                 auto oldId = track->id();
                 auto newId = audioTrackInfo.track->id();
                 track->setPrivate(*audioTrackInfo.track);
@@ -768,7 +768,7 @@ void SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment(Initializa
         ASSERT(segment.videoTracks.size() == videoTracks().length());
         for (auto& videoTrackInfo : segment.videoTracks) {
             if (videoTracks().length() == 1) {
-                auto* track = videoTracks().item(0);
+                RefPtr track = videoTracks().item(0);
                 auto oldId = track->id();
                 auto newId = videoTrackInfo.track->id();
                 track->setPrivate(*videoTrackInfo.track);
@@ -785,7 +785,7 @@ void SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment(Initializa
         ASSERT(segment.textTracks.size() == textTracks().length());
         for (auto& textTrackInfo : segment.textTracks) {
             if (textTracks().length() == 1) {
-                auto* track = downcast<InbandTextTrack>(textTracks().item(0));
+                RefPtr track = downcast<InbandTextTrack>(textTracks().item(0));
                 auto oldId = track->id();
                 auto newId = textTrackInfo.track->id();
                 track->setPrivate(*textTrackInfo.track);

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -131,7 +131,7 @@ void MediaDevices::getUserMedia(StreamConstraints&& constraints, Promise&& promi
         return;
     }
 
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document || !document->isFullyActive()) {
         promise.reject(Exception { InvalidStateError, "Document is not fully active"_s });
         return;
@@ -245,7 +245,7 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
 
 void MediaDevices::getDisplayMedia(DisplayMediaStreamConstraints&& constraints, Promise&& promise)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return;
 
@@ -335,7 +335,7 @@ String MediaDevices::hashedGroupId(const String& groupId)
 
 void MediaDevices::enumerateDevices(EnumerateDevicesPromise&& promise)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return;
 
@@ -397,7 +397,7 @@ const char* MediaDevices::activeDOMObjectName() const
 
 void MediaDevices::listenForDeviceChanges()
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     auto* controller = document ? UserMediaController::from(document->page()) : nullptr;
     if (!controller)
         return;

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -108,7 +108,7 @@ MediaStream::~MediaStream()
     // mediaState(), are short circuited.
     m_isActive = false;
     m_private->removeObserver(*this);
-    if (auto* document = this->document()) {
+    if (RefPtr document = this->document()) {
         if (m_isWaitingUntilMediaCanStart)
             document->removeMediaCanStartListener(*this);
     }
@@ -317,7 +317,7 @@ MediaProducerMediaStateFlags MediaStream::mediaState() const
 
 void MediaStream::statusDidChange()
 {
-    if (auto* document = this->document()) {
+    if (RefPtr document = this->document()) {
         if (!m_isActive)
             return;
         document->updateIsPlayingMedia();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -98,8 +98,8 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
 
     auto& settings = m_private->settings();
     if (settings.supportsGroupId()) {
-        auto* window = downcast<Document>(context).domWindow();
-        if (auto* mediaDevices = window ? NavigatorMediaDevices::mediaDevices(window->navigator()) : nullptr)
+        RefPtr window = downcast<Document>(context).domWindow();
+        if (RefPtr mediaDevices = window ? NavigatorMediaDevices::mediaDevices(window->navigator()) : nullptr)
             m_groupId = mediaDevices->hashedGroupId(settings.groupId());
     }
 
@@ -342,7 +342,7 @@ MediaProducerMediaStateFlags MediaStreamTrack::mediaState() const
     if (m_ended || !isCaptureTrack())
         return MediaProducer::IsNotPlaying;
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context || !is<Document>(context) || !downcast<Document>(context)->page())
         return MediaProducer::IsNotPlaying;
 
@@ -396,7 +396,7 @@ MediaProducerMediaStateFlags sourceCaptureState(RealtimeMediaSource& source)
 MediaProducerMediaStateFlags MediaStreamTrack::captureState(Document& document)
 {
     MediaProducerMediaStateFlags state;
-    for (auto* captureTrack : allCaptureTracks()) {
+    for (RefPtr captureTrack : allCaptureTracks()) {
         if (captureTrack->scriptExecutionContext() != &document || captureTrack->ended())
             continue;
         state.add(sourceCaptureState(captureTrack->source()));
@@ -406,7 +406,7 @@ MediaProducerMediaStateFlags MediaStreamTrack::captureState(Document& document)
 
 void MediaStreamTrack::updateCaptureAccordingToMutedState(Document& document)
 {
-    for (auto* captureTrack : allCaptureTracks()) {
+    for (RefPtr captureTrack : allCaptureTracks()) {
         if (captureTrack->scriptExecutionContext() == &document && !captureTrack->ended())
             captureTrack->updateToPageMutedState();
     }
@@ -415,8 +415,8 @@ void MediaStreamTrack::updateCaptureAccordingToMutedState(Document& document)
 void MediaStreamTrack::updateVideoCaptureAccordingMicrophoneInterruption(Document& document, bool isMicrophoneInterrupted)
 {
     auto* page = document.page();
-    for (auto* captureTrack : allCaptureTracks()) {
-        auto* context = captureTrack->scriptExecutionContext();
+    for (RefPtr captureTrack : allCaptureTracks()) {
+        RefPtr context = captureTrack->scriptExecutionContext();
         if (!context || downcast<Document>(context)->page() != page)
             continue;
         auto& source = captureTrack->source();
@@ -428,7 +428,7 @@ void MediaStreamTrack::updateVideoCaptureAccordingMicrophoneInterruption(Documen
 void MediaStreamTrack::updateToPageMutedState()
 {
     ASSERT(isCaptureTrack());
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
 
     if (!context)
         return;
@@ -486,8 +486,8 @@ static MediaProducerMediaCaptureKind trackTypeForMediaProducerCaptureKind(Captur
 void MediaStreamTrack::endCapture(Document& document, MediaProducerMediaCaptureKind kind)
 {
     bool didEndCapture = false;
-    for (auto* captureTrack : allCaptureTracks()) {
-        auto* trackDocument = downcast<Document>(captureTrack->scriptExecutionContext());
+    for (RefPtr captureTrack : allCaptureTracks()) {
+        RefPtr trackDocument = downcast<Document>(captureTrack->scriptExecutionContext());
         if (trackDocument != &document)
             continue;
         if (kind != MediaProducerMediaCaptureKind::EveryKind && kind != trackTypeForMediaProducerCaptureKind(captureTrack->privateTrack().deviceType()))
@@ -543,12 +543,12 @@ void MediaStreamTrack::trackEnded(MediaStreamTrackPrivate&)
     
 void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (scriptExecutionContext()->activeDOMObjectsAreStopped() || m_ended)
         return;
 
     Function<void()> updateMuted = [this, muted = m_private->muted()] {
-        auto* context = scriptExecutionContext();
+        RefPtr context = scriptExecutionContext();
         if (!context || context ->activeDOMObjectsAreStopped())
             return;
 
@@ -593,7 +593,7 @@ void MediaStreamTrack::trackEnabledChanged(MediaStreamTrackPrivate&)
 
 void MediaStreamTrack::configureTrackRendering()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context || !is<Document>(context))
         return;
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -112,7 +112,7 @@ PeerConnectionBackend::PeerConnectionBackend(RTCPeerConnection& peerConnection)
 #endif
 {
 #if USE(LIBWEBRTC)
-    auto* document = peerConnection.document();
+    RefPtr document = peerConnection.document();
     if (auto* page = document ? document->page() : nullptr)
         m_shouldFilterICECandidates = page->webRTCProvider().isSupportingMDNS();
 #endif

--- a/Source/WebCore/Modules/mediastream/RTCController.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCController.cpp
@@ -74,8 +74,8 @@ bool RTCController::shouldDisableICECandidateFiltering(Document& document)
 
 void RTCController::add(RTCPeerConnection& connection)
 {
-    auto& document = downcast<Document>(*connection.scriptExecutionContext());
-    if (auto* networkManager = document.rtcNetworkManager())
+    Ref document = downcast<Document>(*connection.scriptExecutionContext());
+    if (RefPtr networkManager = document->rtcNetworkManager())
         networkManager->setICECandidateFiltering(!shouldDisableICECandidateFiltering(document));
 
     m_peerConnections.append(connection);
@@ -90,8 +90,8 @@ void RTCController::disableICECandidateFilteringForAllOrigins()
 
     m_shouldFilterICECandidates = false;
     for (RTCPeerConnection& connection : m_peerConnections) {
-        if (auto* document = downcast<Document>(connection.scriptExecutionContext())) {
-            if (auto* networkManager = document->rtcNetworkManager())
+        if (RefPtr document = downcast<Document>(connection.scriptExecutionContext())) {
+            if (RefPtr networkManager = document->rtcNetworkManager())
                 networkManager->setICECandidateFiltering(false);
         }
         connection.disableICECandidateFiltering();
@@ -103,14 +103,14 @@ void RTCController::disableICECandidateFilteringForDocument(Document& document)
     if (!WebRTCProvider::webRTCAvailable())
         return;
 
-    if (auto* networkManager = document.rtcNetworkManager())
+    if (RefPtr networkManager = document.rtcNetworkManager())
         networkManager->setICECandidateFiltering(false);
 
     m_filteringDisabledOrigins.append(PeerConnectionOrigin { document.topOrigin(), document.securityOrigin() });
     for (RTCPeerConnection& connection : m_peerConnections) {
-        if (auto* peerConnectionDocument = downcast<Document>(connection.scriptExecutionContext())) {
+        if (RefPtr peerConnectionDocument = downcast<Document>(connection.scriptExecutionContext())) {
             if (matchDocumentOrigin(*peerConnectionDocument, document.topOrigin(), document.securityOrigin())) {
-                if (auto* networkManager = peerConnectionDocument->rtcNetworkManager())
+                if (RefPtr networkManager = peerConnectionDocument->rtcNetworkManager())
                     networkManager->setICECandidateFiltering(false);
                 connection.disableICECandidateFiltering();
             }
@@ -127,8 +127,8 @@ void RTCController::enableICECandidateFiltering()
     m_shouldFilterICECandidates = true;
     for (RTCPeerConnection& connection : m_peerConnections) {
         connection.enableICECandidateFiltering();
-        if (auto* document = downcast<Document>(connection.scriptExecutionContext())) {
-            if (auto* networkManager = document->rtcNetworkManager())
+        if (RefPtr document = downcast<Document>(connection.scriptExecutionContext())) {
+            if (RefPtr networkManager = document->rtcNetworkManager())
                 networkManager->setICECandidateFiltering(true);
         }
     }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -58,7 +58,7 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, std:
         channel->m_isDetachable = false;
         if (!channel->m_handler)
             return;
-        if (auto* context = channel->scriptExecutionContext())
+        if (RefPtr context = channel->scriptExecutionContext())
             channel->m_handler->setClient(*channel, context->identifier());
     });
     return channel;
@@ -73,7 +73,7 @@ NetworkSendQueue RTCDataChannel::createMessageQueue(ScriptExecutionContext& cont
         if (!channel.m_handler->sendRawData(span.data(), span.size()))
             channel.scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending binary data through RTCDataChannel."_s);
     }, [&channel](ExceptionCode errorCode) {
-        if (auto* context = channel.scriptExecutionContext()) {
+        if (RefPtr context = channel.scriptExecutionContext()) {
             auto code = static_cast<int>(errorCode);
             context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Error ", code, " in retrieving a blob data to be sent through RTCDataChannel."));
         }

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -88,7 +88,7 @@ void RTCDtlsTransport::onStateChanged(RTCDtlsTransportState state, Vector<Ref<JS
 
         if (m_state != state) {
             m_state = state;
-            if (auto* connection = m_iceTransport->connection())
+            if (RefPtr connection = m_iceTransport->connection())
                 connection->updateConnectionState();
             dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
         }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -995,7 +995,7 @@ RefPtr<RTCDtlsTransport> RTCPeerConnection::getOrCreateDtlsTransport(std::unique
     if (!backend)
         return nullptr;
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return nullptr;
 
@@ -1073,7 +1073,7 @@ void RTCPeerConnection::updateSctpBackend(std::unique_ptr<RTCSctpTransportBacken
         m_sctpTransport->update();
         return;
     }
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -152,7 +152,7 @@ void RTCRtpSFrameTransform::initializeTransformer(RTCRtpTransformBackend& backen
 {
     ASSERT(!isAttached());
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -47,7 +47,7 @@ ExceptionOr<Ref<RTCRtpScriptTransform>> RTCRtpScriptTransform::create(JSC::JSGlo
     if (!worker.scriptExecutionContext())
         return Exception { InvalidStateError, "Worker frame is detached"_s };
 
-    auto* context = JSC::jsCast<JSDOMGlobalObject*>(&state)->scriptExecutionContext();
+    RefPtr context = JSC::jsCast<JSDOMGlobalObject*>(&state)->scriptExecutionContext();
     if (!context)
         return Exception { InvalidStateError, "Invalid context"_s };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -91,7 +91,7 @@ ReadableStream& RTCRtpScriptTransformer::readable()
 ExceptionOr<Ref<WritableStream>> RTCRtpScriptTransformer::writable()
 {
     if (!m_writable) {
-        auto* context = downcast<WorkerGlobalScope>(scriptExecutionContext());
+        RefPtr context = downcast<WorkerGlobalScope>(scriptExecutionContext());
         if (!context || !context->globalObject())
             return Exception { InvalidStateError };
 
@@ -193,7 +193,7 @@ void RTCRtpScriptTransformer::enqueueFrame(ScriptExecutionContext& context, Ref<
 
 void RTCRtpScriptTransformer::generateKeyFrame(Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context || !m_backend || m_backend->side() != RTCRtpTransformBackend::Side::Sender || m_backend->mediaType() != RTCRtpTransformBackend::MediaType::Video) {
         promise->reject(Exception { InvalidStateError, "Not attached to a valid video sender"_s });
         return;
@@ -207,7 +207,7 @@ void RTCRtpScriptTransformer::generateKeyFrame(Ref<DeferredPromise>&& promise)
 
 void RTCRtpScriptTransformer::sendKeyFrameRequest(Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context || !m_backend || m_backend->side() != RTCRtpTransformBackend::Side::Receiver || m_backend->mediaType() != RTCRtpTransformBackend::MediaType::Video) {
         promise->reject(Exception { InvalidStateError, "Not attached to a valid video receiver"_s });
         return;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -132,7 +132,7 @@ void RTCRtpSender::replaceTrack(RefPtr<MediaStreamTrack>&& withTrack, Ref<Deferr
             return;
         }
 
-        auto* context = m_connection->scriptExecutionContext();
+        RefPtr context = m_connection->scriptExecutionContext();
         if (!context)
             return;
 

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -57,13 +57,13 @@ void provideUserMediaTo(Page* page, UserMediaClient* client)
 
 void UserMediaController::logGetUserMediaDenial(Document& document)
 {
-    if (auto* window = document.domWindow())
+    if (RefPtr window = document.domWindow())
         window->printErrorMessage(makeString("Not allowed to call getUserMedia."));
 }
 
 void UserMediaController::logGetDisplayMediaDenial(Document& document)
 {
-    if (auto* window = document.domWindow())
+    if (RefPtr window = document.domWindow())
         window->printErrorMessage(makeString("Not allowed to call getDisplayMedia."));
 }
 
@@ -72,7 +72,7 @@ void UserMediaController::logEnumerateDevicesDenial(Document& document)
     // We redo the check to print to the console log.
     isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Camera, document, LogFeaturePolicyFailure::Yes);
     isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document, LogFeaturePolicyFailure::Yes);
-    if (auto* window = document.domWindow())
+    if (RefPtr window = document.domWindow())
         window->printErrorMessage(makeString("Not allowed to call enumerateDevices."));
 }
 

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -78,19 +78,19 @@ UserMediaRequest::~UserMediaRequest()
 
 SecurityOrigin* UserMediaRequest::userMediaDocumentOrigin() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return context ? context->securityOrigin() : nullptr;
 }
 
 SecurityOrigin* UserMediaRequest::topLevelDocumentOrigin() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return context ? &context->topOrigin() : nullptr;
 }
 
 void UserMediaRequest::start()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     ASSERT(context);
     if (!context) {
         deny(MediaAccessDenialReason::UserMediaDisabled);
@@ -182,14 +182,14 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
                 return;
             }
 
-            if (auto* audioTrack = stream->getFirstAudioTrack()) {
+            if (RefPtr audioTrack = stream->getFirstAudioTrack()) {
 #if USE(AUDIO_SESSION)
                 AudioSession::sharedSession().tryToSetActive(true);
 #endif
                 if (std::holds_alternative<MediaTrackConstraints>(m_audioConstraints))
                     audioTrack->setConstraints(std::get<MediaTrackConstraints>(WTFMove(m_audioConstraints)));
             }
-            if (auto* videoTrack = stream->getFirstVideoTrack()) {
+            if (RefPtr videoTrack = stream->getFirstVideoTrack()) {
                 if (std::holds_alternative<MediaTrackConstraints>(m_videoConstraints))
                     videoTrack->setConstraints(std::get<MediaTrackConstraints>(WTFMove(m_videoConstraints)));
             }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -346,7 +346,7 @@ PlatformLayerIdentifier HTMLModelElement::platformLayerID()
     if (!renderLayerModelObject.isComposited() || !renderLayerModelObject.layer() || !renderLayerModelObject.layer()->backing())
         return { };
 
-    auto* graphicsLayer = renderLayerModelObject.layer()->backing()->graphicsLayer();
+    RefPtr graphicsLayer = renderLayerModelObject.layer()->backing()->graphicsLayer();
     if (!graphicsLayer)
         return { };
 

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -193,7 +193,7 @@ void Notification::show(CompletionHandler<void()>&& callback)
     if (m_state != Idle)
         return;
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -201,7 +201,7 @@ void Notification::show(CompletionHandler<void()>&& callback)
     if (!client)
         return;
 
-    if (client->checkPermission(context) != Permission::Granted) {
+    if (client->checkPermission(context.get()) != Permission::Granted) {
         switch (m_notificationSource) {
         case NotificationSource::DedicatedWorker:
         case NotificationSource::Document:
@@ -221,7 +221,7 @@ void Notification::show(CompletionHandler<void()>&& callback)
     m_resourcesLoader->start([this, client, callback = scope.release()](RefPtr<NotificationResources>&& resources) mutable {
         CompletionHandlerCallingScope scope { WTFMove(callback) };
 
-        auto* context = scriptExecutionContext();
+        RefPtr context = scriptExecutionContext();
 
         m_resources = WTFMove(resources);
         if (m_state == Idle && context && client->show(*context, data(), this->resources(), scope.release()))
@@ -247,7 +247,7 @@ void Notification::close()
 
 NotificationClient* Notification::clientFromContext()
 {
-    if (auto* context = scriptExecutionContext())
+    if (RefPtr context = scriptExecutionContext())
         return context->notificationClient();
     return nullptr;
 }
@@ -284,7 +284,7 @@ void Notification::finalize()
 
 void Notification::dispatchShowEvent()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -299,7 +299,7 @@ void Notification::dispatchShowEvent()
 
 void Notification::dispatchClickEvent()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -315,7 +315,7 @@ void Notification::dispatchClickEvent()
 
 void Notification::dispatchCloseEvent()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -329,7 +329,7 @@ void Notification::dispatchCloseEvent()
 
 void Notification::dispatchErrorEvent()
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
@@ -376,7 +376,7 @@ void Notification::requestPermission(Document& document, RefPtr<NotificationPerm
         return resolvePromiseAndCallback(Permission::Denied);
     }
 
-    auto* window = document.frame() ? document.frame()->window() : nullptr;
+    RefPtr window = document.frame() ? document.frame()->window() : nullptr;
     if (!window || !window->consumeTransientActivation()) {
         document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Notification prompting can only be done from a user gesture."_s);
         return resolvePromiseAndCallback(Permission::Denied);

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -36,10 +36,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(NotificationEvent);
 
 Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    auto* notification = init.notification.get();
+    auto notification = init.notification;
     ASSERT(notification);
     auto action = init.action;
-    return adoptRef(*new NotificationEvent(type, WTFMove(init), notification, action, isTrusted));
+    return adoptRef(*new NotificationEvent(type, WTFMove(init), notification.get(), action, isTrusted));
 }
 
 Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Notification* notification, const String& action, IsTrusted isTrusted)

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -374,7 +374,7 @@ void PaymentRequest::show(Document& document, RefPtr<DOMPromise>&& detailsPromis
         return;
     }
 
-    auto* window = document.frame()->window();
+    RefPtr window = document.frame()->window();
     if (!window || !window->consumeTransientActivation()) {
         promise.reject(Exception { SecurityError, "show() must be triggered by user activation."_s });
         return;

--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -66,7 +66,7 @@ PermissionStatus::PermissionStatus(ScriptExecutionContext& context, PermissionSt
     , m_state(state)
     , m_descriptor(descriptor)
 {
-    auto* origin = context.securityOrigin();
+    RefPtr origin = context.securityOrigin();
     auto originData = origin ? origin->data() : SecurityOriginData { };
     ClientOrigin clientOrigin { context.topOrigin().data(), WTFMove(originData) };
 
@@ -93,11 +93,11 @@ void PermissionStatus::stateChanged(PermissionState newState)
     if (m_state == newState)
         return;
 
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
 
-    auto* document = dynamicDowncast<Document>(context);
+    RefPtr document = dynamicDowncast<Document>(context.get());
     if (document && !document->isFullyActive())
         return;
 
@@ -115,8 +115,8 @@ bool PermissionStatus::virtualHasPendingActivity() const
     if (!m_hasChangeEventListener)
         return false;
 
-    auto* context = scriptExecutionContext();
-    if (is<Document>(context))
+    RefPtr context = scriptExecutionContext();
+    if (is<Document>(context.get()))
         return downcast<Document>(*context).hasBrowsingContext();
 
     return true;

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -120,7 +120,7 @@ std::optional<PermissionName> Permissions::toPermissionName(const String& name)
 
 void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DOMPromiseDeferred<IDLInterface<PermissionStatus>>&& promise)
 {
-    auto* context = m_navigator ? m_navigator->scriptExecutionContext() : nullptr;
+    RefPtr context = m_navigator ? m_navigator->scriptExecutionContext() : nullptr;
     if (!context || !context->globalObject()) {
         promise.reject(Exception { InvalidStateError, "The context is invalid"_s });
         return;
@@ -132,7 +132,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
         return;
     }
 
-    auto* document = dynamicDowncast<Document>(*context);
+    RefPtr document = dynamicDowncast<Document>(*context);
     if (document && !document->isFullyActive()) {
         promise.reject(Exception { InvalidStateError, "The document is not fully active"_s });
         return; 
@@ -146,7 +146,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
         return;
     }
 
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     auto originData = origin ? origin->data() : SecurityOriginData { };
 
     if (document) {

--- a/Source/WebCore/Modules/push-api/PushManager.cpp
+++ b/Source/WebCore/Modules/push-api/PushManager.cpp
@@ -139,7 +139,7 @@ void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushS
                 return;
             }
 
-            auto* window = document.frame() ? document.frame()->window() : nullptr;
+            RefPtr window = document.frame() ? document.frame()->window() : nullptr;
             if (!window || !window->consumeTransientActivation()) {
 #if !RELEASE_LOG_DISABLED
                 Seconds lastActivationDuration = window ? MonotonicTime::now() - window->lastActivationTimestamp() : Seconds::infinity();

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -60,10 +60,10 @@ Ref<ReportingObserver> ReportingObserver::create(ScriptExecutionContext& scriptE
 
 static WeakPtr<ReportingScope> reportingScopeForContext(ScriptExecutionContext& scriptExecutionContext)
 {
-    if (auto* document = dynamicDowncast<Document>(&scriptExecutionContext))
+    if (RefPtr document = dynamicDowncast<Document>(&scriptExecutionContext))
         return document->reportingScope();
 
-    if (auto* workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(&scriptExecutionContext))
+    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(&scriptExecutionContext))
         return workerGlobalScope->reportingScope();
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -128,7 +128,7 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
     if (m_queuedReports.size() > 1)
         return;
 
-    auto* context = m_callback->scriptExecutionContext();
+    RefPtr context = m_callback->scriptExecutionContext();
     if (!context)
         return;
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -157,7 +157,7 @@ void ReportingScope::generateTestReport(String&& message, String&& group)
     URL testReportURL;
     String reportURL { ""_s };
 
-    auto* document = dynamicDowncast<Document>(scriptExecutionContext());
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (document) {
         testReportURL = document->url();
         reportURL = testReportURL.strippedForUseAsReferrer();

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -51,7 +51,7 @@ WakeLock::WakeLock(Document* document)
 // https://www.w3.org/TR/screen-wake-lock/#the-request-method
 void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document || !document->isFullyActive() || !document->page()) {
         promise->reject(Exception { NotAllowedError, "Document is not fully active"_s });
         return;

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -45,7 +45,7 @@ WakeLockSentinel::WakeLockSentinel(Document& document, WakeLockType type)
 void WakeLockSentinel::release(Ref<DeferredPromise>&& promise)
 {
     if (!m_wasReleased) {
-        if (auto* document = downcast<Document>(scriptExecutionContext()))
+        if (RefPtr document = downcast<Document>(scriptExecutionContext()))
             Ref { *this }->release(document->wakeLockManager());
     }
     promise->resolve();

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -71,14 +71,14 @@ ExceptionOr<void> SpeechRecognition::startRecognition()
     if (!m_connection)
         return Exception { UnknownError, "Recognition does not have a valid connection"_s };
 
-    auto& document = downcast<Document>(*scriptExecutionContext());
-    auto* frame = document.frame();
+    Ref document = downcast<Document>(*scriptExecutionContext());
+    RefPtr frame = document->frame();
     if (!frame)
         return Exception { UnknownError, "Recognition is not in a valid frame"_s };
 
-    auto optionalFrameIdentifier = document.frameID();
+    auto optionalFrameIdentifier = document->frameID();
     auto frameIdentifier = optionalFrameIdentifier ? *optionalFrameIdentifier : FrameIdentifier { };
-    m_connection->start(identifier(), m_lang, m_continuous, m_interimResults, m_maxAlternatives, ClientOrigin { document.topOrigin().data(), document.securityOrigin().data() }, frameIdentifier);
+    m_connection->start(identifier(), m_lang, m_continuous, m_interimResults, m_maxAlternatives, ClientOrigin { document->topOrigin().data(), document->securityOrigin().data() }, frameIdentifier);
     m_state = State::Starting;
     return { };
 }

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -64,18 +64,18 @@ static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator)
     if (!navigator)
         return Exception { InvalidStateError, "Navigator does not exist"_s };
 
-    auto context = navigator->scriptExecutionContext();
+    RefPtr context = navigator->scriptExecutionContext();
     if (!context)
         return Exception { InvalidStateError, "Context is invalid"_s };
 
     if (context->canAccessResource(ScriptExecutionContext::ResourceType::StorageManager) == ScriptExecutionContext::HasResourceAccess::No)
         return Exception { TypeError, "Context not access storage"_s };
 
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     ASSERT(origin);
 
     if (is<Document>(context)) {
-        if (auto* connection = downcast<Document>(context)->storageConnection())
+        if (RefPtr connection = downcast<Document>(context)->storageConnection())
             return ConnectionInfo { *connection, { context->topOrigin().data(), origin->data() } };
 
         return Exception { InvalidStateError, "Connection is invalid"_s };
@@ -135,7 +135,7 @@ void StorageManager::fileSystemAccessGetDirectory(DOMPromiseDeferred<IDLInterfac
             return promise.reject(result.releaseException());
 
         auto [identifier, connection] = result.releaseReturnValue();
-        auto* context = weakNavigator ? weakNavigator->scriptExecutionContext() : nullptr;
+        RefPtr context = weakNavigator ? weakNavigator->scriptExecutionContext() : nullptr;
         if (!context) {
             connection->closeHandle(identifier);
             return promise.reject(Exception { InvalidStateError, "Context has stopped"_s });

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -50,7 +50,7 @@ static std::optional<ClientOrigin> clientOriginFromContext(ScriptExecutionContex
 {
     if (!context)
         return std::nullopt;
-    auto* origin = context->securityOrigin();
+    RefPtr origin = context->securityOrigin();
     if (!origin || origin->isOpaque())
         return std::nullopt;
     return { { context->topOrigin().data(), origin->data() } };

--- a/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
@@ -99,8 +99,8 @@ void AsyncAudioDecoder::DecodingTask::decode()
 
 void AsyncAudioDecoder::DecodingTask::notifyComplete()
 {
-    if (auto* audioBuffer = this->audioBuffer())
-        callback()(Ref { *audioBuffer });
+    if (RefPtr audioBuffer = this->audioBuffer())
+        callback()(audioBuffer.releaseNonNull());
     else
         callback()(Exception { EncodingError, "Decoding failed"_s });
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -81,7 +81,7 @@ static bool shouldDocumentAllowWebAudioToAutoPlay(const Document& document)
         return true;
     if (document.quirks().shouldAutoplayWebAudioForArbitraryUserGesture() && document.topDocument().hasHadUserInteraction())
         return true;
-    auto* window = document.domWindow();
+    RefPtr window = document.domWindow();
     return window && window->hasTransientActivation();
 }
 
@@ -150,7 +150,7 @@ void AudioContext::constructCommon()
 
 AudioContext::~AudioContext()
 {
-    if (auto* document = this->document())
+    if (RefPtr document = this->document())
         document->removeAudioProducer(*this);
 }
 
@@ -324,7 +324,7 @@ void AudioContext::lazyInitialize()
 
 bool AudioContext::willPausePlayback()
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return false;
 
@@ -378,7 +378,7 @@ void AudioContext::mayResumePlayback(bool shouldResume)
 
 bool AudioContext::willBeginPlayback()
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return false;
 
@@ -449,7 +449,7 @@ void AudioContext::suspendPlayback()
 
 MediaSessionGroupIdentifier AudioContext::mediaSessionGroupIdentifier() const
 {
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     return document && document->page() ? document->page()->mediaSessionGroupIdentifier() : MediaSessionGroupIdentifier { };
 }
 
@@ -485,7 +485,7 @@ void AudioContext::isPlayingAudioDidChange()
     // Make sure to call Document::updateIsPlayingMedia() on the main thread, since
     // we could be on the audio I/O thread here and the call into WebCore could block.
     callOnMainThread([protectedThis = Ref { *this }] {
-        if (auto* document = protectedThis->document())
+        if (RefPtr document = protectedThis->document())
             document->updateIsPlayingMedia();
     });
 }

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -87,7 +87,7 @@ void AudioDestinationNode::renderQuantum(AudioBus* destinationBus, size_t number
     context().handlePreRenderTasks(outputPosition);
 
     RefPtr<AudioWorkletGlobalScope> workletGlobalScope;
-    if (auto* audioWorkletProxy = context().audioWorklet().proxy())
+    if (RefPtr audioWorkletProxy = context().audioWorklet().proxy())
         workletGlobalScope = audioWorkletProxy->workletThread().globalScope();
     if (workletGlobalScope)
         workletGlobalScope->handlePreRenderTasks();

--- a/Source/WebCore/Modules/webaudio/AudioWorklet.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorklet.cpp
@@ -77,7 +77,7 @@ BaseAudioContext* AudioWorklet::audioContext() const
 
 void AudioWorklet::createProcessor(const String& name, TransferredMessagePort port, Ref<SerializedScriptValue>&& options, AudioWorkletNode& node)
 {
-    auto* proxy = this->proxy();
+    RefPtr proxy = this->proxy();
     ASSERT(proxy);
     if (!proxy)
         return;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -121,7 +121,7 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
 
     thread().messagingProxy().postTaskToAudioWorklet([name = WTFMove(name).isolatedCopy(), parameterDescriptors = crossThreadCopy(WTFMove(parameterDescriptors))](AudioWorklet& worklet) mutable {
         ASSERT(isMainThread());
-        if (auto* audioContext = worklet.audioContext())
+        if (RefPtr audioContext = worklet.audioContext())
             audioContext->addAudioParamDescriptors(name, WTFMove(parameterDescriptors));
     });
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 
 static WorkletParameters generateWorkletParameters(AudioWorklet& worklet)
 {
-    auto* document = worklet.document();
+    RefPtr document = worklet.document();
     auto jsRuntimeFlags = document->settings().javaScriptRuntimeFlags();
     RELEASE_ASSERT(document->sessionID());
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -147,7 +147,7 @@ AudioWorkletNode::~AudioWorkletNode()
     {
         Locker locker { m_processLock };
         if (m_processor) {
-            if (auto* workletProxy = context().audioWorklet().proxy()) {
+            if (RefPtr workletProxy = context().audioWorklet().proxy()) {
                 workletProxy->postTaskForModeToWorkletGlobalScope([processor = WTFMove(m_processor)](ScriptExecutionContext& context) {
                     downcast<AudioWorkletGlobalScope>(context).processorIsNoLongerNeeded(*processor);
                 }, WorkerRunLoop::defaultMode());
@@ -171,7 +171,7 @@ void AudioWorkletNode::initializeAudioParameters(const Vector<AudioParamDescript
 
     if (paramValues) {
         for (auto& paramValue : *paramValues) {
-            if (auto* audioParam = m_parameters->map().get(paramValue.key))
+            if (RefPtr audioParam = m_parameters->map().get(paramValue.key))
                 audioParam->setValue(paramValue.value);
         }
     }

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -272,7 +272,7 @@ bool BaseAudioContext::wouldTaintOrigin(const URL& url) const
     if (url.protocolIsData())
         return false;
 
-    if (auto* document = this->document())
+    if (RefPtr document = this->document())
         return !document->securityOrigin().canRequest(url, OriginAccessPatternsForWebProcess::singleton());
 
     return false;
@@ -875,13 +875,13 @@ void BaseAudioContext::postTask(Function<void()>&& task)
 
 const SecurityOrigin* BaseAudioContext::origin() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return context ? context->securityOrigin() : nullptr;
 }
 
 void BaseAudioContext::addConsoleMessage(MessageSource source, MessageLevel level, const String& message)
 {
-    if (auto* context = scriptExecutionContext())
+    if (RefPtr context = scriptExecutionContext())
         context->addConsoleMessage(source, level, message);
 }
 

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -145,8 +145,8 @@ void DefaultAudioDestinationNode::enableInput(const String& inputDeviceId)
 
 Function<void(Function<void()>&&)> DefaultAudioDestinationNode::dispatchToRenderThreadFunction()
 {
-    if (auto* workletProxy = context().audioWorklet().proxy()) {
-        return [workletProxy = Ref { *workletProxy }](Function<void()>&& function) {
+    if (RefPtr workletProxy = context().audioWorklet().proxy()) {
+        return [workletProxy](Function<void()>&& function) {
             workletProxy->postTaskForModeToWorkletGlobalScope([function = WTFMove(function)](ScriptExecutionContext&) mutable {
                 function();
             }, WorkerRunLoop::defaultMode());

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -36,6 +36,7 @@
 #include "Logging.h"
 #include "MediaElementAudioSourceOptions.h"
 #include "MediaPlayer.h"
+#include "SecurityOrigin.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Locker.h>
 
@@ -133,7 +134,7 @@ void MediaElementAudioSourceNode::provideInput(AudioBus* bus, size_t framesToPro
 
 bool MediaElementAudioSourceNode::wouldTaintOrigin()
 {
-    if (auto* origin = context().origin())
+    if (RefPtr origin = context().origin())
         return m_mediaElement->taintsOrigin(*origin);
 
     return true;

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -92,7 +92,7 @@ void OfflineAudioDestinationNode::uninitialize()
             m_renderThread->waitForCompletion();
             m_renderThread = nullptr;
         }
-        if (auto* workletProxy = context().audioWorklet().proxy()) {
+        if (RefPtr workletProxy = context().audioWorklet().proxy()) {
             BinarySemaphore semaphore;
             workletProxy->postTaskForModeToWorkletGlobalScope([&semaphore](ScriptExecutionContext&) mutable {
                 semaphore.signal();
@@ -139,7 +139,7 @@ void OfflineAudioDestinationNode::startRendering(CompletionHandler<void(std::opt
         });
     };
 
-    if (auto* workletProxy = context().audioWorklet().proxy()) {
+    if (RefPtr workletProxy = context().audioWorklet().proxy()) {
         workletProxy->postTaskForModeToWorkletGlobalScope([offThreadRendering = WTFMove(offThreadRendering)](ScriptExecutionContext&) mutable {
             offThreadRendering();
         }, WorkerRunLoop::defaultMode());

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -102,7 +102,7 @@ void AuthenticatorCoordinator::create(const Document& document, const PublicKeyC
     using namespace AuthenticatorCoordinatorInternal;
 
     const auto& callerOrigin = document.securityOrigin();
-    auto* frame = document.frame();
+    RefPtr frame = document.frame();
     ASSERT(frame);
     // The following implements https://www.w3.org/TR/webauthn-2/#createCredential as of 28 June 2022.
     // Step 1, 3, 16 are handled by the caller.
@@ -200,7 +200,7 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     using namespace AuthenticatorCoordinatorInternal;
 
     auto& callerOrigin = document.securityOrigin();
-    auto* frame = document.frame();
+    RefPtr frame = document.frame();
     const auto& options = requestOptions.publicKey.value();
     ASSERT(frame);
     // The following implements https://www.w3.org/TR/webauthn/#createCredential as of 5 December 2017.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -250,7 +250,7 @@ ExceptionOr<void> WebCodecsVideoEncoder::encode(Ref<WebCodecsVideoFrame>&& frame
 
             --m_beingEncodedQueueSize;
             if (!result.isNull()) {
-                if (auto* context = scriptExecutionContext())
+                if (RefPtr context = scriptExecutionContext())
                     context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("VideoEncoder encode failed: ", result));
                 closeEncoder(Exception { EncodingError, WTFMove(result) });
                 return;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -70,7 +70,7 @@ WebCodecsVideoFrame::~WebCodecsVideoFrame()
 {
     if (m_isDetached)
         return;
-    if (auto* context = scriptExecutionContext()) {
+    if (RefPtr context = scriptExecutionContext()) {
         context->postTask([](auto& context) {
             context.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "A VideoFrame was destroyed without having been closed explicitly"_s);
         });
@@ -85,7 +85,7 @@ static std::optional<Exception> checkImageUsability(ScriptExecutionContext& cont
         if (!imageElement->originClean(*context.securityOrigin()))
             return Exception { SecurityError, "Image element is tainted"_s };
 
-        auto* image = imageElement->cachedImage() ? imageElement->cachedImage()->image() : nullptr;
+        RefPtr image = imageElement->cachedImage() ? imageElement->cachedImage()->image() : nullptr;
         if (!image)
             return Exception { InvalidStateError,  "Image element has no data"_s };
         if (!image->width() || !image->height())
@@ -96,7 +96,7 @@ static std::optional<Exception> checkImageUsability(ScriptExecutionContext& cont
         if (imageElement->renderingTaintsOrigin())
             return Exception { SecurityError, "Image element is tainted"_s };
 
-        auto* image = imageElement->cachedImage() ? imageElement->cachedImage()->image() : nullptr;
+        RefPtr image = imageElement->cachedImage() ? imageElement->cachedImage()->image() : nullptr;
         if (!image)
             return Exception { InvalidStateError,  "Image element has no data"_s };
         if (!image->width() || !image->height())
@@ -110,7 +110,7 @@ static std::optional<Exception> checkImageUsability(ScriptExecutionContext& cont
     },
 #if ENABLE(VIDEO)
     [&] (const RefPtr<HTMLVideoElement>& video) -> std::optional<Exception> {
-        auto* origin = context.securityOrigin();
+        RefPtr origin = context.securityOrigin();
         if (video->taintsOrigin(*origin))
             return Exception { SecurityError, "Video element is tainted"_s };
 
@@ -213,7 +213,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         if (!canvas->width() || !canvas->height())
             return Exception { InvalidStateError,  "Input canvas has a bad size"_s };
 
-        auto* imageBuffer = canvas->buffer();
+        RefPtr imageBuffer = canvas->buffer();
         if (!imageBuffer)
             return Exception { InvalidStateError,  "Input canvas has no image buffer"_s };
 
@@ -227,7 +227,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         if (!image->width() || !image->height())
             return Exception { InvalidStateError,  "Input image has a bad size"_s };
 
-        auto* imageBuffer = image->buffer();
+        RefPtr imageBuffer = image->buffer();
         if (!imageBuffer)
             return Exception { InvalidStateError,  "Input image has no image buffer"_s };
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
@@ -176,7 +176,7 @@ bool DatabaseContext::stopDatabases(DatabaseTaskSynchronizer* synchronizer)
 
 bool DatabaseContext::allowDatabaseAccess() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (is<Document>(*context)) {
         auto& document = downcast<Document>(*context);
         if (!document.page() || (document.page()->usesEphemeralSession() && !LegacySchemeRegistry::allowsDatabaseAccessInPrivateBrowsing(document.securityOrigin().protocol())))
@@ -190,7 +190,7 @@ bool DatabaseContext::allowDatabaseAccess() const
 
 void DatabaseContext::databaseExceededQuota(const String& name, DatabaseDetails details)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (is<Document>(*context)) {
         auto& document = downcast<Document>(*context);
         if (Page* page = document.page())

--- a/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
+++ b/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
@@ -42,7 +42,7 @@ ExceptionOr<RefPtr<Database>> LocalDOMWindowWebDatabase::openDatabase(LocalDOMWi
     auto& manager = DatabaseManager::singleton();
     if (!manager.isAvailable())
         return Exception { SecurityError };
-    auto* document = window.document();
+    RefPtr document = window.document();
     if (!document)
         return Exception { SecurityError };
     document->addConsoleMessage(MessageSource::Storage, MessageLevel::Warning, "Web SQL is deprecated. Please use IndexedDB instead."_s);

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
@@ -44,7 +44,7 @@ const char* NavigatorWebDriver::supplementName()
 
 bool NavigatorWebDriver::isControlledByAutomation(const Navigator& navigator)
 {
-    auto* frame = navigator.frame();
+    RefPtr frame = navigator.frame();
     if (!frame || !frame->page())
         return false;
 

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -78,7 +78,7 @@ std::optional<ThreadableWebSocketChannel::ValidatedURL> ThreadableWebSocketChann
         if (!page->allowsLoadFromURL(requestedURL, MainFrameMainResource::No))
             return { };
 #if ENABLE(CONTENT_EXTENSIONS)
-        if (auto* documentLoader = document.loader()) {
+        if (RefPtr documentLoader = document.loader()) {
             auto results = page->userContentProvider().processContentRuleListsForLoad(*page, validatedURL.url, ContentExtensions::ResourceType::WebSocket, *documentLoader);
             if (results.summary.blockedLoad)
                 return { };
@@ -108,7 +108,7 @@ std::optional<ResourceRequest> ThreadableWebSocketChannel::webSocketConnectReque
     request.setFirstPartyForCookies(document.firstPartyForCookies());
     request.setHTTPHeaderField(HTTPHeaderName::Origin, document.securityOrigin().toString());
 
-    if (auto* documentLoader = document.loader())
+    if (RefPtr documentLoader = document.loader())
         request.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
 
     FrameLoader::addSameSiteInfoToRequestIfNeeded(request, &document);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -276,7 +276,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         return Exception { SecurityError };
     }
 
-    if (auto* provider = context.socketProvider())
+    if (RefPtr provider = context.socketProvider())
         m_channel = ThreadableWebSocketChannel::create(*scriptExecutionContext(), *this, *provider);
 
     // Every ScriptExecutionContext should have a SocketProvider.
@@ -331,7 +331,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
 
 #if ENABLE(TRACKING_PREVENTION)
     auto reportRegistrableDomain = [domain = RegistrableDomain(m_url).isolatedCopy()](auto& context) mutable {
-        if (auto* frame = downcast<Document>(context).frame())
+        if (RefPtr frame = downcast<Document>(context).frame())
             frame->loader().client().didLoadFromRegistrableDomain(WTFMove(domain));
     };
     if (is<Document>(context))

--- a/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp
@@ -79,7 +79,7 @@ ExceptionOr<Ref<WebXRReferenceSpace>> WebXRBoundedReferenceSpace::getOffsetRefer
     if (!m_session)
         return Exception { InvalidStateError };
 
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return Exception { InvalidStateError };
 

--- a/Source/WebCore/Modules/webxr/WebXRHand.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRHand.cpp
@@ -43,8 +43,8 @@ Ref<WebXRHand> WebXRHand::create(const WebXRInputSource& inputSource)
 WebXRHand::WebXRHand(const WebXRInputSource& inputSource)
     : m_inputSource(inputSource)
 {
-    auto* session = this->session();
-    auto* document = session ? downcast<Document>(session->scriptExecutionContext()) : nullptr;
+    RefPtr session = this->session();
+    RefPtr document = session ? downcast<Document>(session->scriptExecutionContext()) : nullptr;
     if (!document)
         return;
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -79,7 +79,7 @@ void WebXRInputSource::update(double timestamp, const PlatformXR::Device::FrameD
     if (auto gripOrigin = source.gripOrigin) {
         if (m_gripSpace)
             m_gripSpace->setPose(*gripOrigin);
-        else if (auto* document = downcast<Document>(session->scriptExecutionContext()))
+        else if (RefPtr document = downcast<Document>(session->scriptExecutionContext()))
             m_gripSpace = WebXRInputSpace::create(*document, *session, *gripOrigin);
     } else
         m_gripSpace = nullptr;

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -138,7 +138,7 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
 // https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources
 void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& added, Vector<RefPtr<WebXRInputSource>>& removed, Vector<Ref<XRInputSourceEvent>>& inputEvents)
 {
-    auto* document = downcast<Document>(m_session.scriptExecutionContext());
+    RefPtr document = downcast<Document>(m_session.scriptExecutionContext());
     if (!document)
         return;
 

--- a/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
@@ -102,7 +102,7 @@ ExceptionOr<Ref<WebXRReferenceSpace>> WebXRReferenceSpace::getOffsetReferenceSpa
     if (!m_session)
         return Exception { InvalidStateError };
 
-    auto* document = downcast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (!document)
         return Exception { InvalidStateError };
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -643,7 +643,7 @@ void WebXRSession::onFrame(PlatformXR::Device::FrameData&& frameData)
 bool WebXRSession::posesCanBeReported(const Document& document) const
 {
     // 1. If session’s relevant global object is not the current global object, return false.
-    auto* sessionDocument = downcast<Document>(scriptExecutionContext());
+    RefPtr sessionDocument = downcast<Document>(scriptExecutionContext());
     if (!sessionDocument || sessionDocument->domWindow() != document.domWindow())
         return false;
 

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -455,7 +455,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
     // 3. Let global object be the relevant Global object for the XRSystem on which this method was invoked.
     bool immersive = mode == XRSessionMode::ImmersiveAr || mode == XRSessionMode::ImmersiveVr;
     Ref protectedDocument { document };
-    auto* globalObject = protectedDocument->domWindow();
+    RefPtr globalObject = protectedDocument->domWindow();
     if (!globalObject) {
         promise.reject(Exception { InvalidAccessError});
         return;


### PR DESCRIPTION
#### 5ba6f209bd3e1ec692e3ea9de3f4c74737dca0f9
<pre>
Use more smart pointers in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=261380">https://bugs.webkit.org/show_bug.cgi?id=261380</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/applepay/PaymentSession.cpp:
(WebCore::PaymentSession::canCreateSession):
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::setType):
(WebCore::DOMAudioSession::type const):
(WebCore::DOMAudioSession::state const):
(WebCore::DOMAudioSession::scheduleStateChangeEvent):
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::logError):
(WebCore::NavigatorBeacon::sendBeacon):
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::origin const):
* Source/WebCore/Modules/contact-picker/ContactsManager.cpp:
(WebCore::ContactsManager::select):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):
(WebCore::CookieStore::set):
(WebCore::CookieStore::remove):
(WebCore::CookieStore::cookiesAdded):
(WebCore::CookieStore::cookiesDeleted):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::scopeAndCrossOriginParent const):
* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
(WebCore::CDM::storageDirectory const):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::load):
(WebCore::MediaKeySession::displayID):
(WebCore::MediaKeySession::mediaKeysStorageDirectory const):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp:
(WebCore::MediaKeySystemController::logRequestMediaKeySystemDenial):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::topLevelDocumentOrigin const):
(WebCore::MediaKeySystemRequest::start):
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
(WebCore::WebKitMediaKeySession::mediaKeysStorageDirectory const):
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.cpp:
(WebCore::FileSystemDirectoryEntry::getEntry):
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp:
(WebCore::FileSystemDirectoryReader::readEntries):
* Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp:
(WebCore::FileSystemEntry::getParent):
* Source/WebCore/Modules/entriesapi/FileSystemFileEntry.cpp:
(WebCore::FileSystemFileEntry::file):
* Source/WebCore/Modules/entriesapi/HTMLInputElementEntriesAPI.cpp:
(WebCore::HTMLInputElementEntriesAPI::webkitEntries):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::resolveWithTypeAndData):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::clone):
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::WindowOrWorkerGlobalScopeFetch::fetch):
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp:
(WebCore::FileSystemDirectoryHandle::getFileHandle):
(WebCore::FileSystemDirectoryHandle::getDirectoryHandle):
(WebCore::FileSystemDirectoryHandle::getHandle):
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp:
(WebCore::FileSystemFileHandle::getFile):
(WebCore::FileSystemFileHandle::createSyncAccessHandle):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::visibilityStateChanged):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::getGamepads):
* Source/WebCore/Modules/highlight/AppHighlightStorage.cpp:
(WebCore::findNodeByPathIndex):
(WebCore::computePathIndex):
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
(WebCore::IDBCursor::setGetResult):
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::stop):
* Source/WebCore/Modules/indexeddb/IDBKey.cpp:
(WebCore::IDBKey::createBinary):
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::setResult):
(WebCore::IDBRequest::setResultToStructuredClone):
(WebCore::IDBRequest::setResultToUndefined):
(WebCore::IDBRequest::willIterateCursor):
(WebCore::IDBRequest::didOpenOrIterateCursor):
(WebCore::IDBRequest::clearWrappers):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::IDBTransaction):
(WebCore::IDBTransaction::iterateCursorOnServer):
* Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp:
(WebCore::DOMWindowIndexedDatabase::indexedDB):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::setMatchingItemsContextSuspended):
* Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp:
(WebCore::IDBClient::TransactionOperation::TransactionOperation):
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::connectionToClientClosed):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::MediaSession):
(WebCore::MediaSession::activeMediaElement const):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::removeSourceBuffer):
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::maximumBufferSize const):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::getUserMedia):
(WebCore::MediaDevices::getDisplayMedia):
(WebCore::MediaDevices::enumerateDevices):
(WebCore::MediaDevices::listenForDeviceChanges):
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::~MediaStream):
(WebCore::MediaStream::statusDidChange):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
(WebCore::MediaStreamTrack::mediaState const):
(WebCore::MediaStreamTrack::captureState):
(WebCore::MediaStreamTrack::updateCaptureAccordingToMutedState):
(WebCore::MediaStreamTrack::updateVideoCaptureAccordingMicrophoneInterruption):
(WebCore::MediaStreamTrack::updateToPageMutedState):
(WebCore::MediaStreamTrack::endCapture):
(WebCore::MediaStreamTrack::trackMutedChanged):
(WebCore::MediaStreamTrack::configureTrackRendering):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::PeerConnectionBackend):
* Source/WebCore/Modules/mediastream/RTCController.cpp:
(WebCore::RTCController::add):
(WebCore::RTCController::disableICECandidateFilteringForAllOrigins):
(WebCore::RTCController::disableICECandidateFilteringForDocument):
(WebCore::RTCController::enableICECandidateFiltering):
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::create):
(WebCore::RTCDataChannel::createMessageQueue):
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
(WebCore::RTCDtlsTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::getOrCreateDtlsTransport):
(WebCore::RTCPeerConnection::updateSctpBackend):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::RTCRtpSFrameTransform::initializeTransformer):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
(WebCore::RTCRtpScriptTransform::create):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::writable):
(WebCore::RTCRtpScriptTransformer::generateKeyFrame):
(WebCore::RTCRtpScriptTransformer::sendKeyFrameRequest):
* Source/WebCore/Modules/mediastream/RTCRtpSender.cpp:
(WebCore::RTCRtpSender::replaceTrack):
* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::logGetUserMediaDenial):
(WebCore::UserMediaController::logGetDisplayMediaDenial):
(WebCore::UserMediaController::logEnumerateDevicesDenial):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::userMediaDocumentOrigin const):
(WebCore::UserMediaRequest::topLevelDocumentOrigin const):
(WebCore::UserMediaRequest::start):
(WebCore::UserMediaRequest::allow):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::platformLayerID):
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::show):
(WebCore::Notification::clientFromContext):
(WebCore::Notification::dispatchShowEvent):
(WebCore::Notification::dispatchClickEvent):
(WebCore::Notification::dispatchCloseEvent):
(WebCore::Notification::dispatchErrorEvent):
(WebCore::Notification::requestPermission):
* Source/WebCore/Modules/notifications/NotificationEvent.cpp:
(WebCore::NotificationEvent::create):
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::show):
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::PermissionStatus):
(WebCore::PermissionStatus::stateChanged):
(WebCore::PermissionStatus::virtualHasPendingActivity const):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
* Source/WebCore/Modules/push-api/PushManager.cpp:
(WebCore::PushManager::subscribe):
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::reportingScopeForContext):
(WebCore::ReportingObserver::appendQueuedReportIfCorrectType):
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::generateTestReport):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
(WebCore::WakeLockSentinel::release):
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::startRecognition):
* Source/WebCore/Modules/storage/StorageManager.cpp:
(WebCore::connectionInfo):
(WebCore::StorageManager::fileSystemAccessGetDirectory):
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::clientOriginFromContext):
* Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp:
(WebCore::AsyncAudioDecoder::DecodingTask::notifyComplete):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::shouldDocumentAllowWebAudioToAutoPlay):
(WebCore::AudioContext::~AudioContext):
(WebCore::AudioContext::willPausePlayback):
(WebCore::AudioContext::willBeginPlayback):
(WebCore::AudioContext::mediaSessionGroupIdentifier const):
(WebCore::AudioContext::isPlayingAudioDidChange):
* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::renderQuantum):
* Source/WebCore/Modules/webaudio/AudioWorklet.cpp:
(WebCore::AudioWorklet::createProcessor):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::registerProcessor):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::generateWorkletParameters):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::~AudioWorkletNode):
(WebCore::AudioWorkletNode::initializeAudioParameters):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::wouldTaintOrigin const):
(WebCore::BaseAudioContext::origin const):
(WebCore::BaseAudioContext::addConsoleMessage):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::Function&lt;void):
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::wouldTaintOrigin):
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp:
(WebCore::OfflineAudioDestinationNode::uninitialize):
(WebCore::OfflineAudioDestinationNode::startRendering):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::encode):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::~WebCodecsVideoFrame):
(WebCore::checkImageUsability):
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webdatabase/DatabaseContext.cpp:
(WebCore::DatabaseContext::allowDatabaseAccess const):
(WebCore::DatabaseContext::databaseExceededQuota):
* Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.cpp:
(WebCore::LocalDOMWindowWebDatabase::openDatabase):
* Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp:
(WebCore::NavigatorWebDriver::isControlledByAutomation):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::validateURL):
(WebCore::ThreadableWebSocketChannel::webSocketConnectRequest):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp:
(WebCore::WebXRBoundedReferenceSpace::getOffsetReferenceSpace):
* Source/WebCore/Modules/webxr/WebXRHand.cpp:
(WebCore::WebXRHand::WebXRHand):
* Source/WebCore/Modules/webxr/WebXRInputSource.cpp:
(WebCore::WebXRInputSource::update):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::handleAddedOrUpdatedInputSources):
* Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp:
(WebCore::WebXRReferenceSpace::getOffsetReferenceSpace):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::posesCanBeReported const):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::requestSession):

Canonical link: <a href="https://commits.webkit.org/267850@main">https://commits.webkit.org/267850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c3a778ee041d026b509572129282151dd7610f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18361 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20576 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16297 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16466 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17030 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16132 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4257 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->