### PR TITLE
Avoid branching in CSSParserToken's value() & initValueFromStringView()

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -67,6 +67,7 @@ public:
     StringView(const LChar*, unsigned length);
     StringView(const UChar*, unsigned length);
     StringView(const char*, unsigned length);
+    StringView(const void*, unsigned length, bool is8bit);
     StringView(ASCIILiteral);
     ALWAYS_INLINE StringView(std::span<const LChar> characters) : StringView(characters.data(), characters.size()) { }
     ALWAYS_INLINE StringView(std::span<const UChar> characters) : StringView(characters.data(), characters.size()) { }
@@ -94,6 +95,7 @@ public:
     bool is8Bit() const;
     const LChar* characters8() const;
     const UChar* characters16() const;
+    const void* rawCharacters() const { return m_characters; }
     std::span<const LChar> span8() const { return { characters8(), length() }; }
     std::span<const UChar> span16() const { return { characters16(), length() }; }
 
@@ -392,6 +394,13 @@ inline StringView::StringView(const char* characters)
 inline StringView::StringView(const char* characters, unsigned length)
 {
     initialize(reinterpret_cast<const LChar*>(characters), length);
+}
+
+inline StringView::StringView(const void* characters, unsigned length, bool is8bit)
+    : m_characters(characters)
+    , m_length(length)
+    , m_is8Bit(is8bit)
+{
 }
 
 inline StringView::StringView(ASCIILiteral string)

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -117,12 +117,7 @@ public:
     void convertToPercentage();
 
     CSSParserTokenType type() const { return static_cast<CSSParserTokenType>(m_type); }
-    StringView value() const
-    {
-        if (m_valueIs8Bit)
-            return StringView(static_cast<const LChar*>(m_valueDataCharRaw), m_valueLength);
-        return StringView(static_cast<const UChar*>(m_valueDataCharRaw), m_valueLength);
-    }
+    StringView value() const { return { m_valueDataCharRaw, m_valueLength, m_valueIs8Bit }; }
 
     UChar delimiter() const;
     NumericSign numericSign() const;
@@ -152,7 +147,7 @@ private:
     {
         m_valueLength = string.length();
         m_valueIs8Bit = string.is8Bit();
-        m_valueDataCharRaw = m_valueIs8Bit ? static_cast<const void*>(string.characters8()) : static_cast<const void*>(string.characters16());
+        m_valueDataCharRaw = string.rawCharacters();
     }
     unsigned m_type : 6; // CSSParserTokenType
     unsigned m_blockType : 2; // BlockType


### PR DESCRIPTION
#### dd81c72345be6c482cb26c05682d0fc6c1ab135b
<pre>
Avoid branching in CSSParserToken&apos;s value() &amp; initValueFromStringView()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261451">https://bugs.webkit.org/show_bug.cgi?id=261451</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
(WTF::StringView::rawCharacters):
* Source/WebCore/css/parser/CSSParserToken.h:
(WebCore::CSSParserToken::value const):
(WebCore::CSSParserToken::initValueFromStringView):

Canonical link: <a href="https://commits.webkit.org/267911@main">https://commits.webkit.org/267911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f01c6b7e6a86088a13c0af0751264716401a9b74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18464 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20683 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22933 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20801 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17254 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14516 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21327 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16228 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4293 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20588 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22560 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16977 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5082 "Passed tests") | 
<!--EWS-Status-Bubble-End-->