### PR TITLE
GraphicsContext::createImageBuffer should not create ImageBuffers that are backed by display lists

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -223,14 +223,9 @@ IntSize GraphicsContext::compatibleImageBufferSize(const FloatSize& size) const
     return scaledImageBufferSize(size, scaleFactor());
 }
 
-RefPtr<ImageBuffer> GraphicsContext::createImageBuffer(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod> renderingMethod) const
+RefPtr<ImageBuffer> GraphicsContext::createImageBuffer(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod>) const
 {
     auto bufferOptions = bufferOptionsForRendingMode(renderingMode.value_or(this->renderingMode()));
-
-    if (!renderingMethod || *renderingMethod == RenderingMethod::Local)
-        return ImageBuffer::create(size, RenderingPurpose::Unspecified, resolutionScale, colorSpace, PixelFormat::BGRA8, bufferOptions);
-
-    bufferOptions.add(ImageBufferOptions::UseDisplayList);
     return ImageBuffer::create(size, RenderingPurpose::Unspecified, resolutionScale, colorSpace, PixelFormat::BGRA8, bufferOptions);
 }
 

--- a/Source/WebCore/platform/graphics/RenderingMode.cpp
+++ b/Source/WebCore/platform/graphics/RenderingMode.cpp
@@ -58,7 +58,6 @@ TextStream& operator<<(TextStream& ts, RenderingMethod method)
 {
     switch (method) {
     case RenderingMethod::Local: ts << "Local"; break;
-    case RenderingMethod::DisplayList: ts << "DisplayList"; break;
     }
 
     return ts;

--- a/Source/WebCore/platform/graphics/RenderingMode.h
+++ b/Source/WebCore/platform/graphics/RenderingMode.h
@@ -43,7 +43,7 @@ enum class RenderingPurpose : uint8_t {
 };
 
 enum class RenderingMode : bool { Unaccelerated, Accelerated };
-enum class RenderingMethod : bool { Local, DisplayList };
+enum class RenderingMethod : bool { Local };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RenderingPurpose);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RenderingMode);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -620,11 +620,6 @@ void Recorder::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& dest
     recordClipToImageBuffer(imageBuffer, destRect);
 }
 
-RefPtr<ImageBuffer> Recorder::createImageBuffer(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, std::optional<RenderingMode> renderingMode, std::optional<RenderingMethod> renderingMethod) const
-{
-    return GraphicsContext::createImageBuffer(size, resolutionScale, colorSpace, renderingMode, renderingMethod.value_or(RenderingMethod::DisplayList));
-}
-
 #if ENABLE(VIDEO)
 void Recorder::paintFrameForMedia(MediaPlayer& player, const FloatRect& destination)
 {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -181,8 +181,6 @@ protected:
     const ContextState& currentState() const;
     ContextState& currentState();
 
-    WEBCORE_EXPORT RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, float resolutionScale, const DestinationColorSpace&, std::optional<RenderingMode>, std::optional<RenderingMethod>) const override;
-
 private:
     bool hasPlatformContext() const final { return false; }
     PlatformGraphicsContext* platformContext() const final { return nullptr; }


### PR DESCRIPTION
#### afbd4f014569daae52e242ac90282b49ae9952b9
<pre>
GraphicsContext::createImageBuffer should not create ImageBuffers that are backed by display lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=261406">https://bugs.webkit.org/show_bug.cgi?id=261406</a>
rdar://115283169

Reviewed by Antti Koivisto.

Remove the polymorphic feature where DisplayList::Recorder could create a
DisplayList::ImageBuffer in response to
GraphicsContext::createImageBuffer.

The calling code which creates ImageBuffers is never agnostic to
whether the created buffer is backed by a display list or not. If the
calling code intends to use the drawing as a display list, it needs to
access the list. This is done by
calling DisplayList::Recorder::displayList() explicitly through Recorder,
not through ImageBuffer interface.

Even if the target GraphicsContext would be a DisplayList::Recorder,
creating a new image buffer as a display list and drawing that to the
target would end up resulting a bitmap drawn to the target. This means
that there was no benefit, only harm, to creating the ImageBuffer as
a display list.

The intended feature was probably to obtain a master display list with
the drawing commands that contain also cached sub areas as drawing
commands. This was never realized with current code, as the semantics of
the interfaces of ImageBuffer and a display list are different. Most
notably items are composed differently: image buffer starts as cleared,
but the above intention of the API was probably to support compositing
subtrees in a nice way. The alternatives that work within the
abstractions are the &quot;begin transparency layer&quot; for uncached subtrees and
explicit DisplayList::Recorder for cached subtrees.

Does not remove RenderingMethod enum because currently it affects
the &quot;local or remote&quot; decision via holding it with std::optional.
This will be addressed in the future.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::createImageBuffer const):
* Source/WebCore/platform/graphics/RenderingMode.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/RenderingMode.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::createImageBuffer const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:

Canonical link: <a href="https://commits.webkit.org/268193@main">https://commits.webkit.org/268193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17d82b17e82f3a58a4c4f8a6948464d1f3348a0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18838 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20704 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22944 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20813 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16245 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4514 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->