### PR TITLE
New test added in 265747@main hits assertion failure: ScriptDisallowedScope::InMainThread::isScriptAllowed()

### DIFF
--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -786,7 +786,7 @@ void ScriptController::executeAsynchronousUserAgentScriptInWorld(DOMWrapperWorld
 bool ScriptController::canExecuteScripts(ReasonForCallingCanExecuteScripts reason)
 {
     if (reason == ReasonForCallingCanExecuteScripts::AboutToExecuteScript)
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess());
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
 
     if (m_frame.document() && m_frame.document()->isSandboxed(SandboxScripts)) {
         // FIXME: This message should be moved off the console once a solution to https://bugs.webkit.org/show_bug.cgi?id=103274 exists.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3647,7 +3647,7 @@ void Element::dispatchFocusInEventIfNeeded(RefPtr<Element>&& oldFocusedElement)
 {
     if (!document().hasListenerType(Document::ListenerType::FocusIn))
         return;
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
     dispatchScopedEvent(FocusEvent::create(eventNames().focusinEvent, Event::CanBubble::Yes, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(oldFocusedElement)));
 }
 
@@ -3655,7 +3655,7 @@ void Element::dispatchFocusOutEventIfNeeded(RefPtr<Element>&& newFocusedElement)
 {
     if (!document().hasListenerType(Document::ListenerType::FocusOut))
         return;
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
     dispatchScopedEvent(FocusEvent::create(eventNames().focusoutEvent, Event::CanBubble::Yes, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(newFocusedElement)));
 }
 

--- a/Source/WebCore/dom/ScriptDisallowedScope.h
+++ b/Source/WebCore/dom/ScriptDisallowedScope.h
@@ -86,7 +86,7 @@ public:
         static bool isEventDispatchAllowedInSubtree(Node& node)
         {
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
-            return !isInWebProcess() || isScriptAllowed() || EventAllowedScope::isAllowedNode(node);
+            return isScriptAllowed() || EventAllowedScope::isAllowedNode(node);
 #else
             UNUSED_PARAM(node);
             return true;
@@ -103,9 +103,9 @@ public:
         {
             ASSERT(isMainThread());
 #if PLATFORM(IOS_FAMILY)
-            return !s_count || webThreadDelegateMessageScopeCount;
+            return !s_count || !isInWebProcess() || webThreadDelegateMessageScopeCount;
 #else
-            return !s_count;
+            return !s_count || !isInWebProcess();
 #endif
         }
     };

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -403,7 +403,7 @@ bool ScriptElement::requestImportMap(LocalFrame& frame, const String& sourceURL)
 
 void ScriptElement::executeClassicScript(const ScriptSourceCode& sourceCode)
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed() || !isInWebProcess());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
     ASSERT(m_alreadyStarted);
 
     if (sourceCode.isEmpty())


### PR DESCRIPTION
#### f33e99829e4f572a15eb8c2a6ca3d78fa227e9cc
<pre>
New test added in 265747@main hits assertion failure: ScriptDisallowedScope::InMainThread::isScriptAllowed()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261305">https://bugs.webkit.org/show_bug.cgi?id=261305</a>

Reviewed by Chris Dumez.

Disable these assertions in WebKit1 as we&apos;ve done elsewhere.

* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::canExecuteScripts): Removed the check for isInWebProcess given
InMainThread::isScriptAllowed now checks that condition.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchFocusInEventIfNeeded): Ditto.
(WebCore::Element::dispatchFocusOutEventIfNeeded): Ditto.
* Source/WebCore/dom/ScriptDisallowedScope.h:
(WebCore::ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree): Ditto.
(WebCore::ScriptDisallowedScope::InMainThread::isScriptAllowed): Make this function always return true in
WebKit1 to avoid hitting assertion failures.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::executeClassicScript): Ditto for removing the check for isInWebProcess.

Canonical link: <a href="https://commits.webkit.org/267935@main">https://commits.webkit.org/267935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daf49d8d88aa46a44c31f399ebeda0870ab4f4ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18840 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20707 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22948 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20816 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20608 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->