### PR TITLE
[JSC] Add emitGetVirtualRegisters which loads multiple registers via ldp if possible

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -458,6 +458,9 @@ private:
 #define FINALIZE_CODE(linkBufferReference, resultPtrTag, ...)  \
     FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)
 
+#define FINALIZE_BASELINE_CODE(linkBufferReference, resultPtrTag, ...)  \
+    FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpBaselineDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)
+
 #define FINALIZE_DFG_CODE(linkBufferReference, resultPtrTag, ...)  \
     FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpDFGDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)
 

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -760,7 +760,7 @@ std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> JIT::compileAnd
             m_stringSwitchJumpTables = FixedVector<StringJumpTable>(m_unlinkedCodeBlock->numberOfUnlinkedStringSwitchJumpTables());
     }
 
-    if (UNLIKELY(Options::dumpDisassembly() || (m_vm->m_perBytecodeProfiler && Options::disassembleBaselineForProfiler()))) {
+    if (UNLIKELY(Options::dumpDisassembly() || Options::dumpBaselineDisassembly() || (m_vm->m_perBytecodeProfiler && Options::disassembleBaselineForProfiler()))) {
         // FIXME: build a disassembler off of UnlinkedCodeBlock.
         m_disassembler = makeUnique<JITDisassembler>(m_profiledCodeBlock);
     }
@@ -988,7 +988,7 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
             jitCodeMapBuilder.append(BytecodeIndex(bytecodeOffset), patchBuffer.locationOf<JSEntryPtrTag>(m_labels[bytecodeOffset]));
     }
 
-    if (UNLIKELY(Options::dumpDisassembly())) {
+    if (UNLIKELY(Options::dumpDisassembly() || Options::dumpBaselineDisassembly())) {
         m_disassembler->dump(patchBuffer);
         patchBuffer.didAlreadyDisassemble();
     }
@@ -1005,7 +1005,7 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
         pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTFMove(m_pcToCodeOriginMapBuilder), patchBuffer);
     
     // FIXME: Make a version of CodeBlockWithJITType that knows about UnlinkedCodeBlock.
-    CodeRef<JSEntryPtrTag> result = FINALIZE_CODE(
+    CodeRef<JSEntryPtrTag> result = FINALIZE_BASELINE_CODE(
         patchBuffer, JSEntryPtrTag,
         "Baseline JIT code for %s", toCString(CodeBlockWithJITType(m_profiledCodeBlock, JITType::BaselineJIT)).data());
     

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -338,6 +338,7 @@ namespace JSC {
         ECMAMode ecmaMode(Op);
 
         void emitGetVirtualRegister(VirtualRegister src, JSValueRegs dst);
+        void emitGetVirtualRegisters(std::initializer_list<std::tuple<VirtualRegister, JSValueRegs>>);
         void emitGetVirtualRegisterPayload(VirtualRegister src, RegisterID dst);
         void emitPutVirtualRegister(VirtualRegister dst, JSValueRegs src);
 

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -189,8 +189,15 @@ void JIT::compileCallDirectEval(const OpCallDirectEval& bytecode)
 
     resetSP();
 
+#if USE(JSVALUE32_64)
     emitGetVirtualRegister(bytecode.m_thisValue, thisValueJSR);
     emitGetVirtualRegisterPayload(bytecode.m_scope, scopeGPR);
+#else
+    emitGetVirtualRegisters({
+        { bytecode.m_thisValue, thisValueJSR },
+        { bytecode.m_scope, JSValueRegs { scopeGPR } }
+    });
+#endif
     callOperation(bytecode.m_ecmaMode.isStrict() ? operationCallDirectEvalStrict : operationCallDirectEvalSloppy, calleeFrameGPR, scopeGPR, thisValueJSR);
     addSlowCase(branchIfEmpty(returnValueJSR));
 

--- a/Source/JavaScriptCore/jit/JITCode.cpp
+++ b/Source/JavaScriptCore/jit/JITCode.cpp
@@ -158,7 +158,7 @@ JITCodeWithCodeRef::JITCodeWithCodeRef(CodeRef<JSEntryPtrTag> ref, JITType jitTy
 
 JITCodeWithCodeRef::~JITCodeWithCodeRef()
 {
-    if ((Options::dumpDisassembly() || (isOptimizingJIT(jitType()) && Options::dumpDFGDisassembly()))
+    if ((Options::dumpDisassembly() || ((jitType() == JITType::BaselineJIT) && Options::dumpBaselineDisassembly()) || (isOptimizingJIT(jitType()) && Options::dumpDFGDisassembly()))
         && m_executableMemory)
         dataLog("Destroying JIT code at ", pointerDump(m_executableMemory.get()), "\n");
 }

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -339,6 +339,60 @@ ALWAYS_INLINE double JIT::getOperandConstantDouble(VirtualRegister src)
 }
 #endif
 
+ALWAYS_INLINE void JIT::emitGetVirtualRegisters(std::initializer_list<std::tuple<VirtualRegister, JSValueRegs>> tuples)
+{
+    ASSERT(m_bytecodeIndex); // This method should only be called during hot/cold path generation, so that m_bytecodeIndex is set.
+#if USE(JSVALUE64)
+    Vector<std::tuple<VirtualRegister, JSValueRegs>, 8> targets;
+#if ASSERT_ENABLED
+    ScalarRegisterSet registerSet;
+#endif
+    for (auto [ src, dst ] : tuples) {
+#if ASSERT_ENABLED
+        ASSERT(!registerSet.contains(dst.payloadGPR(), IgnoreVectors));
+        registerSet.add(dst.payloadGPR(), IgnoreVectors);
+#endif
+        if (src.isConstant())
+            emitGetVirtualRegister(src, dst);
+        else
+            targets.append(std::tuple { src, dst });
+    }
+
+    std::sort(targets.begin(), targets.end(),
+        [](const auto& lhs, const auto& rhs) {
+            auto [lsrc, ldst] = lhs;
+            auto [rsrc, rdst] = rhs;
+            UNUSED_PARAM(ldst);
+            UNUSED_PARAM(rdst);
+            return lsrc.offset() < rsrc.offset();
+        });
+
+    unsigned index = 0;
+    while (index < targets.size()) {
+        if ((index + 1) == targets.size()) {
+            auto [src, dst] = targets[index];
+            emitGetVirtualRegister(src, dst);
+            ++index;
+            continue;
+        }
+
+        auto [src1, dst1] = targets[index];
+        auto [src2, dst2] = targets[index + 1];
+        if ((src1.offset() + 1) == src2.offset()) {
+            loadPair64(addressFor(src1), dst1.payloadGPR(), dst2.payloadGPR());
+            index += 2;
+            continue;
+        }
+
+        emitGetVirtualRegister(src1, dst1);
+        ++index;
+    }
+#else
+    for (auto [ src, dst ] : tuples)
+        emitGetVirtualRegister(src, dst);
+#endif
+}
+
 ALWAYS_INLINE void JIT::emitGetVirtualRegister(VirtualRegister src, JSValueRegs dst)
 {
     ASSERT(m_bytecodeIndex); // This method should only be called during hot/cold path generation, so that m_bytecodeIndex is set.

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -158,8 +158,10 @@ void JIT::emit_op_instanceof(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::Instanceof::protoJSR;
     using BaselineJITRegisters::Instanceof::stubInfoGPR;
 
-    emitGetVirtualRegister(value, valueJSR);
-    emitGetVirtualRegister(proto, protoJSR);
+    emitGetVirtualRegisters({
+        { value, valueJSR },
+        { proto, protoJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -427,8 +429,15 @@ void JIT::emit_op_set_function_name(const JSInstruction* currentInstruction)
     constexpr GPRReg functionGPR = preferredArgumentGPR<SlowOperation, 1>();
     constexpr JSValueRegs nameJSR = preferredArgumentJSR<SlowOperation, 2>();
 
+#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(bytecode.m_function, functionGPR);
     emitGetVirtualRegister(bytecode.m_name, nameJSR);
+#else
+    emitGetVirtualRegisters({
+        { bytecode.m_function, JSValueRegs { functionGPR } },
+        { bytecode.m_name, nameJSR }
+    });
+#endif
     loadGlobalObject(globalObjectGPR);
     callOperation(operationSetFunctionName, globalObjectGPR, functionGPR, nameJSR);
 }
@@ -610,8 +619,10 @@ void JIT::emit_op_jneq_ptr(const JSInstruction* currentInstruction)
 void JIT::emit_op_eq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpEq>();
-    emitGetVirtualRegister(bytecode.m_lhs, regT0);
-    emitGetVirtualRegister(bytecode.m_rhs, regT1);
+    emitGetVirtualRegisters({
+        { bytecode.m_lhs, JSValueRegs { regT0 } },
+        { bytecode.m_rhs, JSValueRegs { regT1 } }
+    });
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     compare32(Equal, regT1, regT0, regT0);
     boxBoolean(regT0, jsRegT10);
@@ -622,8 +633,10 @@ void JIT::emit_op_jeq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpJeq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
-    emitGetVirtualRegister(bytecode.m_lhs, regT0);
-    emitGetVirtualRegister(bytecode.m_rhs, regT1);
+    emitGetVirtualRegisters({
+        { bytecode.m_lhs, JSValueRegs { regT0 } },
+        { bytecode.m_rhs, JSValueRegs { regT1 } }
+    });
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     addJump(branch32(Equal, regT0, regT1), target);
 }
@@ -676,8 +689,10 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JIT::valueIsTruthyGenerator(VM& vm)
 void JIT::emit_op_neq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpNeq>();
-    emitGetVirtualRegister(bytecode.m_lhs, regT0);
-    emitGetVirtualRegister(bytecode.m_rhs, regT1);
+    emitGetVirtualRegisters({
+        { bytecode.m_lhs, JSValueRegs { regT0 } },
+        { bytecode.m_rhs, JSValueRegs { regT1 } }
+    });
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     compare32(NotEqual, regT1, regT0, regT0);
     boxBoolean(regT0, jsRegT10);
@@ -689,8 +704,10 @@ void JIT::emit_op_jneq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpJneq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
-    emitGetVirtualRegister(bytecode.m_lhs, regT0);
-    emitGetVirtualRegister(bytecode.m_rhs, regT1);
+    emitGetVirtualRegisters({
+        { bytecode.m_lhs, JSValueRegs { regT0 } },
+        { bytecode.m_rhs, JSValueRegs { regT1 } }
+    });
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     addJump(branch32(NotEqual, regT0, regT1), target);
 }
@@ -751,8 +768,10 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
     VirtualRegister src1 = bytecode.m_lhs;
     VirtualRegister src2 = bytecode.m_rhs;
 
-    emitGetVirtualRegister(src1, regT0);
-    emitGetVirtualRegister(src2, regT1);
+    emitGetVirtualRegisters({
+        { src1, JSValueRegs { regT0 } },
+        { src2, JSValueRegs { regT1 } }
+    });
 
 #if USE(BIGINT32)
     /* At a high level we do (assuming 'type' to be StrictEq):
@@ -837,8 +856,10 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     VirtualRegister src1 = bytecode.m_lhs;
     VirtualRegister src2 = bytecode.m_rhs;
 
-    emitGetVirtualRegister(src1, regT0);
-    emitGetVirtualRegister(src2, regT1);
+    emitGetVirtualRegisters({
+        { src1, JSValueRegs { regT0 } },
+        { src2, JSValueRegs { regT1 } }
+    });
 
 #if USE(BIGINT32)
     /* At a high level we do (assuming 'type' to be StrictEq):
@@ -1842,8 +1863,15 @@ void JIT::emit_op_log_shadow_chicken_tail(const JSInstruction* currentInstructio
         GPRReg scratch2Reg = regT2;
         ensureShadowChickenPacket(vm(), shadowPacketReg, scratch1Reg, scratch2Reg);
     }
+#if USE(JSVALUE32_64)
     emitGetVirtualRegister(bytecode.m_thisValue, jsRegT32);
     emitGetVirtualRegisterPayload(bytecode.m_scope, regT4);
+#else
+    emitGetVirtualRegisters({
+        { bytecode.m_thisValue, jsRegT32 },
+        { bytecode.m_scope, JSValueRegs { regT4 } }
+    });
+#endif
     loadPtr(addressFor(CallFrameSlot::codeBlock), regT1);
     logShadowChickenTailPacket(shadowPacketReg, jsRegT32, regT4, regT1, CallSiteIndex(m_bytecodeIndex));
 }

--- a/Source/JavaScriptCore/jit/JITOpcodes32_64.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes32_64.cpp
@@ -44,8 +44,10 @@ namespace JSC {
 
 void JIT::compileOpEqCommon(VirtualRegister src1, VirtualRegister src2)
 {
-    emitGetVirtualRegister(src1, jsRegT10);
-    emitGetVirtualRegister(src2, jsRegT32);
+    emitGetVirtualRegisters({
+        { src1, jsRegT10 },
+        { src2, jsRegT32 }
+    });
     addSlowCase(branch32(NotEqual, jsRegT10.tagGPR(), jsRegT32.tagGPR()));
     addSlowCase(branchIfCell(jsRegT10));
     addSlowCase(branch32(Below, jsRegT10.tagGPR(), TrustedImm32(JSValue::LowestTag)));
@@ -160,8 +162,10 @@ void JIT::emitSlow_op_jneq(const JSInstruction* currentInstruction, Vector<SlowC
 
 void JIT::compileOpStrictEqCommon(VirtualRegister src1,  VirtualRegister src2)
 {
-    emitGetVirtualRegister(src1, jsRegT10);
-    emitGetVirtualRegister(src2, jsRegT32);
+    emitGetVirtualRegisters({
+        { src1, jsRegT10 },
+        { src2, jsRegT32 }
+    });
 
     // Bail if the tags differ, or are double.
     addSlowCase(branch32(NotEqual, jsRegT10.tagGPR(), jsRegT32.tagGPR()));

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -60,8 +60,10 @@ void JIT::emit_op_get_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByVal::profileGPR;
     using BaselineJITRegisters::GetByVal::scratch1GPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -154,8 +156,10 @@ void JIT::emit_op_get_private_name(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByVal::resultJSR;
     using BaselineJITRegisters::GetByVal::stubInfoGPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -231,8 +235,10 @@ void JIT::emit_op_set_private_brand(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PrivateBrand::propertyJSR;
     using BaselineJITRegisters::PrivateBrand::stubInfoGPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(brand, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { brand, propertyJSR }
+    });
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
 
@@ -274,8 +280,10 @@ void JIT::emit_op_check_private_brand(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PrivateBrand::propertyJSR;
     using BaselineJITRegisters::PrivateBrand::stubInfoGPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(brand, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { brand, propertyJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -317,9 +325,11 @@ void JIT::emit_op_put_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutByVal::stubInfoGPR;
     using BaselineJITRegisters::PutByVal::scratch1GPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
-    emitGetVirtualRegister(value, valueJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR },
+        { value, valueJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -434,9 +444,11 @@ void JIT::emit_op_put_private_name(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutByVal::valueJSR;
     using BaselineJITRegisters::PutByVal::stubInfoGPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
-    emitGetVirtualRegister(value, valueJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR },
+        { value, valueJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -547,10 +559,18 @@ void JIT::emit_op_put_getter_by_val(const JSInstruction* currentInstruction)
     // Attributes in argument 3
     constexpr GPRReg setterGPR = preferredArgumentGPR<SlowOperation, 4>();
 
+    int32_t attributes = bytecode.m_attributes;
+#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(bytecode.m_base, baseGPR);
     emitGetVirtualRegister(bytecode.m_property, propertyJSR);
-    int32_t attributes = bytecode.m_attributes;
     emitGetVirtualRegisterPayload(bytecode.m_accessor, setterGPR);
+#else
+    emitGetVirtualRegisters({
+        { bytecode.m_base, JSValueRegs { baseGPR } },
+        { bytecode.m_property, propertyJSR },
+        { bytecode.m_accessor, JSValueRegs { setterGPR } }
+    });
+#endif
     loadGlobalObject(globalObjectGRP);
     callOperation(operationPutGetterByVal, globalObjectGRP, baseGPR, propertyJSR, attributes, setterGPR);
 }
@@ -566,10 +586,18 @@ void JIT::emit_op_put_setter_by_val(const JSInstruction* currentInstruction)
     // Attributes in argument 3
     constexpr GPRReg setterGPR = preferredArgumentGPR<SlowOperation, 4>();
 
+    int32_t attributes = bytecode.m_attributes;
+#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(bytecode.m_base, baseGPR);
     emitGetVirtualRegister(bytecode.m_property, propertyJSR);
-    int32_t attributes = bytecode.m_attributes;
     emitGetVirtualRegisterPayload(bytecode.m_accessor, setterGPR);
+#else
+    emitGetVirtualRegisters({
+        { bytecode.m_base, JSValueRegs { baseGPR } },
+        { bytecode.m_property, propertyJSR },
+        { bytecode.m_accessor, JSValueRegs { setterGPR } }
+    });
+#endif
     loadGlobalObject(globalObjectGRP);
     callOperation(operationPutSetterByVal, globalObjectGRP, baseGPR, propertyJSR, attributes, setterGPR);
 }
@@ -668,8 +696,10 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::DelByVal::resultJSR;
     using BaselineJITRegisters::DelByVal::stubInfoGPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR }
+    });
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
 
@@ -927,8 +957,10 @@ void JIT::emit_op_get_by_id_with_this(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByIdWithThis::resultJSR;
     using BaselineJITRegisters::GetByIdWithThis::stubInfoGPR;
 
-    emitGetVirtualRegister(baseVReg, baseJSR);
-    emitGetVirtualRegister(thisVReg, thisJSR);
+    emitGetVirtualRegisters({
+        { baseVReg, baseJSR },
+        { thisVReg, thisJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -1013,8 +1045,10 @@ void JIT::emit_op_put_by_id(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutById::stubInfoGPR;
     using BaselineJITRegisters::PutById::scratch1GPR;
 
-    emitGetVirtualRegister(baseVReg, baseJSR);
-    emitGetVirtualRegister(valueVReg, valueJSR);
+    emitGetVirtualRegisters({
+        { baseVReg, baseJSR },
+        { valueVReg, valueJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -1139,8 +1173,10 @@ void JIT::emit_op_in_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::InByVal::profileGPR;
     using BaselineJITRegisters::InByVal::scratch1GPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -1183,8 +1219,10 @@ void JIT::emitHasPrivate(VirtualRegister dst, VirtualRegister base, VirtualRegis
     using BaselineJITRegisters::InByVal::resultJSR;
     using BaselineJITRegisters::InByVal::stubInfoGPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(propertyOrBrand, propertyJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { propertyOrBrand, propertyJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -1771,8 +1809,15 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             loadPtrFromMetadata(bytecode, OpPutToScope::Metadata::offsetOfWatchpointSet(), regT3);
             loadPtrFromMetadata(bytecode, OpPutToScope::Metadata::offsetOfOperand(), regT2);
             emitNotifyWriteWatchpoint(regT3);
+#if USE(JSVALUE32_64)
             emitGetVirtualRegister(value, jsRegT10);
             emitGetVirtualRegisterPayload(scope, regT3);
+#else
+            emitGetVirtualRegisters({
+                { value, jsRegT10 },
+                { scope, JSValueRegs { regT3 } }
+            });
+#endif
             storeValue(jsRegT10, BaseIndex(regT3, regT2, TimesEight, JSLexicalEnvironment::offsetOfVariables()));
 
             emitWriteBarrier(scope, value, ShouldFilterValue);
@@ -1918,8 +1963,15 @@ void JIT::emit_op_put_to_arguments(const JSInstruction* currentInstruction)
     VirtualRegister value = bytecode.m_value;
 
     static_assert(noOverlap(regT2, jsRegT10));
+#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(arguments, regT2);
     emitGetVirtualRegister(value, jsRegT10);
+#else
+    emitGetVirtualRegisters({
+        { arguments, JSValueRegs { regT2 } },
+        { value, jsRegT10 }
+    });
+#endif
     storeValue(jsRegT10, Address(regT2, DirectArguments::storageOffset() + index * sizeof(WriteBarrier<Unknown>)));
 
     emitWriteBarrier(arguments, value, ShouldFilterValue);
@@ -1947,8 +1999,15 @@ void JIT::emit_op_put_internal_field(const JSInstruction* currentInstruction)
     unsigned index = bytecode.m_index;
 
     static_assert(noOverlap(regT2, jsRegT10));
+#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(base, regT2);
     emitGetVirtualRegister(value, jsRegT10);
+#else
+    emitGetVirtualRegisters({
+        { base, JSValueRegs { regT2 } },
+        { value, jsRegT10 }
+    });
+#endif
     storeValue(jsRegT10, Address(regT2, JSInternalFieldObjectImpl<>::offsetOfInternalField(index)));
     emitWriteBarrier(base, value, ShouldFilterValue);
 }
@@ -1971,9 +2030,11 @@ void JIT::emit_op_get_by_val_with_this(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByValWithThis::profileGPR;
     using BaselineJITRegisters::GetByValWithThis::scratch1GPR;
 
-    emitGetVirtualRegister(base, baseJSR);
-    emitGetVirtualRegister(property, propertyJSR);
-    emitGetVirtualRegister(thisValue, thisJSR);
+    emitGetVirtualRegisters({
+        { base, baseJSR },
+        { property, propertyJSR },
+        { thisValue, thisJSR }
+    });
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -2101,9 +2162,11 @@ void JIT::emit_op_enumerator_next(const JSInstruction* currentInstruction)
     if (bytecode.metadata(m_profiledCodeBlock).m_enumeratorMetadata == JSPropertyNameEnumerator::OwnStructureMode) {
         GPRReg enumeratorGPR = regT3;
         GPRReg scratch1GPR = regT4;
-        emitGetVirtualRegister(enumerator, enumeratorGPR);
+        emitGetVirtualRegisters({
+            { enumerator, JSValueRegs { enumeratorGPR } },
+            { base, JSValueRegs { baseGPR } }
+        });
         operationCases.append(branchTest32(NonZero, Address(enumeratorGPR, JSPropertyNameEnumerator::flagsOffset()), TrustedImm32((~JSPropertyNameEnumerator::OwnStructureMode) & JSPropertyNameEnumerator::enumerationModeMask)));
-        emitGetVirtualRegister(base, baseGPR);
 
         load8FromMetadata(bytecode, OpEnumeratorNext::Metadata::offsetOfEnumeratorMetadata(), scratch1GPR);
         or32(TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode), scratch1GPR);
@@ -2112,8 +2175,10 @@ void JIT::emit_op_enumerator_next(const JSInstruction* currentInstruction)
         load32(Address(enumeratorGPR, JSPropertyNameEnumerator::cachedStructureIDOffset()), indexGPR);
         operationCases.append(branch32(NotEqual, indexGPR, Address(baseGPR, JSCell::structureIDOffset())));
 
-        emitGetVirtualRegister(mode, modeGPR);
-        emitGetVirtualRegister(index, indexGPR);
+        emitGetVirtualRegisters({
+            { mode, JSValueRegs { modeGPR } },
+            { index, JSValueRegs { indexGPR } }
+        });
         Jump notInit = branchTest32(Zero, modeGPR);
         // Need to use add64 since this is a JSValue int32.
         add64(TrustedImm32(1), indexGPR);
@@ -2153,18 +2218,18 @@ void JIT::emit_enumerator_has_propertyImpl(const Bytecode& bytecode, SlowPathFun
 
     JumpList slowCases;
 
-    emitGetVirtualRegister(mode, regT0);
-    load8FromMetadata(bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata(), regT1);
-    or32(regT0, regT1);
-    store8ToMetadata(regT1, bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata());
+    emitGetVirtualRegisters({
+        { base, JSValueRegs { regT0 } },
+        { enumerator, JSValueRegs { regT1 } },
+        { mode, JSValueRegs { regT2 } }
+    });
+    load8FromMetadata(bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata(), regT3);
+    or32(regT2, regT3);
+    store8ToMetadata(regT3, bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata());
 
-    slowCases.append(branchTest32(Zero, regT0, TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode)));
-
-    emitGetVirtualRegister(base, regT0);
-
+    slowCases.append(branchTest32(Zero, regT2, TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode)));
     slowCases.append(branchIfNotCell(regT0));
 
-    emitGetVirtualRegister(enumerator, regT1);
     load32(Address(regT0, JSCell::structureIDOffset()), regT0);
     slowCases.append(branch32(NotEqual, regT0, Address(regT1, JSPropertyNameEnumerator::cachedStructureIDOffset())));
 
@@ -2213,9 +2278,11 @@ void JIT::emit_op_enumerator_get_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::EnumeratorGetByVal::scratch2GPR;
     using BaselineJITRegisters::EnumeratorGetByVal::scratch3GPR;
 
-    emitGetVirtualRegister(base, baseGPR);
-    emitGetVirtualRegister(mode, scratch3GPR);
-    emitGetVirtualRegister(propertyName, propertyGPR);
+    emitGetVirtualRegisters({
+        { base, JSValueRegs { baseGPR } },
+        { mode, JSValueRegs { scratch3GPR } },
+        { propertyName, JSValueRegs { propertyGPR } }
+    });
 
     load8FromMetadata(bytecode, OpEnumeratorGetByVal::Metadata::offsetOfEnumeratorMetadata(), scratch2GPR);
     or32(scratch3GPR, scratch2GPR);
@@ -2306,12 +2373,13 @@ void JIT::emit_op_enumerator_put_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::EnumeratorPutByVal::scratch2GPR;
 
     // These four registers need to be set up before jumping to SlowPath code.
-    emitGetVirtualRegister(base, baseGPR);
-    emitGetVirtualRegister(value, valueGPR);
-    emitGetVirtualRegister(propertyName, propertyGPR);
+    emitGetVirtualRegisters({
+        { base, JSValueRegs { baseGPR } },
+        { value, JSValueRegs { valueGPR } },
+        { propertyName, JSValueRegs { propertyGPR } },
+        { mode, JSValueRegs { scratch2GPR } }
+    });
     materializePointerIntoMetadata(bytecode, OpEnumeratorPutByVal::Metadata::offsetOfArrayProfile(), profileGPR);
-
-    emitGetVirtualRegister(mode, scratch2GPR);
 
     load8FromMetadata(bytecode, OpEnumeratorPutByVal::Metadata::offsetOfEnumeratorMetadata(), scratch1GPR);
     or32(scratch2GPR, scratch1GPR);

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -607,6 +607,7 @@ static inline void disableAllJITOptions()
 
     Options::dumpDisassembly() = false;
     Options::asyncDisassembly() = false;
+    Options::dumpBaselineDisassembly() = false;
     Options::dumpDFGDisassembly() = false;
     Options::dumpFTLDisassembly() = false;
     Options::dumpRegExpDisassembly() = false;
@@ -705,6 +706,7 @@ void Options::notifyOptionsChanged()
 
         if (Options::dumpDisassembly()
             || Options::asyncDisassembly()
+            || Options::dumpBaselineDisassembly()
             || Options::dumpDFGDisassembly()
             || Options::dumpFTLDisassembly()
             || Options::dumpRegExpDisassembly()

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -134,6 +134,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpDisassembly, false, Normal, "dumps disassembly of all JIT compiled code upon compilation") \
     v(Bool, asyncDisassembly, false, Normal, nullptr) \
     v(Bool, logJIT, false, Normal, nullptr) \
+    v(Bool, dumpBaselineDisassembly, false, Normal, "dumps disassembly of Baseline function upon compilation") \
     v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation") \
     v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation") \
     v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation") \


### PR DESCRIPTION
#### b41739f9f4a4234ddb07271bcf91a2ae0e4506c5
<pre>
[JSC] Add emitGetVirtualRegisters which loads multiple registers via ldp if possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=261399">https://bugs.webkit.org/show_bug.cgi?id=261399</a>
rdar://115274448

Reviewed by Keith Miller.

This patch adds emitGetVirtualRegisters, which optimizes multiple loads from stack in baseline JIT.
This uses ldp if possible in 64bit platform. We also add dumpBaselineDisassembly option to dump
disassembly only for Baseline for testing.

* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileAndLinkWithoutFinalizing):
(JSC::JIT::link):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emit_compareImpl):
(JSC::JIT::emit_compareSlowImpl):
(JSC::JIT::emit_op_mod):
(JSC::JIT::emit_op_pow):
(JSC::JIT::emitBitBinaryOpFastPath):
(JSC::JIT::emitRightShiftFastPath):
(JSC::JIT::emitMathICFast):
(JSC::JIT::emitMathICSlow):
(JSC::JIT::emit_op_div):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileCallDirectEval):
* Source/JavaScriptCore/jit/JITCode.cpp:
(JSC::JITCodeWithCodeRef::~JITCodeWithCodeRef):
* Source/JavaScriptCore/jit/JITInlines.h:
(JSC::JIT::emitGetVirtualRegisters):
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_instanceof):
(JSC::JIT::emit_op_set_function_name):
(JSC::JIT::emit_op_eq):
(JSC::JIT::emit_op_jeq):
(JSC::JIT::emit_op_neq):
(JSC::JIT::emit_op_jneq):
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):
(JSC::JIT::emit_op_log_shadow_chicken_tail):
* Source/JavaScriptCore/jit/JITOpcodes32_64.cpp:
(JSC::JIT::compileOpEqCommon):
(JSC::JIT::compileOpStrictEqCommon):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_get_by_val):
(JSC::JIT::emit_op_get_private_name):
(JSC::JIT::emit_op_set_private_brand):
(JSC::JIT::emit_op_check_private_brand):
(JSC::JIT::emit_op_put_by_val):
(JSC::JIT::emit_op_put_private_name):
(JSC::JIT::emit_op_put_getter_by_val):
(JSC::JIT::emit_op_put_setter_by_val):
(JSC::JIT::emit_op_del_by_val):
(JSC::JIT::emit_op_get_by_id_with_this):
(JSC::JIT::emit_op_put_by_id):
(JSC::JIT::emit_op_in_by_val):
(JSC::JIT::emitHasPrivate):
(JSC::JIT::emit_op_put_to_scope):
(JSC::JIT::emit_op_put_to_arguments):
(JSC::JIT::emit_op_put_internal_field):
(JSC::JIT::emit_op_get_by_val_with_this):
(JSC::JIT::emit_op_enumerator_next):
(JSC::JIT::emit_enumerator_has_propertyImpl):
(JSC::JIT::emit_op_enumerator_get_by_val):
(JSC::JIT::emit_op_enumerator_put_by_val):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::disableAllJITOptions):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/267869@main">https://commits.webkit.org/267869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f86c337adfb718e6e239527b5fff059cd0f209b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17892 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16739 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18751 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22848 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15482 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20714 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14436 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21238 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16143 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5223 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20502 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22470 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2199 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16890 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5070 "Passed tests") | 
<!--EWS-Status-Bubble-End-->