### PR TITLE
Port remaining WebCore SimpleArgumentCoders to the new serialization format

### DIFF
--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -109,7 +109,7 @@ ViewportAttributes ViewportArguments::resolve(const FloatSize& initialViewportSi
         break;
     }
 
-    if (type == ViewportArguments::CSSDeviceAdaptation) {
+    if (type == ViewportArguments::Type::CSSDeviceAdaptation) {
         switch (int(resultMinWidth)) {
         case ViewportArguments::ValueDeviceWidth:
             resultMinWidth = deviceSize.width();
@@ -179,7 +179,7 @@ ViewportAttributes ViewportArguments::resolve(const FloatSize& initialViewportSi
         resultHeight = std::max<float>(1, resultHeight);
     }
 
-    if (type != ViewportArguments::CSSDeviceAdaptation && type != ViewportArguments::Implicit) {
+    if (type != ViewportArguments::Type::CSSDeviceAdaptation && type != ViewportArguments::Type::Implicit) {
         // Clamp values to a valid range, but not for @viewport since is
         // not mandated by the specification.
         resultWidth = clampLengthValue(resultWidth);
@@ -233,7 +233,7 @@ ViewportAttributes ViewportArguments::resolve(const FloatSize& initialViewportSi
     if (resultHeight == ViewportArguments::ValueAuto)
         resultHeight = resultWidth * (initialViewportSize.height() / initialViewportSize.width());
 
-    if (type == ViewportArguments::ViewportMeta) {
+    if (type == ViewportArguments::Type::ViewportMeta) {
         // Extend width and height to fill the visual viewport for the resolved initial-scale.
         resultWidth = std::max<float>(resultWidth, initialViewportSize.width() / result.initialScale);
         resultHeight = std::max<float>(resultHeight, initialViewportSize.height() / result.initialScale);

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -63,7 +63,7 @@ struct ViewportAttributes {
 
 struct ViewportArguments {
 
-    enum Type {
+    enum class Type : uint8_t {
         // These are ordered in increasing importance.
         Implicit,
 #if PLATFORM(IOS_FAMILY)
@@ -80,8 +80,27 @@ struct ViewportArguments {
     static constexpr int ValuePortrait = -4;
     static constexpr int ValueLandscape = -5;
 
-    explicit ViewportArguments(Type type = Implicit)
+    explicit ViewportArguments(Type type = Type::Implicit)
         : type(type)
+    {
+    }
+
+    ViewportArguments(Type type, float width, float minWidth, float maxWidth, float height, float minHeight, float maxHeight, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, ViewportFit viewportFit, bool widthWasExplicit)
+        : type(type)
+        , width(width)
+        , minWidth(minWidth)
+        , maxWidth(maxWidth)
+        , height(height)
+        , minHeight(minHeight)
+        , maxHeight(maxHeight)
+        , zoom(zoom)
+        , minZoom(minZoom)
+        , maxZoom(maxZoom)
+        , userZoom(userZoom)
+        , orientation(orientation)
+        , shrinkToFit(shrinkToFit)
+        , viewportFit(viewportFit)
+        , widthWasExplicit(widthWasExplicit)
     {
     }
 

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -339,7 +339,7 @@ void FTPDirectoryDocumentParser::createBasicDocument()
 
     bodyElement->appendChild(*m_tableElement);
 
-    document.processViewport("width=device-width"_s, ViewportArguments::ViewportMeta);
+    document.processViewport("width=device-width"_s, ViewportArguments::Type::ViewportMeta);
 }
 
 void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -173,7 +173,7 @@ void HTMLMetaElement::process()
         return;
 
     if (equalLettersIgnoringASCIICase(nameValue, "viewport"_s))
-        document().processViewport(contentValue, ViewportArguments::ViewportMeta);
+        document().processViewport(contentValue, ViewportArguments::Type::ViewportMeta);
     else if (document().settings().disabledAdaptationsMetaTagEnabled() && equalLettersIgnoringASCIICase(nameValue, "disabled-adaptations"_s))
         document().processDisabledAdaptations(contentValue);
 #if ENABLE(DARK_MODE_CSS)

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -257,7 +257,7 @@ void ImageDocument::createDocumentStructure()
     if (m_shouldShrinkImage) {
 #if PLATFORM(IOS_FAMILY)
         // Set the viewport to be in device pixels (rather than the default of 980).
-        processViewport("width=device-width,viewport-fit=cover"_s, ViewportArguments::ImageDocument);
+        processViewport("width=device-width,viewport-fit=cover"_s, ViewportArguments::Type::ImageDocument);
 #else
         auto listener = ImageEventListener::create(*this);
         imageElement->addEventListener(eventNames().clickEvent, WTFMove(listener), false);
@@ -284,7 +284,7 @@ void ImageDocument::imageUpdated()
 #if PLATFORM(IOS_FAMILY)
         FloatSize screenSize = page()->chrome().screenSize();
         if (imageSize.width() > screenSize.width())
-            processViewport(makeString("width=", imageSize.width().toInt(), ",viewport-fit=cover"), ViewportArguments::ImageDocument);
+            processViewport(makeString("width=", imageSize.width().toInt(), ",viewport-fit=cover"), ViewportArguments::Type::ImageDocument);
 
         if (page())
             page()->chrome().client().imageOrMediaDocumentSizeChanged(IntSize(imageSize.width(), imageSize.height()));

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -81,7 +81,7 @@ void PluginDocumentParser::createDocumentStructure()
 
 #if PLATFORM(IOS_FAMILY)
     // Should not be able to zoom into standalone plug-in documents.
-    document.processViewport("user-scalable=no"_s, ViewportArguments::PluginDocument);
+    document.processViewport("user-scalable=no"_s, ViewportArguments::Type::PluginDocument);
 #endif
 
     auto body = HTMLBodyElement::create(document);

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -141,7 +141,7 @@ public:
         }
 
         if (m_metaIsViewport && !m_metaContent.isNull())
-            document->processViewport(m_metaContent, ViewportArguments::ViewportMeta);
+            document->processViewport(m_metaContent, ViewportArguments::Type::ViewportMeta);
 
         if (m_metaIsDisabledAdaptations && !m_metaContent.isNull())
             document->processDisabledAdaptations(m_metaContent);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -291,29 +291,6 @@ std::optional<DOMCacheEngine::Record> ArgumentCoder<DOMCacheEngine::Record>::dec
     return {{ WTFMove(identifier), WTFMove(updateResponseCounter), WTFMove(requestHeadersGuard), WTFMove(request), WTFMove(options.value()), WTFMove(referrer), WTFMove(responseHeadersGuard), WTFMove(response), WTFMove(responseBody), responseBodySize }};
 }
 
-void ArgumentCoder<RectEdges<bool>>::encode(Encoder& encoder, const RectEdges<bool>& boxEdges)
-{
-    SimpleArgumentCoder<RectEdges<bool>>::encode(encoder, boxEdges);
-}
-    
-std::optional<RectEdges<bool>> ArgumentCoder<RectEdges<bool>>::decode(Decoder& decoder)
-{
-    return SimpleArgumentCoder<RectEdges<bool>>::decode(decoder);
-}
-
-#if ENABLE(META_VIEWPORT)
-void ArgumentCoder<ViewportArguments>::encode(Encoder& encoder, const ViewportArguments& viewportArguments)
-{
-    SimpleArgumentCoder<ViewportArguments>::encode(encoder, viewportArguments);
-}
-
-std::optional<ViewportArguments> ArgumentCoder<ViewportArguments>::decode(Decoder& decoder)
-{
-    return SimpleArgumentCoder<ViewportArguments>::decode(decoder);
-}
-
-#endif // ENABLE(META_VIEWPORT)
-
 void ArgumentCoder<Length>::encode(Encoder& encoder, const Length& length)
 {
     encoder << length.type() << length.hasQuirk();
@@ -2064,46 +2041,6 @@ std::optional<Ref<Filter>> ArgumentCoder<Filter>::decode(Decoder& decoder)
     (*filter)->setFilterRegion(*filterRegion);
 
     return filter;
-}
-
-template<typename Encoder>
-void ArgumentCoder<Path>::encode(Encoder& encoder, const Path& path)
-{
-    if (auto segment = path.singleSegment())
-        encoder << false << *segment;
-    else if (auto* segments = path.segmentsIfExists())
-        encoder << true << *segments;
-    else
-        encoder << true << path.segments();
-}
-
-template
-void ArgumentCoder<Path>::encode<Encoder>(Encoder&, const Path&);
-template
-void ArgumentCoder<Path>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, const Path&);
-
-std::optional<Path> ArgumentCoder<Path>::decode(Decoder& decoder)
-{
-    std::optional<bool> hasVector;
-    decoder >> hasVector;
-    if (!hasVector)
-        return std::nullopt;
-
-    if (!*hasVector) {
-        std::optional<PathSegment> segment;
-        decoder >> segment;
-        if (!segment)
-            return std::nullopt;
-
-        return Path(WTFMove(*segment));
-    }
-
-    std::optional<Vector<PathSegment>> segments;
-    decoder >> segments;
-    if (!segments)
-        return std::nullopt;
-
-    return Path(WTFMove(*segments));
 }
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -119,7 +119,6 @@ class Font;
 class FontPlatformData;
 class FragmentedSharedBuffer;
 class LightSource;
-class Path;
 class PaymentInstallmentConfiguration;
 class PixelBuffer;
 class ResourceError;
@@ -154,18 +153,6 @@ template<> struct ArgumentCoder<WebCore::DOMCacheEngine::Record> {
     static void encode(Encoder&, const WebCore::DOMCacheEngine::Record&);
     static std::optional<WebCore::DOMCacheEngine::Record> decode(Decoder&);
 };
-
-template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
-    static void encode(Encoder&, const WebCore::RectEdges<bool>&);
-    static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
-};
-
-#if ENABLE(META_VIEWPORT)
-template<> struct ArgumentCoder<WebCore::ViewportArguments> {
-    static void encode(Encoder&, const WebCore::ViewportArguments&);
-    static std::optional<WebCore::ViewportArguments> decode(Decoder&);
-};
-#endif
 
 template<> struct ArgumentCoder<WebCore::Length> {
     static void encode(Encoder&, const WebCore::Length&);
@@ -430,12 +417,6 @@ template<> struct ArgumentCoder<WebCore::Filter> {
     template<typename Encoder>
     static void encode(Encoder&, const WebCore::Filter&);
     static std::optional<Ref<WebCore::Filter>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::Path> {
-    template<typename Encoder>
-    static void encode(Encoder&, const WebCore::Path&);
-    static std::optional<WebCore::Path> decode(Decoder&);
 };
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1728,6 +1728,48 @@ header: <WebCore/RectEdges.h>
     float left()
 };
 
+[Alias=class RectEdges<bool>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebCore::BoolBoxExtent {
+    bool top();
+    bool right();
+    bool bottom();
+    bool left();
+}
+
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::Path {
+    Vector<WebCore::PathSegment> segments();
+}
+
+#if ENABLE(META_VIEWPORT)
+
+[Nested] enum class WebCore::ViewportArguments::Type : uint8_t {
+    Implicit,
+#if PLATFORM(IOS_FAMILY)
+    PluginDocument,
+    ImageDocument,
+#endif
+    ViewportMeta,
+    CSSDeviceAdaptation
+};
+
+struct WebCore::ViewportArguments {
+    WebCore::ViewportArguments::Type type;
+    float width;
+    float minWidth;
+    float maxWidth;
+    float height;
+    float minHeight;
+    float maxHeight;
+    float zoom;
+    float minZoom;
+    float maxZoom;
+    float userZoom;
+    float orientation;
+    float shrinkToFit;
+    WebCore::ViewportFit viewportFit;
+    bool widthWasExplicit;
+};
+#endif // ENABLE(META_VIEWPORT)
+
 header: <WebCore/DisplayListItems.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineFillColor {
     uint8_t colorData().resolved().red

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4132,7 +4132,7 @@ static std::optional<WebCore::ViewportArguments> viewportArgumentsFromDictionary
     if (!viewportArgumentPairs)
         return std::nullopt;
 
-    WebCore::ViewportArguments viewportArguments(WebCore::ViewportArguments::ViewportMeta);
+    WebCore::ViewportArguments viewportArguments(WebCore::ViewportArguments::Type::ViewportMeta);
 
     [viewportArgumentPairs enumerateKeysAndObjectsUsingBlock:makeBlockPtr([&] (NSString *key, NSString *value, BOOL* stop) {
         if (![key isKindOfClass:[NSString class]] || ![value isKindOfClass:[NSString class]])

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -907,7 +907,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         if (auto* manager = self._manager)
             manager->setAnimatingFullScreen(true);
 
-        WebCore::ViewportArguments arguments { WebCore::ViewportArguments::CSSDeviceAdaptation };
+        WebCore::ViewportArguments arguments { WebCore::ViewportArguments::Type::CSSDeviceAdaptation };
         arguments.zoom = WebKit::ZoomForFullscreenWindow;
         arguments.minZoom = WebKit::ZoomForFullscreenWindow;
         arguments.maxZoom = WebKit::ZoomForFullscreenWindow;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4684,7 +4684,7 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     layerTransaction.setInitialScaleFactor(m_viewportConfiguration.initialScale());
     layerTransaction.setViewportMetaTagWidth(m_viewportConfiguration.viewportArguments().width);
     layerTransaction.setViewportMetaTagWidthWasExplicit(m_viewportConfiguration.viewportArguments().widthWasExplicit);
-    layerTransaction.setViewportMetaTagCameFromImageDocument(m_viewportConfiguration.viewportArguments().type == ViewportArguments::ImageDocument);
+    layerTransaction.setViewportMetaTagCameFromImageDocument(m_viewportConfiguration.viewportArguments().type == ViewportArguments::Type::ImageDocument);
     layerTransaction.setAvoidsUnsafeArea(m_viewportConfiguration.avoidsUnsafeArea());
     layerTransaction.setIsInStableState(m_isInStableState);
     layerTransaction.setAllowsUserScaling(allowsUserScaling());


### PR DESCRIPTION
#### 1ab6dbfa6478d9f5118bbaac4079c0cfd867575c
<pre>
Port remaining WebCore SimpleArgumentCoders to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=261416">https://bugs.webkit.org/show_bug.cgi?id=261416</a>
rdar://115361200

Reviewed by Alex Christensen.

This change includes the porting of:
    - RectEdges&lt;bool&gt;
    - ViewportArguments
    - Path

* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RectEdges&lt;bool&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RectEdges&lt;bool&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;ViewportArguments&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ViewportArguments&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;Path&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Path&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268309@main">https://commits.webkit.org/268309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ea0e3e4185ef10315ea104268efffda417400a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22058 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17565 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17465 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4614 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->