### PR TITLE
visionOS: backdrop-filter in a transparent web view on top of material background renders black

### DIFF
--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -141,8 +141,17 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
             CAFilter *filter = [CAFilter filterWithType:kCAFilterGaussianBlur];
             [filter setValue:[NSNumber numberWithFloat:floatValueForLength(blurOperation.stdDeviation(), 0)] forKey:@"inputRadius"];
 #if ENABLE(FILTERS_LEVEL_2)
-            if ([layer isKindOfClass:[CABackdropLayer class]])
+            if ([layer isKindOfClass:[CABackdropLayer class]]) {
+#if PLATFORM(VISION)
+                // If the backdrop is displayed inside a transparent web view over
+                // a material background, we need `normalizeEdgesTransparent`
+                // in order to render correctly.
+                [filter setValue:@YES forKey:@"inputNormalizeEdgesTransparent"];
+#else
                 [filter setValue:@YES forKey:@"inputNormalizeEdges"];
+#endif
+
+            }
 #endif
             [filter setName:filterName];
             return filter;


### PR DESCRIPTION
#### 780a84bad82a6f368abb6de667dc983fdd14ef5b
<pre>
visionOS: backdrop-filter in a transparent web view on top of material background renders black
<a href="https://bugs.webkit.org/show_bug.cgi?id=261419">https://bugs.webkit.org/show_bug.cgi?id=261419</a>
rdar://112798317

Reviewed by Mike Wyrzykowski.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::setFiltersOnLayer):
Use the visionOS-specific `normalizeEdgesTransparent` filter option in order
to make backdrops render correctly on top of material backgrounds.

Technically we only need this in cases where we&apos;re on top of a material, and could
use the cheaper `normalizeEdges` in the opaque-web-view case, but that would
require plumbing that knowledge through the fairly-distant filter application code.

Canonical link: <a href="https://commits.webkit.org/267875@main">https://commits.webkit.org/267875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/593e4b95caab3ee3bf07cbe55c54cd751c9cfec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18417 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20640 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16353 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20754 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17083 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16184 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4272 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->