### PR TITLE
WebCodecs hardware encoders may loose a frame in case of calling configure and encoding a frame just after

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.js
@@ -19,7 +19,6 @@ promise_setup(async () => {
   }[location.search];
   config.hardwareAcceleration = 'prefer-software';
   config.bitrateMode = "constant";
-  config.scalabilityMode = "L1T2";
   config.framerate = 30;
   ENCODER_CONFIG = config;
 });

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_annexb-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Reconfiguring encoder Unsupported config: {"codec":"avc1.42001F","avc":{"format":"annexb"},"hardwareAcceleration":"prefer-software","bitrateMode":"constant","scalabilityMode":"L1T2","framerate":30,"width":800,"height":600,"bitrate":3000000}
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_avc-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Reconfiguring encoder Unsupported config: {"codec":"avc1.42001F","avc":{"format":"avc"},"hardwareAcceleration":"prefer-software","bitrateMode":"constant","scalabilityMode":"L1T2","framerate":30,"width":800,"height":600,"bitrate":3000000}
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Reconfiguring encoder Unsupported config: {"codec":"vp09.02.10.10","hardwareAcceleration":"prefer-software","bitrateMode":"constant","scalabilityMode":"L1T2","framerate":30,"width":800,"height":600,"bitrate":3000000}
+NOTRUN Reconfiguring encoder Unsupported config: {"codec":"vp09.02.10.10","hardwareAcceleration":"prefer-software","bitrateMode":"constant","framerate":30,"width":800,"height":600,"bitrate":3000000}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Reconfiguring encoder Unsupported config: {"codec":"avc1.42001F","avc":{"format":"annexb"},"hardwareAcceleration":"prefer-software","bitrateMode":"constant","scalabilityMode":"L1T2","framerate":30,"width":800,"height":600,"bitrate":3000000}
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Reconfiguring encoder Unsupported config: {"codec":"avc1.42001F","avc":{"format":"avc"},"hardwareAcceleration":"prefer-software","bitrateMode":"constant","scalabilityMode":"L1T2","framerate":30,"width":800,"height":600,"bitrate":3000000}
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN Reconfiguring encoder Unsupported config: {"codec":"vp09.02.10.10","hardwareAcceleration":"prefer-software","bitrateMode":"constant","scalabilityMode":"L1T2","framerate":30,"width":800,"height":600,"bitrate":3000000}
+NOTRUN Reconfiguring encoder Unsupported config: {"codec":"vp09.02.10.10","hardwareAcceleration":"prefer-software","bitrateMode":"constant","framerate":30,"width":800,"height":600,"bitrate":3000000}
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -39,7 +39,7 @@
 #include "VideoDecoderIdentifier.h"
 #include "VideoEncoderIdentifier.h"
 #include "WorkQueueMessageReceiver.h"
-#include <WebCore/VideoEncoderActiveConfiguration.h>
+#include <WebCore/VideoEncoder.h>
 #include <map>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
@@ -137,7 +137,7 @@ public:
     };
 
     Encoder* createEncoder(VideoCodecType, const std::map<std::string, std::string>&);
-    void createEncoderAndWaitUntilReady(VideoCodecType, const String& codec, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
+    void createEncoderAndWaitUntilInitialized(VideoCodecType, const String& codec, const std::map<std::string, std::string>&, const WebCore::VideoEncoder::Config&, Function<void(Encoder*)>&&);
     int32_t releaseEncoder(Encoder&);
     int32_t initializeEncoder(Encoder&, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
     int32_t encodeFrame(Encoder&, const WebCore::VideoFrame&, int64_t timestamp, std::optional<uint64_t> duration, bool shouldEncodeAsKeyFrame);
@@ -193,6 +193,7 @@ private:
     Decoder* createDecoderInternal(VideoCodecType, const String& codec, Function<void(Decoder(*))>&&);
     Encoder* createEncoderInternal(VideoCodecType, const String& codec, const std::map<std::string, std::string>&, bool isRealtime, bool useAnnexB, Function<void(Encoder*)>&&);
     template<typename Frame> int32_t encodeFrameInternal(Encoder&, const Frame&, bool shouldEncodeAsKeyFrame, WebCore::VideoFrameRotation, MediaTime, int64_t timestamp, std::optional<uint64_t> duration);
+    void initializeEncoderInternal(Encoder&, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
 
 private:
     HashMap<VideoDecoderIdentifier, std::unique_ptr<Decoder>> m_decoders WTF_GUARDED_BY_CAPABILITY(workQueue());


### PR DESCRIPTION
#### 11c16abe0e925e42914d86836716d1941f355231
<pre>
WebCodecs hardware encoders may loose a frame in case of calling configure and encoding a frame just after
<a href="https://bugs.webkit.org/show_bug.cgi?id=261385">https://bugs.webkit.org/show_bug.cgi?id=261385</a>
rdar://115252749

Reviewed by Eric Carlson.

Before the patch, we were creating the encoder, and once done initializing it and setting the bitrate.
We were then running the process queue which could mean encoding a frame.

The initializing step was going to main thread then to LibWebRTCCodecs work queue.
The encoding of a frame would go directly to the LibWebRTCCodecs work queue,
which means there would be cases where the encoding of the frame would happen in GPUProcess sooner than initializing the encoder.

To prevent this, we make sure to send the initialize IPC message at the time the encoder gets created.

We provide bitrate estimates at initialization time like done for WebRTC.
We also fix the bitrate parameters which needs to be given as kbps and not bps.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.js:
(promise_setup):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createEncoder):
(WebKit::RemoteVideoEncoder::RemoteVideoEncoder):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::createEncoderAndWaitUntilInitialized):
(WebKit::LibWebRTCCodecs::initializeEncoder):
(WebKit::LibWebRTCCodecs::initializeEncoderInternal):
(WebKit::LibWebRTCCodecs::createEncoderAndWaitUntilReady): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::initializeEncoder):

Canonical link: <a href="https://commits.webkit.org/267865@main">https://commits.webkit.org/267865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/badc1d3bcc69bd2a43df83f9ba45ae9e3269ef64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19734 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16753 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18761 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20602 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22856 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14450 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16157 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4266 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->