### PR TITLE
downcast() should return a smart pointer when passed in a smart pointer

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -265,27 +265,28 @@ inline Ref<T, U> adoptRef(T& reference)
 }
 
 template<typename ExpectedType, typename ArgType, typename PtrTraits>
-inline bool is(Ref<ArgType, PtrTraits>& source)
-{
-    return is<ExpectedType>(source.get());
-}
-
-template<typename ExpectedType, typename ArgType, typename PtrTraits>
 inline bool is(const Ref<ArgType, PtrTraits>& source)
 {
     return is<ExpectedType>(source.get());
 }
 
 template<typename Target, typename Source, typename PtrTraits>
-inline Target& downcast(Ref<Source, PtrTraits>& source)
+inline Ref<Target> downcast(Ref<Source, PtrTraits> source)
 {
-    return downcast<Target>(source.get());
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
+    return static_reference_cast<Target>(WTFMove(source));
 }
 
 template<typename Target, typename Source, typename PtrTraits>
-inline Target& downcast(const Ref<Source, PtrTraits>& source)
+inline RefPtr<Target> dynamicDowncast(Ref<Source, PtrTraits> source)
 {
-    return downcast<Target>(source.get());
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    if (!is<Target>(source))
+        return nullptr;
+    return static_reference_cast<Target>(WTFMove(source));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -254,43 +254,23 @@ struct IsSmartPtr<RefPtr<T, U, V>> {
 };
 
 template<typename ExpectedType, typename ArgType, typename PtrTraits, typename RefDerefTraits>
-inline bool is(RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
-{
-    return is<ExpectedType>(source.get());
-}
-
-template<typename ExpectedType, typename ArgType, typename PtrTraits, typename RefDerefTraits>
 inline bool is(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
 {
     return is<ExpectedType>(source.get());
 }
 
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
-inline Target* downcast(RefPtr<Source, PtrTraits, RefDerefTraits>& source)
-{
-    return downcast<Target>(source.get());
-}
-
-template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
-inline Target* downcast(const RefPtr<Source, PtrTraits, RefDerefTraits>& source)
-{
-    return downcast<Target>(source.get());
-}
-
-template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
-    typename SourcePtrTraits, typename SourceRefDerefTraits>
-inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(const RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits>& source)
+inline RefPtr<Target> downcast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    if (!is<Target>(source))
-        return nullptr;
-    return static_pointer_cast<Target, TargetPtrTraits, TargetRefDerefTraits>(source);
+    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+    return static_pointer_cast<Target>(WTFMove(source));
 }
 
 template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
     typename SourcePtrTraits, typename SourceRefDerefTraits>
-inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits>&& source)
+inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits> source)
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -52,7 +52,7 @@ struct TypeCastTraits<ExpectedType, ArgType, true /* isBaseType */> {
 
 // Type checking function, to use before casting with downcast<>().
 template <typename ExpectedType, typename ArgType>
-inline bool is(ArgType& source)
+inline bool is(const ArgType& source)
 {
     static_assert(std::is_base_of_v<ArgType, ExpectedType>, "Unnecessary type check");
     return TypeCastTraits<const ExpectedType, const ArgType>::isOfType(source);

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -434,7 +434,7 @@ public:
         RefPtr target = event.target();
         if (!is<Node>(target.get()))
             return;
-        Ref node = static_reference_cast<Node>(target.releaseNonNull());
+        Ref node = downcast<Node>(target.releaseNonNull());
 
         auto* page = node->document().page();
         if (!page)

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -56,12 +56,12 @@ using namespace HTMLNames;
 static JSValue createNewElementWrapper(JSDOMGlobalObject* globalObject, Ref<Element>&& element)
 {
     if (is<HTMLElement>(element))
-        return createJSHTMLWrapper(globalObject, static_reference_cast<HTMLElement>(WTFMove(element)));
+        return createJSHTMLWrapper(globalObject, downcast<HTMLElement>(WTFMove(element)));
     if (is<SVGElement>(element))
-        return createJSSVGWrapper(globalObject, static_reference_cast<SVGElement>(WTFMove(element)));
+        return createJSSVGWrapper(globalObject, downcast<SVGElement>(WTFMove(element)));
 #if ENABLE(MATHML)
     if (is<MathMLElement>(element))
-        return createJSMathMLWrapper(globalObject, static_reference_cast<MathMLElement>(WTFMove(element)));
+        return createJSMathMLWrapper(globalObject, downcast<MathMLElement>(WTFMove(element)));
 #endif
     return createWrapper<Element>(globalObject, WTFMove(element));
 }

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -107,12 +107,12 @@ static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalOb
     switch (node->nodeType()) {
         case Node::ELEMENT_NODE:
             if (is<HTMLElement>(node))
-                wrapper = createJSHTMLWrapper(globalObject, static_reference_cast<HTMLElement>(WTFMove(node)));
+                wrapper = createJSHTMLWrapper(globalObject, downcast<HTMLElement>(WTFMove(node)));
             else if (is<SVGElement>(node))
-                wrapper = createJSSVGWrapper(globalObject, static_reference_cast<SVGElement>(WTFMove(node)));
+                wrapper = createJSSVGWrapper(globalObject, downcast<SVGElement>(WTFMove(node)));
 #if ENABLE(MATHML)
             else if (is<MathMLElement>(node))
-                wrapper = createJSMathMLWrapper(globalObject, static_reference_cast<MathMLElement>(WTFMove(node)));
+                wrapper = createJSMathMLWrapper(globalObject, downcast<MathMLElement>(WTFMove(node)));
 #endif
             else
                 wrapper = createWrapper<Element>(globalObject, WTFMove(node));

--- a/Source/WebCore/bindings/js/JSWebXRSpaceCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRSpaceCustom.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 JSValue toJSNewlyCreated(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebXRSpace>&& space)
 {
     if (is<WebXRReferenceSpace>(space))
-        return toJSNewlyCreated(lexicalGlobalObject, globalObject, static_reference_cast<WebXRReferenceSpace>(WTFMove(space)));
+        return toJSNewlyCreated(lexicalGlobalObject, globalObject, downcast<WebXRReferenceSpace>(WTFMove(space)));
     return createWrapper<WebXRSpace>(globalObject, WTFMove(space));
 }
 

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -87,8 +87,7 @@ static CSSCounterStyleDescriptors::Name nameFromCSSValue(Ref<CSSValue> value)
     if (!value->isPrimitiveValue())
         return { };
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    return makeAtomString(primitiveValue.stringValue());
+    return makeAtomString(downcast<CSSPrimitiveValue>(WTFMove(value))->stringValue());
 }
 
 static CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromStyleProperties(const StyleProperties& properties)
@@ -102,7 +101,7 @@ static CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromStylePrope
 CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromCSSValue(Ref<CSSValue> value)
 {
     CSSCounterStyleDescriptors::AdditiveSymbols result;
-    for (auto& additiveSymbol : downcast<CSSValueList>(value)) {
+    for (auto& additiveSymbol : downcast<CSSValueList>(value.get())) {
         auto& pair = downcast<CSSValuePair>(additiveSymbol);
         auto weight = downcast<CSSPrimitiveValue>(pair.first()).value<unsigned>();
         auto symbol = symbolFromCSSValue(&pair.second());
@@ -121,11 +120,11 @@ static CSSCounterStyleDescriptors::Pad padFromStyleProperties(const StylePropert
 
 CSSCounterStyleDescriptors::Pad padFromCSSValue(Ref<CSSValue> value)
 {
-    auto& list = downcast<CSSValueList>(value);
-    ASSERT(list.size() == 2);
-    auto length = downcast<CSSPrimitiveValue>(list[0]).intValue();
+    auto list = downcast<CSSValueList>(WTFMove(value));
+    ASSERT(list->size() == 2);
+    auto length = downcast<CSSPrimitiveValue>(list.get()[0]).intValue();
     ASSERT(length >= 0);
-    return { static_cast<unsigned>(std::max(0, length)), symbolFromCSSValue(&list[1]) };
+    return { static_cast<unsigned>(std::max(0, length)), symbolFromCSSValue(&list.get()[1]) };
 }
 
 static CSSCounterStyleDescriptors::NegativeSymbols negativeSymbolsFromStyleProperties(const StyleProperties& properties)
@@ -159,7 +158,7 @@ static Vector<CSSCounterStyleDescriptors::Symbol> symbolsFromStyleProperties(con
 Vector<CSSCounterStyleDescriptors::Symbol> symbolsFromCSSValue(Ref<CSSValue> value)
 {
     Vector<CSSCounterStyleDescriptors::Symbol> result;
-    for (auto& symbolValue : downcast<CSSValueList>(value)) {
+    for (auto& symbolValue : downcast<CSSValueList>(value.get())) {
         auto symbol = symbolFromCSSValue(&symbolValue);
         if (!symbol.text.isNull())
             result.append(symbol);

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -125,7 +125,7 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
     CSSStyleSheet::RuleMutationScope mutationScope(this);
 
     if (m_styleRule->isStyleRuleWithNesting())
-        downcast<StyleRuleWithNesting>(m_styleRule).wrapperAdoptOriginalSelectorList(WTFMove(*selectorList));
+        downcast<StyleRuleWithNesting>(m_styleRule)->wrapperAdoptOriginalSelectorList(WTFMove(*selectorList));
     else
         m_styleRule->wrapperAdoptSelectorList(WTFMove(*selectorList));
 
@@ -231,7 +231,7 @@ ExceptionOr<unsigned> CSSStyleRule::insertRule(const String& ruleString, unsigne
 
     CSSStyleSheet::RuleMutationScope mutationScope(this);
     ASSERT(m_styleRule->isStyleRuleWithNesting());
-    downcast<StyleRuleWithNesting>(m_styleRule).nestedRules().insert(index, newRule.releaseNonNull());
+    downcast<StyleRuleWithNesting>(m_styleRule)->nestedRules().insert(index, newRule.releaseNonNull());
     m_childRuleCSSOMWrappers.insert(index, RefPtr<CSSRule>());
     return index;
 }
@@ -247,7 +247,7 @@ ExceptionOr<void> CSSStyleRule::deleteRule(unsigned index)
     }
 
     ASSERT(m_styleRule->isStyleRuleWithNesting());
-    auto& rules = downcast<StyleRuleWithNesting>(m_styleRule).nestedRules();
+    auto& rules = downcast<StyleRuleWithNesting>(m_styleRule.get()).nestedRules();
     
     CSSStyleSheet::RuleMutationScope mutationScope(this);
     rules.remove(index);

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -490,7 +490,7 @@ static bool traverseRulesInVector(const Vector<Ref<StyleRuleBase>>& rules, const
         }
         if (!rule->isGroupRule())
             continue;
-        if (traverseRulesInVector(downcast<StyleRuleGroup>(rule).childRules(), handler))
+        if (traverseRulesInVector(downcast<StyleRuleGroup>(rule.get()).childRules(), handler))
             return true;
     }
     return false;

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -778,7 +778,6 @@ RefPtr<StyleRuleFontFeatureValues> CSSParserImpl::consumeFontFeatureValuesRule(C
     consumeRuleList(block, FontFeatureValuesRuleList, [&rules](auto rule) {
         rules.append(rule);
     });
-    rules.shrinkToFit();
     
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
@@ -786,10 +785,10 @@ RefPtr<StyleRuleFontFeatureValues> CSSParserImpl::consumeFontFeatureValuesRule(C
     // Convert block rules to value (remove duplicate...etc)
     auto fontFeatureValues = FontFeatureValues::create();
 
-    for (auto block : rules) {
+    for (auto& block : rules) {
         if (!block->isFontFeatureValuesBlockRule())
             continue;
-        const auto& fontFeatureValuesBlockRule = downcast<StyleRuleFontFeatureValuesBlock>(block);
+        const auto& fontFeatureValuesBlockRule = downcast<StyleRuleFontFeatureValuesBlock>(block.get());
         fontFeatureValues->updateOrInsertForType(fontFeatureValuesBlockRule.fontFeatureValuesType(), fontFeatureValuesBlockRule.tags());
     }
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -396,7 +396,7 @@ ExceptionOr<Ref<CSSMathSum>> CSSNumericValue::toSum(FixedVector<String>&& units)
 
     if (parsedUnits.isEmpty()) {
         std::sort(values.begin(), values.end(), [](auto& a, auto& b) {
-            return strcmp(static_reference_cast<CSSUnitValue>(a)->unitSerialization().characters(), static_reference_cast<CSSUnitValue>(b)->unitSerialization().characters()) < 0;
+            return strcmp(downcast<CSSUnitValue>(a)->unitSerialization().characters(), downcast<CSSUnitValue>(b)->unitSerialization().characters()) < 0;
         });
         return CSSMathSum::create(WTFMove(values));
     }
@@ -405,7 +405,7 @@ ExceptionOr<Ref<CSSMathSum>> CSSNumericValue::toSum(FixedVector<String>&& units)
     for (auto& parsedUnit : parsedUnits) {
         auto temp = CSSUnitValue::create(0, parsedUnit);
         for (size_t i = 0; i < values.size();) {
-            auto value = static_reference_cast<CSSUnitValue>(values[i]);
+            auto value = downcast<CSSUnitValue>(values[i]);
             if (auto convertedValue = value->convertTo(parsedUnit)) {
                 temp->setValue(temp->value() + convertedValue->value());
                 values.remove(i);

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -75,7 +75,7 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
         auto value = styleValues[0]->toCSSValue();
         if (!value)
             return Exception { TypeError, "Invalid values"_s };
-        setCustomProperty(document, property, static_reference_cast<CSSVariableReferenceValue>(value.releaseNonNull()));
+        setCustomProperty(document, property, downcast<CSSVariableReferenceValue>(value.releaseNonNull()));
         return { };
     }
     auto propertyID = cssPropertyID(property);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -805,7 +805,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
     if (pixelBuffer)
         postProcessPixelBufferResults(*pixelBuffer);
 
-    return ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
+    return ImageData::create(downcast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
 #else
     return nullptr;
 #endif

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -160,9 +160,7 @@ Vector<Ref<Node>> HTMLSlotElement::assignedNodes(const AssignedNodesOptions& opt
 Vector<Ref<Element>> HTMLSlotElement::assignedElements(const AssignedNodesOptions& options) const
 {
     return compactMap(assignedNodes(options), [](auto&& node) -> RefPtr<Element> {
-        if (!is<Element>(node))
-            return nullptr;
-        return static_reference_cast<Element>(WTFMove(node));
+        return dynamicDowncast<Element>(WTFMove(node));
     });
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2470,7 +2470,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
 
     ASSERT(pixelBuffer->format().colorSpace == toDestinationColorSpace(computedColorSpace));
 
-    return { { ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull())) } };
+    return { { ImageData::create(downcast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull())) } };
 }
 
 void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy)

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -389,11 +389,11 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
     StringBuilder sanitizedStyleSheetBuilder;
     
     for (const auto& rule : childRules) {
-        if (!rule->isStyleRule())
+        auto styleRule = dynamicDowncast<StyleRule>(rule);
+        if (!styleRule)
             return true;
-        const auto& styleRule = downcast<StyleRule>(rule);
 
-        const auto& selectorList = styleRule.selectorList();
+        const auto& selectorList = styleRule->selectorList();
         if (selectorList.listSize() != 1)
             return true;
         auto selector = selectorList.selectorAt(0);
@@ -403,10 +403,10 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         if (!isCue)
             return true;
 
-        if (styleRule.properties().isEmpty())
+        if (styleRule->properties().isEmpty())
             continue;
 
-        sanitizedStyleSheetBuilder.append(selectorText, " { ", styleRule.properties().asText(), "  }\n");
+        sanitizedStyleSheetBuilder.append(selectorText, " { ", styleRule->properties().asText(), "  }\n");
     }
 
     // It would be more stylish to parse the stylesheet only once instead of serializing a sanitized version.

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -37,7 +37,7 @@ public:
 
     const URL& url() const { return m_url; }
     const ResourceResponse& response() const { return m_response; }
-    FragmentedSharedBuffer& data() const { return static_reference_cast<FragmentedSharedBuffer>(Ref { *m_data.get() }); }
+    FragmentedSharedBuffer& data() const { return *m_data.get(); }
     void append(const SharedBuffer& buffer) { m_data.append(buffer); }
     void clear() { m_data.empty(); }
 

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -62,7 +62,7 @@ public:
         , m_contextIsDocument(is<Document>(m_context))
         // For worker threads, don't update the current DOMTimerFireState.
         // Setting this from workers would not be thread-safe, and its not relevant to current uses.
-        , m_initialDOMTreeVersion(m_contextIsDocument ? downcast<Document>(m_context).domTreeVersion() : 0)
+        , m_initialDOMTreeVersion(m_contextIsDocument ? downcast<Document>(context).domTreeVersion() : 0)
         , m_previous(m_contextIsDocument ? std::exchange(current, this) : nullptr)
     {
         m_context->setTimerNestingLevel(nestingLevel);
@@ -75,7 +75,7 @@ public:
         m_context->setTimerNestingLevel(0);
     }
 
-    const Document* contextDocument() const { return m_contextIsDocument ? &downcast<Document>(m_context) : nullptr; }
+    const Document* contextDocument() const { return m_contextIsDocument ? downcast<Document>(m_context.ptr()) : nullptr; }
 
     void setScriptMadeUserObservableChanges() { m_scriptMadeUserObservableChanges = true; }
     void setScriptMadeNonUserObservableChanges() { m_scriptMadeNonUserObservableChanges = true; }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2330,7 +2330,7 @@ bool LocalFrameView::scrollToFragment(const URL& url)
                 if (commonAncestor && !is<Element>(commonAncestor))
                     commonAncestor = commonAncestor->parentElement();
                 if (commonAncestor)
-                    document->setCSSTarget(downcast<Element>(commonAncestor));
+                    document->setCSSTarget(downcast<Element>(commonAncestor.get()));
                 // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
                 TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
                 maintainScrollPositionAtScrollToTextFragmentRange(range);

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -100,7 +100,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
     if (markOptions && markOptions->startTime)
         timestamp = m_performance.monotonicTimeFromRelativeTime(*markOptions->startTime);
 
-    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, is<Document>(context) ? downcast<Document>(context).frame() : nullptr);
+    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, is<Document>(context) ? downcast<Document>(context.get()).frame() : nullptr);
 
     auto mark = PerformanceMark::create(globalObject, context, markName, WTFMove(markOptions));
     if (mark.hasException())

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -296,7 +296,7 @@ std::unique_ptr<ScrollingStateTree> ScrollingStateTree::commit(LayerRepresentati
     treeStateClone->setPreferredLayerRepresentation(preferredLayerRepresentation);
 
     if (m_rootStateNode)
-        treeStateClone->setRootStateNode(static_reference_cast<ScrollingStateFrameScrollingNode>(m_rootStateNode->cloneAndReset(*treeStateClone)));
+        treeStateClone->setRootStateNode(downcast<ScrollingStateFrameScrollingNode>(m_rootStateNode->cloneAndReset(*treeStateClone)));
 
     // Now the clone tree has changed properties, and the original tree does not.
     treeStateClone->m_hasChangedProperties = std::exchange(m_hasChangedProperties, false);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1209,7 +1209,7 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSample>&& sample, const 
     if (!is<MediaSampleAVFObjC>(sample))
         return;
 
-    Ref<MediaSampleAVFObjC> sampleAVFObjC = static_reference_cast<MediaSampleAVFObjC>(WTFMove(sample));
+    Ref sampleAVFObjC = downcast<MediaSampleAVFObjC>(WTFMove(sample));
     if (!canEnqueueSample(trackID, sampleAVFObjC)) {
         m_blockedSamples.append({ trackID, WTFMove(sampleAVFObjC) });
         return;

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -50,12 +50,12 @@ static bool shouldDirtyAllStyle(const Vector<Ref<StyleRuleBase>>& rules)
 {
     for (auto& rule : rules) {
         if (is<StyleRuleMedia>(rule)) {
-            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(rule).childRules()))
+            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(rule.get()).childRules()))
                 return true;
             continue;
         }
         if (is<StyleRuleWithNesting>(rule)) {
-            if (shouldDirtyAllStyle(downcast<StyleRuleWithNesting>(rule).nestedRules()))
+            if (shouldDirtyAllStyle(downcast<StyleRuleWithNesting>(rule.get()).nestedRules()))
                 return true;
             continue;
         }

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -141,15 +141,15 @@ void UserAgentStyle::addToDefaultStyle(StyleSheetContents& sheet)
     // Build a stylesheet consisting of non-trivial media queries seen in default style.
     // Rulesets for these can't be global and need to be built in document context.
     for (auto& rule : sheet.childRules()) {
-        if (!is<StyleRuleMedia>(rule))
+        auto mediaRule = dynamicDowncast<StyleRuleMedia>(rule);
+        if (!mediaRule)
             continue;
-        auto& mediaRule = downcast<StyleRuleMedia>(rule);
-        auto& mediaQuery = mediaRule.mediaQueries();
+        auto& mediaQuery = mediaRule->mediaQueries();
         if (screenEval().evaluate(mediaQuery))
             continue;
         if (printEval().evaluate(mediaQuery))
             continue;
-        mediaQueryStyleSheet->parserAppendRule(mediaRule.copy());
+        mediaQueryStyleSheet->parserAppendRule(mediaRule->copy());
     }
 
     ++defaultStyleVersion;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -938,9 +938,8 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FloatPoint locati
             auto lookupResult = pluginView->lookupTextAtLocation(locationInViewCoordinates, immediateActionResult);
             if (auto lookupText = std::get<String>(lookupResult); !lookupText.isEmpty()) {
                 // FIXME (144030): Focus does not seem to get set to the PDF when invoking the menu.
-                Ref document = element->document();
-                if (is<PluginDocument>(document))
-                    downcast<PluginDocument>(document).setFocusedElement(element.get());
+                if (RefPtr pluginDocument = dynamicDowncast<PluginDocument>(element->document()))
+                    pluginDocument->setFocusedElement(element.get());
 
                 auto selection = std::get<PDFSelection *>(lookupResult);
                 auto options = std::get<NSDictionary *>(lookupResult);


### PR DESCRIPTION
#### 245867d0781caf78b6b400c2f97386488b38254c
<pre>
downcast() should return a smart pointer when passed in a smart pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=261415">https://bugs.webkit.org/show_bug.cgi?id=261415</a>

Reviewed by NOBODY (OOPS!).

downcast() should return a smart pointer when passed in a smart pointer.
Otherwise, it forces us to use the less-safe static_pointer_cast() /
static_reference_cast() to cast without causing ref counting churn.

This will help with our increased adoption of smart pointers in WebKit.

* Source/WTF/wtf/Ref.h:
(WTF::is):
(WTF::downcast):
(WTF::dynamicDowncast):
* Source/WTF/wtf/RefPtr.h:
(WTF::is):
(WTF::downcast):
* Source/WTF/wtf/TypeCasts.h:
(WTF::is):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::createNewElementWrapper):
* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::createWrapperInline):
* Source/WebCore/bindings/js/JSWebXRSpaceCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::nameFromCSSValue):
(WebCore::additiveSymbolsFromCSSValue):
(WebCore::padFromCSSValue):
(WebCore::symbolsFromCSSValue):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::setSelectorText):
(WebCore::CSSStyleRule::insertRule):
(WebCore::CSSStyleRule::deleteRule):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::traverseRulesInVector):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::toSum):
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::assignedElements const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getImageData const):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndStoreStyleSheet):
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::data const):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimerFireState::DOMTimerFireState):
(WebCore::DOMTimerFireState::contextDocument const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragment):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::mark):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::commit):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::shouldDirtyAllStyle):
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::addToDefaultStyle):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/245867d0781caf78b6b400c2f97386488b38254c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18054 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20765 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16468 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15646 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20876 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14585 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21404 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16300 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4301 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20662 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22639 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17052 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5093 "Passed tests") | 
<!--EWS-Status-Bubble-End-->