### PR TITLE
Invalidate :default pseudo-class changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has-expected.txt
@@ -5,8 +5,9 @@ PASS :indeterminate invalidation on <progress>
 PASS :disabled invalidation
 PASS :read-only invalidation
 PASS :valid invalidation
-FAIL :default invalidation with input[type=radio] assert_equals: ancestor should be lightblue expected "rgb(173, 216, 230)" but got "rgb(0, 0, 0)"
+PASS :default invalidation with input[type=radio]
 PASS :required invalidation
 PASS :out-of-range invalidation
 PASS :placeholder-shown invalidation
+PASS :default invalidation with input[type=checkbox] and assignment to .checked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has.html
@@ -16,6 +16,7 @@
   .ancestor:has(#numberinput:out-of-range) { color: darkgreen }
   .ancestor:has(#numberinput:required) { color: pink }
   .ancestor:has(#progress:indeterminate) { color: orange }
+  .ancestor:has(#checkboxinput:default) { color: purple; }
 </style>
 <div id=subject class=ancestor>
   <input type="checkbox" name="my-checkbox" id="checkme">
@@ -24,6 +25,7 @@
   <input id="radioinput" checked>
   <input id="numberinput" type="number" min="1" max="10" value="5">
   <progress id="progress" value="50" max="100"></progress>
+  <input id="checkboxinput" type="checkbox">
 </div>
 <script>
   test(function() {
@@ -138,4 +140,25 @@
     assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 128)",
                   "ancestor should be navy");
   }, ":placeholder-shown invalidation");
+
+  test(function() {
+    this.add_cleanup(() => {
+      checkboxinput.checked = false;
+      checkboxinput.removeAttribute("checked");
+    });
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+    checkboxinput.checked = true;
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should still be black");
+    checkboxinput.setAttribute("checked", "");
+    assert_equals(getComputedStyle(subject).color, "rgb(128, 0, 128)",
+                  "ancestor should be purple");
+    checkboxinput.checked = false;
+    assert_equals(getComputedStyle(subject).color, "rgb(128, 0, 128)",
+                  "ancestor should still be purple");
+    checkboxinput.removeAttribute("checked");
+    assert_equals(getComputedStyle(subject).color, "rgb(0, 0, 0)",
+                  "ancestor should be black");
+  }, ":default invalidation with input[type=checkbox] and assignment to .checked");
 </script>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -512,6 +512,8 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
         return;
     ASSERT(m_inputType->type() != newType->type());
 
+    Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassType::Default, Style::PseudoClassChangeInvalidation::AnyValue);
+
     removeFromRadioButtonGroup();
     resignStrongPasswordAppearance();
 
@@ -781,8 +783,7 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         HTMLTextFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
         break;
     case AttributeNames::checkedAttr:
-        if (m_inputType->isCheckable())
-            invalidateStyleForSubtree();
+        setDefaultCheckedState(!newValue.isNull());
         // Another radio button in the same group might be checked by state
         // restore. We shouldn't call setChecked() even if this has the checked
         // attribute. So, delay the setChecked() call until
@@ -955,7 +956,7 @@ bool HTMLInputElement::matchesDefaultPseudoClass() const
     ASSERT(m_inputType);
     if (m_inputType->canBeSuccessfulSubmitButton())
         return !isDisabledFormControl() && form() && form()->defaultButton() == this;
-    return m_inputType->isCheckable() && hasAttributeWithoutSynchronization(checkedAttr);
+    return m_inputType->isCheckable() && m_isDefaultChecked;
 }
 
 bool HTMLInputElement::isActivatedSubmit() const
@@ -998,6 +999,17 @@ bool HTMLInputElement::isTextField() const
 bool HTMLInputElement::isTextType() const
 {
     return m_inputType->isTextType();
+}
+
+void HTMLInputElement::setDefaultCheckedState(bool isDefaultChecked)
+{
+    if (m_isDefaultChecked == isDefaultChecked)
+        return;
+
+    std::optional<Style::PseudoClassChangeInvalidation> defaultInvalidation;
+    if (m_inputType->isCheckable())
+        defaultInvalidation.emplace(*this, CSSSelector::PseudoClassType::Default, isDefaultChecked);
+    m_isDefaultChecked = isDefaultChecked;
 }
 
 void HTMLInputElement::setChecked(bool isChecked)
@@ -1059,6 +1071,7 @@ void HTMLInputElement::copyNonAttributePropertiesFromElement(const Element& sour
     m_valueIfDirty = sourceElement.m_valueIfDirty;
     m_wasModifiedByUser = false;
     setChecked(sourceElement.m_isChecked);
+    m_isDefaultChecked = sourceElement.m_isDefaultChecked;
     m_dirtyCheckednessFlag = sourceElement.m_dirtyCheckednessFlag;
     m_isIndeterminate = sourceElement.m_isIndeterminate;
 

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -191,6 +191,7 @@ public:
     bool shouldAppearChecked() const;
     bool matchesIndeterminatePseudoClass() const final;
     bool shouldAppearIndeterminate() const final;
+    void setDefaultCheckedState(bool);
 
     bool sizeShouldIncludeDecoration(int& preferredSize) const;
     float decorationWidth() const;
@@ -453,6 +454,7 @@ private:
     short m_maxResults { -1 };
     bool m_isChecked : 1 { false };
     bool m_dirtyCheckednessFlag : 1 { false };
+    bool m_isDefaultChecked : 1 { false };
     bool m_isIndeterminate : 1 { false };
     bool m_hasType : 1 { false };
     bool m_isActivatedSubmit : 1 { false };


### PR DESCRIPTION
#### ec255a8cd5cce23106c903bd2fc8620c7eac1e01
<pre>
Invalidate :default pseudo-class changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261382">https://bugs.webkit.org/show_bug.cgi?id=261382</a>
&lt;rdar://problem/115236525&gt;

Reviewed by Tim Nguyen.

On an &lt;input type=checked&gt;, the presence of the checked=&quot;&quot; attribute
determines whether :default matches. We must invalidate :default when
the attribute is added or removed on a checkable input element.

We also must invalidate :default when the type=&quot;&quot; changes. Just use
AnyValue rather than compute ahead of time what the new pseudo-class
match value will be, in HTMLInputElement::updateType.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/input-pseudo-classes-in-has.html:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::matchesDefaultPseudoClass const):
(WebCore::HTMLInputElement::setDefaultCheckedState):
(WebCore::HTMLInputElement::copyNonAttributePropertiesFromElement):
* Source/WebCore/html/HTMLInputElement.h:

Canonical link: <a href="https://commits.webkit.org/267848@main">https://commits.webkit.org/267848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d262947bdf1f6d19b25657607435560ced0a844c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19706 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18359 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20574 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22831 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20696 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14422 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16135 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20488 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2192 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->