### PR TITLE
GraphicsContext::createScaledImageBuffer uses different equations for different variants

### DIFF
--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -270,6 +270,11 @@ inline void FloatPoint::rotate(double angleInRadians, const FloatPoint& aboutPoi
     m_x = newX;
 }
 
+inline FloatSize toFloatSize(const FloatPoint& a)
+{
+    return FloatSize(a.x(), a.y());
+}
+
 inline IntSize flooredIntSize(const FloatPoint& p)
 {
     return IntSize(clampToInteger(floorf(p.x())), clampToInteger(floorf(p.y())));
@@ -285,9 +290,19 @@ inline IntPoint flooredIntPoint(const FloatPoint& p)
     return IntPoint(clampToInteger(floorf(p.x())), clampToInteger(floorf(p.y())));
 }
 
+inline IntPoint essentiallyFlooredIntPoint(const FloatPoint& p)
+{
+    return IntPoint { essentiallyFlooredIntSize(toFloatSize(p)) };
+}
+
 inline IntPoint ceiledIntPoint(const FloatPoint& p)
 {
     return IntPoint(clampToInteger(ceilf(p.x())), clampToInteger(ceilf(p.y())));
+}
+
+inline IntPoint essentiallyCeiledIntPoint(const FloatPoint& p)
+{
+    return IntPoint { essentiallyExpandedIntSize(toFloatSize(p)) };
 }
 
 inline FloatPoint floorPointToDevicePixels(const FloatPoint& p, float deviceScaleFactor)
@@ -298,11 +313,6 @@ inline FloatPoint floorPointToDevicePixels(const FloatPoint& p, float deviceScal
 inline FloatPoint ceilPointToDevicePixels(const FloatPoint& p, float deviceScaleFactor)
 {
     return FloatPoint(ceilf(p.x() * deviceScaleFactor)  / deviceScaleFactor, ceilf(p.y() * deviceScaleFactor)  / deviceScaleFactor);
-}
-
-inline FloatSize toFloatSize(const FloatPoint& a)
-{
-    return FloatSize(a.x(), a.y());
 }
 
 inline FloatPoint toFloatPoint(const FloatSize& a)

--- a/Source/WebCore/platform/graphics/FloatRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRect.cpp
@@ -194,6 +194,13 @@ IntRect enclosingIntRect(const FloatRect& rect)
     return IntRect(IntPoint(location), IntSize(maxPoint - location));
 }
 
+IntRect essentiallyEnclosingIntRect(const FloatRect& rect)
+{
+    IntPoint minMin = essentiallyFlooredIntPoint(rect.minXMinYCorner());
+    IntPoint maxMax = essentiallyCeiledIntPoint(rect.maxXMaxYCorner());
+    return { minMin, IntSize { maxMax - minMin } };
+}
+
 IntRect enclosingIntRectPreservingEmptyRects(const FloatRect& rect)
 {
     // Empty rects with fractional x, y values turn into non-empty rects when converting to enclosing.

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -373,6 +373,7 @@ WEBCORE_EXPORT FloatRect encloseRectToDevicePixels(const FloatRect&, float devic
 WEBCORE_EXPORT IntRect enclosingIntRect(const FloatRect&);
 WEBCORE_EXPORT IntRect enclosingIntRectPreservingEmptyRects(const FloatRect&);
 WEBCORE_EXPORT IntRect roundedIntRect(const FloatRect&);
+WEBCORE_EXPORT IntRect essentiallyEnclosingIntRect(const FloatRect&);
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatRect&);
 

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -267,6 +267,26 @@ inline IntPoint flooredIntPoint(const FloatSize& p)
     return IntPoint(clampToInteger(floorf(p.width())), clampToInteger(floorf(p.height())));
 }
 
+inline IntSize essentiallyFlooredIntSize(const FloatSize& p)
+{
+    IntSize result { clampToInteger(p.width()), clampToInteger(p.height()) };
+    if (!WTF::areEssentiallyEqual<float>(p.width(), result.width()))
+        result.setWidth(clampToInteger(floorf(p.width())));
+    if (!WTF::areEssentiallyEqual<float>(p.height(), result.height()))
+        result.setHeight(clampToInteger(floorf(p.height())));
+    return result;
+}
+
+inline IntSize essentiallyExpandedIntSize(const FloatSize& p)
+{
+    IntSize result { clampToInteger(p.width()), clampToInteger(p.height()) };
+    if (!WTF::areEssentiallyEqual<float>(p.width(), result.width()))
+        result.setWidth(clampToInteger(ceilf(p.width())));
+    if (!WTF::areEssentiallyEqual<float>(p.height(), result.height()))
+        result.setHeight(clampToInteger(ceilf(p.height())));
+    return result;
+}
+
 constexpr FloatSize FloatSize::nanSize()
 {
     return {

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -211,14 +211,14 @@ static IntSize scaledImageBufferSize(const FloatSize& size, const FloatSize& sca
 {
     // Enlarge the buffer size if the context's transform is scaling it so we need a higher
     // resolution than one pixel per unit.
-    return expandedIntSize(size * scale);
+    return essentiallyExpandedIntSize(size * scale);
 }
 
 static IntRect scaledImageBufferRect(const FloatRect& rect, const FloatSize& scale)
 {
     auto scaledRect = rect;
     scaledRect.scale(scale);
-    return enclosingIntRect(scaledRect);
+    return essentiallyEnclosingIntRect(scaledRect);
 }
 
 static FloatSize clampingScaleForImageBufferSize(const FloatSize& size)
@@ -272,13 +272,11 @@ RefPtr<ImageBuffer> GraphicsContext::createScaledImageBuffer(const FloatRect& re
         return nullptr;
 
     imageBuffer->context().scale(clampingScale);
-    
-    // 'rect' is mapped to a rectangle inside expandedScaledRect.
-    imageBuffer->context().translate(-expandedScaledRect.location());
-    
-    // The size of this rectangle is not necessarily equal to expandedScaledRect.size().
-    // So use 'scale' not 'expandedScaledRect.size() / rect.size()'.
-    imageBuffer->context().scale(scale);
+
+    // 'expandedScaledRect' is mapped to 'rect'. So use 'expandedScaledRect.size() / size'
+    // not 'scale' because they are not necessarily equal.
+    imageBuffer->context().scale(expandedScaledRect.size() / rect.size());
+    imageBuffer->context().translate(-rect.location());
     return imageBuffer;
 }
 


### PR DESCRIPTION
#### 4d987776941baf25113a68c6dd7fb96d474645c2
<pre>
GraphicsContext::createScaledImageBuffer uses different equations for different variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=261462">https://bugs.webkit.org/show_bug.cgi?id=261462</a>
<a href="https://rdar.apple.com/115352084">rdar://115352084</a>

Reviewed by NOBODY (OOPS!).

GraphicsContext::createScaledImageBuffer(sizeOrRect, scale) intends to
create a new ImageBuffer that:
- is of size sizeOrRect * scale ..
- .. but don&apos;t create physical backend bigger than the crop limit
- apply transform to the context in such a way that it would be as if
  drawing to sizeOrRect

The variant with FloatSize would compute the transform differently
to the variant with FloatRect. This is incorrect. When used with
FloatRect, non-cropped coordinates would get translated incorrectly,
resulting in last pixel row and column being filled only partially.

Fix by using the same equation. Later commits will further simplify
the code.

Ensure that sizes and rects that are essentially integral stay integral.
Test cases such as svg/filters/container-with-filters.svg would
create intermediate ImageBuffers for filter rects. Due to the rects
being generated with FloatRect arithmetic, they did not always exactly
align to integral numbers. Otherwise, these would expand the intermediate
buffers by one pixel, which is not currently handled correctly at
draw time by either the filter code or ImageBuffer draw code.

Add test which tests that FloatSize variant does the same as FloatRect
variant.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::createScaledImageBuffer const):
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::getImageBufferPixel):
(TestWebKitAPI::imageBufferPixelIs):
(TestWebKitAPI::createPixelBufferTestPattern):
(TestWebKitAPI::TEST):
(TestWebKitAPI::toImageBufferOptions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d987776941baf25113a68c6dd7fb96d474645c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25749 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40064 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg, svg/masking/mask-transformed-text-missing.svg (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50109 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25865 "Found 3 new test failures: svg/custom/hidpi-masking-clipping.svg, svg/stroke/non-scaling-stroke-gradient-text.html, svg/transforms/transformed-text-fill-gradient.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21172 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23324 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-objectboundingbox-content-clip-transform.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-userspaceonuse-content-clip-transform.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43427 "Found 6 new test failures: imported/mozilla/svg/text-scale-02.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-objectboundingbox-content-clip-transform.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-userspaceonuse-content-clip-transform.svg, svg/masking/mask-transformed-text-missing.svg, svg/stroke/non-scaling-stroke-gradient-text.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45248 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43951 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-objectboundingbox-content-clip-transform.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-userspaceonuse-content-clip-transform.svg, svg/masking/mask-transformed-text-missing.svg, svg/stroke/non-scaling-stroke-gradient-text.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24059 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20311 "Found 6 new test failures: imported/mozilla/svg/paint-order-02.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-objectboundingbox-content-clip-transform.svg, imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/mask-userspaceonuse-content-clip-transform.svg, svg/masking/mask-transformed-text-missing.svg, svg/stroke/non-scaling-stroke-gradient-text.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47383 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg, svg/masking/mask-transformed-text-missing.svg (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46359 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->