### PR TITLE
Use more smart pointers in Source/WebKit/WebProcess

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h
@@ -45,8 +45,8 @@ public:
 
     virtual void didCreatePage(WebKit::InjectedBundle&, WebKit::WebPage&) { }
     virtual void willDestroyPage(WebKit::InjectedBundle&, WebKit::WebPage&) { }
-    virtual void didReceiveMessage(WebKit::InjectedBundle&, const WTF::String&, API::Object*) { }
-    virtual void didReceiveMessageToPage(WebKit::InjectedBundle&, WebKit::WebPage&, const WTF::String&, API::Object*) { }
+    virtual void didReceiveMessage(WebKit::InjectedBundle&, const WTF::String&, RefPtr<API::Object>&&) { }
+    virtual void didReceiveMessageToPage(WebKit::InjectedBundle&, WebKit::WebPage&, const WTF::String&, RefPtr<API::Object>&&) { }
 };
 
 } // namespace InjectedBundle

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
@@ -77,11 +77,11 @@ struct WebProcessCreationParameters;
 
 class InjectedBundle : public API::ObjectImpl<API::Object::Type::Bundle> {
 public:
-    static RefPtr<InjectedBundle> create(WebProcessCreationParameters&, API::Object* initializationUserData);
+    static RefPtr<InjectedBundle> create(WebProcessCreationParameters&, RefPtr<API::Object>&& initializationUserData);
 
     ~InjectedBundle();
 
-    bool initialize(const WebProcessCreationParameters&, API::Object* initializationUserData);
+    bool initialize(const WebProcessCreationParameters&, RefPtr<API::Object>&& initializationUserData);
 
     void setBundleParameter(const String&, const IPC::DataReference&);
     void setBundleParameters(const IPC::DataReference&);
@@ -118,10 +118,10 @@ public:
     size_t javaScriptObjectsCount();
 
     // Callback hooks
-    void didCreatePage(WebPage*);
-    void willDestroyPage(WebPage*);
-    void didReceiveMessage(const String&, API::Object*);
-    void didReceiveMessageToPage(WebPage*, const String&, API::Object*);
+    void didCreatePage(WebPage&);
+    void willDestroyPage(WebPage&);
+    void didReceiveMessage(const String&, RefPtr<API::Object>&&);
+    void didReceiveMessageToPage(WebPage&, const String&, RefPtr<API::Object>&&);
 
     static void reportException(JSContextRef, JSValueRef exception);
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp
@@ -54,20 +54,20 @@ void InjectedBundleClient::willDestroyPage(InjectedBundle& bundle, WebPage& page
     m_client.willDestroyPage(toAPI(&bundle), toAPI(&page), m_client.base.clientInfo);
 }
 
-void InjectedBundleClient::didReceiveMessage(InjectedBundle& bundle, const String& messageName, API::Object* messageBody)
+void InjectedBundleClient::didReceiveMessage(InjectedBundle& bundle, const String& messageName, RefPtr<API::Object>&& messageBody)
 {
     if (!m_client.didReceiveMessage)
         return;
 
-    m_client.didReceiveMessage(toAPI(&bundle), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessage(toAPI(&bundle), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
-void InjectedBundleClient::didReceiveMessageToPage(InjectedBundle& bundle, WebPage& page, const String& messageName, API::Object* messageBody)
+void InjectedBundleClient::didReceiveMessageToPage(InjectedBundle& bundle, WebPage& page, const String& messageName, RefPtr<API::Object>&& messageBody)
 {
     if (!m_client.didReceiveMessageToPage)
         return;
 
-    m_client.didReceiveMessageToPage(toAPI(&bundle), toAPI(&page), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessageToPage(toAPI(&bundle), toAPI(&page), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.h
@@ -51,8 +51,8 @@ public:
 
     void didCreatePage(InjectedBundle&, WebPage&) override;
     void willDestroyPage(InjectedBundle&, WebPage&) override;
-    void didReceiveMessage(InjectedBundle&, const WTF::String&, API::Object*) override;
-    void didReceiveMessageToPage(InjectedBundle&, WebPage&, const WTF::String&, API::Object*) override;
+    void didReceiveMessage(InjectedBundle&, const WTF::String&, RefPtr<API::Object>&&) override;
+    void didReceiveMessageToPage(InjectedBundle&, WebPage&, const WTF::String&, RefPtr<API::Object>&&) override;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters&, RefPtr<API::Object>&& initializationUserData)
 {
     m_platformBundle = g_module_open(FileSystem::fileSystemRepresentation(m_path).data(), G_MODULE_BIND_LOCAL);
     if (!m_platformBundle) {
@@ -48,7 +48,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object
         return false;
     }
 
-    initializeFunction(toAPI(this), toAPI(initializationUserData));
+    initializeFunction(toAPI(this), toAPI(initializationUserData.get()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -115,7 +115,7 @@ bool InjectedBundle::decodeBundleParameters(API::Data* bundleParameterDataPtr)
     return true;
 }
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, RefPtr<API::Object>&& initializationUserData)
 {
     if (auto sandboxExtension = std::exchange(m_sandboxExtension, nullptr)) {
         if (!sandboxExtension->consumePermanently()) {
@@ -160,7 +160,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
 
     // Update list of valid classes for the parameter coder
     if (additionalClassesForParameterCoderFunction)
-        additionalClassesForParameterCoderFunction(toAPI(this), toAPI(initializationUserData));
+        additionalClassesForParameterCoderFunction(toAPI(this), toAPI(initializationUserData.get()));
 
 #if PLATFORM(MAC)
     // Swizzle [NSEvent modiferFlags], since it always returns 0 when the WindowServer is blocked.
@@ -172,7 +172,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
     if (initializeFunction) {
         if (!decodeBundleParameters(parameters.bundleParameterData.get()))
             return false;
-        initializeFunction(toAPI(this), toAPI(initializationUserData));
+        initializeFunction(toAPI(this), toAPI(initializationUserData.get()));
         return true;
     }
 
@@ -206,7 +206,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
     if ([instance respondsToSelector:@selector(webProcessPlugIn:initializeWithObject:)]) {
         RetainPtr<id> objCInitializationUserData;
         if (initializationUserData && initializationUserData->type() == API::Object::Type::ObjCObjectGraph)
-            objCInitializationUserData = static_cast<ObjCObjectGraph*>(initializationUserData)->rootObject();
+            objCInitializationUserData = static_cast<ObjCObjectGraph*>(initializationUserData.get())->rootObject();
         [instance webProcessPlugIn:plugInController initializeWithObject:objCInitializationUserData.get()];
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, RefPtr<API::Object>&& initializationUserData)
 {
     auto bundle = LibraryBundle::create(m_path.utf8().data());
     m_platformBundle = bundle;
@@ -45,7 +45,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
         printf("PlayStation::Bundle::resolve failed\n");
         return false;
     }
-    initializeFunction(toAPI(this), toAPI(initializationUserData));
+    initializeFunction(toAPI(this), toAPI(initializationUserData.get()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters&, RefPtr<API::Object>&& initializationUserData)
 {
     HMODULE lib = ::LoadLibrary(m_path.wideCharacters().data());
     if (!lib)
@@ -41,7 +41,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object
     if (!proc)
         return false;
 
-    proc(toAPI(this), toAPI(initializationUserData));
+    proc(toAPI(this), toAPI(initializationUserData.get()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -65,6 +65,7 @@ public:
     }
     ~NetworkProcessConnection();
     
+    Ref<IPC::Connection> protectedConnection() { return m_connection; }
     IPC::Connection& connection() { return m_connection.get(); }
 
     void didReceiveNetworkProcessConnectionMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -461,7 +461,7 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyCheckIdentifi
 {
 #if ENABLE(APP_BOUND_DOMAINS)
     if (m_page)
-        m_page->setIsNavigatingToAppBoundDomain(policyDecision.isNavigatingToAppBoundDomain, this);
+        m_page->setIsNavigatingToAppBoundDomain(policyDecision.isNavigatingToAppBoundDomain, Ref { *this });
 #endif
 
     if (!m_coreFrame)
@@ -486,7 +486,7 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyCheckIdentifi
     m_policyDownloadID = policyDecision.downloadID;
     if (policyDecision.navigationID) {
         auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-        if (WebDocumentLoader* documentLoader = localFrame ? static_cast<WebDocumentLoader*>(localFrame->loader().policyDocumentLoader()) : nullptr)
+        if (RefPtr documentLoader = localFrame ? static_cast<WebDocumentLoader*>(localFrame->loader().policyDocumentLoader()) : nullptr)
             documentLoader->setNavigationID(policyDecision.navigationID);
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1515,7 +1515,7 @@ public:
 
 #if ENABLE(APP_BOUND_DOMAINS)
     void notifyPageOfAppBoundBehavior();
-    void setIsNavigatingToAppBoundDomain(std::optional<NavigatingToAppBoundDomain>, WebFrame*);
+    void setIsNavigatingToAppBoundDomain(std::optional<NavigatingToAppBoundDomain>, WebFrame&);
     bool needsInAppBrowserPrivacyQuirks() { return m_needsInAppBrowserPrivacyQuirks; }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -515,7 +515,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
     SandboxExtension::consumePermanently(parameters.additionalSandboxExtensionHandles);
 
     if (!parameters.injectedBundlePath.isEmpty())
-        m_injectedBundle = InjectedBundle::create(parameters, transformHandlesToObjects(parameters.initializationUserData.object()).get());
+        m_injectedBundle = InjectedBundle::create(parameters, transformHandlesToObjects(parameters.initializationUserData.object()));
 
     for (auto& supplement : m_supplements.values())
         supplement->initialize(parameters);
@@ -854,7 +854,7 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
     if (result.isNewEntry) {
         ASSERT(!result.iterator->value);
         auto page = WebPage::create(pageID, WTFMove(parameters));
-        result.iterator->value = page.ptr();
+        result.iterator->value = page.copyRef();
 
 #if ENABLE(GPU_PROCESS)
         if (RefPtr gpuProcessConnection = m_gpuProcessConnection)
@@ -1127,7 +1127,7 @@ void WebProcess::handleInjectedBundleMessage(const String& messageName, const Us
     if (!injectedBundle)
         return;
 
-    injectedBundle->didReceiveMessage(messageName, transformHandlesToObjects(messageBody.object()).get());
+    injectedBundle->didReceiveMessage(messageName, transformHandlesToObjects(messageBody.object()));
 }
 
 void WebProcess::setInjectedBundleParameter(const String& key, const IPC::DataReference& value)

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -106,8 +106,8 @@ void StorageAreaMap::setItem(LocalFrame& sourceFrame, StorageAreaImpl* sourceAre
         if (weakThis)
             weakThis->didSetItem(seed, key, hasError, WTFMove(allItems));
     };
-    auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
-    connection.sendWithAsyncReply(Messages::NetworkStorageManager::SetItem(*m_remoteAreaIdentifier, sourceArea->identifier(), key, value, sourceFrame.document()->url().string()), WTFMove(callback));
+    auto connection = WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection();
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::SetItem(*m_remoteAreaIdentifier, sourceArea->identifier(), key, value, sourceFrame.document()->url().string()), WTFMove(callback));
 }
 
 void StorageAreaMap::removeItem(WebCore::LocalFrame& sourceFrame, StorageAreaImpl* sourceArea, const String& key)

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -58,7 +58,7 @@ void RemoteCaptureSampleManager::stopListeningForIPC()
     setConnection(nullptr);
 }
 
-void RemoteCaptureSampleManager::setConnection(IPC::Connection* connection)
+void RemoteCaptureSampleManager::setConnection(RefPtr<IPC::Connection>&& connection)
 {
     if (m_connection == connection)
         return;
@@ -83,7 +83,7 @@ void RemoteCaptureSampleManager::setConnection(IPC::Connection* connection)
 void RemoteCaptureSampleManager::addSource(Ref<RemoteRealtimeAudioSource>&& source)
 {
     ASSERT(WTF::isMainRunLoop());
-    setConnection(Ref { source->connection() }.ptr());
+    setConnection(Ref { source->connection() });
 
     m_queue->dispatch([this, protectedThis = Ref { *this }, source = WTFMove(source)]() mutable {
         auto identifier = source->identifier();
@@ -96,7 +96,7 @@ void RemoteCaptureSampleManager::addSource(Ref<RemoteRealtimeAudioSource>&& sour
 void RemoteCaptureSampleManager::addSource(Ref<RemoteRealtimeVideoSource>&& source)
 {
     ASSERT(WTF::isMainRunLoop());
-    setConnection(&source->connection());
+    setConnection(Ref { source->connection() });
 
     m_queue->dispatch([this, protectedThis = Ref { *this }, source = WTFMove(source)]() mutable {
         auto identifier = source->identifier();

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -76,7 +76,7 @@ private:
     // FIXME: Will be removed once RemoteVideoFrameProxy providers are the only ones sending data.
     void videoFrameAvailableCV(WebCore::RealtimeMediaSourceIdentifier, RetainPtr<CVPixelBufferRef>&&, WebCore::VideoFrameRotation, bool mirrored, MediaTime, WebCore::VideoFrameTimeMetadata);
 
-    void setConnection(IPC::Connection*);
+    void setConnection(RefPtr<IPC::Connection>&&);
 
     class RemoteAudio {
         WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -43,7 +43,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static IPC::Connection& getSourceConnection(bool shouldCaptureInGPUProcess)
+static Ref<IPC::Connection> getSourceConnection(bool shouldCaptureInGPUProcess)
 {
     ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### 34689c1d3c27fccd79b9083103f3df2ed8c2a6e3
<pre>
Use more smart pointers in Source/WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=261411">https://bugs.webkit.org/show_bug.cgi?id=261411</a>

Reviewed by Darin Adler.

* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h:
(API::InjectedBundle::Client::didCreatePage):
(API::InjectedBundle::Client::willDestroyPage):
(API::InjectedBundle::Client::didReceiveMessage):
(API::InjectedBundle::Client::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebExtension.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebProcessExtension.cpp:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::create):
(WebKit::InjectedBundle::didCreatePage):
(WebKit::InjectedBundle::willDestroyPage):
(WebKit::InjectedBundle::didReceiveMessage):
(WebKit::InjectedBundle::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp:
(WebKit::InjectedBundleClient::didCreatePage):
(WebKit::InjectedBundleClient::willDestroyPage):
(WebKit::InjectedBundleClient::didReceiveMessage):
(WebKit::InjectedBundleClient::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.h:
* Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
(WebKit::NetworkProcessConnection::protectedConnection):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didReceivePolicyDecision):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::create):
(WebKit::WebPage::editorState const):
(WebKit::WebPage::focusedPluginViewForFrame):
(WebKit::WebPage::pluginViewForFrame):
(WebKit::WebPage::executeEditingCommand):
(WebKit::WebPage::isEditingCommandEnabled):
(WebKit::WebPage::close):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::loadDataImpl):
(WebKit::WebPage::postInjectedBundleMessage):
(WebKit::WebPage::validateCommand):
(WebKit::WebPage::setIsNavigatingToAppBoundDomain):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getStringSelectionForPasteboard):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::handleInjectedBundleMessage):
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::setItem):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::setConnection):
(WebKit::RemoteCaptureSampleManager::addSource):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::getSourceConnection):

Canonical link: <a href="https://commits.webkit.org/267906@main">https://commits.webkit.org/267906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c998a94c5734da71884ad17c53a17225fc9fd42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18504 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20729 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15719 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17167 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16265 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4288 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->