### PR TITLE
Add support for simple Web Extension tabs APIs.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -87,10 +87,6 @@ NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *);
 NSDictionary *mergeDictionaries(NSDictionary *, NSDictionary *);
 NSDictionary *mergeDictionariesAndSetValues(NSDictionary *, NSDictionary *);
 
-// MARK: NSLocale helper methods.
-
-NSString *localeStringInWebExtensionFormat(NSLocale *);
-
 // MARK: NSError helper methods.
 
 NSString *privacyPreservingDescription(NSError *);

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -242,18 +242,6 @@ NSDictionary *mergeDictionariesAndSetValues(NSDictionary *dictionaryA, NSDiction
     return [newDictionary copy];
 }
 
-// MARK: NSLocale helper methods.
-
-NSString *localeStringInWebExtensionFormat(NSLocale *locale)
-{
-    if (!locale.languageCode)
-        return @"";
-
-    if (locale.countryCode.length)
-        return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];
-    return locale.languageCode;
-}
-
 // MARK: NSError helper methods
 
 NSString *privacyPreservingDescription(NSError *error)

--- a/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
@@ -22,6 +22,8 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+headers: "WebExtensionContext.h"
+
 struct WebKit::WebExtensionTabParameters {
     std::optional<WebKit::WebExtensionTabIdentifier> identifier;
 
@@ -63,5 +65,7 @@ struct WebKit::WebExtensionTabQueryParameters {
     std::optional<bool> pinned;
     std::optional<bool> selected;
 }
+
+[Nested] enum class WebKit::WebExtensionContext::ReloadFromOrigin : bool;
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
@@ -32,11 +32,13 @@ namespace WebKit {
 struct WebExtensionTabIdentifierType;
 using WebExtensionTabIdentifier = ObjectIdentifier<WebExtensionTabIdentifierType>;
 
-struct WebExtensionTabConstants {
+namespace WebExtensionTabConstants {
+
     static constexpr double None { -1 };
 
     static constexpr const WebExtensionTabIdentifier NoneIdentifier { std::numeric_limits<uint64_t>::max() - 1 };
-};
+
+}
 
 inline bool isNone(WebExtensionTabIdentifier identifier)
 {

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -58,6 +58,8 @@ NSString *toErrorString(NSString *callingAPIName, NSString *sourceKey, NSString 
 /// Returns an error object that combines the provided information into a single, descriptive message.
 JSObjectRef toJSError(JSContextRef, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString);
 
+NSString *toWebAPI(NSLocale *);
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -321,6 +321,16 @@ JSObjectRef toJSError(JSContextRef context, NSString *callingAPIName, NSString *
     return toJSError(context, toErrorString(callingAPIName, sourceKey, underlyingErrorString));
 }
 
+NSString *toWebAPI(NSLocale *locale)
+{
+    if (!locale.languageCode)
+        return nil;
+
+    if (locale.countryCode.length)
+        return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];
+    return locale.languageCode;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
@@ -33,13 +33,15 @@ namespace WebKit {
 struct WebExtensionWindowIdentifierType;
 using WebExtensionWindowIdentifier = ObjectIdentifier<WebExtensionWindowIdentifierType>;
 
-struct WebExtensionWindowConstants {
+namespace WebExtensionWindowConstants {
+
     static constexpr double None { -1 };
     static constexpr double Current { -2 };
 
     static constexpr const WebExtensionWindowIdentifier NoneIdentifier { std::numeric_limits<uint64_t>::max() - 1 };
     static constexpr const WebExtensionWindowIdentifier CurrentIdentifier { std::numeric_limits<uint64_t>::max() - 2 };
-};
+
+}
 
 inline bool isNone(WebExtensionWindowIdentifier identifier)
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -477,7 +477,7 @@ static inline id<_WKWebExtensionWindow> toAPI(const RefPtr<WebKit::WebExtensionW
     return window ? window->delegate() : nil;
 }
 
-static inline NSArray *toAPI(const Vector<Ref<WebKit::WebExtensionWindow>>& windows)
+static inline NSArray *toAPI(const WebKit::WebExtensionContext::WindowVector& windows)
 {
     if (windows.isEmpty())
         return [NSArray array];
@@ -502,7 +502,7 @@ static inline NSArray *toAPI(const Vector<Ref<WebKit::WebExtensionWindow>>& wind
     return toAPI(_webExtensionContext->focusedWindow());
 }
 
-static inline NSSet *toAPI(const HashSet<Ref<WebKit::WebExtensionTab>>& tabs)
+static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabMapValueIterator& tabs)
 {
     if (tabs.isEmpty())
         return [NSSet set];

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -54,6 +54,14 @@ messages -> WebExtensionContext {
     TabsGet(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
     TabsGetCurrent(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
     TabsQuery(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabQueryParameters queryParameters) -> (Vector<WebKit::WebExtensionTabParameters> tabs, WebKit::WebExtensionWindow::Error error);
+    TabsReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionContext::ReloadFromOrigin reloadFromOrigin) -> (WebKit::WebExtensionWindow::Error error);
+    TabsGoBack(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
+    TabsGoForward(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
+    TabsDetectLanguage(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> language, WebKit::WebExtensionTab::Error error);
+    TabsToggleReaderMode(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
+    TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<double> zoomFactor, WebKit::WebExtensionTab::Error error);
+    TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (WebKit::WebExtensionTab::Error error);
+    TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (WebKit::WebExtensionWindow::Error error);
 
     // Windows APIs
     WindowsCreate(WebKit::WebExtensionWindowParameters creationParameters) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -35,12 +35,13 @@
 #import "MessageSenderInlines.h"
 #import "WebExtensionContextMessages.h"
 #import "WebExtensionContextProxy.h"
+#import "WebExtensionUtilities.h"
 #import "WebProcess.h"
 #import "_WKWebExtensionLocalization.h"
 #import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/ScriptCallStack.h>
 #import <JavaScriptCore/ScriptCallStackFactory.h>
-#include <wtf/CompletionHandler.h>
+#import <wtf/CompletionHandler.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -70,7 +71,7 @@ NSString *WebExtensionAPILocalization::getUILanguage()
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getUILanguage
 
-    return localeStringInWebExtensionFormat(NSLocale.currentLocale);
+    return toWebAPI(NSLocale.currentLocale);
 }
 
 void WebExtensionAPILocalization::getAcceptLanguages(Ref<WebExtensionCallbackHandler>&& callback)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -56,19 +56,19 @@ public:
     void getSelected(WebPage*, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void duplicate(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void update(double tabID, NSDictionary *updateProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void update(WebPage*, double tabID, NSDictionary *updateProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void reload(double tabID, NSDictionary *reloadProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void goBack(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void goForward(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void reload(WebPage*, double tabID, NSDictionary *reloadProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void goBack(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void goForward(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void getZoom(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void setZoom(double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getZoom(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setZoom(WebPage*, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void detectLanguage(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void detectLanguage(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void toggleReaderMode(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void toggleReaderMode(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     double tabIdentifierNone() const { return -1; }
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -38,19 +38,19 @@
     [RaisesException, Dynamic, NeedsPage] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void duplicate(double tabID, [Optional, CallbackHandler] function callback);
-    [RaisesException] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any tabIDs, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void reload([Optional] double tabID, [Optional, NSDictionary] any reloadProperties, [Optional, CallbackHandler] function callback);
-    [RaisesException] void goBack([Optional] double tabID, [Optional, CallbackHandler] function callback);
-    [RaisesException] void goForward([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void reload([Optional] double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void goBack([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void goForward([Optional] double tabID, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void getZoom([Optional] double tabID, [Optional, CallbackHandler] function callback);
-    [RaisesException] void setZoom([Optional] double tabID, double zoomFactor, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void getZoom([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void setZoom([Optional] double tabID, double zoomFactor, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void detectLanguage([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void detectLanguage([Optional] double tabID, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void toggleReaderMode([Optional] double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void toggleReaderMode([Optional] double tabID, [Optional, CallbackHandler] function callback);
 
     // [RaisesException] void captureVisibleTab([Optional] double windowID, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -62,12 +62,24 @@
 @property (nonatomic, weak) id<_WKWebExtensionWindow> window;
 @property (nonatomic, strong) WKWebView *mainWebView;
 
+@property (nonatomic, getter=isShowingReaderMode) bool showingReaderMode;
+
+@property (nonatomic, copy) void (^toggleReaderMode)(void);
+@property (nonatomic, copy) NSLocale *(^detectWebpageLocale)(void);
+
+@property (nonatomic, copy) void (^reload)(void);
+@property (nonatomic, copy) void (^reloadFromOrigin)(void);
+@property (nonatomic, copy) void (^goBack)(void);
+@property (nonatomic, copy) void (^goForward)(void);
+
 @end
 
 @interface TestWebExtensionWindow : NSObject <_WKWebExtensionWindow>
 
 @property (nonatomic, copy) NSArray<id<_WKWebExtensionTab>> *tabs;
 @property (nonatomic, strong) id<_WKWebExtensionTab> activeTab;
+
+- (void)closeTab:(id<_WKWebExtensionTab>)tab;
 
 @property (nonatomic) _WKWebExtensionWindowState windowState;
 @property (nonatomic) _WKWebExtensionWindowType windowType;


### PR DESCRIPTION
#### 4f73dc6538b368a37e5b18ed205910a28658c988
<pre>
Add support for simple Web Extension tabs APIs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261412">https://bugs.webkit.org/show_bug.cgi?id=261412</a>
rdar://problem/115291352

Reviewed by Brian Weinstein.

Support for tabs.reload(), goBack(), goForward(), detectLanguage(), toggleReaderMode(),
setZoom(), getZoom(), and remove().

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::localeStringInWebExtensionFormat): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::toWebAPI): Added. Moved localeStringInWebExtensionFormat from CocoaHelpers.
Since this is a Web Extension specific function it makes more since here.
* Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toAPI): Use WindowVector and TabMapValueIterator from WebExtensionContext.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsReload): Added.
(WebKit::WebExtensionContext::tabsGoBack): Added.
(WebKit::WebExtensionContext::tabsGoForward): Added.
(WebKit::WebExtensionContext::tabsDetectLanguage): Added.
(WebKit::WebExtensionContext::tabsToggleReaderMode): Added.
(WebKit::WebExtensionContext::tabsGetZoom): Added.
(WebKit::WebExtensionContext::tabsSetZoom): Added.
(WebKit::WebExtensionContext::tabsRemove): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getWindow): Use page identifier to find the tab.
(WebKit::WebExtensionContext::getTab): Added. Use page identifier to lookup active tab in window
if a tab identifier isn&apos;t specified.
(WebKit::WebExtensionContext::openWindows const): Made const and fixed a typo.
(WebKit::WebExtensionContext::openWindows): Deleted.
(WebKit::WebExtensionContext::openTabs): Deleted. Made inline in the header.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::openTabs const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getUILanguage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::remove): Implemented. Send message to the UIProcess.
(WebKit::WebExtensionAPITabs::reload): Implemented. Ditto.
(WebKit::WebExtensionAPITabs::goBack): Implemented. Ditto.
(WebKit::WebExtensionAPITabs::goForward): Implemented. Ditto.
(WebKit::WebExtensionAPITabs::getZoom): Implemented. Ditto.
(WebKit::WebExtensionAPITabs::setZoom): Implemented. Ditto.
(WebKit::WebExtensionAPITabs::detectLanguage): Implemented. Ditto.
(WebKit::WebExtensionAPITabs::toggleReaderMode): Implemented. Ditto.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl: Added NeedsPage for more functions.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST): Added tests for all added APIs.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab initWithWindow:extensionController:]): Store the extensions controller for later.
(-[TestWebExtensionTab isShowingReaderModeForWebExtensionContext:]): Added.
(-[TestWebExtensionTab toggleReaderModeForWebExtensionContext:completionHandler:]): Added.
(-[TestWebExtensionTab detectWebpageLocaleForWebExtensionContext:completionHandler:]): Added.
(-[TestWebExtensionTab reloadForWebExtensionContext:completionHandler:]): Added.
(-[TestWebExtensionTab reloadFromOriginForWebExtensionContext:completionHandler:]): Added.
(-[TestWebExtensionTab goBackForWebExtensionContext:completionHandler:]): Added.
(-[TestWebExtensionTab goForwardForWebExtensionContext:completionHandler:]): Added.
(-[TestWebExtensionTab closeForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow init]): Make _tabs mutable.
(-[TestWebExtensionWindow tabs]): Added.
(-[TestWebExtensionWindow setTabs:]): Mutable copy.
(-[TestWebExtensionWindow closeTab:]): Added.

Canonical link: <a href="https://commits.webkit.org/267880@main">https://commits.webkit.org/267880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/174b599ae0e6aea112adfad1d1209da326ce67dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17944 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18427 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20644 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16360 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16529 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20553 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2203 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->