### PR TITLE
[iOS] Mail compose loses focus after long pressing and inserting text using  Pencil

### DIFF
--- a/LayoutTests/editing/text-placeholder/removing-placeholder-restores-selection-expected.txt
+++ b/LayoutTests/editing/text-placeholder/removing-placeholder-restores-selection-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that the selection is restored to a position before the placeholder, after removing the placeholder.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().type is "Caret"
+PASS getSelection().rangeCount is 1
+PASS editor.textContent is "Hello from Cupertino!"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello from Cupertino!

--- a/LayoutTests/editing/text-placeholder/removing-placeholder-restores-selection.html
+++ b/LayoutTests/editing/text-placeholder/removing-placeholder-restores-selection.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="initial-scale=1, width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div contenteditable="true" id="editor">Hello Cupertino!</div>
+<script>
+jsTestIsAsync = true;
+
+(async () => {
+    description("This test verifies that the selection is restored to a position before the placeholder, after removing the placeholder.");
+    editor = document.getElementById("editor");
+    if (window.testRunner)
+        await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    let textNode = editor.firstChild;
+    getSelection().setPosition(textNode, 6);
+
+    if (!window.internals)
+        return;
+
+    let placeholderElement = internals.insertTextPlaceholder(60, 0);
+    internals.removeTextPlaceholder(placeholderElement);
+
+    shouldBeEqualToString("getSelection().type", "Caret");
+    shouldBe("getSelection().rangeCount", "1");
+
+    document.execCommand("InsertText", true, "from ");
+    shouldBeEqualToString("editor.textContent", "Hello from Cupertino!");
+
+    editor.blur();
+    if (window.testRunner)
+        await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3532,17 +3532,16 @@ void Editor::removeTextPlaceholder(TextPlaceholderElement& placeholder)
 {
     ASSERT(placeholder.isConnected());
 
-    Ref<Document> document { this->document() };
+    Ref document { this->document() };
 
     // Save off state so that we can set the text insertion position to just before the placeholder element after removal.
     RefPtr savedRootEditableElement { placeholder.rootEditableElement() };
-    auto savedPositionBeforePlaceholder = positionBeforeNode(&placeholder).parentAnchoredEquivalent();
+    auto savedPositionBeforePlaceholder = positionInParentBeforeNode(&placeholder);
 
     // FIXME: Save the current selection if it has changed since the placeholder was inserted
     // and restore it after text insertion.
     placeholder.remove();
-
-    // To match the Legacy WebKit implementation, set the text insertion point to be before where the placeholder use to be.
+    // To match the Legacy WebKit implementation, set the text insertion point to be before where the placeholder used to be.
     if (m_document.selection().isFocusedAndActive() && document->focusedElement() == savedRootEditableElement)
         m_document.selection().setSelection(VisibleSelection { savedPositionBeforePlaceholder }, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));
 }


### PR DESCRIPTION
#### e3415c365a3f9135590b552cbf9326cc2bbf9c6d
<pre>
[iOS] Mail compose loses focus after long pressing and inserting text using  Pencil
<a href="https://bugs.webkit.org/show_bug.cgi?id=261388">https://bugs.webkit.org/show_bug.cgi?id=261388</a>
rdar://114253457

Reviewed by Aditya Keerthi.

When tapping and holding over text in Mail compose to insert text by scribbling with  Pencil, we
insert a text placeholder at the beginning of the scribble interaction, and remove it after
committing the final recognized text.

Currently, the implementation of `Editor::removeTextPlaceholder` (unsuccessfully) attempts to
restore the selection to where it was prior to inserting the placeholder by saving the parent-
anchored equivalent DOM position before the placeholder element using `parentAnchoredEquivalent()`.
However, for a DOM position that&apos;s before or after the anchor node, the parent anchored equivalent
might end up returning a position anchored to the node itself. This causes the selection to be
&quot;restored&quot; to an position that&apos;s no longer in the DOM after removing the placeholder, which has the
effect of clearing out the selection entirely.

To fix this, we simply use the `positionInParentBeforeNode` helper instead, which actually
guarantees that we&apos;re anchored to an ancestor of the placeholder when computing the DOM position to
restore after removing the placeholder.

Test: editing/text-placeholder/removing-placeholder-restores-selection.html

* LayoutTests/editing/text-placeholder/removing-placeholder-restores-selection-expected.txt: Added.
* LayoutTests/editing/text-placeholder/removing-placeholder-restores-selection.html: Added.
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::removeTextPlaceholder):

Canonical link: <a href="https://commits.webkit.org/267854@main">https://commits.webkit.org/267854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8b8cb7fd09d2c465b5339f4687be7c5ddba1ef6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18354 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18731 "12 flakes 160 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18090 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18355 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20570 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14417 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4259 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->