### PR TITLE
Use WeakHashSet<T> / ThreadSafeWeakHashSet<T> instead of HashSet<T*> more in WebCore

### DIFF
--- a/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
@@ -171,14 +171,13 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 
     HashMap<mach_port_t, String> knownWorkerThreads;
     {
-        Locker locker { WorkerOrWorkletThread::workerOrWorkletThreadsLock() };
-        for (auto* thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
+        for (auto& thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
             // Ignore worker threads that have not been fully started yet.
-            if (!thread->thread())
+            if (!thread.thread())
                 continue;
-            mach_port_t machThread = thread->thread()->machThread();
+            mach_port_t machThread = thread.thread()->machThread();
             if (MACH_PORT_VALID(machThread))
-                knownWorkerThreads.set(machThread, thread->inspectorIdentifier().isolatedCopy());
+                knownWorkerThreads.set(machThread, thread.inspectorIdentifier().isolatedCopy());
         }
     }
 

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -250,14 +250,13 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 
     HashMap<pid_t, String> knownWorkerThreads;
     {
-        Locker locker { WorkerOrWorkletThread::workerOrWorkletThreadsLock() };
-        for (auto* thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
+        for (auto& thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
             // Ignore worker threads that have not been fully started yet.
-            if (!thread->thread())
+            if (!thread.thread())
                 continue;
 
-            if (auto id = thread->thread()->id())
-                knownWorkerThreads.set(id, thread->inspectorIdentifier().isolatedCopy());
+            if (auto id = thread.thread()->id())
+                knownWorkerThreads.set(id, thread.inspectorIdentifier().isolatedCopy());
         }
     }
 

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -415,9 +415,8 @@ static void dispatchToAllFontCaches(F function)
 
     function(FontCache::forCurrentThread());
 
-    Locker locker { WorkerOrWorkletThread::workerOrWorkletThreadsLock() };
-    for (auto thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
-        thread->runLoop().postTask([function](ScriptExecutionContext&) {
+    for (auto& thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
+        thread.runLoop().postTask([function](ScriptExecutionContext&) {
             if (auto fontCache = FontCache::forCurrentThreadIfExists())
                 function(*fontCache);
         });

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -93,7 +93,7 @@ void RenderLayerFilters::updateReferenceFilterClients(const FilterOperations& op
             auto* renderer = filterElement->renderer();
             if (!is<RenderSVGResourceFilter>(renderer))
                 continue;
-            downcast<RenderSVGResourceFilter>(*renderer).addClientRenderLayer(&m_layer);
+            downcast<RenderSVGResourceFilter>(*renderer).addClientRenderLayer(m_layer);
             m_internalSVGReferences.append(filterElement);
         }
     }
@@ -108,7 +108,7 @@ void RenderLayerFilters::removeReferenceFilterClients()
 
     for (auto& filterElement : m_internalSVGReferences) {
         if (auto* renderer = filterElement->renderer())
-            downcast<RenderSVGResourceContainer>(*renderer).removeClientRenderLayer(&m_layer);
+            downcast<RenderSVGResourceContainer>(*renderer).removeClientRenderLayer(m_layer);
     }
     m_internalSVGReferences.clear();
 }

--- a/Source/WebCore/rendering/style/StyleImage.h
+++ b/Source/WebCore/rendering/style/StyleImage.h
@@ -29,6 +29,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ struct ResourceLoaderOptions;
 
 typedef const void* WrappedImagePtr;
 
-class StyleImage : public RefCounted<StyleImage> {
+class StyleImage : public RefCounted<StyleImage>, public CanMakeWeakPtr<StyleImage> {
 public:
     virtual ~StyleImage() = default;
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -22,6 +22,7 @@
 #include "LegacyRenderSVGHiddenContainer.h"
 #include "RenderSVGResource.h"
 #include "SVGDocumentExtensions.h"
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -43,8 +44,8 @@ public:
 
     void idChanged();
     void markAllClientsForRepaint();
-    void addClientRenderLayer(RenderLayer*);
-    void removeClientRenderLayer(RenderLayer*);
+    void addClientRenderLayer(RenderLayer&);
+    void removeClientRenderLayer(RenderLayer&);
     void markAllClientLayersForInvalidation();
 
 protected:
@@ -72,8 +73,8 @@ private:
     void registerResource();
 
     AtomString m_id;
-    HashSet<RenderElement*> m_clients;
-    HashSet<RenderLayer*> m_clientLayers;
+    WeakHashSet<RenderElement> m_clients;
+    WeakHashSet<RenderLayer> m_clientLayers;
     bool m_registered { false };
     bool m_isInvalidating { false };
 };

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -55,7 +55,7 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
 {
     bool layoutSizeChanged = layoutSizeOfNearestViewportChanged();
     bool transformChanged = transformToRootChanged(&m_container);
-    HashSet<RenderElement*> elementsThatDidNotReceiveLayout;
+    WeakHashSet<RenderElement> elementsThatDidNotReceiveLayout;
 
     m_positionedChildren.clear();
     for (auto& child : childrenOfType<RenderObject>(m_container)) {
@@ -103,7 +103,7 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
                 layoutDifferentRootIfNeeded(element);
                 element.layout();
             } else if (layoutSizeChanged)
-                elementsThatDidNotReceiveLayout.add(&element);
+                elementsThatDidNotReceiveLayout.add(element);
 
             if (!childEverHadLayout && element.checkForRepaintDuringLayout())
                 child.repaint();
@@ -114,10 +114,10 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
 
     if (layoutSizeChanged) {
         // If the layout size changed, invalidate all resources of all children that didn't go through the layout() code path.
-        for (auto* element : elementsThatDidNotReceiveLayout)
-            invalidateResourcesOfChildren(*element);
+        for (auto& element : elementsThatDidNotReceiveLayout)
+            invalidateResourcesOfChildren(element);
     } else
-        ASSERT(elementsThatDidNotReceiveLayout.isEmpty());
+        ASSERT(elementsThatDidNotReceiveLayout.isEmptyIgnoringNullReferences());
 }
 
 void SVGContainerLayout::positionChildrenRelativeToContainer()

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -244,7 +244,7 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
 {
     bool layoutSizeChanged = layoutSizeOfNearestViewportChanged(start);
     bool transformChanged = transformToRootChanged(&start);
-    HashSet<RenderElement*> elementsThatDidNotReceiveLayout;
+    WeakHashSet<RenderElement> elementsThatDidNotReceiveLayout;
 
     for (auto& child : childrenOfType<RenderObject>(start)) {
         bool needsLayout = selfNeedsLayout;
@@ -287,19 +287,19 @@ void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout
             if (!childEverHadLayout)
                 child.repaint();
         } else if (layoutSizeChanged && is<RenderElement>(child))
-            elementsThatDidNotReceiveLayout.add(&downcast<RenderElement>(child));
+            elementsThatDidNotReceiveLayout.add(downcast<RenderElement>(child));
 
         ASSERT(!child.needsLayout());
     }
 
     if (!layoutSizeChanged) {
-        ASSERT(elementsThatDidNotReceiveLayout.isEmpty());
+        ASSERT(elementsThatDidNotReceiveLayout.isEmptyIgnoringNullReferences());
         return;
     }
 
     // If the layout size changed, invalidate all resources of all children that didn't go through the layout() code path.
-    for (auto* element : elementsThatDidNotReceiveLayout)
-        invalidateResourcesOfChildren(*element);
+    for (auto& element : elementsThatDidNotReceiveLayout)
+        invalidateResourcesOfChildren(element);
 }
 
 bool SVGRenderSupport::isOverflowHidden(const RenderElement& renderer)

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -55,7 +55,7 @@ Ref<SVGCursorElement> SVGCursorElement::create(const QualifiedName& tagName, Doc
 SVGCursorElement::~SVGCursorElement()
 {
     for (auto& client : m_clients)
-        client->cursorElementRemoved(*this);
+        client.cursorElementRemoved(*this);
 }
 
 void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -76,12 +76,12 @@ void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomStr
 
 void SVGCursorElement::addClient(StyleCursorImage& value)
 {
-    m_clients.add(&value);
+    m_clients.add(value);
 }
 
 void SVGCursorElement::removeClient(StyleCursorImage& value)
 {
-    m_clients.remove(&value);
+    m_clients.remove(value);
 }
 
 void SVGCursorElement::svgAttributeChanged(const QualifiedName& attrName)
@@ -89,7 +89,7 @@ void SVGCursorElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
         for (auto& client : m_clients)
-            client->cursorElementChanged(*this);
+            client.cursorElementChanged(*this);
         return;
     }
 

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -60,7 +60,7 @@ private:
 
     Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
     Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
-    HashSet<StyleCursorImage*> m_clients;
+    WeakHashSet<StyleCursorImage> m_clients;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -152,7 +152,7 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
     if (!renderer())
         return false;
 
-    HashSet<SVGGradientElement*> processedGradients;
+    HashSet<RefPtr<SVGGradientElement>> processedGradients;
     SVGGradientElement* current = this;
 
     setGradientAttributes(*current, attributes);

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -41,17 +41,13 @@
 
 namespace WebCore {
 
-Lock WorkerOrWorkletThread::s_workerOrWorkletThreadsLock;
-
-Lock& WorkerOrWorkletThread::workerOrWorkletThreadsLock()
+ThreadSafeWeakHashSet<WorkerOrWorkletThread>& WorkerOrWorkletThread::workerOrWorkletThreads()
 {
-    return s_workerOrWorkletThreadsLock;
-}
-
-HashSet<WorkerOrWorkletThread*>& WorkerOrWorkletThread::workerOrWorkletThreads()
-{
-    ASSERT(workerOrWorkletThreadsLock().isHeld());
-    static NeverDestroyed<HashSet<WorkerOrWorkletThread*>> workerOrWorkletThreads;
+    static LazyNeverDestroyed<ThreadSafeWeakHashSet<WorkerOrWorkletThread>> workerOrWorkletThreads;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        workerOrWorkletThreads.construct();
+    });
     return workerOrWorkletThreads;
 }
 
@@ -70,15 +66,12 @@ WorkerOrWorkletThread::WorkerOrWorkletThread(const String& inspectorIdentifier, 
     : m_inspectorIdentifier(inspectorIdentifier)
     , m_runLoop(constructRunLoop(workerThreadMode))
 {
-    Locker locker { workerOrWorkletThreadsLock() };
-    workerOrWorkletThreads().add(this);
+    workerOrWorkletThreads().add(*this);
 }
 
 WorkerOrWorkletThread::~WorkerOrWorkletThread()
 {
-    Locker locker { workerOrWorkletThreadsLock() };
-    ASSERT(workerOrWorkletThreads().contains(this));
-    workerOrWorkletThreads().remove(this);
+    workerOrWorkletThreads().remove(*this);
 }
 
 void WorkerOrWorkletThread::dispatch(Function<void()>&& func)
@@ -197,7 +190,7 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
     g_main_context_pop_thread_default(mainContext.get());
 #endif
 
-    if (!m_childThreads.isEmpty()) {
+    if (!m_childThreads.isEmptyIgnoringNullReferences()) {
         m_runWhenLastChildThreadIsGone = [this, protectedThis = WTFMove(protectedThis)]() mutable {
             destroyWorkerGlobalScope(WTFMove(protectedThis));
         };
@@ -208,7 +201,7 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
 
 void WorkerOrWorkletThread::destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&& protectedThis)
 {
-    ASSERT(m_childThreads.isEmpty());
+    ASSERT(m_childThreads.isEmptyIgnoringNullReferences());
 
     RefPtr<Thread> protector = m_thread;
 
@@ -351,9 +344,8 @@ void WorkerOrWorkletThread::resume()
 
 void WorkerOrWorkletThread::releaseFastMallocFreeMemoryInAllThreads()
 {
-    Locker locker { workerOrWorkletThreadsLock() };
-    for (auto* workerOrWorkletThread : workerOrWorkletThreads()) {
-        workerOrWorkletThread->runLoop().postTask([] (ScriptExecutionContext&) {
+    for (auto& workerOrWorkletThread : workerOrWorkletThreads()) {
+        workerOrWorkletThread.runLoop().postTask([] (ScriptExecutionContext&) {
             WTF::releaseFastMallocFreeMemory();
         });
     }
@@ -361,13 +353,13 @@ void WorkerOrWorkletThread::releaseFastMallocFreeMemoryInAllThreads()
 
 void WorkerOrWorkletThread::addChildThread(WorkerOrWorkletThread& childThread)
 {
-    m_childThreads.add(&childThread);
+    m_childThreads.add(childThread);
 }
 
 void WorkerOrWorkletThread::removeChildThread(WorkerOrWorkletThread& childThread)
 {
-    m_childThreads.remove(&childThread);
-    if (m_childThreads.isEmpty() && m_runWhenLastChildThreadIsGone)
+    m_childThreads.remove(childThread);
+    if (m_childThreads.isEmptyIgnoringNullReferences() && m_runWhenLastChildThreadIsGone)
         std::exchange(m_runWhenLastChildThreadIsGone, nullptr)();
 }
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -32,6 +32,8 @@
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WTF {
@@ -43,7 +45,7 @@ namespace WebCore {
 class WorkerDebuggerProxy;
 class WorkerLoaderProxy;
 
-class WorkerOrWorkletThread : public SerialFunctionDispatcher, public ThreadSafeRefCounted<WorkerOrWorkletThread> {
+class WorkerOrWorkletThread : public SerialFunctionDispatcher, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WorkerOrWorkletThread> {
 public:
     virtual ~WorkerOrWorkletThread();
 
@@ -70,8 +72,7 @@ public:
 
     const String& inspectorIdentifier() const { return m_inspectorIdentifier; }
 
-    static HashSet<WorkerOrWorkletThread*>& workerOrWorkletThreads() WTF_REQUIRES_LOCK(workerOrWorkletThreadsLock());
-    static Lock& workerOrWorkletThreadsLock() WTF_RETURNS_LOCK(s_workerOrWorkletThreadsLock);
+    static ThreadSafeWeakHashSet<WorkerOrWorkletThread>& workerOrWorkletThreads();
     static void releaseFastMallocFreeMemoryInAllThreads();
 
     void addChildThread(WorkerOrWorkletThread&);
@@ -91,8 +92,6 @@ private:
     virtual bool shouldWaitForWebInspectorOnStartup() const { return false; }
     void destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&& protectedThis);
 
-    static Lock s_workerOrWorkletThreadsLock;
-
     String m_inspectorIdentifier;
     Lock m_threadCreationAndGlobalScopeLock;
     RefPtr<WorkerOrWorkletGlobalScope> m_globalScope;
@@ -101,7 +100,7 @@ private:
     Function<void(const String&)> m_evaluateCallback;
     Function<void()> m_stoppedCallback;
     BinarySemaphore m_suspensionSemaphore;
-    HashSet<WorkerOrWorkletThread*> m_childThreads;
+    ThreadSafeWeakHashSet<WorkerOrWorkletThread> m_childThreads;
     Function<void()> m_runWhenLastChildThreadIsGone;
     bool m_isSuspended { false };
     bool m_pausedForDebugger { false };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -54,7 +54,7 @@ class ServiceWorkerInspectorProxy;
 struct ServiceWorkerContextData;
 enum class WorkerThreadMode : bool;
 
-class ServiceWorkerThreadProxy final : public ThreadSafeRefCounted<ServiceWorkerThreadProxy>, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
+class ServiceWorkerThreadProxy final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ServiceWorkerThreadProxy, WTF::DestructionThread::Main>, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
 public:
     template<typename... Args> static Ref<ServiceWorkerThreadProxy> create(Args&&... args)
     {


### PR DESCRIPTION
#### 6ec1bbcc639f159ceb4986135267b1b609c4acdb
<pre>
Use WeakHashSet&lt;T&gt; / ThreadSafeWeakHashSet&lt;T&gt; instead of HashSet&lt;T*&gt; more in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=261430">https://bugs.webkit.org/show_bug.cgi?id=261430</a>

Reviewed by Darin Adler.

Use WeakHashSet&lt;T&gt; / ThreadSafeWeakHashSet&lt;T&gt; instead of HashSet&lt;T*&gt; more in WebCore,
for extra safety.

* Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm:
(WebCore::ResourceUsageThread::platformCollectCPUData):
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::ResourceUsageThread::platformCollectCPUData):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::dispatchToAllFontCaches):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::updateReferenceFilterClients):
(WebCore::RenderLayerFilters::removeReferenceFilterClients):
* Source/WebCore/rendering/style/StyleImage.h:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::markAllClientsForInvalidation):
(WebCore::RenderSVGResourceContainer::markAllClientLayersForInvalidation):
(WebCore::RenderSVGResourceContainer::markClientForInvalidation):
(WebCore::RenderSVGResourceContainer::addClient):
(WebCore::RenderSVGResourceContainer::removeClient):
(WebCore::RenderSVGResourceContainer::addClientRenderLayer):
(WebCore::RenderSVGResourceContainer::removeClientRenderLayer):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutChildren):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::layoutChildren):
* Source/WebCore/svg/SVGCursorElement.cpp:
(WebCore::SVGCursorElement::~SVGCursorElement):
(WebCore::SVGCursorElement::addClient):
(WebCore::SVGCursorElement::removeClient):
(WebCore::SVGCursorElement::svgAttributeChanged):
* Source/WebCore/svg/SVGCursorElement.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::workerOrWorkletThreads):
(WebCore::WorkerOrWorkletThread::WorkerOrWorkletThread):
(WebCore::WorkerOrWorkletThread::~WorkerOrWorkletThread):
(WebCore::WorkerOrWorkletThread::workerOrWorkletThread):
(WebCore::WorkerOrWorkletThread::destroyWorkerGlobalScope):
(WebCore::WorkerOrWorkletThread::releaseFastMallocFreeMemoryInAllThreads):
(WebCore::WorkerOrWorkletThread::addChildThread):
(WebCore::WorkerOrWorkletThread::removeChildThread):
(WebCore::WorkerOrWorkletThread::workerOrWorkletThreadsLock): Deleted.
(): Deleted.
* Source/WebCore/workers/WorkerOrWorkletThread.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::allServiceWorkerThreadProxies):
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
(WebCore::ServiceWorkerThreadProxy::~ServiceWorkerThreadProxy):
(WebCore::ServiceWorkerThreadProxy::networkStateChanged):
(): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:

Canonical link: <a href="https://commits.webkit.org/267914@main">https://commits.webkit.org/267914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8979c4eec12952f5bf4cede0af5acf1a1bcd4d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18822 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20679 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22925 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20794 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16225 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4295 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->