### PR TITLE
[JSC] Implement HasVarDeclaration abstract operation

### DIFF
--- a/JSTests/stress/global-add-var-should-not-be-shadowed-by-lexical-bindings.js
+++ b/JSTests/stress/global-add-var-should-not-be-shadowed-by-lexical-bindings.js
@@ -1,4 +1,4 @@
-function shouldThrow(func, errorMessage) {
+var shouldThrow = function(func, errorMessage) {
     var errorThrown = false;
     var error = null;
     try {
@@ -11,7 +11,7 @@ function shouldThrow(func, errorMessage) {
         throw new Error('not thrown');
     if (String(error) !== errorMessage)
         throw new Error(`bad error: ${String(error)}`);
-}
+};
 
 shouldThrow(() => {
     $.evalScript(`const shouldThrow = 42`);

--- a/JSTests/stress/has-var-declaration.js
+++ b/JSTests/stress/has-var-declaration.js
@@ -1,0 +1,41 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+function shouldThrow(func, expectedError) {
+    let errorThrown = false;
+    try {
+        func();
+    } catch (error) {
+        errorThrown = true;
+        if (error.toString() !== expectedError)
+            throw new Error(`Bad error: ${error}!`);
+    }
+    if (!errorThrown)
+        throw new Error("Didn't throw!");
+}
+
+
+eval("var theVar");
+shouldThrow(() => { $262.evalScript("let theVar = 1"); }, "SyntaxError: Can't create duplicate variable: 'theVar'");
+shouldThrow(() => { $262.evalScript("const theVar = 1"); }, "SyntaxError: Can't create duplicate variable: 'theVar'");
+delete globalThis.theVar;
+$262.evalScript("let theVar = 2");
+assert(theVar === 2);
+
+
+eval("function theTopLevelFunctionDeclaration() {}");
+shouldThrow(() => { $262.evalScript("let theTopLevelFunctionDeclaration = 3"); }, "SyntaxError: Can't create duplicate variable: 'theTopLevelFunctionDeclaration'");
+shouldThrow(() => { $262.evalScript("const theTopLevelFunctionDeclaration = 3"); }, "SyntaxError: Can't create duplicate variable: 'theTopLevelFunctionDeclaration'");
+delete globalThis.theTopLevelFunctionDeclaration;
+$262.evalScript("const theTopLevelFunctionDeclaration = 4");
+assert(theTopLevelFunctionDeclaration === 4);
+
+
+eval("if (true) { function theHoistedBlockLevelFunctionDeclaration() {} }");
+shouldThrow(() => { $262.evalScript("const theHoistedBlockLevelFunctionDeclaration = 5"); }, "SyntaxError: Can't create duplicate variable: 'theHoistedBlockLevelFunctionDeclaration'");
+shouldThrow(() => { $262.evalScript("let theHoistedBlockLevelFunctionDeclaration = 5"); }, "SyntaxError: Can't create duplicate variable: 'theHoistedBlockLevelFunctionDeclaration'");
+delete globalThis.theHoistedBlockLevelFunctionDeclaration;
+$262.evalScript("let theHoistedBlockLevelFunctionDeclaration = 6");
+assert(theHoistedBlockLevelFunctionDeclaration === 6);

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -317,9 +317,9 @@ JSObject* createInvalidPrototypeError(JSGlobalObject* globalObject, JSValue valu
     return createError(globalObject, value, "is not an object or null"_s, invalidPrototypeSourceAppender);
 }
 
-JSObject* createErrorForInvalidGlobalAssignment(JSGlobalObject* globalObject, const String& propertyName)
+JSObject* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject* globalObject, UniquedStringImpl* key)
 {
-    return createReferenceError(globalObject, makeString("Strict mode forbids implicit creation of global property '"_s, propertyName, '\''));
+    return createSyntaxError(globalObject, makeString("Can't create duplicate variable: '"_s, StringView(key), '\''));
 }
 
 JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject* globalObject, const Identifier& ident)

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.h
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.h
@@ -52,7 +52,7 @@ JSObject* createInvalidInstanceofParameterErrorHasInstanceValueNotFunction(JSGlo
 JSObject* createNotAConstructorError(JSGlobalObject*, JSValue);
 JSObject* createNotAFunctionError(JSGlobalObject*, JSValue);
 JSObject* createInvalidPrototypeError(JSGlobalObject*, JSValue);
-JSObject* createErrorForInvalidGlobalAssignment(JSGlobalObject*, const String&);
+JSObject* createErrorForDuplicateGlobalVariableDeclaration(JSGlobalObject*, UniquedStringImpl*);
 JSObject* createErrorForInvalidGlobalFunctionDeclaration(JSGlobalObject*, const Identifier&);
 JSObject* createErrorForInvalidGlobalVarDeclaration(JSGlobalObject*, const Identifier&);
 JSObject* createInvalidPrivateNameError(JSGlobalObject*);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -539,6 +539,8 @@ public:
     bool m_webAssemblyEnabled { true };
     bool m_needsSiteSpecificQuirks { false };
     unsigned m_globalLexicalBindingEpoch { 1 };
+    ScopeOffset m_lastStaticGlobalOffset;
+    IdentifierSet m_varNamesDeclaredViaEval;
     String m_evalDisabledErrorMessage;
     String m_webAssemblyDisabledErrorMessage;
     RuntimeFlags m_runtimeFlags;
@@ -616,6 +618,9 @@ public:
     JS_EXPORT_PRIVATE static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
+    JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
+
+    bool hasVarDeclaration(const RefPtr<UniquedStringImpl>&);
 
     bool canDeclareGlobalFunction(const Identifier&);
     template<BindingCreationContext> void createGlobalFunctionBinding(const Identifier&);


### PR DESCRIPTION
#### 66468f0cb22104024c0485895b647744b943eaab
<pre>
[JSC] Implement HasVarDeclaration abstract operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=261179">https://bugs.webkit.org/show_bug.cgi?id=261179</a>
&lt;rdar://problem/115014147&gt;

Reviewed by Yusuke Suzuki.

Prior to this change, during script evaluation, variable bindings created via eval() -- including
those for hoisted block-level function declarations (Annex B) -- were ignored when checking for
duplicates with lexical declarations.

HasVarDeclaration [1] is introduced to remedy that. It correctly handling static global properties
(like NaN) that only pose as variables for performance reasons, which is achieved due to the fact that
static global properties are declared in the very first place, by the finishCreation() overrides,
and consecutively. So instead of maintaing a list of their identifiers, or adding a SymbolTableEntry
flag, we only need to keep an offset of the last such property.

Also, this change reorders duplicate variable checks into a single loop to match the spec [2],
making error messages more precise, and adds an optimization to avoid looking up each lexical
declaration if JSGlobalLexicalEnvironment is empty.

Even prior to this change, JSGlobalObject did override deleteProperty(), so no possible regression
is introduced.

Aligns JSC with the spec and SpiderMonkey yet not with V8 yet.

[1] <a href="https://tc39.es/ecma262/#sec-hasvardeclaration">https://tc39.es/ecma262/#sec-hasvardeclaration</a>
[2] <a href="https://tc39.es/ecma262/#sec-globaldeclarationinstantiation">https://tc39.es/ecma262/#sec-globaldeclarationinstantiation</a> (step 3)

* JSTests/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js:
* JSTests/stress/global-add-var-should-not-be-shadowed-by-lexical-bindings.js: Added.
* JSTests/stress/has-var-declaration.js: Added.
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::createErrorForDuplicateGlobalVariableDeclaration):
(JSC::createErrorForInvalidGlobalAssignment): Deleted.
* Source/JavaScriptCore/runtime/ExceptionHelpers.h: Removed unused createErrorForInvalidGlobalAssignment().
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::deleteProperty):
(JSC::JSGlobalObject::createGlobalFunctionBinding):
(JSC::JSGlobalObject::addStaticGlobals):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::hasVarDeclaration):
(JSC::JSGlobalObject::createGlobalVarBinding):
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):

Canonical link: <a href="https://commits.webkit.org/267891@main">https://commits.webkit.org/267891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cadec7296d2a303958969d9d95c918e6e497fa3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/17980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/18307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/18872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/19811 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/21602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/18465 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/19811 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/18196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/21602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/18872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20684 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/21602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/18872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/20684 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/15571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/21602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/18872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20684 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/17255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/18465 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/18872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/21328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/22561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2206 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/16978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/22561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->