### PR TITLE
[JSC] Get rid of CodeBlock dependency from DataIC

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -1290,6 +1290,17 @@ public:
         storePair32(src1, src2, Address(armAddress.base, armAddress.u.offset));
     }
 
+    void transfer32(Address src, Address dest)
+    {
+        load32(src, dataTempRegister);
+        store32(dataTempRegister, dest);
+    }
+
+    void transferPtr(Address src, Address dest)
+    {
+        transfer32(src, dest);
+    }
+
     void storeCond8(RegisterID src, Address addr, RegisterID result)
     {
         ASSERT(!addr.offset);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
@@ -1740,6 +1740,17 @@ public:
         storePair32(src1, src2, addrTempRegister);
     }
 
+    void transfer32(Address src, Address dest)
+    {
+        load32(src, dataTempRegister);
+        store32(dataTempRegister, dest);
+    }
+
+    void transferPtr(Address src, Address dest)
+    {
+        transfer32(src, dest);
+    }
+
     // Floating-point operations:
 
     static bool supportsFloatingPoint()

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -1230,6 +1230,13 @@ public:
         m_assembler.sdInsn(temp.memory(), immRegister, Imm::S<0>());
     }
 
+    void transfer32(Address src, Address dest)
+    {
+        auto temp = temps<Data>();
+        load32(src, temp.data());
+        store32(temp.data(), dest);
+    }
+
     void transfer64(Address src, Address dest)
     {
         auto temp = temps<Data>();

--- a/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
@@ -53,10 +53,6 @@ public:
         // We spill (1) the used registers by IC and (2) the used registers by Snippet.
         InlineCacheCompiler::SpillState spillState = compiler.preserveLiveRegistersToStackForCall(usedRegistersBySnippet.buildAndValidate());
 
-        jit.store32(
-            CCallHelpers::TrustedImm32(compiler.callSiteIndexForExceptionHandlingOrOriginal().bits()),
-            CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
-
         jit.makeSpaceOnStackForCCall();
 
         jit.setupArguments<FunctionType>(std::get<ArgumentsIndex>(m_arguments)...);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -760,7 +760,7 @@ void CodeBlock::setupWithUnlinkedBaselineCode(Ref<BaselineJITCode> jitCode)
     {
         ConcurrentJSLocker locker(m_lock);
         ASSERT(!m_jitData);
-        auto baselineJITData = BaselineJITData::create(jitCode->m_constantPool.size(), m_globalObject.get());
+        auto baselineJITData = BaselineJITData::create(jitCode->m_constantPool.size(), this);
         baselineJITData->m_stubInfos = FixedVector<StructureStubInfo>(jitCode->m_unlinkedStubInfos.size());
         for (auto& unlinkedCallLinkInfo : jitCode->m_unlinkedCalls) {
             CallLinkInfo* callLinkInfo = getCallLinkInfoForBytecodeIndex(locker, unlinkedCallLinkInfo.bytecodeIndex);

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -234,7 +234,6 @@ public:
 
     const ScalarRegisterSet& liveRegistersForCall();
 
-    CallSiteIndex callSiteIndexForExceptionHandlingOrOriginal();
     DisposableCallSiteIndex callSiteIndexForExceptionHandling();
 
     const HandlerInfo& originalExceptionHandler();
@@ -286,6 +285,7 @@ public:
     AccessGenerationResult regenerate(const GCSafeConcurrentJSLocker&, PolymorphicAccess&, CodeBlock*);
 
 private:
+    CallSiteIndex callSiteIndexForExceptionHandlingOrOriginal();
     const ScalarRegisterSet& liveRegistersToPreserveAtExceptionHandlingCallSite();
 
     void emitDOMJITGetter(GetterSetterAccessCase&, const DOMJIT::GetterSetter*, GPRReg baseForGetGPR);

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -362,6 +362,7 @@ public:
     static ptrdiff_t offsetOfSlowPathStartLocation() { return OBJECT_OFFSETOF(StructureStubInfo, slowPathStartLocation); }
     static ptrdiff_t offsetOfSlowOperation() { return OBJECT_OFFSETOF(StructureStubInfo, m_slowOperation); }
     static ptrdiff_t offsetOfCountdown() { return OBJECT_OFFSETOF(StructureStubInfo, countdown); }
+    static ptrdiff_t offsetOfCallSiteIndex() { return OBJECT_OFFSETOF(StructureStubInfo, callSiteIndex); }
 
     GPRReg thisGPR() const { return m_extraGPR; }
     GPRReg prototypeGPR() const { return m_extraGPR; }

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -86,6 +86,13 @@ static bool attemptToWatch(CodeBlock* codeBlock, WatchpointSet& set, CodeBlockJe
 
 bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode)
 {
+    // We share the same layout for particular fields in all JITData to make our data IC assume this.
+    ASSERT(BaselineJITData::offsetOfGlobalObject() == JITData::offsetOfGlobalObject());
+    ASSERT(BaselineJITData::offsetOfStackOffset() == JITData::offsetOfStackOffset());
+
+    m_globalObject = codeBlock->globalObject();
+    m_stackOffset = codeBlock->stackPointerOffset() * sizeof(Register);
+
     unsigned indexOfWatchpoints = 0;
     bool success = true;
     for (unsigned i = 0; i < jitCode.m_linkerIR.size(); ++i) {
@@ -112,69 +119,58 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
             break;
         }
         case LinkerIR::Type::HavingABadTimeWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->havingABadTimeWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->havingABadTimeWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::MasqueradesAsUndefinedWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->masqueradesAsUndefinedWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->masqueradesAsUndefinedWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::ArrayIteratorProtocolWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->arrayIteratorProtocolWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->arrayIteratorProtocolWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::NumberToStringWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->numberToStringWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->numberToStringWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::StructureCacheClearedWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->structureCacheClearedWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->structureCacheClearedWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::StringSymbolReplaceWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->stringSymbolReplaceWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->stringSymbolReplaceWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::RegExpPrimordialPropertiesWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->regExpPrimordialPropertiesWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->regExpPrimordialPropertiesWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::ArraySpeciesWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->arraySpeciesWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->arraySpeciesWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::ArrayPrototypeChainIsSaneWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->arrayPrototypeChainIsSaneWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->arrayPrototypeChainIsSaneWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::StringPrototypeChainIsSaneWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->stringPrototypeChainIsSaneWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->stringPrototypeChainIsSaneWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::ObjectPrototypeChainIsSaneWatchpointSet: {
-            auto* globalObject = codeBlock->globalObject();
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
-            success &= attemptToWatch(codeBlock, globalObject->objectPrototypeChainIsSaneWatchpointSet(), watchpoint);
+            success &= attemptToWatch(codeBlock, m_globalObject->objectPrototypeChainIsSaneWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::Invalid:
@@ -199,6 +195,11 @@ JITCode::~JITCode()
 }
 
 CommonData* JITCode::dfgCommon()
+{
+    return &common;
+}
+
+const CommonData* JITCode::dfgCommon() const
 {
     return &common;
 }

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -186,11 +186,16 @@ public:
     FixedVector<StructureStubInfo>& stubInfos() { return m_stubInfos; }
     FixedVector<OptimizingCallLinkInfo>& callLinkInfos() { return m_callLinkInfos; }
 
+    static ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(JITData, m_globalObject); }
+    static ptrdiff_t offsetOfStackOffset() { return OBJECT_OFFSETOF(JITData, m_stackOffset); }
+
 private:
     explicit JITData(const JITCode&, ExitVector&&);
 
     bool tryInitialize(VM&, CodeBlock*, const JITCode&);
 
+    JSGlobalObject* m_globalObject { nullptr }; // This is not marked since owner CodeBlock will mark JSGlobalObject.
+    intptr_t m_stackOffset { 0 };
     FixedVector<StructureStubInfo> m_stubInfos;
     FixedVector<OptimizingCallLinkInfo> m_callLinkInfos;
     FixedVector<CodeBlockJettisoningWatchpoint> m_watchpoints;
@@ -204,6 +209,7 @@ public:
     ~JITCode() final;
     
     CommonData* dfgCommon() final;
+    const CommonData* dfgCommon() const final;
     JITCode* dfg() final;
     bool isUnlinked() const { return common.isUnlinked(); }
     

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -360,7 +360,7 @@ public:
         Address unlinkedAddress()
         {
             ASSERT(isUnlinked());
-            return Address(GPRInfo::constantsRegister, JITData::offsetOfData() + sizeof(void*) * m_index);
+            return Address(GPRInfo::jitDataRegister, JITData::offsetOfData() + sizeof(void*) * m_index);
         }
 #endif
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -547,7 +547,7 @@ void SpeculativeJIT::compileInvalidationPoint(Node* node)
 
 #if USE(JSVALUE64)
     if (m_graph.m_plan.isUnlinked()) {
-        auto exitJump = branchTest8(NonZero, Address(GPRInfo::constantsRegister, JITData::offsetOfIsInvalidated()));
+        auto exitJump = branchTest8(NonZero, Address(GPRInfo::jitDataRegister, JITData::offsetOfIsInvalidated()));
         speculationCheck(UncountableInvalidation, JSValueRegs(), nullptr, exitJump);
         noResult(node);
         return;
@@ -2482,8 +2482,8 @@ void SpeculativeJIT::compileCurrentBlock()
         emitMaterializeTagCheckRegisters();
 #if USE(JSVALUE64)
         if (m_graph.m_plan.isUnlinked()) {
-            emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, GPRInfo::constantsRegister);
-            loadPtr(Address(GPRInfo::constantsRegister, CodeBlock::offsetOfJITData()), GPRInfo::constantsRegister);
+            emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, GPRInfo::jitDataRegister);
+            loadPtr(Address(GPRInfo::jitDataRegister, CodeBlock::offsetOfJITData()), GPRInfo::jitDataRegister);
         }
 #endif
     }

--- a/Source/JavaScriptCore/dfg/DFGThunks.cpp
+++ b/Source/JavaScriptCore/dfg/DFGThunks.cpp
@@ -168,8 +168,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> osrEntryThunkGenerator(VM& vm)
     jit.restoreCalleeSavesFromEntryFrameCalleeSavesBuffer(vm.topEntryFrame);
     jit.emitMaterializeTagCheckRegisters();
 #if USE(JSVALUE64)
-    jit.emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, GPRInfo::constantsRegister);
-    jit.loadPtr(CCallHelpers::Address(GPRInfo::constantsRegister, CodeBlock::offsetOfJITData()), GPRInfo::constantsRegister);
+    jit.emitGetFromCallFrameHeaderPtr(CallFrameSlot::codeBlock, GPRInfo::jitDataRegister);
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, CodeBlock::offsetOfJITData()), GPRInfo::jitDataRegister);
 #endif
 
     jit.farJump(GPRInfo::regT1, GPRInfo::callFrameRegister);

--- a/Source/JavaScriptCore/ftl/FTLJITCode.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.cpp
@@ -136,6 +136,11 @@ DFG::CommonData* JITCode::dfgCommon()
     return &common;
 }
 
+const DFG::CommonData* JITCode::dfgCommon() const
+{
+    return &common;
+}
+
 void JITCode::shrinkToFit(const ConcurrentJSLocker&)
 {
     common.shrinkToFit();

--- a/Source/JavaScriptCore/ftl/FTLJITCode.h
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.h
@@ -66,6 +66,7 @@ public:
     
     JITCode* ftl() override;
     DFG::CommonData* dfgCommon() override;
+    const DFG::CommonData* dfgCommon() const override;
     static ptrdiff_t commonDataOffset() { return OBJECT_OFFSETOF(JITCode, common); }
     void shrinkToFit(const ConcurrentJSLocker&) override;
 

--- a/Source/JavaScriptCore/jit/BaselineJITCode.cpp
+++ b/Source/JavaScriptCore/jit/BaselineJITCode.cpp
@@ -57,6 +57,15 @@ BaselineJITCode::~BaselineJITCode()
 {
 }
 
+BaselineJITData::BaselineJITData(unsigned size, CodeBlock* codeBlock)
+    : Base(size)
+    , m_globalObject(codeBlock->globalObject())
+    , m_stackOffset(codeBlock->stackPointerOffset() * sizeof(Register))
+{
+}
+
+
+
 } // namespace JSC
 
 #endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/BaselineJITCode.h
+++ b/Source/JavaScriptCore/jit/BaselineJITCode.h
@@ -108,20 +108,18 @@ class BaselineJITData final : public TrailingArray<BaselineJITData, void*> {
 public:
     using Base = TrailingArray<BaselineJITData, void*>;
 
-    static std::unique_ptr<BaselineJITData> create(unsigned poolSize, JSGlobalObject* globalObject)
+    static std::unique_ptr<BaselineJITData> create(unsigned poolSize, CodeBlock* codeBlock)
     {
-        return std::unique_ptr<BaselineJITData> { new (NotNull, fastMalloc(Base::allocationSize(poolSize))) BaselineJITData(poolSize, globalObject) };
+        return std::unique_ptr<BaselineJITData> { new (NotNull, fastMalloc(Base::allocationSize(poolSize))) BaselineJITData(poolSize, codeBlock) };
     }
 
-    explicit BaselineJITData(unsigned size, JSGlobalObject* globalObject)
-        : Base(size)
-        , m_globalObject(globalObject)
-    {
-    }
+    explicit BaselineJITData(unsigned size, CodeBlock*);
 
     static ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(BaselineJITData, m_globalObject); }
+    static ptrdiff_t offsetOfStackOffset() { return OBJECT_OFFSETOF(BaselineJITData, m_stackOffset); }
 
     JSGlobalObject* m_globalObject { nullptr }; // This is not marked since owner CodeBlock will mark JSGlobalObject.
+    intptr_t m_stackOffset { 0 };
     FixedVector<StructureStubInfo> m_stubInfos;
 };
 

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -420,7 +420,7 @@ public:
     static constexpr GPRReg callFrameRegister = X86Registers::ebp;
     static constexpr GPRReg numberTagRegister = X86Registers::r14;
     static constexpr GPRReg notCellMaskRegister = X86Registers::r15;
-    static constexpr GPRReg constantsRegister = X86Registers::r13;
+    static constexpr GPRReg jitDataRegister = X86Registers::r13;
     static constexpr GPRReg metadataTableRegister = X86Registers::r12;
 
     // Temporary registers.
@@ -445,14 +445,14 @@ public:
 
 #if !OS(WINDOWS)
     static constexpr GPRReg regCS1 = X86Registers::r12; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS2 = X86Registers::r13; // constantsRegister
+    static constexpr GPRReg regCS2 = X86Registers::r13; // jitDataRegister
     static constexpr GPRReg regCS3 = X86Registers::r14; // numberTagRegister
     static constexpr GPRReg regCS4 = X86Registers::r15; // notCellMaskRegister
 #else
     static constexpr GPRReg regCS1 = X86Registers::esi;
     static constexpr GPRReg regCS2 = X86Registers::edi;
     static constexpr GPRReg regCS3 = X86Registers::r12; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS4 = X86Registers::r13; // constantsRegister
+    static constexpr GPRReg regCS4 = X86Registers::r13; // jitDataRegister
     static constexpr GPRReg regCS5 = X86Registers::r14; // numberTagRegister
     static constexpr GPRReg regCS6 = X86Registers::r15; // notCellMaskRegister
 #endif
@@ -570,11 +570,11 @@ public:
     static constexpr GPRReg regT6 = ARMRegisters::r8;
     static constexpr GPRReg regT7 = ARMRegisters::r9;
     static constexpr GPRReg regCS0 = ARMRegisters::r10; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS1 = ARMRegisters::r11; // constantsRegister
+    static constexpr GPRReg regCS1 = ARMRegisters::r11; // jitDataRegister
 
     // These registers match the baseline JIT.
     static constexpr GPRReg callFrameRegister = ARMRegisters::fp;
-    static constexpr GPRReg constantsRegister = regCS1;
+    static constexpr GPRReg jitDataRegister = regCS1;
     static constexpr GPRReg metadataTableRegister = regCS0;
 
     // These constants provide the names for the general purpose argument & return value registers.
@@ -645,7 +645,7 @@ public:
     static constexpr GPRReg callFrameRegister = ARM64Registers::fp;
     static constexpr GPRReg numberTagRegister = ARM64Registers::x27;
     static constexpr GPRReg notCellMaskRegister = ARM64Registers::x28;
-    static constexpr GPRReg constantsRegister = ARM64Registers::x26;
+    static constexpr GPRReg jitDataRegister = ARM64Registers::x26;
     static constexpr GPRReg metadataTableRegister = ARM64Registers::x25;
     static constexpr GPRReg dataTempRegister = MacroAssembler::dataTempRegister;
     static constexpr GPRReg memoryTempRegister = MacroAssembler::memoryTempRegister;
@@ -785,11 +785,11 @@ public:
     static constexpr GPRReg regT10 = MIPSRegisters::a3;
 
     static constexpr GPRReg regCS0 = MIPSRegisters::s0; // metadataTable in LLInt/Baseline
-    static constexpr GPRReg regCS1 = MIPSRegisters::s1; // constantsRegister
+    static constexpr GPRReg regCS1 = MIPSRegisters::s1; // jitDataRegister
 
     // These registers match the baseline JIT.
     static constexpr GPRReg callFrameRegister = MIPSRegisters::fp;
-    static constexpr GPRReg constantsRegister = regCS1;
+    static constexpr GPRReg jitDataRegister = regCS1;
     static constexpr GPRReg metadataTableRegister = regCS0;
 
     // These constants provide the names for the general purpose argument & return value registers.
@@ -854,7 +854,7 @@ public:
     static constexpr GPRReg callFrameRegister = RISCV64Registers::fp;
     static constexpr GPRReg numberTagRegister = RISCV64Registers::x25;
     static constexpr GPRReg notCellMaskRegister = RISCV64Registers::x26;
-    static constexpr GPRReg constantsRegister = RISCV64Registers::x24;
+    static constexpr GPRReg jitDataRegister = RISCV64Registers::x24;
     static constexpr GPRReg metadataTableRegister = RISCV64Registers::x23;
 
     static constexpr GPRReg regT0 = RISCV64Registers::x10;

--- a/Source/JavaScriptCore/jit/JITCode.cpp
+++ b/Source/JavaScriptCore/jit/JITCode.cpp
@@ -101,6 +101,12 @@ DFG::CommonData* JITCode::dfgCommon()
     return nullptr;
 }
 
+const DFG::CommonData* JITCode::dfgCommon() const
+{
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
 DFG::JITCode* JITCode::dfg()
 {
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/jit/JITCode.h
+++ b/Source/JavaScriptCore/jit/JITCode.h
@@ -199,6 +199,7 @@ public:
     virtual unsigned offsetOf(void* pointerIntoCode) = 0;
     
     virtual DFG::CommonData* dfgCommon();
+    virtual const DFG::CommonData* dfgCommon() const;
     virtual DFG::JITCode* dfg();
     virtual FTL::JITCode* ftl();
     virtual FTL::ForOSREntryJITCode* ftlForOSREntry();

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -235,7 +235,7 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
 #elif CPU(X86_64)
 #if !OS(WINDOWS)
     result.add(GPRInfo::regCS1, IgnoreVectors);
-    static_assert(GPRInfo::regCS2 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS2 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS3 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS4 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS2, IgnoreVectors);
@@ -243,7 +243,7 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
     result.add(GPRInfo::regCS4, IgnoreVectors);
 #else
     result.add(GPRInfo::regCS3, IgnoreVectors);
-    static_assert(GPRInfo::regCS4 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS4 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS5 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS6 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS4, IgnoreVectors);
@@ -255,7 +255,7 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
     result.add(GPRInfo::regCS1, IgnoreVectors);
 #elif CPU(ARM64) || CPU(RISCV64)
     result.add(GPRInfo::regCS6, IgnoreVectors);
-    static_assert(GPRInfo::regCS7 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS7 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS8 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS9 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS7, IgnoreVectors);
@@ -275,7 +275,7 @@ RegisterSet RegisterSetBuilder::dfgCalleeSaveRegisters()
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);
 #if !OS(WINDOWS)
-    static_assert(GPRInfo::regCS2 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS2 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS3 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS4 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS2, IgnoreVectors);
@@ -284,7 +284,7 @@ RegisterSet RegisterSetBuilder::dfgCalleeSaveRegisters()
 #else
     result.add(GPRInfo::regCS2, IgnoreVectors);
     result.add(GPRInfo::regCS3, IgnoreVectors);
-    static_assert(GPRInfo::regCS4 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS4 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS5 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS6 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS4, IgnoreVectors);
@@ -295,7 +295,7 @@ RegisterSet RegisterSetBuilder::dfgCalleeSaveRegisters()
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);
 #elif CPU(ARM64) || CPU(RISCV64)
-    static_assert(GPRInfo::regCS7 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS7 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS8 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS9 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS7, IgnoreVectors);
@@ -314,7 +314,7 @@ RegisterSet RegisterSetBuilder::ftlCalleeSaveRegisters()
 #if CPU(X86_64) && !OS(WINDOWS)
     result.add(GPRInfo::regCS0, IgnoreVectors);
     result.add(GPRInfo::regCS1, IgnoreVectors);
-    static_assert(GPRInfo::regCS2 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS2 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS3 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS4 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS2, IgnoreVectors);
@@ -329,7 +329,7 @@ RegisterSet RegisterSetBuilder::ftlCalleeSaveRegisters()
     result.add(GPRInfo::regCS4, IgnoreVectors);
     result.add(GPRInfo::regCS5, IgnoreVectors);
     result.add(GPRInfo::regCS6, IgnoreVectors);
-    static_assert(GPRInfo::regCS7 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS7 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS8 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS9 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS7, IgnoreVectors);
@@ -351,7 +351,7 @@ RegisterSet RegisterSetBuilder::ftlCalleeSaveRegisters()
     result.add(GPRInfo::regCS4, IgnoreVectors);
     result.add(GPRInfo::regCS5, IgnoreVectors);
     result.add(GPRInfo::regCS6, IgnoreVectors);
-    static_assert(GPRInfo::regCS7 == GPRInfo::constantsRegister);
+    static_assert(GPRInfo::regCS7 == GPRInfo::jitDataRegister);
     static_assert(GPRInfo::regCS8 == GPRInfo::numberTagRegister);
     static_assert(GPRInfo::regCS9 == GPRInfo::notCellMaskRegister);
     result.add(GPRInfo::regCS7, IgnoreVectors);

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -392,7 +392,7 @@ ALWAYS_INLINE void* getWide32CodePtr(OpcodeID id)
 #if ENABLE(JIT)
 struct Registers {
     static constexpr GPRReg pcGPR = GPRInfo::regT4;
-    static constexpr GPRReg pbGPR = GPRInfo::constantsRegister;
+    static constexpr GPRReg pbGPR = GPRInfo::jitDataRegister;
     static constexpr GPRReg metadataTableGPR = GPRInfo::metadataTableRegister;
 };
 #endif

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -688,6 +688,7 @@ void Options::notifyOptionsChanged()
     Options::useWebAssemblySIMD() = false;
     Options::useBBQJIT() = false;
 #endif
+    Options::useDataICInFTL() = false; // Currently, it is not completed. Disable forcefully.
 
     if (!Options::allowDoubleShape())
         Options::useJIT() = false; // We don't support JIT with !allowDoubleShape. So disable it.


### PR DESCRIPTION
#### 58fbd8418cf40ae43400f9b19fc5edbe772a8c03
<pre>
[JSC] Get rid of CodeBlock dependency from DataIC
<a href="https://bugs.webkit.org/show_bug.cgi?id=261440">https://bugs.webkit.org/show_bug.cgi?id=261440</a>
rdar://115317826

Reviewed by Keith Miller.

Towards handler IC, we would like to make IC code independent from attached CodeBlock since the code
will be shared by multiple CodeBlocks&apos; IC sites. Right now, we have two places. This patch gets rid
of these dependencies.

1. Before calling a function, we need to store CallSiteIndex to the stack. And this is tied the CodeBlock.
   In this patch, we get this from StructureStubInfo data structure, materialized per IC site. And it is
   already storing this information. So, code itself gets independent from CallSiteIndex.
2. After calling JS function, we need to adjust stack pointer since it gets changed due to tail calls etc.
   Previously we got stack height from the CodeBlock and adjusted it with callFrameRegister. However this
   is tied to CodeBlock. In this patch, we made JITData always having this stack height information so that
   we can load this from JITData. JITData is always stored in a particular callee-save register and it exists
   in Baseline and DFG. So we can easily get this per-CodeBlock information from JITData. We disable DataIC
   in FTL (this is only for testing. No production is using DataIC in FTL) for now since FTL does not have
   JITData right now. We should make it enabled after we fully convert our IC to the new form.

* Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::setupWithUnlinkedBaselineCode):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::emitDOMJITGetter):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
(JSC::StructureStubInfo::offsetOfCallSiteIndex):
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::tryInitialize):
(JSC::DFG::JITCode::dfgCommon const):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/ftl/FTLJITCode.cpp:
(JSC::FTL::JITCode::dfgCommon const):
* Source/JavaScriptCore/ftl/FTLJITCode.h:
* Source/JavaScriptCore/jit/BaselineJITCode.cpp:
(JSC::BaselineJITData::BaselineJITData):
* Source/JavaScriptCore/jit/BaselineJITCode.h:
* Source/JavaScriptCore/jit/JITCode.cpp:
(JSC::JITCode::dfgCommon const):
* Source/JavaScriptCore/jit/JITCode.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):

Canonical link: <a href="https://commits.webkit.org/267915@main">https://commits.webkit.org/267915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fb4427b523662d8daf22f39f6c4756787cefa4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19880 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15705 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16458 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22986 "layout-tests (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15639 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20856 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17334 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17195 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21394 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5243 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22629 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2214 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17044 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5090 "Passed tests") | 
<!--EWS-Status-Bubble-End-->