### PR TITLE
Make explicit where WebAssembly actually depends on JIT

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -574,13 +574,15 @@ CatchInfo::CatchInfo(const Wasm::HandlerInfo* handler, const Wasm::Callee* calle
     m_valid = !!handler;
     if (m_valid) {
         m_type = HandlerType::Catch;
+#if ENABLE(JIT)
         m_nativeCode = handler->m_nativeCode;
         m_nativeCodeForDispatchAndCatch = nullptr;
+#endif
         m_catchPCForInterpreter = { static_cast<WasmInstruction*>(nullptr) };
         if (callee->compilationMode() == Wasm::CompilationMode::LLIntMode)
             m_catchPCForInterpreter = { static_cast<const Wasm::LLIntCallee*>(callee)->instructions().at(handler->m_target).ptr() };
         else {
-#if USE(JSVALUE64)
+#if USE(JSVALUE64) && ENABLE(JIT)
             m_nativeCode = Wasm::Thunks::singleton().stub(Wasm::catchInWasmThunkGenerator).template retagged<ExceptionHandlerPtrTag>().code();
             m_nativeCodeForDispatchAndCatch = handler->m_nativeCode;
 #endif

--- a/Source/JavaScriptCore/jit/JITExceptions.cpp
+++ b/Source/JavaScriptCore/jit/JITExceptions.cpp
@@ -66,16 +66,17 @@ void genericUnwind(VM& vm, CallFrame* callFrame)
         if (handler.m_nativeCodeForDispatchAndCatch)
             dispatchAndCatchRoutine = handler.m_nativeCodeForDispatchAndCatch.taggedPtr();
 #else
-#if ENABLE(WEBASSEMBLY)
-#error WASM requires the JIT, so this section assumes we are in JS
-#endif
-        const auto* pc = std::get<const JSInstruction*>(catchPCForInterpreter);
-        if (pc->isWide32())
-            catchRoutine = LLInt::getWide32CodePtr(pc->opcodeID());
-        else if (pc->isWide16())
-            catchRoutine = LLInt::getWide16CodePtr(pc->opcodeID());
-        else
-            catchRoutine = LLInt::getCodePtr(pc->opcodeID());
+        auto getCatchRoutine = [](const auto* pc) {
+            if (pc->isWide32())
+                return LLInt::getWide32CodePtr(pc->opcodeID());
+            if (pc->isWide16())
+                return LLInt::getWide16CodePtr(pc->opcodeID());
+            return LLInt::getCodePtr(pc->opcodeID());
+        };
+
+        catchRoutine = std::holds_alternative<const JSInstruction*>(catchPCForInterpreter)
+            ? getCatchRoutine(std::get<const JSInstruction*>(catchPCForInterpreter))
+            : getCatchRoutine(std::get<const WasmInstruction*>(catchPCForInterpreter));
 #endif
     } else
         catchRoutine = LLInt::handleUncaughtException(vm).code().taggedPtr();

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -441,6 +441,7 @@ end
 # OSR
 
 macro ipintPrologueOSR(increment)
+if JIT
     loadp WasmCodeBlock[cfr], ws0
     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::LLIntTierUpCounter::m_counter[ws0], .continue
 
@@ -518,8 +519,10 @@ end
     loadp WasmCodeBlock[cfr], ws0
 .continue:
 end
+end
 
 macro ipintLoopOSR(increment)
+if JIT
     loadp WasmCodeBlock[cfr], ws0
     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::LLIntTierUpCounter::m_counter[ws0], .continue
 
@@ -546,8 +549,10 @@ macro ipintLoopOSR(increment)
     loadp WasmCodeBlock[cfr], ws0
 .continue:
 end
+end
 
 macro ipintEpilogueOSR(increment)
+if JIT
     loadp WasmCodeBlock[cfr], ws0
     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::LLIntTierUpCounter::m_counter[ws0], .continue
 
@@ -555,6 +560,8 @@ macro ipintEpilogueOSR(increment)
     operationCall(macro() cCall2(_ipint_extern_epilogue_osr) end)
 .continue:
 end
+end
+
 
 ########################
 # In-Place Interpreter #

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -240,8 +240,22 @@ ALWAYS_INLINE LLIntCode getWide32CodeFunctionPtr(OpcodeID opcodeID)
     return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr());
 #endif
 }
+#else // not ENABLE(JIT)
+ALWAYS_INLINE void* getCodePtr(OpcodeID id)
+{
+    return reinterpret_cast<void*>(getOpcode(id));
+}
 
-#if ENABLE(WEBASSEMBLY)
+ALWAYS_INLINE void* getWide16CodePtr(OpcodeID id)
+{
+    return reinterpret_cast<void*>(getOpcodeWide16(id));
+}
+
+ALWAYS_INLINE void* getWide32CodePtr(OpcodeID id)
+{
+    return reinterpret_cast<void*>(getOpcodeWide32(id));
+}
+#endif // ENABLE(JIT)
 
 inline Opcode getOpcode(WasmOpcodeID id)
 {
@@ -340,6 +354,7 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(WasmOpcodeID opcodeID)
     return MacroAssemblerCodeRef<tag>::createSelfManagedCodeRef(getWide32CodePtr<tag>(opcodeID));
 }
 
+#if ENABLE(JIT)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
 {
@@ -369,21 +384,18 @@ ALWAYS_INLINE LLIntCode getWide32CodeFunctionPtr(WasmOpcodeID opcodeID)
     return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr());
 #endif
 }
-
-#endif // ENABLE(WEBASSEMBLY)
-
 #else // not ENABLE(JIT)
-ALWAYS_INLINE void* getCodePtr(OpcodeID id)
+ALWAYS_INLINE void* getCodePtr(WasmOpcodeID id)
 {
     return reinterpret_cast<void*>(getOpcode(id));
 }
 
-ALWAYS_INLINE void* getWide16CodePtr(OpcodeID id)
+ALWAYS_INLINE void* getWide16CodePtr(WasmOpcodeID id)
 {
     return reinterpret_cast<void*>(getOpcodeWide16(id));
 }
 
-ALWAYS_INLINE void* getWide32CodePtr(OpcodeID id)
+ALWAYS_INLINE void* getWide32CodePtr(WasmOpcodeID id)
 {
     return reinterpret_cast<void*>(getOpcodeWide32(id));
 }

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -118,7 +118,7 @@ void initialize()
         thread.setSavedLastStackTop(thread.stack().origin());
 
         NativeCalleeRegistry::initialize();
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
         if (Wasm::isSupported()) {
             Wasm::Thunks::initialize();
         }

--- a/Source/JavaScriptCore/wasm/WasmBinding.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBinding.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WasmBinding.h"
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "CCallHelpers.h"
 #include "DisallowMacroScratchRegisterUsage.h"
@@ -77,4 +77,4 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/WasmBinding.h
+++ b/Source/JavaScriptCore/wasm/WasmBinding.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "JITCompilation.h"
 #include "WasmBinding.h"
@@ -46,4 +46,4 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToWasm(unsi
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -82,7 +82,9 @@ inline void Callee::runWithDowncast(const Func& func)
         func(static_cast<JSEntrypointCallee*>(this));
         break;
     case CompilationMode::JSToWasmICMode:
+#if ENABLE(JIT)
         func(static_cast<JSToWasmICCallee*>(this));
+#endif
         break;
     case CompilationMode::WasmToJSMode:
         func(static_cast<WasmToJSCallee*>(this));
@@ -142,6 +144,7 @@ const HandlerInfo* Callee::handlerForIndex(Instance& instance, unsigned index, c
     return HandlerInfo::handlerForIndex(instance, m_exceptionHandlers, index, tag);
 }
 
+#if ENABLE(JIT)
 JITCallee::JITCallee(Wasm::CompilationMode compilationMode)
     : Callee(compilationMode)
 {
@@ -157,6 +160,7 @@ void JITCallee::setEntrypoint(Wasm::Entrypoint&& entrypoint)
     m_entrypoint = WTFMove(entrypoint);
     NativeCalleeRegistry::singleton().registerCallee(this);
 }
+#endif
 
 WasmToJSCallee::WasmToJSCallee()
     : Callee(Wasm::CompilationMode::WasmToJSMode)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -85,6 +85,7 @@ protected:
     FixedVector<HandlerInfo> m_exceptionHandlers;
 };
 
+#if ENABLE(JIT)
 class JITCallee : public Callee {
 public:
     friend class Callee;
@@ -127,6 +128,34 @@ private:
     }
 };
 
+#else
+
+class JSEntrypointCallee final : public Callee {
+public:
+    friend class Callee;
+
+    static Ref<JSEntrypointCallee> create()
+    {
+        return adoptRef(*new JSEntrypointCallee);
+    }
+
+private:
+    JSEntrypointCallee()
+        : Callee(Wasm::CompilationMode::JSEntrypointMode)
+    {
+    }
+
+    std::tuple<void*, void*> rangeImpl() const
+    {
+        return { nullptr, nullptr };
+    }
+
+    CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
+
+    RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
+};
+#endif // ENABLE(JIT)
+
 class WasmToJSCallee final : public Callee {
 public:
     friend class Callee;
@@ -149,7 +178,7 @@ private:
     RegisterAtOffsetList* calleeSaveRegistersImpl() { return nullptr; }
 };
 
-
+#if ENABLE(JIT)
 class JSToWasmICCallee final : public JITCallee {
 public:
     static Ref<JSToWasmICCallee> create()
@@ -165,7 +194,7 @@ private:
     {
     }
 };
-
+#endif
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -121,6 +121,7 @@ void EntryPlan::prepare()
 
     m_unlinkedWasmToWasmCalls.resize(functions.size());
 
+#if ENABLE(JIT)
     for (unsigned importIndex = 0; importIndex < m_moduleInformation->imports.size(); ++importIndex) {
         Import* import = &m_moduleInformation->imports[importIndex];
         if (import->kind != ExternalKind::Function)
@@ -139,6 +140,7 @@ void EntryPlan::prepare()
         }
         m_wasmToWasmExitStubs.uncheckedAppend(binding.value());
     }
+#endif
 
     const uint32_t importFunctionCount = m_moduleInformation->importFunctionCount();
     for (const auto& exp : m_moduleInformation->exports) {

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -60,7 +60,9 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
     void* faultingInstruction = instructionPointer->untaggedPtr();
     dataLogLnIf(WasmFaultSignalHandlerInternal::verbose, "starting handler for fault at: ", RawPointer(faultingInstruction));
 
+#if ENABLE(JIT)
     dataLogLnIf(WasmFaultSignalHandlerInternal::verbose, "JIT memory start: ", RawPointer(startOfFixedExecutableMemoryPool()), " end: ", RawPointer(endOfFixedExecutableMemoryPool()));
+#endif
     dataLogLnIf(WasmFaultSignalHandlerInternal::verbose, "WasmLLInt memory start: ", RawPointer(untagCodePtr<void*, CFunctionPtrTag>(LLInt::wasmLLIntPCRangeStart)), " end: ", RawPointer(untagCodePtr<void*, CFunctionPtrTag>(LLInt::wasmLLIntPCRangeEnd)));
     // First we need to make sure we are in JIT code or Wasm LLInt code before we can aquire any locks. Otherwise,
     // we might have crashed in code that is already holding one of the locks we want to aquire.

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -32,6 +32,7 @@
 #include "Identifier.h"
 #include "JSString.h"
 #include "MacroAssemblerCodeRef.h"
+#include "MathCommon.h"
 #include "PageCount.h"
 #include "RegisterAtOffsetList.h"
 #include "WasmMemoryInformation.h"
@@ -658,11 +659,13 @@ struct UnlinkedWasmToWasmCall {
     size_t functionIndexSpace;
 };
 
+#if ENABLE(JIT)
 struct Entrypoint {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
     std::unique_ptr<Compilation> compilation;
     RegisterAtOffsetList calleeSaveRegisters;
 };
+#endif
 
 struct InternalFunction {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -670,9 +673,11 @@ struct InternalFunction {
     StackMaps stackmaps;
 #endif
     Vector<UnlinkedHandlerInfo> exceptionHandlers;
+#if ENABLE(JIT)
     Vector<CCallHelpers::Label> bbqLoopEntrypoints;
     std::optional<CCallHelpers::Label> bbqSharedLoopEntrypoint;
     Entrypoint entrypoint;
+#endif
     unsigned osrEntryScratchBufferSize { 0 };
 };
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -110,6 +110,7 @@ void IPIntPlan::compileFunction(uint32_t functionIndex)
 
 void IPIntPlan::didCompleteCompilation()
 {
+#if ENABLE(JIT)
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
         // IPInt entrypoint thunks generation
@@ -155,9 +156,12 @@ void IPIntPlan::didCompleteCompilation()
         if (!m_moduleInformation->clobberingTailCalls().isEmpty())
             computeTransitiveTailCalls();
     }
+#endif
+
     if (m_compilerMode == CompilerMode::Validation)
         return;
 
+#if ENABLE(JIT)
     for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
         const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
         if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
@@ -185,6 +189,7 @@ void IPIntPlan::didCompleteCompilation()
             ASSERT_UNUSED(result, result.isNewEntry);
         }
     }
+#endif
 
     for (auto& unlinked : m_unlinkedWasmToWasmCalls) {
         for (auto& call : unlinked) {

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -111,6 +111,7 @@ void LLIntPlan::compileFunction(uint32_t functionIndex)
 
 void LLIntPlan::didCompleteCompilation()
 {
+#if ENABLE(JIT)
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
         // LLInt entrypoint thunks generation
@@ -157,10 +158,12 @@ void LLIntPlan::didCompleteCompilation()
         if (!m_moduleInformation->clobberingTailCalls().isEmpty())
             computeTransitiveTailCalls();
     }
+#endif
 
     if (m_compilerMode == CompilerMode::Validation)
         return;
 
+#if ENABLE(JIT)
     for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
         const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
         if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
@@ -188,6 +191,7 @@ void LLIntPlan::didCompleteCompilation()
             ASSERT_UNUSED(result, result.isNewEntry);
         }
     }
+#endif
 
     for (auto& unlinked : m_unlinkedWasmToWasmCalls) {
         for (auto& call : unlinked) {

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WasmThunks.h"
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "AllowMacroScratchRegisterUsage.h"
 #include "CCallHelpers.h"
@@ -214,4 +214,4 @@ MacroAssemblerCodeRef<JITThunkPtrTag> Thunks::existingStub(ThunkGenerator genera
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "MacroAssemblerCodeRef.h"
 #include "WasmJS.h"
@@ -71,4 +71,4 @@ private:
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "JSToWasm.h"
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "CCallHelpers.h"
 #include "JSCJSValueInlines.h"
@@ -362,4 +362,4 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, Calle
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.h
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "InternalFunction.h"
 #include "WasmB3IRGenerator.h"
@@ -48,4 +48,4 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers&, Callee&, 
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
@@ -71,7 +71,9 @@ public:
     SymbolTable* exportSymbolTable() const;
     Wasm::TypeIndex typeIndexFromFunctionIndexSpace(unsigned functionIndexSpace) const;
 
+#if ENABLE(JIT)
     Expected<void, Wasm::BindingFailure> generateWasmToJSStubs(VM&);
+#endif
     CodePtr<WasmEntryPtrTag> importFunctionStub(size_t importFunctionNum) { return m_wasmToJSExitStubs[importFunctionNum].code(); }
 
     void clearJSCallICs(VM&);
@@ -87,7 +89,9 @@ private:
     Ref<Wasm::Module> m_module;
     WriteBarrier<SymbolTable> m_exportSymbolTable;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToJSExitStubs;
+#if ENABLE(JIT)
     FixedVector<OptimizingCallLinkInfo> m_callLinkInfos;
+#endif
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WasmToJS.h"
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "CCallHelpers.h"
 #include "JSCJSValueInlines.h"
@@ -556,4 +556,4 @@ void emitThrowWasmToJSException(CCallHelpers& jit, GPRReg wasmInstance, Wasm::Ex
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.h
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && ENABLE(JIT)
 
 #include "JITCompilation.h"
 #include "WasmBinding.h"
@@ -49,4 +49,4 @@ void emitThrowWasmToJSException(CCallHelpers&, GPRReg wasmInstance, Wasm::Except
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -144,6 +144,7 @@ RegisterAtOffsetList WebAssemblyFunction::usedCalleeSaveRegisters() const
     return RegisterAtOffsetList { calleeSaves(), RegisterAtOffsetList::OffsetBaseType::FramePointerBased };
 }
 
+#if ENABLE(JIT)
 static size_t trampolineReservedStackSize()
 {
     // If we are jumping to the function which can have stack-overflow check,
@@ -435,6 +436,7 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
     m_jsToWasmICCallee->setEntrypoint({ WTFMove(compilation), WTFMove(registersToSpill) });
     return m_jsToWasmICCallee->entrypoint().retagged<JSEntryPtrTag>();
 }
+#endif // ENABLE(JIT)
 
 WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::Callee& jsEntrypoint, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -67,16 +67,22 @@ public:
 
     CodePtr<JSEntryPtrTag> jsCallEntrypoint()
     {
+#if ENABLE(JIT)
         if (m_jsToWasmICCallee)
             return m_jsToWasmICCallee->entrypoint().retagged<JSEntryPtrTag>();
         return jsCallEntrypointSlow();
+#else
+        return nullptr;
+#endif
     }
 
 private:
     DECLARE_VISIT_CHILDREN;
     WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::Callee& jsEntrypoint, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
 
+#if ENABLE(JIT)
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();
+#endif
     bool usesTagRegisters() const;
     RegisterAtOffsetList usedCalleeSaveRegisters() const;
 
@@ -86,7 +92,9 @@ private:
     // to our Instance, which points to the Module that exported us, which
     // ensures that the actual Signature/code doesn't get deallocated.
     CodePtr<WasmEntryPtrTag> m_jsEntrypoint;
+#if ENABLE(JIT)
     RefPtr<Wasm::JSToWasmICCallee> m_jsToWasmICCallee;
+#endif
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### fb59fe503475013a28183568e48c35bfebc7b1b9
<pre>
Make explicit where WebAssembly actually depends on JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=261458">https://bugs.webkit.org/show_bug.cgi?id=261458</a>

Reviewed by Justin Michaud.

As a step toward removing our WebAssembly implementation&apos;s JIT dependence,
this patch makes it possible to build an ENABLE(WEBASSEMBLY) &amp;&amp; !ENABLE(JIT) configuration.

Such a build will of course encounter runtime issues, since this patch does not implement replacement functionality;
however, it is still useful to clearly demarcate which code is dependent on JIT and thereby discontinue our assumption
that ENABLE(WEBASSEMBLY) implies ENABLE(JIT).

* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::CatchInfo::CatchInfo):
* Source/JavaScriptCore/jit/JITExceptions.cpp:
(JSC::genericUnwind):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/LLIntData.h:
(JSC::LLInt::getCodePtr):
(JSC::LLInt::getWide16CodePtr):
(JSC::LLInt::getWide32CodePtr):
(JSC::LLInt::getWide32CodeFunctionPtr):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/wasm/WasmBinding.cpp:
* Source/JavaScriptCore/wasm/WasmBinding.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::prepare):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::trapHandler):
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
* Source/JavaScriptCore/wasm/WasmThunks.h:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
* Source/JavaScriptCore/wasm/js/JSToWasm.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::createStub):
(JSC::JSWebAssemblyModule::clearJSCallICs):
(JSC::JSWebAssemblyModule::finalizeUnconditionally):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h:
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
* Source/JavaScriptCore/wasm/js/WasmToJS.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:

Canonical link: <a href="https://commits.webkit.org/268172@main">https://commits.webkit.org/268172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9342ad57ba0d5e49fa3225e27fdffaf417a1f5a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19013 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20965 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23130 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15806 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21018 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14734 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21600 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16469 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20832 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22833 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17217 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5139 "Passed tests") | 
<!--EWS-Status-Bubble-End-->