### PR TITLE
[Cocoa] Fix warnings in WebKitSwift

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Apple Inc. All rights reserved.
+// Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,17 +25,20 @@
 
 import AVFoundation
 import Combine
-@_spi(Safari) import GroupActivities
 import Foundation
+@_spi(Safari) import GroupActivities
 
-@objc public enum WKGroupSessionState : Int {
+@available(macOS 12.0, *)
+@objc(WKGroupSessionState)
+public enum GroupSessionState : Int {
     case waiting = 0
     case joined = 1
     case invalidated = 2
 }
 
+@available(macOS 12.0, *)
 @objc(WKURLActivity)
-public final class WKURLActivityWrapper : NSObject {
+public final class URLActivityWrapper : NSObject {
     private var urlActivity: URLActivity
     init(activity: URLActivity) {
         self.urlActivity = activity
@@ -47,15 +50,16 @@ public final class WKURLActivityWrapper : NSObject {
     }
 }
 
+@available(macOS 12.0, *)
 @objc(WKGroupSession)
-public final class WKGroupSessionWrapper : NSObject {
+public final class GroupSessionWrapper : NSObject {
     private var groupSession: GroupSession<URLActivity>
-    private var activityWrapper : WKURLActivityWrapper
+    private var activityWrapper : URLActivityWrapper
     private var cancellables: Set<AnyCancellable> = []
 
     init(groupSession: GroupSession<URLActivity>) {
         self.groupSession = groupSession
-        self.activityWrapper = WKURLActivityWrapper(activity: groupSession.activity)
+        self.activityWrapper = .init(activity: groupSession.activity)
 
         super.init()
 
@@ -67,30 +71,30 @@ public final class WKGroupSessionWrapper : NSObject {
             .store(in: &cancellables)
     }
 
-    @objc public var activity: WKURLActivityWrapper { self.activityWrapper }
+    @objc public var activity: URLActivityWrapper { self.activityWrapper }
     @objc public var uuid: UUID { groupSession.id }
 
-    private static func wrapperSessionState(state: GroupSession<URLActivity>.State) -> WKGroupSessionState {
+    private static func wrapperSessionState(state: GroupSession<URLActivity>.State) -> GroupSessionState {
         switch state {
         case .waiting:
-            return WKGroupSessionState.waiting
+            return GroupSessionState.waiting
         case .joined:
-            return WKGroupSessionState.joined
+            return GroupSessionState.joined
         case .invalidated:
-            return WKGroupSessionState.invalidated
+            return GroupSessionState.invalidated
         @unknown default:
             // Unanticipated state value.
             assertionFailure()
-            return WKGroupSessionState.invalidated
+            return GroupSessionState.invalidated
         }
     }
 
-    @objc public var state: WKGroupSessionState {
-        return WKGroupSessionWrapper.wrapperSessionState(state: groupSession.state)
+    @objc public var state: GroupSessionState {
+        return Self.wrapperSessionState(state: groupSession.state)
     }
 
-    @objc public var newActivityCallback: ((WKURLActivityWrapper) -> Void)?
-    @objc public var stateChangedCallback: ((WKGroupSessionState) -> Void)?
+    @objc public var newActivityCallback: ((URLActivityWrapper) -> Void)?
+    @objc public var stateChangedCallback: ((GroupSessionState) -> Void)?
 
     @objc public func join() {
         groupSession.join()
@@ -106,7 +110,7 @@ public final class WKGroupSessionWrapper : NSObject {
     }
 
     private func activityChanged(activity: URLActivity) {
-        self.activityWrapper = WKURLActivityWrapper(activity: groupSession.activity)
+        self.activityWrapper = .init(activity: groupSession.activity)
 
         guard let callback = newActivityCallback else {
             return
@@ -120,20 +124,21 @@ public final class WKGroupSessionWrapper : NSObject {
             return
         }
 
-        callback(WKGroupSessionWrapper.wrapperSessionState(state: state))
+        callback(Self.wrapperSessionState(state: state))
     }
 }
 
+@available(macOS 12.0, *)
 @objc(WKGroupSessionObserver)
-public class WKGroupSessionObserver : NSObject {
-    @objc public var newSessionCallback: ((WKGroupSessionWrapper) -> Void)?
+public class GroupSessionObserver : NSObject {
+    @objc public var newSessionCallback: ((GroupSessionWrapper) -> Void)?
 
-    private var incomingSessionsTask: Task.Handle<Void, Never>?
+    private var incomingSessionsTask: Task<Void, Never>?
 
     @objc public override init() {
         super.init()
 
-        incomingSessionsTask = detach { [weak self] in
+        incomingSessionsTask = Task.detached { [weak self] in
             for await newSession in URLActivity.self.sessions() {
                 DispatchQueue.main.async { [weak self] in
                     self?.receivedSession(newSession)
@@ -151,9 +156,9 @@ public class WKGroupSessionObserver : NSObject {
             return
         }
 
-        let sessionWrapper = WKGroupSessionWrapper(groupSession: session)
+        let sessionWrapper = GroupSessionWrapper(groupSession: session)
         callback(sessionWrapper)
     }
 }
 
-#endif
+#endif // canImport(GroupActivities)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -91,7 +91,6 @@
 			buildPhases = (
 			);
 			dependencies = (
-				CD0C36DD2639D3B4004E35D8 /* PBXTargetDependency */,
 				CD0C36DB2639D3AF004E35D8 /* PBXTargetDependency */,
 			);
 			name = Everything;
@@ -2528,6 +2527,13 @@
 			remoteGlobalIDString = A16E65FF2581930800EE1749;
 			remoteInfo = MediaFormatReader;
 		};
+		A1EB7B652AAE7D7700CBDC5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD95493426159004008372D9;
+			remoteInfo = WebKitSwift;
+		};
 		A1EF36D02581F7A70090B02A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2562,13 +2568,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1A50DB38110A3C13000D3FE5;
 			remoteInfo = "Framework & XPC Services";
-		};
-		CD0C36DC2639D3B4004E35D8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CD95493426159004008372D9;
-			remoteInfo = WebKitSwift;
 		};
 		DFBD8A3B2718B38C00BEC5B0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -15867,6 +15866,7 @@
 				37F7407912721F740093869B /* PBXTargetDependency */,
 				2D11BA052126A5AE006F8878 /* PBXTargetDependency */,
 				7B9FC5BD28A5233B007570E7 /* PBXTargetDependency */,
+				A1EB7B662AAE7D7700CBDC5D /* PBXTargetDependency */,
 			);
 			name = WebKit;
 			productInstallPath = "$(HOME)/Library/Frameworks";
@@ -17742,6 +17742,11 @@
 			target = A16E65FF2581930800EE1749 /* MediaFormatReader */;
 			targetProxy = A15797422582AE9B00528236 /* PBXContainerItemProxy */;
 		};
+		A1EB7B662AAE7D7700CBDC5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CD95493426159004008372D9 /* WebKitSwift */;
+			targetProxy = A1EB7B652AAE7D7700CBDC5D /* PBXContainerItemProxy */;
+		};
 		A1EF36D12581F7A70090B02A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A16E65FF2581930800EE1749 /* MediaFormatReader */;
@@ -17766,11 +17771,6 @@
 			isa = PBXTargetDependency;
 			target = 1A50DB38110A3C13000D3FE5 /* Framework, XPC Services, and daemons */;
 			targetProxy = CD0C36DA2639D3AF004E35D8 /* PBXContainerItemProxy */;
-		};
-		CD0C36DD2639D3B4004E35D8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CD95493426159004008372D9 /* WebKitSwift */;
-			targetProxy = CD0C36DC2639D3B4004E35D8 /* PBXContainerItemProxy */;
 		};
 		DFBD8A3C2718B38C00BEC5B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
#### b40a8604e4ebfd274664198564dd88bbdd93136a
<pre>
[Cocoa] Fix warnings in WebKitSwift
<a href="https://bugs.webkit.org/show_bug.cgi?id=261389">https://bugs.webkit.org/show_bug.cgi?id=261389</a>
rdar://115260515

Reviewed by Richard Robinson.

- Added availability annotations to public types.
- Replaced deprecated Task APIs with modern replacements.
- Removed the unnecessary WK prefix from Swift types.
- Ensured that WebKitSwift is built in engineering builds.

* Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift:
(GroupSessionWrapper.activity):
(GroupSessionWrapper.wrapperSessionState(_:)):
(GroupSessionWrapper.state):
(GroupSessionWrapper.newActivityCallback):
(GroupSessionWrapper.stateChangedCallback):
(GroupSessionWrapper.activityChanged(_:)):
(GroupSessionWrapper.stateChanged(_:)):
(WKGroupSessionObserver.newSessionCallback):
(WKGroupSessionObserver.incomingSessionsTask):
(WKGroupSessionObserver.receivedSession(_:)):
(WKURLActivityWrapper.urlActivity): Deleted.
(WKURLActivityWrapper.fallbackURL): Deleted.
(WKGroupSessionWrapper.groupSession): Deleted.
(WKGroupSessionWrapper.cancellables): Deleted.
(WKGroupSessionWrapper.activity): Deleted.
(WKGroupSessionWrapper.uuid): Deleted.
(WKGroupSessionWrapper.wrapperSessionState(_:)): Deleted.
(WKGroupSessionWrapper.state): Deleted.
(WKGroupSessionWrapper.newActivityCallback): Deleted.
(WKGroupSessionWrapper.stateChangedCallback): Deleted.
(WKGroupSessionWrapper.join): Deleted.
(WKGroupSessionWrapper.leave): Deleted.
(WKGroupSessionWrapper.coordinate(_:)): Deleted.
(WKGroupSessionWrapper.activityChanged(_:)): Deleted.
(WKGroupSessionWrapper.stateChanged(_:)): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/267853@main">https://commits.webkit.org/267853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cc68135604058a66a1513fd81bc3077eb22fe15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18732 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20571 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15584 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22828 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20693 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16127 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4258 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->