### PR TITLE
Add telemetry for rarely used syscalls

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1098,6 +1098,7 @@
 
 (define (syscall-unix-rarely-in-use)
     (syscall-number
+        SYS___pthread_kill
         SYS_fgetxattr
         SYS_getxattr
         SYS_iopolicysys
@@ -1128,11 +1129,6 @@
         SYS_thread_selfusage
         SYS_write))
 
-(define (syscall-unix-rarely-in-use-need-backtrace)
-    (syscall-number
-        SYS___pthread_kill
-        ))
-
 (deny syscall-unix (with telemetry))
 (allow syscall-unix
     (syscall-unix-in-use-after-launch)
@@ -1145,12 +1141,9 @@
 (allow syscall-unix (syscall-unix-only-in-use-during-launch))
 #endif
 
-(allow syscall-unix
+(allow syscall-unix (with report) (with telemetry-backtrace)
     (syscall-unix-rarely-in-use)
     (syscall-unix-rarely-in-use-blocked-in-lockdown-mode))
-
-(allow syscall-unix (with report)
-    (syscall-unix-rarely-in-use-need-backtrace))
 
 (deny syscall-unix (with no-report) (syscall-number
     SYS_connect


### PR DESCRIPTION
#### 6e45e2b4b6490eb49efe0d1543119213e2ca1216
<pre>
Add telemetry for rarely used syscalls
<a href="https://bugs.webkit.org/show_bug.cgi?id=261435">https://bugs.webkit.org/show_bug.cgi?id=261435</a>
rdar://115315995

Reviewed by Brent Fulgham.

Add telemetry for rarely used syscalls in the WebContent process sandbox.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/267919@main">https://commits.webkit.org/267919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82cb9aa76fd6be3df04dd62e44e69eee2c5e3119

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16803 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18803 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20657 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15657 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22902 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20769 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14495 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16205 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4299 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->