### PR TITLE
Bake in DYLD_FRAMEWORK_PATH to MiniBrowser's Info.plist at build time

### DIFF
--- a/Tools/MiniBrowser/mac/Info.plist
+++ b/Tools/MiniBrowser/mac/Info.plist
@@ -56,6 +56,13 @@
 	<string>Recording video on behalf of websites</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Recording audio on behalf of websites</string>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>__XPC_DYLD_FRAMEWORK_PATH</key>
+		<string>${BUILT_PRODUCTS_DIR}</string>
+		<key>DYLD_FRAMEWORK_PATH</key>
+		<string>${BUILT_PRODUCTS_DIR}</string>
+	</dict>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Recognizing captured audio on behalf of websites</string>
 </dict>


### PR DESCRIPTION
#### 81b4e3d53c4d29334955a668721571718112da6b
<pre>
Bake in DYLD_FRAMEWORK_PATH to MiniBrowser&apos;s Info.plist at build time
<a href="https://bugs.webkit.org/show_bug.cgi?id=261446">https://bugs.webkit.org/show_bug.cgi?id=261446</a>
rdar://115322226

Reviewed by Elliott Williams and Megan Gardner.

This will allow MiniBrowser to better behave with LaunchServices (e.g. opening from Finder).

* Tools/MiniBrowser/mac/Info.plist:

Canonical link: <a href="https://commits.webkit.org/267909@main">https://commits.webkit.org/267909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33c3cf534aae7954156f00d6139eadaa82d43f94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18814 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20674 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22918 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20787 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14508 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16221 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4292 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->