### PR TITLE
alignment-baseline should not support the value "auto"

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -3,7 +3,7 @@ Attributes that are exposed in the CSS computed style object:
 align-content: normal;
 align-items: normal;
 align-self: auto;
-alignment-baseline: auto;
+alignment-baseline: baseline;
 appearance: none;
 background-attachment: scroll;
 background-clip: border-box;

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -2,7 +2,7 @@ Computed style of an element whose parent's 'display' value is 'none':
 align-content: normal
 align-items: normal
 align-self: auto
-alignment-baseline: auto
+alignment-baseline: baseline
 appearance: none
 background-attachment: scroll
 background-clip: border-box

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/animation/alignment-baseline-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/animation/alignment-baseline-no-interpolation-expected.txt
@@ -16,15 +16,15 @@ PASS CSS Transitions with transition: all: property <alignment-baseline> from [i
 PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial]
 PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (0) should be [initial]
 PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial]
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central] assert_equals: expected "central " but got "auto "
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central] assert_equals: expected "central " but got "auto "
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central] assert_equals: expected "central " but got "auto "
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central] assert_equals: expected "central " but got "auto "
+FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central] assert_equals: expected "central " but got "baseline "
+FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central] assert_equals: expected "central " but got "baseline "
+FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central] assert_equals: expected "central " but got "baseline "
+FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central] assert_equals: expected "central " but got "baseline "
 PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial]
 PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (0) should be [initial]
 PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial]
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central] assert_equals: expected "central " but got "auto "
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central] assert_equals: expected "central " but got "auto "
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central] assert_equals: expected "central " but got "auto "
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central] assert_equals: expected "central " but got "auto "
+FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central] assert_equals: expected "central " but got "baseline "
+FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central] assert_equals: expected "central " but got "baseline "
+FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central] assert_equals: expected "central " but got "baseline "
+FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central] assert_equals: expected "central " but got "baseline "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/inheritance-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property alignment-baseline has initial value baseline assert_equals: expected "baseline" but got "auto"
+PASS Property alignment-baseline has initial value baseline
 PASS Property alignment-baseline does not inherit
 FAIL Property baseline-shift has initial value 0px assert_equals: expected "0px" but got "baseline"
 PASS Property baseline-shift does not inherit

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL e.style['alignment-baseline'] = "auto" should not set the property value assert_equals: expected "" but got "auto"
+PASS e.style['alignment-baseline'] = "auto" should not set the property value
 PASS e.style['alignment-baseline'] = "none" should not set the property value
 PASS e.style['alignment-baseline'] = "baseline text-bottom" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt
@@ -3,7 +3,7 @@ PASS Testing 'stroke-width' on '#box1'.
 PASS Testing 'stroke-width' on '#box2'.
 PASS Testing 'stroke-width' on '#box3'.
 PASS Testing 'clip' on '#test4'.
-FAIL Testing 'alignment-baseline'. assert_equals: Default value. expected "baseline" but got "auto"
+PASS Testing 'alignment-baseline'.
 PASS Testing 'baseline-shift'.
 PASS Testing 'clip-rule'.
 PASS Testing 'color'.

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -4,7 +4,7 @@ rect: style.getPropertyValue(align-items) : normal
 rect: style.getPropertyCSSValue(align-items) : [object CSSValueList]
 rect: style.getPropertyValue(align-self) : auto
 rect: style.getPropertyCSSValue(align-self) : [object CSSValueList]
-rect: style.getPropertyValue(alignment-baseline) : auto
+rect: style.getPropertyValue(alignment-baseline) : baseline
 rect: style.getPropertyCSSValue(alignment-baseline) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(appearance) : none
 rect: style.getPropertyCSSValue(appearance) : [object CSSPrimitiveValue]
@@ -498,7 +498,7 @@ g: style.getPropertyValue(align-items) : normal
 g: style.getPropertyCSSValue(align-items) : [object CSSValueList]
 g: style.getPropertyValue(align-self) : auto
 g: style.getPropertyCSSValue(align-self) : [object CSSValueList]
-g: style.getPropertyValue(alignment-baseline) : auto
+g: style.getPropertyValue(alignment-baseline) : baseline
 g: style.getPropertyCSSValue(alignment-baseline) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(appearance) : none
 g: style.getPropertyCSSValue(appearance) : [object CSSPrimitiveValue]

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1895,7 +1895,7 @@ template<> constexpr WindRule fromCSSValueID(CSSValueID valueID)
 }
 
 #define TYPE AlignmentBaseline
-#define FOR_EACH(CASE) CASE(AfterEdge) CASE(Alphabetic) CASE(Auto) CASE(Baseline) \
+#define FOR_EACH(CASE) CASE(AfterEdge) CASE(Alphabetic) CASE(Baseline) \
     CASE(BeforeEdge) CASE(Central) CASE(Hanging) CASE(Ideographic) CASE(Mathematical) \
     CASE(Middle) CASE(TextAfterEdge) CASE(TextBeforeEdge)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1389,7 +1389,6 @@
         },
         "alignment-baseline": {
             "values": [
-                "auto",
                 "baseline",
                 "before-edge",
                 "text-before-edge",

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -50,7 +50,7 @@ public:
     bool operator==(const SVGRenderStyle&) const;
 
     // Initial values for all the properties
-    static AlignmentBaseline initialAlignmentBaseline() { return AlignmentBaseline::Auto; }
+    static AlignmentBaseline initialAlignmentBaseline() { return AlignmentBaseline::Baseline; }
     static DominantBaseline initialDominantBaseline() { return DominantBaseline::Auto; }
     static BaselineShift initialBaselineShift() { return BaselineShift::Baseline; }
     static VectorEffect initialVectorEffect() { return VectorEffect::None; }

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -302,7 +302,6 @@ bool StyleLayoutData::operator==(const StyleLayoutData& other) const
 TextStream& operator<<(TextStream& ts, AlignmentBaseline value)
 {
     switch (value) {
-    case AlignmentBaseline::Auto: ts << "auto"; break;
     case AlignmentBaseline::Baseline: ts << "baseline"; break;
     case AlignmentBaseline::BeforeEdge: ts << "before-edge"; break;
     case AlignmentBaseline::TextBeforeEdge: ts << "text-before-edge"; break;

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -96,7 +96,6 @@ enum class GlyphOrientation : uint8_t {
 };
 
 enum class AlignmentBaseline : uint8_t {
-    Auto,
     Baseline,
     BeforeEdge,
     TextBeforeEdge,

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -101,7 +101,7 @@ AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseli
         return AlignmentBaseline::TextBeforeEdge;
     default:
         ASSERT_NOT_REACHED();
-        return AlignmentBaseline::Auto;
+        return AlignmentBaseline::Baseline;
     }
 }
 
@@ -111,9 +111,9 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
     ASSERT(textRendererParent);
 
     AlignmentBaseline baseline = textRenderer.style().svgStyle().alignmentBaseline();
-    if (baseline == AlignmentBaseline::Auto || baseline == AlignmentBaseline::Baseline) {
+    if (baseline == AlignmentBaseline::Baseline) {
         baseline = dominantBaselineToAlignmentBaseline(isVerticalText, textRendererParent);
-        ASSERT(baseline != AlignmentBaseline::Auto && baseline != AlignmentBaseline::Baseline);
+        ASSERT(baseline != AlignmentBaseline::Baseline);
     }
 
     const FontMetrics& fontMetrics = m_font.metricsOfPrimaryFont();
@@ -138,9 +138,6 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
     case AlignmentBaseline::Mathematical:
         return fontMetrics.floatAscent() / 2;
     case AlignmentBaseline::Baseline:
-        ASSERT_NOT_REACHED();
-        return 0;
-    case AlignmentBaseline::Auto:
         ASSERT_NOT_REACHED();
         return 0;
     }


### PR DESCRIPTION
#### 62aac54b7bcd4f14d3a4c41c3a09b24f50e50151
<pre>
alignment-baseline should not support the value &quot;auto&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=260346">https://bugs.webkit.org/show_bug.cgi?id=260346</a>
rdar://114024256

Reviewed by Tim Nguyen.

The spec defines alignment-baseline without the value auto
and the initial value being baseline.
<a href="https://drafts.csswg.org/css-inline/#alignment-baseline-property">https://drafts.csswg.org/css-inline/#alignment-baseline-property</a>

This will also make pass the relevant WPT test
<a href="http://wpt.live/css/css-inline/parsing/alignment-baseline-invalid.html">http://wpt.live/css/css-inline/parsing/alignment-baseline-invalid.html</a>

* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/animation/alignment-baseline-no-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/parsing/alignment-baseline-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-presentation-attribute-expected.txt:
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
(WebCore::SVGRenderStyle::initialAlignmentBaseline):
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline const):
(WebCore::SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift const):

Canonical link: <a href="https://commits.webkit.org/268008@main">https://commits.webkit.org/268008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bd0e9ae5b48eccb8a32c3b7d49eda62b3c12bed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19044 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21003 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14767 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16505 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4374 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->