### PR TITLE
Add new Apple contributors

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -2687,6 +2687,13 @@
    },
    {
       "emails" : [
+         "lerica@apple.com"
+      ],
+      "github" : "lericaa",
+      "name" : "Erica Li"
+   },
+   {
+      "emails" : [
          "arv@chromium.org"
       ],
       "name" : "Erik Arvidsson",
@@ -4290,7 +4297,6 @@
       "emails" : [
          "jc_hanson@apple.com"
       ],
-      "github" : "julia-c-hanson",
       "name" : "Julia Hanson"
    },
    {
@@ -5742,6 +5748,13 @@
    },
    {
       "emails" : [
+         "nicole_rosario@apple.com"
+      ],
+      "github" : "NKRosario",
+      "name" : "Nicole Rosario"
+   },
+   {
+      "emails" : [
          "nvasilyev@apple.com",
          "me@elv1s.ru"
       ],
@@ -5801,6 +5814,13 @@
       "nicks" : [
          "nghanavatian"
       ]
+   },
+   {
+      "emails" : [
+         "nisha_jain@apple.com"
+      ],
+      "github" : "nishajain61",
+      "name" : "Nisha Jain"
    },
    {
       "emails" : [
@@ -6641,6 +6661,13 @@
          "satish@chromium.org"
       ],
       "name" : "Satish Sampath"
+   },
+   {
+      "emails" : [
+         "mscott@apple.com"
+      ],
+      "github" : "mscottapple",
+      "name" : "Scott Marcy"
    },
    {
       "emails" : [


### PR DESCRIPTION
#### 4d3d07b1edf39f299a34adad283fcb3867a3766b
<pre>
Add new Apple contributors

Unreviewed contributor maintence.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/267870@main">https://commits.webkit.org/267870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/528e7495ae136d1a72eadf638b860ab99bfaab79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17925 "Failed to checkout and rebase branch from PR 17656") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16773 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18408 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18141 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/18406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20623 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18075 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/16649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20535 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2200 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/16923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->