### PR TITLE
Move Context2D testing properties from HTMLCanvasElement to context options

### DIFF
--- a/LayoutTests/fast/canvas/image-buffer-iosurface-disabled.html
+++ b/LayoutTests/fast/canvas/image-buffer-iosurface-disabled.html
@@ -4,9 +4,7 @@ if (window.testRunner)
     testRunner.dumpAsText();
 var canvas = document.createElement('canvas');
 canvas.height = 16385;
-canvas.width = 16385;
-if (window.internals)
-    internals.avoidIOSurfaceSizeCheckInWebProcess(canvas);
-var context = canvas.getContext("2d");
+canvas.width = 7;
+var context = canvas.getContext("2d", { renderingModeForTesting: "Accelerated" });
 context.fillRect(0,0,canvas.width, canvas.height);
 </script>

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -148,7 +148,7 @@ protected:
     virtual bool hasCreatedImageBuffer() const { return false; }
     static size_t activePixelMemory();
 
-    RefPtr<ImageBuffer> allocateImageBuffer(bool avoidBackendSizeCheckForTesting) const;
+    RefPtr<ImageBuffer> allocateImageBuffer() const;
     String lastFillText() const { return m_lastFillText; }
 
 private:

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -876,18 +876,13 @@ SecurityOrigin* HTMLCanvasElement::securityOrigin() const
     return &document().securityOrigin();
 }
 
-void HTMLCanvasElement::setAvoidIOSurfaceSizeCheckInWebProcessForTesting()
-{
-    m_avoidBackendSizeCheckForTesting = true;
-}
-
 void HTMLCanvasElement::createImageBuffer() const
 {
     ASSERT(!hasCreatedImageBuffer());
 
     m_hasCreatedImageBuffer = true;
     m_didClearImageBuffer = true;
-    setImageBuffer(allocateImageBuffer(m_avoidBackendSizeCheckForTesting));
+    setImageBuffer(allocateImageBuffer());
 
 #if USE(IOSURFACE_CANVAS_BACKING_STORE)
     if (m_context && m_context->is2d()) {

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -136,8 +136,6 @@ public:
 
     bool isControlledByOffscreen() const;
 
-    WEBCORE_EXPORT void setAvoidIOSurfaceSizeCheckInWebProcessForTesting();
-
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
 
@@ -191,7 +189,6 @@ private:
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
     std::unique_ptr<CSSParserContext> m_cssParserContext;
-    bool m_avoidBackendSizeCheckForTesting { false };
     bool m_ignoreReset { false };
     // m_hasCreatedImageBuffer means we tried to malloc the buffer. We didn't necessarily get it.
     mutable bool m_hasCreatedImageBuffer { false };

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -318,7 +318,7 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
             return { RefPtr<ImageBitmap> { nullptr } };
 
         if (!m_hasCreatedImageBuffer) {
-            auto buffer = allocateImageBuffer(false);
+            auto buffer = allocateImageBuffer();
             if (!buffer)
                 return { RefPtr<ImageBitmap> { nullptr } };
             return { ImageBitmap::create(ImageBitmapBacking(WTFMove(buffer))) };
@@ -354,7 +354,7 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
         // store from this canvas (or its context), but for now we'll just
         // create a new bitmap and paint into it.
 
-        auto imageBitmap = ImageBitmap::create(allocateImageBuffer(false));
+        auto imageBitmap = ImageBitmap::create(allocateImageBuffer());
         if (!imageBitmap->buffer())
             return { RefPtr<ImageBitmap> { nullptr } };
 
@@ -542,7 +542,7 @@ void OffscreenCanvas::scheduleCommitToPlaceholderCanvas()
 void OffscreenCanvas::createImageBuffer() const
 {
     m_hasCreatedImageBuffer = true;
-    setImageBuffer(allocateImageBuffer(false));
+    setImageBuffer(allocateImageBuffer());
 }
 
 void OffscreenCanvas::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -95,6 +95,7 @@ public:
 
     virtual PixelFormat pixelFormat() const;
     virtual DestinationColorSpace colorSpace() const;
+    virtual OptionSet<ImageBufferOptions> adjustImageBufferOptionsForTesting(OptionSet<ImageBufferOptions> bufferOptions) { return bufferOptions; }
 
 protected:
     explicit CanvasRenderingContext(CanvasBase&);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2876,4 +2876,23 @@ DestinationColorSpace CanvasRenderingContext2DBase::colorSpace() const
     return toDestinationColorSpace(m_settings.colorSpace);
 }
 
+OptionSet<ImageBufferOptions> CanvasRenderingContext2DBase::adjustImageBufferOptionsForTesting(OptionSet<ImageBufferOptions> bufferOptions)
+{
+    if (!m_settings.renderingModeForTesting)
+        return bufferOptions;
+    switch (*m_settings.renderingModeForTesting) {
+    case CanvasRenderingContext2DSettings::RenderingMode::Default:
+        break;
+    case CanvasRenderingContext2DSettings::RenderingMode::Unaccelerated:
+        bufferOptions.remove(ImageBufferOptions::Accelerated);
+        bufferOptions.add(ImageBufferOptions::AvoidBackendSizeCheckForTesting);
+        break;
+    case CanvasRenderingContext2DSettings::RenderingMode::Accelerated:
+        bufferOptions.add(ImageBufferOptions::Accelerated);
+        bufferOptions.add(ImageBufferOptions::AvoidBackendSizeCheckForTesting);
+        break;
+    }
+    return bufferOptions;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -325,6 +325,8 @@ protected:
 
     bool usesCSSCompatibilityParseMode() const { return m_usesCSSCompatibilityParseMode; }
 
+    OptionSet<ImageBufferOptions> adjustImageBufferOptionsForTesting(OptionSet<ImageBufferOptions>) final;
+
 private:
     struct CachedImageData {
         CachedImageData(CanvasRenderingContext2DBase&);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h
@@ -26,12 +26,19 @@
 #pragma once
 
 #include "PredefinedColorSpace.h"
+#include <optional>
 
 namespace WebCore {
 
 struct CanvasRenderingContext2DSettings {
+    enum class RenderingMode {
+        Default,
+        Unaccelerated,
+        Accelerated,
+    };
     bool desynchronized { false };
     PredefinedColorSpace colorSpace { PredefinedColorSpace::SRGB };
+    std::optional<RenderingMode> renderingModeForTesting;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
@@ -23,6 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum CanvasRenderingContext2DRenderingMode {
+    "Default",
+    "Unaccelerated",
+    "Accelerated",
+};
+
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2dsettings
 [
     JSGenerateToJSObject,
@@ -31,4 +37,5 @@
     // boolean alpha = true;
     boolean desynchronized = false;
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace = "srgb";
+    [EnabledBySetting=DOMTestingAPIsEnabled] CanvasRenderingContext2DRenderingMode renderingModeForTesting;
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7111,19 +7111,6 @@ String Internals::modelInlinePreviewUUIDForModelElement(const HTMLModelElement& 
 
 #endif
 
-void Internals::avoidIOSurfaceSizeCheckInWebProcess(HTMLCanvasElement& element)
-{
-    auto* document = contextDocument();
-    if (!document)
-        return;
-    auto* page = document->page();
-    if (!page)
-        return;
-    page->settings().setMaximumAccelerated2dCanvasSize(UINT_MAX);
-    CanvasBase::setMaxCanvasAreaForTesting(UINT_MAX);
-    element.setAvoidIOSurfaceSizeCheckInWebProcessForTesting();
-}
-
 bool Internals::hasSleepDisabler() const
 {
     auto* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1385,7 +1385,6 @@ public:
     String modelInlinePreviewUUIDForModelElement(const HTMLModelElement&) const;
 #endif
 
-    void avoidIOSurfaceSizeCheckInWebProcess(HTMLCanvasElement&);
     bool hasSleepDisabler() const;
 
     void acceptTypedArrays(Int32Array&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1212,7 +1212,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     [Conditional=ARKIT_INLINE_PREVIEW_MAC] Promise<sequence<DOMString>> modelInlinePreviewUUIDs();
     [Conditional=ARKIT_INLINE_PREVIEW_MAC] DOMString modelInlinePreviewUUIDForModelElement(HTMLModelElement modelElement);
-    undefined avoidIOSurfaceSizeCheckInWebProcess(HTMLCanvasElement element);
 
     boolean hasSleepDisabler();
 


### PR DESCRIPTION
#### 5f5c97abe1092e1c087bdd5fffd3ba3c1c5fea33
<pre>
Move Context2D testing properties from HTMLCanvasElement to context options
<a href="https://bugs.webkit.org/show_bug.cgi?id=261404">https://bugs.webkit.org/show_bug.cgi?id=261404</a>
rdar://115282259

Reviewed by Matt Woodrow.

Context2D testing options should be related to the rendering context,
not to the canvas element. Move the property
avoidIOSurfaceSizeCheckInWebProcess as general purpose context 2d
option &quot;renderingMode&quot;. This enables testing the various backends
comprehensively in the future.

* LayoutTests/fast/canvas/image-buffer-iosurface-disabled.html:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::allocateImageBuffer const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createImageBuffer const):
(WebCore::HTMLCanvasElement::setAvoidIOSurfaceSizeCheckInWebProcessForTesting): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::transferToImageBitmap):
(WebCore::OffscreenCanvas::createImageBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::adjustImageBufferOptionsForTesting):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::adjustImageBufferOptionsForTesting):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::avoidIOSurfaceSizeCheckInWebProcess): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/267934@main">https://commits.webkit.org/267934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bad3e4c1f3a150d45a44c30376352c71d302d467

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18760 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20599 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22854 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20721 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14449 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16164 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4312 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->