### PR TITLE
FKA: The auto-generated label in a <details> element without a <summary> is not keyboard accessible

### DIFF
--- a/LayoutTests/fast/html/details-no-summary-keyboard-show-hide-expected.txt
+++ b/LayoutTests/fast/html/details-no-summary-keyboard-show-hide-expected.txt
@@ -1,0 +1,16 @@
+This test verifies that auto-generated <summary> in a <details> element is keyboard accessible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS openAttribute("details") is false
+Toggle <display> using Enter key:
+PASS openAttribute("details") is true
+PASS openAttribute("details") is false
+Toggle <display> using Spacebar key:
+PASS openAttribute("details") is true
+PASS openAttribute("details") is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/html/details-no-summary-keyboard-show-hide.html
+++ b/LayoutTests/fast/html/details-no-summary-keyboard-show-hide.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<details id="details"><input></details>
+<script src="../../resources/js-test.js"></script>
+<script>
+function openAttribute(id) {
+    return document.getElementById(id).open;
+}
+
+ description("This test verifies that auto-generated &lt;summary&gt; in a &lt;details&gt; element is keyboard accessible.");
+
+ if (window.eventSender) {
+     eventSender.keyDown("\t");
+
+    shouldBeFalse('openAttribute("details")');
+    debug("Toggle &lt;display&gt; using Enter key:");
+    eventSender.keyDown("\r");
+    shouldBeTrue('openAttribute("details")');
+    eventSender.keyDown("\r");
+    shouldBeFalse('openAttribute("details")');
+
+    debug("Toggle &lt;display&gt; using Spacebar key:");
+    eventSender.keyDown(" ");
+    shouldBeTrue('openAttribute("details")');
+    eventSender.keyDown(" ");
+    shouldBeFalse('openAttribute("details")');
+} else
+    debug('There are tests using eventSender.');
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/shadow-dom/focus-across-details-element-expected.txt
+++ b/LayoutTests/fast/shadow-dom/focus-across-details-element-expected.txt
@@ -2,14 +2,11 @@ Tests for moving focus across details element. The existence of shadow tree on d
 To manually test, press tab key five times and then shift+tab five times. It should traverse focusable elements in the increasing numerical order and then in the reverse order.
 
 1. Focusable element with tabindex=1
-2. Focusable element in details with tabindex=2
-3. Focusable element in details with tabindex=3
-4. Focusable element in summary with tabindex=4
-5. Focusable element in details with tabindex=5
-6. Focusable element in details with tabindex=6
-5. Focusable element in details with tabindex=5
-4. Focusable element in summary with tabindex=4
-3. Focusable element in details with tabindex=3
-2. Focusable element in details with tabindex=2
+2. Focusable element in summary with tabindex=4
+3. Focusable element in details with tabindex=2
+4. Focusable element in details with tabindex=6
+4. Focusable element in details with tabindex=6
+3. Focusable element in details with tabindex=2
+2. Focusable element in summary with tabindex=4
 1. Focusable element with tabindex=1
 

--- a/LayoutTests/fast/shadow-dom/focus-across-details-element.html
+++ b/LayoutTests/fast/shadow-dom/focus-across-details-element.html
@@ -8,13 +8,13 @@ It should traverse focusable elements in the increasing numerical order and then
 <div id="test-content">
 <div id="first" tabindex="1" onfocus="log(this)">1. Focusable element with tabindex=1</div>
 <details open>
-    <div tabindex="6" onfocus="log(this)">6. Focusable element in details with tabindex=6</div>
-    <summary><div tabindex="4" onfocus="log(this)">4. Focusable element in summary with tabindex=4</div></summary>
-    <div tabindex="2" onfocus="log(this)">2. Focusable element in details with tabindex=2</div>
+    <div tabindex="6" onfocus="log(this)">4. Focusable element in details with tabindex=6</div>
+    <summary><div tabindex="4" onfocus="log(this)">2. Focusable element in summary with tabindex=4</div></summary>
+    <div tabindex="2" onfocus="log(this)">3. Focusable element in details with tabindex=2</div>
 </details>
 <details open>
-    <div tabindex="5" onfocus="log(this)">5. Focusable element in details with tabindex=5</div>
-    <div tabindex="3" onfocus="log(this)">3. Focusable element in details with tabindex=3</div>
+    <div tabindex="5" onfocus="log(this)">6. Focusable element in details with tabindex=5</div>
+    <div tabindex="3" onfocus="log(this)">5. Focusable element in details with tabindex=3</div>
 </details>
 </div>
 <pre></pre>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1035,6 +1035,7 @@ fast/forms/validation-message-maxLength.html [ Skip ]
 fast/forms/ValidityState-valueMissing-002.html [ Skip ]
 fast/frames/focus-controller-crash-change-event.html
 fast/html/details-keyboard-show-hide.html [ Skip ]
+fast/html/details-no-summary-keyboard-show-hide.html [ Skip ]
 fast/html/transient-activation.html [ Skip ]
 fast/shadow-dom/activate-over-slotted-content.html [ Skip ]
 fast/shadow-dom/clear-active-state-in-shadow.html [ Skip ]

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -60,7 +60,6 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
-    bool hasCustomFocusLogic() const final { return true; }
     bool isInteractiveContent() const final { return true; }
 
     bool m_isOpen { false };


### PR DESCRIPTION
#### 2115ac47e42743ef7d1178995ffe8968c0bd3878
<pre>
FKA: The auto-generated label in a &lt;details&gt; element without a &lt;summary&gt; is not keyboard accessible
<a href="https://bugs.webkit.org/show_bug.cgi?id=78499">https://bugs.webkit.org/show_bug.cgi?id=78499</a>

Reviewed by Tim Nguyen.

The bug was caused by the summary element in details element&apos;s shadow tree getting skipped during
sequential focus navigation because it has custom focus logic. Fixed the bug by removing this.

The test was originally written by Arko Saha.

* LayoutTests/fast/html/details-no-summary-keyboard-show-hide-expected.txt: Added.
* LayoutTests/fast/html/details-no-summary-keyboard-show-hide.html: Added.
* LayoutTests/fast/shadow-dom/focus-across-details-element-expected.txt: Rebaselined the test. New
behavior matches that of Chrome.
* LayoutTests/fast/shadow-dom/focus-across-details-element.html: Ditto.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/HTMLDetailsElement.h:

Canonical link: <a href="https://commits.webkit.org/267899@main">https://commits.webkit.org/267899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1505d7acb66b6d17b4cb00b12dc6de6ec0174b16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16849 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18842 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20708 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22949 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20817 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14537 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16255 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20609 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2210 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->