### PR TITLE
OffscreenCanvas WebGL does not produce console log messages

### DIFF
--- a/LayoutTests/webgl/offscreen-webgl-errors-to-console-expected.txt
+++ b/LayoutTests/webgl/offscreen-webgl-errors-to-console-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: WebGL: INVALID_ENUM: activeTexture: texture unit out of range
+PASS Case: true
+PASS Case: false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/offscreen-webgl-errors-to-console.html
+++ b/LayoutTests/webgl/offscreen-webgl-errors-to-console.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true, OffscreenCanvasEnabled=true ] -->
+<html>
+<body>
+<script src="../resources/js-test-pre.js"></script>
+<script>
+// Tests that using offscreen canvas WebGL, we log a warning to the console if the setting is enabled.
+// One log should be produced.
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function runTest() {
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        return;
+    }
+    for (let errorsToConsole of [true, false]) {
+        if (window.internals)
+            window.internals.settings.setWebGLErrorsToConsoleEnabled(errorsToConsole);
+        var canvas = new OffscreenCanvas(10, 10);
+        var gl = canvas.getContext('webgl');
+        if (!gl) {
+            testPassed("No OffscreenCanvas WebGL");
+            continue;
+        }
+        gl.activeTexture(gl.TEXTURE31 + 444);
+        testPassed(`Case: ${errorsToConsole}`);
+    }
+}
+
+runTest();
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -636,18 +636,15 @@ WebGLRenderingContextBase::WebGLRenderingContextBase(CanvasBase& canvas, WebGLCo
     : GPUBasedCanvasRenderingContext(canvas)
     , m_generatedImageCache(4)
     , m_attributes(attributes)
-    , m_numGLErrorsToConsoleAllowed(maxGLErrorsAllowedToConsole)
+    , m_numGLErrorsToConsoleAllowed(canvas.scriptExecutionContext()->settingsValues().webGLErrorsToConsoleEnabled ? maxGLErrorsAllowedToConsole : 0)
     , m_checkForContextLossHandlingTimer(*this, &WebGLRenderingContextBase::checkForContextLossHandling)
 #if ENABLE(WEBXR)
     , m_isXRCompatible(attributes.xrCompatible)
 #endif
 {
     registerWithWebGLStateTracker();
-    if (auto* canvas = htmlCanvas()) {
+    if (htmlCanvas())
         m_checkForContextLossHandlingTimer.startOneShot(checkContextLossHandlingDelay);
-        if (Page* page = canvas->document().page())
-            m_synthesizedErrorsToConsole = page->settings().webGLErrorsToConsoleEnabled();
-    }
 }
 
 WebGLCanvas WebGLRenderingContextBase::canvas()
@@ -748,7 +745,6 @@ void WebGLRenderingContextBase::initializeContextState()
     m_stencilFuncMask = 0xFFFFFFFF;
     m_stencilFuncMaskBack = 0xFFFFFFFF;
     m_layerCleared = false;
-    m_numGLErrorsToConsoleAllowed = maxGLErrorsAllowedToConsole;
 
     m_rasterizerDiscardEnabled = false;
 
@@ -5300,13 +5296,17 @@ bool WebGLRenderingContextBase::validateStencilFunc(const char* functionName, GC
 
 bool WebGLRenderingContextBase::shouldPrintToConsole() const
 {
-    return m_synthesizedErrorsToConsole && m_numGLErrorsToConsoleAllowed;
+    return m_numGLErrorsToConsoleAllowed;
 }
 
 // Frequent call sites should use above condition before constructing the message for the printToConsole().
 void WebGLRenderingContextBase::printToConsole(MessageLevel level, String&& message)
 {
     if (!shouldPrintToConsole())
+        return;
+
+    auto* scriptExecutionContext = this->scriptExecutionContext();
+    if (!scriptExecutionContext)
         return;
 
     std::unique_ptr<Inspector::ConsoleMessage> consoleMessage;
@@ -5318,13 +5318,11 @@ void WebGLRenderingContextBase::printToConsole(MessageLevel level, String&& mess
     } else
         consoleMessage = makeUnique<Inspector::ConsoleMessage>(MessageSource::Rendering, MessageType::Log, level, WTFMove(message));
 
-    auto* canvas = htmlCanvas();
-    if (canvas)
-        canvas->document().addConsoleMessage(WTFMove(consoleMessage));
+    scriptExecutionContext->addConsoleMessage(WTFMove(consoleMessage));
 
     --m_numGLErrorsToConsoleAllowed;
-    if (m_numGLErrorsToConsoleAllowed == 1)
-        printToConsole(MessageLevel::Warning, "WebGL: too many errors, no more errors will be reported to the console for this context."_s);
+    if (!m_numGLErrorsToConsoleAllowed)
+        scriptExecutionContext->addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::Rendering, MessageType::Log, MessageLevel::Warning, "WebGL: too many errors, no more errors will be reported to the console for this context."_s));
 }
 
 bool WebGLRenderingContextBase::validateFramebufferTarget(GCGLenum target)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -670,7 +670,6 @@ protected:
     bool m_isGLES2Compliant;
     bool m_isDepthStencilSupported;
 
-    bool m_synthesizedErrorsToConsole { true };
     int m_numGLErrorsToConsoleAllowed;
 
     bool m_preventBufferClearForInspector { false };


### PR DESCRIPTION
#### c8113478349e7c301c177862a4a70e75f1bd9fc4
<pre>
OffscreenCanvas WebGL does not produce console log messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=261400">https://bugs.webkit.org/show_bug.cgi?id=261400</a>
rdar://115275708

Reviewed by Dan Glastonbury.

Use ScriptExecutionContext of the CanvasBase to add the console message.
This works for HTMLElement as well as OffscreenCanvas.

Do not reset the error counter on context restore. The counter is logical
to be for the context object, not for the underlying OpenGL context.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::shouldPrintToConsole const):
(WebCore::WebGLRenderingContextBase::printToConsole):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/267895@main">https://commits.webkit.org/267895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6966101301dd2d2e563ded170299b71e794a38a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18752 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20593 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22847 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20713 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17047 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14440 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4283 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->