### PR TITLE
REGRESSION(267280@main): costco.com crash in WebCore::ShorthandSerializer::serializeGridTemplate const

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-node-not-connected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-node-not-connected-expected.txt
@@ -1,0 +1,3 @@
+
+PASS grid-template-node-not-connected
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-node-not-connected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-node-not-connected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=261421">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="test should not crash and grid-template for child should be the empty string after disconnecting the element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<style>
+#child {
+  grid-template: 10px / 10px;
+}
+</style>
+<div>
+  <div id="child"></div>
+</div>
+<script>
+test(() => {
+  let styleDeclaration = window.getComputedStyle(document.getElementById("child"));
+  document.querySelector("body > div:nth-child(1)").textContent = "";
+  assert_equals(styleDeclaration.gridTemplate, "");
+});
+</script>
+</html>

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -191,8 +191,14 @@ bool ShorthandSerializer::commonSerializationChecks(const ComputedStyleExtractor
 
     ASSERT(m_shorthand.id() != CSSPropertyAll);
 
-    for (unsigned i = 0; i < length(); ++i)
-        m_longhandValues[i] = properties.propertyValue(longhandProperty(i));
+    for (unsigned i = 0; i < length(); ++i) {
+        auto longhandValue = properties.propertyValue(longhandProperty(i));
+        if (!longhandValue) {
+            m_result = emptyString();
+            return true;
+        }
+        m_longhandValues[i] = longhandValue;
+    }
 
     return false;
 }


### PR DESCRIPTION
#### 7d7be769ce2d1407bdac2234c29f91630ca959fd
<pre>
REGRESSION(267280@main): costco.com crash in WebCore::ShorthandSerializer::serializeGridTemplate const
<a href="https://bugs.webkit.org/show_bug.cgi?id=261421">https://bugs.webkit.org/show_bug.cgi?id=261421</a>
rdar://115046351

Reviewed by Darin Adler.

Costco&apos;s checkout page uses element.TextContent = &quot;&quot; which ends up
disconnecting some nodes from the tree. When the ShorthandSerializer
tries to get the value for each of the longhands of grid-template,
the ComputedStyleExtractor is unable to resolve the RenderStyle to use
via computeRenderStyleForProperty and returns nullptr for the longhand
value. This results in a hard nullptr deref
ShorthandSerializer::longhandValue.

Any time we are using the ComputedStyleExtractor version of the
ShorthandSerializer and we end up getting a nullptr back for one of
the longhand values we should instead set m_result to the emptyString
(which would have been returned anyways in
CSSComputedStyleDeclaration::getPropertyValue if we used the
ComputedStyleExtractor rather than the ShorthandSerializer for the
shorthand&apos;s computed style) and return true from
commonSerializationChecks. The serialize function will see that
commonSerializationChecks set the value and return it back to the
caller.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-node-not-connected-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-node-not-connected.html: Added.
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::commonSerializationChecks):

Canonical link: <a href="https://commits.webkit.org/267989@main">https://commits.webkit.org/267989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1b48a8109c05fe2f1ad693e8d3910d9c3f2a737

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18887 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20770 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22996 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20866 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17207 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14586 "6 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4360 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->