### PR TITLE
[ macOS Debug ] ASSERTION FAILED: m_wrapper and text failures on storage/indexeddb/cursor-update.html

### DIFF
--- a/LayoutTests/storage/indexeddb/cursor-request-cycle-expected.txt
+++ b/LayoutTests/storage/indexeddb/cursor-request-cycle-expected.txt
@@ -32,9 +32,10 @@ gc()
 PASS isAnyCollected(cursorObservers) is false
 PASS isAnyCollected(cursorRequestObservers) is false
 finalRequest = store.get(0)
+Check result after transaction commits automatically after finishing requests.
 
-finalRequestSuccess():
-Ensure requests and cursors are released.
+onTransactionComplete():
+Ensure requests and cursors are released after transaction commits.
 PASS cursors is non-null.
 PASS cursors.length is 1000
 cursors = null

--- a/LayoutTests/storage/indexeddb/cursor-request-cycle-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/cursor-request-cycle-private-expected.txt
@@ -32,9 +32,10 @@ gc()
 PASS isAnyCollected(cursorObservers) is false
 PASS isAnyCollected(cursorRequestObservers) is false
 finalRequest = store.get(0)
+Check result after transaction commits automatically after finishing requests.
 
-finalRequestSuccess():
-Ensure requests and cursors are released.
+onTransactionComplete():
+Ensure requests and cursors are released after transaction commits.
 PASS cursors is non-null.
 PASS cursors.length is 1000
 cursors = null

--- a/LayoutTests/storage/indexeddb/resources/cursor-request-cycle.js
+++ b/LayoutTests/storage/indexeddb/resources/cursor-request-cycle.js
@@ -104,17 +104,24 @@ function onOpen(evt)
 
         evalAndLog("finalRequest = store.get(0)");
         finalRequest.onsuccess = function finalRequestSuccess(evt) {
-            preamble(evt);
-            debug("Ensure requests and cursors are released.");
-            shouldBeNonNull("cursors");
-            shouldBe("cursors.length", "1000");
-            evalAndLog("cursors = null");
-            evalAndLog("gc()");
-
-            shouldBeTrue("isAnyCollected(cursorObservers)");
-            shouldBeTrue("isAnyCollected(cursorRequestObservers)");
+            debug("Check result after transaction commits automatically after finishing requests.");
         };
     };
 
-    tx.oncomplete = finishJSTest;
+    tx.oncomplete = onTransactionComplete;
+}
+
+function onTransactionComplete(evt)
+{
+    preamble(evt);
+    debug("Ensure requests and cursors are released after transaction commits.");
+
+    shouldBeNonNull("cursors");
+    shouldBe("cursors.length", "1000");
+    evalAndLog("cursors = null");
+    evalAndLog("gc()");
+    shouldBeTrue("isAnyCollected(cursorObservers)");
+    shouldBeTrue("isAnyCollected(cursorRequestObservers)");
+
+    finishJSTest();
 }

--- a/LayoutTests/storage/indexeddb/resources/value-cursor-cycle.js
+++ b/LayoutTests/storage/indexeddb/resources/value-cursor-cycle.js
@@ -39,6 +39,9 @@ function onOpen(evt)
 
         cursorObservation = internals.observeGC(cursor);
         valueObservation = internals.observeGC(value);
+    };
+
+    tx.oncomplete = () => {
         evalAndLog("cursor = null");
         evalAndLog("cursorRequest = null");
         evalAndLog("gc()");
@@ -48,7 +51,6 @@ function onOpen(evt)
         evalAndLog("gc()");
         shouldBeTrue("cursorObservation.wasCollected");
         shouldBeTrue("valueObservation.wasCollected");
+        finishJSTest();
     }
-
-    tx.oncomplete = finishJSTest;
 }

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -126,6 +126,7 @@ public:
 
     void setTransactionOperationID(uint64_t transactionOperationID) { m_currentTransactionOperationID = transactionOperationID; }
     bool willAbortTransactionAfterDispatchingEvent() const;
+    void transactionTransitionedToFinishing();
 
 protected:
     IDBRequest(ScriptExecutionContext&, IDBClient::IDBConnectionProxy&, IndexedDB::RequestType);
@@ -156,6 +157,7 @@ private:
 
     virtual void cancelForStop();
 
+    // EventTarget
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void uncaughtExceptionInEventHandler() final;
@@ -196,7 +198,8 @@ private:
     IndexedDB::IndexRecordType m_requestedIndexRecordType { IndexedDB::IndexRecordType::Key };
 
     bool m_shouldExposeTransactionToDOM { true };
-    bool m_hasPendingActivity { true };
+    enum class PendingActivityType : uint8_t { EndingEvent, CursorIteration, None };
+    PendingActivityType m_pendingActivity { PendingActivityType::EndingEvent };
     bool m_hasUncaughtException { false };
     RefPtr<Event> m_eventBeingDispatched;
 };

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -236,6 +236,7 @@ private:
     void completeCursorRequest(IDBRequest&, const IDBResultData&);
 
     void trySchedulePendingOperationTimer();
+    void addCursorRequest(IDBRequest&);
 
     Ref<IDBDatabase> m_database;
     IDBTransactionInfo m_info;
@@ -247,6 +248,7 @@ private:
     RefPtr<DOMException> m_domError;
 
     RefPtr<IDBOpenDBRequest> m_openDBRequest;
+    WeakHashSet<IDBRequest, WeakPtrImplWithEventTargetData> m_cursorRequests;
 
     Deque<RefPtr<IDBClient::TransactionOperation>> m_pendingTransactionOperationQueue;
     Deque<IDBClient::TransactionOperation*> m_transactionOperationsInProgressQueue;


### PR DESCRIPTION
#### cf4b2dd3b585e77561edbc98f822a7dcbef399c9
<pre>
[ macOS Debug ] ASSERTION FAILED: m_wrapper and text failures on storage/indexeddb/cursor-update.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=259539">https://bugs.webkit.org/show_bug.cgi?id=259539</a>
rdar://112943647

Reviewed by Chris Dumez.

IDBRequest generated from creating a IDBCursor will be re-used when the created cursor advances, i.e. the request&apos;s done
flag will become false again, and the request will receive event and result about the advancing operation. Therefore, we
need to keep wrapper of IDBRequest alive when the cursor can still advance, i.e. when transaction is still active and
cursor has not reached to end. We used to keep it alive only when the operation has already started, and IDBRequest and
its the wrapper go away before `IDBCursor.continue()` is called (as IDBCursor currently only holds weak reference to
IDBRequest).

* LayoutTests/storage/indexeddb/cursor-request-cycle-expected.txt:
* LayoutTests/storage/indexeddb/cursor-request-cycle-private-expected.txt:
* LayoutTests/storage/indexeddb/resources/cursor-request-cycle.js:
(onOpen.otherRequest.onsuccess.otherRequestSuccess.finalRequest.onsuccess):
(onOpen.otherRequest.onsuccess):
(onOpen):
(onTransactionComplete):
* LayoutTests/storage/indexeddb/resources/value-cursor-cycle.js:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::virtualHasPendingActivity const):
(WebCore::IDBRequest::stop):
(WebCore::IDBRequest::dispatchEvent):
(WebCore::IDBRequest::willIterateCursor):
(WebCore::IDBRequest::transactionTransitionedToFinishing):
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::transitionedToFinishing):
(WebCore::IDBTransaction::addCursorRequest):
(WebCore::IDBTransaction::doRequestOpenCursor):
(WebCore::IDBTransaction::connectionClosedFromServer):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:

Canonical link: <a href="https://commits.webkit.org/268521@main">https://commits.webkit.org/268521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70a8e357f946d6e11da399bf31c33aa21e32882f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20069 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22583 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24323 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22306 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18811 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15939 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17982 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4770 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->