### PR TITLE
[WGSL] Add support for texture_storage

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -274,6 +274,8 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
             case Primitive::Void:
             case Primitive::Sampler:
             case Primitive::TextureExternal:
+            case Primitive::AccessMode:
+            case Primitive::TexelFormat:
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
@@ -296,6 +298,9 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Texture&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const TextureStorage&) {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const TypeConstructor&) {

--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -58,6 +58,8 @@ bool satisfies(const Type* type, Constraint constraint)
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
     case Types::Primitive::TextureExternal:
+    case Types::Primitive::AccessMode:
+    case Types::Primitive::TexelFormat:
         return false;
     }
 }
@@ -126,6 +128,8 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
     case Types::Primitive::TextureExternal:
+    case Types::Primitive::AccessMode:
+    case Types::Primitive::TexelFormat:
         return nullptr;
     }
 }

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -602,18 +602,6 @@ void printInternal(PrintStream& out, WGSL::Types::Texture::Kind textureKind)
     case WGSL::Types::Texture::Kind::TextureMultisampled2d:
         out.print("texture_multisampled_2d");
         return;
-    case WGSL::Types::Texture::Kind::TextureStorage1d:
-        out.print("texture_storage_1d");
-        return;
-    case WGSL::Types::Texture::Kind::TextureStorage2d:
-        out.print("texture_storage_2d");
-        return;
-    case WGSL::Types::Texture::Kind::TextureStorage2dArray:
-        out.print("texture_storage_2d_array");
-        return;
-    case WGSL::Types::Texture::Kind::TextureStorage3d:
-        out.print("texture_storage_3d");
-        return;
     }
 }
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -36,6 +36,7 @@
 #include "Types.h"
 #include "WGSLShaderModule.h"
 #include <wtf/DataLog.h>
+#include <wtf/SortedArrayMap.h>
 
 namespace WGSL {
 
@@ -131,6 +132,7 @@ private:
 
     template<typename TargetConstructor, typename... Arguments>
     void allocateSimpleConstructor(ASCIILiteral, TargetConstructor, Arguments&&...);
+    void allocateTextureStorageConstructor(ASCIILiteral, Types::TextureStorage::Kind);
 
     template<typename CallArguments>
     const Type* chooseOverload(const char*, const SourceSpan&, const String&, CallArguments&& valueArguments, const Vector<const Type*>& typeArguments);
@@ -175,10 +177,33 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     allocateSimpleConstructor("texture_cube"_s, &TypeStore::textureType, Types::Texture::Kind::TextureCube);
     allocateSimpleConstructor("texture_cube_array"_s, &TypeStore::textureType, Types::Texture::Kind::TextureCubeArray);
     allocateSimpleConstructor("texture_multisampled_2d"_s, &TypeStore::textureType, Types::Texture::Kind::TextureMultisampled2d);
-    allocateSimpleConstructor("texture_storage_1d"_s, &TypeStore::textureType, Types::Texture::Kind::TextureStorage1d);
-    allocateSimpleConstructor("texture_storage_2d"_s, &TypeStore::textureType, Types::Texture::Kind::TextureStorage2d);
-    allocateSimpleConstructor("texture_storage_2d_array"_s, &TypeStore::textureType, Types::Texture::Kind::TextureStorage2dArray);
-    allocateSimpleConstructor("texture_storage_3d"_s, &TypeStore::textureType, Types::Texture::Kind::TextureStorage3d);
+
+    allocateTextureStorageConstructor("texture_storage_1d"_s, Types::TextureStorage::Kind::TextureStorage1d);
+    allocateTextureStorageConstructor("texture_storage_2d"_s, Types::TextureStorage::Kind::TextureStorage2d);
+    allocateTextureStorageConstructor("texture_storage_2d_array"_s, Types::TextureStorage::Kind::TextureStorage2dArray);
+    allocateTextureStorageConstructor("texture_storage_3d"_s, Types::TextureStorage::Kind::TextureStorage3d);
+
+    introduceValue(AST::Identifier::make("read"_s), m_types.accessModeType());
+    introduceValue(AST::Identifier::make("write"_s), m_types.accessModeType());
+    introduceValue(AST::Identifier::make("read_write"_s), m_types.accessModeType());
+
+    introduceValue(AST::Identifier::make("bgra8unorm"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("r32float"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("r32sint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("r32uint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rg32float"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rg32sint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rg32uint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba16float"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba16sint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba16uint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba32float"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba32sint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba32uint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba8sint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba8snorm"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba8uint"_s), m_types.texelFormatType());
+    introduceValue(AST::Identifier::make("rgba8unorm"_s), m_types.texelFormatType());
 
     // This file contains the declarations generated from `TypeDeclarations.rb`
 #include "TypeDeclarations.h" // NOLINT
@@ -1111,6 +1136,68 @@ void TypeChecker::allocateSimpleConstructor(ASCIILiteral name, TargetConstructor
                 return m_types.bottomType();
 
             return (m_types.*constructor)(elementType, arguments...);
+        }
+    ));
+}
+
+void TypeChecker::allocateTextureStorageConstructor(ASCIILiteral name, Types::TextureStorage::Kind kind)
+{
+    introduceType(AST::Identifier::make(name), m_types.typeConstructorType(
+        name,
+        [this, kind](AST::ElaboratedTypeExpression& type) -> const Type* {
+            if (type.arguments().size() != 2) {
+                typeError(InferBottom::No, type.span(), "'", type.base(), "' requires 2 template argument");
+                return m_types.bottomType();
+            }
+
+            auto* formatType = infer(type.arguments()[0]);
+            if (!unify(formatType, m_types.texelFormatType())) {
+                typeError(InferBottom::No, type.span(), "cannot use '", *formatType, "' as texel format");
+                return m_types.bottomType();
+            }
+
+            auto* accessType = infer(type.arguments()[1]);
+            if (!unify(accessType, m_types.accessModeType())) {
+                typeError(InferBottom::No, type.span(), "cannot use '", *accessType, "' as access mode");
+                return m_types.bottomType();
+            }
+
+            ASSERT(is<AST::IdentifierExpression>(type.arguments()[0]));
+            ASSERT(is<AST::IdentifierExpression>(type.arguments()[1]));
+            auto& formatName = downcast<AST::IdentifierExpression>(type.arguments()[0]).identifier();
+            auto& accessName = downcast<AST::IdentifierExpression>(type.arguments()[1]).identifier();
+
+            static constexpr std::pair<ComparableASCIILiteral, TexelFormat> texelFormatMappings[] {
+                { "bgra8unorm", TexelFormat::BGRA8unorm },
+                { "r32float", TexelFormat::R32float },
+                { "r32sint", TexelFormat::R32sint },
+                { "r32uint", TexelFormat::R32uint },
+                { "rg32float", TexelFormat::RG32float },
+                { "rg32sint", TexelFormat::RG32sint },
+                { "rg32uint", TexelFormat::RG32uint },
+                { "rgba16float", TexelFormat::RGBA16float },
+                { "rgba16sint", TexelFormat::RGBA16sint },
+                { "rgba16uint", TexelFormat::RGBA16uint },
+                { "rgba32float", TexelFormat::RGBA32float },
+                { "rgba32sint", TexelFormat::RGBA32sint },
+                { "rgba32uint", TexelFormat::RGBA32uint },
+                { "rgba8sint", TexelFormat::RGBA8sint },
+                { "rgba8snorm", TexelFormat::RGBA8snorm },
+                { "rgba8uint", TexelFormat::RGBA8uint },
+                { "rgba8unorm", TexelFormat::RGBA8unorm },
+            };
+            static constexpr SortedArrayMap texelFormats { texelFormatMappings };
+
+            static constexpr std::pair<ComparableASCIILiteral, AccessMode> accessModeMappings[] {
+                { "read", AccessMode::Read },
+                { "read_write", AccessMode::ReadWrite },
+                { "write", AccessMode::Write },
+            };
+            static constexpr SortedArrayMap accessModes { accessModeMappings };
+
+            auto format = texelFormats.get(formatName.id());
+            auto access = accessModes.get(accessName.id());
+            return m_types.textureStorageType(kind, format, access);
         }
     ));
 }

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -33,27 +33,11 @@ namespace WGSL {
 
 using namespace Types;
 
-// These keys are used so that, for a given type T, we can have keys for all of
-// the following types:
-// vecN<T>, matCxR<T>, array<T, N?>
-//
-// To make sure they never collide, we encode them into a pair<Type*, uint64_t>
-// where the first element of the pair is always T and the second word is used
-// to disambiguate between all the possible types. That's possible because we
-// we only have 3 possibilities for Vector (2, 3, 4), 9 possibilities for Matrix
-// ((2, 3, 4) * (2, 3, 4)) and 2**32 for Array. To avoid collisions, the
-// data is encoded as follows:
-//
-// Vector: size in the least significant byte.
-// Matrix: rows in byte 1 and columns in byte 2
-// Array: 0 for dynamic array or 32-bit size in the upper 32-bits
-// Texture: kind << 16
-// Reference: AddressSpace + AccessMode compacted into 1 byte and shifted 24 bits left
 struct VectorKey {
     const Type* elementType;
     uint8_t size;
 
-    uint64_t extra() const { return size; }
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Vector, size, 0, 0, bitwise_cast<uintptr_t>(elementType)); }
 };
 
 struct MatrixKey {
@@ -61,21 +45,29 @@ struct MatrixKey {
     uint8_t columns;
     uint8_t rows;
 
-    uint64_t extra() const { return (static_cast<uint64_t>(columns) << 8) | rows; }
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Matrix, columns, rows, 0, bitwise_cast<uintptr_t>(elementType)); }
 };
 
 struct ArrayKey {
     const Type* elementType;
     std::optional<unsigned> size;
 
-    uint64_t extra() const { return size.has_value() ? static_cast<uint64_t>(*size) << 32 : 0; }
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Array, 0, 0, size.value_or(0), bitwise_cast<uintptr_t>(elementType)); }
 };
 
 struct TextureKey {
     const Type* elementType;
     Texture::Kind kind;
 
-    uint64_t extra() const { return static_cast<uint64_t>(kind) << 16; }
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Texture, WTF::enumToUnderlyingType(kind), 0, 0, bitwise_cast<uintptr_t>(elementType)); }
+};
+
+struct TextureStorageKey {
+    TextureStorage::Kind kind;
+    TexelFormat format;
+    AccessMode access;
+
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::TextureStorage, WTF::enumToUnderlyingType(kind), WTF::enumToUnderlyingType(format), WTF::enumToUnderlyingType(access), 0); }
 };
 
 struct ReferenceKey {
@@ -83,33 +75,22 @@ struct ReferenceKey {
     AddressSpace addressSpace;
     AccessMode accessMode;
 
-    uint64_t extra() const
-    {
-        constexpr unsigned addressSpaceShift = 2;
-
-        auto addressSpace = WTF::enumToUnderlyingType(this->addressSpace);
-        auto accessMode = WTF::enumToUnderlyingType(this->accessMode);
-
-        ASSERT(accessMode < (1 << addressSpaceShift));
-        ASSERT(addressSpace < (1 << (sizeof(addressSpace) * 8 - addressSpaceShift)));
-
-        return static_cast<uint64_t>(accessMode | (addressSpace << addressSpaceShift)) << 24;
-    }
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Reference, WTF::enumToUnderlyingType(addressSpace), WTF::enumToUnderlyingType(accessMode), 0, bitwise_cast<uintptr_t>(elementType)); }
 };
 
 template<typename Key>
-const Type* TypeStore::TypeCache::find(const Key& key) const
+const Type* TypeCache::find(const Key& key) const
 {
-    auto it = m_storage.find(std::pair(key.elementType, key.extra()));
+    auto it = m_storage.find(key.encode());
     if (it != m_storage.end())
         return it->value;
     return nullptr;
 }
 
 template<typename Key>
-void TypeStore::TypeCache::insert(const Key& key, const Type* type)
+void TypeCache::insert(const Key& key, const Type* type)
 {
-    auto it = m_storage.add(std::pair(key.elementType, key.extra()), type);
+    auto it = m_storage.add(key.encode(), type);
     ASSERT_UNUSED(it, it.isNewEntry);
 }
 
@@ -125,6 +106,8 @@ TypeStore::TypeStore()
     m_f32 = allocateType<Primitive>(Primitive::F32);
     m_sampler = allocateType<Primitive>(Primitive::Sampler);
     m_textureExternal = allocateType<Primitive>(Primitive::TextureExternal);
+    m_accessMode = allocateType<Primitive>(Primitive::AccessMode);
+    m_texelFormat = allocateType<Primitive>(Primitive::TexelFormat);
 }
 
 const Type* TypeStore::structType(AST::Structure& structure, HashMap<String, const Type*>&& fields)
@@ -172,6 +155,17 @@ const Type* TypeStore::textureType(const Type* elementType, Texture::Kind kind)
     if (type)
         return type;
     type = allocateType<Texture>(elementType, kind);
+    m_cache.insert(key, type);
+    return type;
+}
+
+const Type* TypeStore::textureStorageType(TextureStorage::Kind kind, TexelFormat format, AccessMode access)
+{
+    TextureStorageKey key { kind, format, access };
+    const Type* type = m_cache.find(key);
+    if (type)
+        return type;
+    type = allocateType<TextureStorage>(kind, format, access);
     m_cache.insert(key, type);
     return type;
 }

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -39,6 +39,29 @@ namespace AST {
 class Identifier;
 }
 
+class TypeCache {
+public:
+    enum KeyKind : uint8_t {
+        Vector = 1,
+        Matrix,
+        Array,
+        Texture,
+        TextureStorage,
+        Reference,
+    };
+
+    using EncodedKey = std::tuple<uint8_t, uint8_t, uint16_t, uint32_t, uintptr_t>;
+
+    template<typename Key>
+    const Type* find(const Key&) const;
+
+    template<typename Key>
+    void insert(const Key&, const Type*);
+
+private:
+    HashMap<EncodedKey, const Type*> m_storage;
+};
+
 class TypeStore {
 public:
     TypeStore();
@@ -55,29 +78,20 @@ public:
     const Type* f32Type() const { return m_f32; }
     const Type* samplerType() const { return m_sampler; }
     const Type* textureExternalType() const { return m_textureExternal; }
+    const Type* accessModeType() const { return m_accessMode; }
+    const Type* texelFormatType() const { return m_texelFormat; }
 
     const Type* structType(AST::Structure&, HashMap<String, const Type*>&& = { });
     const Type* arrayType(const Type*, std::optional<unsigned>);
     const Type* vectorType(const Type*, uint8_t);
     const Type* matrixType(const Type*, uint8_t columns, uint8_t rows);
     const Type* textureType(const Type*, Types::Texture::Kind);
+    const Type* textureStorageType(Types::TextureStorage::Kind, TexelFormat, AccessMode);
     const Type* functionType(Vector<const Type*>&&, const Type*);
     const Type* referenceType(AddressSpace, const Type*, AccessMode);
     const Type* typeConstructorType(ASCIILiteral, std::function<const Type*(AST::ElaboratedTypeExpression&)>&&);
 
 private:
-    class TypeCache {
-    public:
-        template<typename Key>
-        const Type* find(const Key&) const;
-
-        template<typename Key>
-        void insert(const Key&, const Type*);
-
-    private:
-        HashMap<std::pair<const Type*, uint64_t>, const Type*> m_storage;
-    };
-
     template<typename TypeKind, typename... Arguments>
     const Type* allocateType(Arguments&&...);
 
@@ -94,6 +108,8 @@ private:
     const Type* m_f32;
     const Type* m_sampler;
     const Type* m_textureExternal;
+    const Type* m_accessMode;
+    const Type* m_texelFormat;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -97,20 +97,91 @@ void Type::dump(PrintStream& out) const
             case Texture::Kind::TextureMultisampled2d:
                 out.print("texture_multisampled_2d");
                 break;
-            case Texture::Kind::TextureStorage1d:
+            }
+            out.print("<", *texture.element, ">");
+        },
+        [&](const TextureStorage& texture) {
+            switch (texture.kind) {
+            case TextureStorage::Kind::TextureStorage1d:
                 out.print("texture_storage_1d");
                 break;
-            case Texture::Kind::TextureStorage2d:
+            case TextureStorage::Kind::TextureStorage2d:
                 out.print("texture_storage_2d");
                 break;
-            case Texture::Kind::TextureStorage2dArray:
+            case TextureStorage::Kind::TextureStorage2dArray:
                 out.print("texture_storage_2d_array");
                 break;
-            case Texture::Kind::TextureStorage3d:
+            case TextureStorage::Kind::TextureStorage3d:
                 out.print("texture_storage_3d");
                 break;
             }
-            out.print("<", *texture.element, ">");
+            out.print("<");
+            switch (texture.format) {
+            case TexelFormat::BGRA8unorm:
+                out.print("bgra8unorm");
+                break;
+            case TexelFormat::RGBA8unorm:
+                out.print("rgba8unorm");
+                break;
+            case TexelFormat::RGBA8snorm:
+                out.print("rbga8snorm");
+                break;
+            case TexelFormat::RGBA8uint:
+                out.print("rgba8uint");
+                break;
+            case TexelFormat::RGBA8sint:
+                out.print("rgba8sint");
+                break;
+            case TexelFormat::RGBA16uint:
+                out.print("rgba16uint");
+                break;
+            case TexelFormat::RGBA16sint:
+                out.print("rgba16sint");
+                break;
+            case TexelFormat::RGBA16float:
+                out.print("rgba16float");
+                break;
+            case TexelFormat::R32uint:
+                out.print("r32uint");
+                break;
+            case TexelFormat::R32sint:
+                out.print("r32sint");
+                break;
+            case TexelFormat::R32float:
+                out.print("r32float");
+                break;
+            case TexelFormat::RG32uint:
+                out.print("rg32uint");
+                break;
+            case TexelFormat::RG32sint:
+                out.print("rg32sint");
+                break;
+            case TexelFormat::RG32float:
+                out.print("rg32float");
+                break;
+            case TexelFormat::RGBA32uint:
+                out.print("rgba32uint");
+                break;
+            case TexelFormat::RGBA32sint:
+                out.print("rgba32sint");
+                break;
+            case TexelFormat::RGBA32float:
+                out.print("rgba32float");
+                break;
+            }
+            out.print(", ");
+            switch (texture.access) {
+            case AccessMode::Read:
+                out.print("read");
+                break;
+            case AccessMode::Write:
+                out.print("write");
+                break;
+            case AccessMode::ReadWrite:
+                out.print("read_write");
+                break;
+            }
+            out.print(">");
         },
         [&](const Reference& reference) {
             out.print("ref<", reference.addressSpace, ", ", *reference.element, ", ", reference.accessMode, ">");
@@ -230,6 +301,8 @@ unsigned Type::size() const
             case Types::Primitive::AbstractFloat:
             case Types::Primitive::Sampler:
             case Types::Primitive::TextureExternal:
+            case Types::Primitive::AccessMode:
+            case Types::Primitive::TexelFormat:
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
@@ -265,6 +338,9 @@ unsigned Type::size() const
         [&](const Texture&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const TextureStorage&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const Reference&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
@@ -291,6 +367,8 @@ unsigned Type::alignment() const
             case Types::Primitive::AbstractFloat:
             case Types::Primitive::Sampler:
             case Types::Primitive::TextureExternal:
+            case Types::Primitive::AccessMode:
+            case Types::Primitive::TexelFormat:
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
@@ -319,6 +397,9 @@ unsigned Type::alignment() const
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Texture&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const TextureStorage&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Reference&) -> unsigned {

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -51,6 +51,26 @@ enum class AccessMode : uint8_t {
     ReadWrite,
 };
 
+enum class TexelFormat : uint8_t {
+    BGRA8unorm,
+    RGBA8unorm,
+    RGBA8snorm,
+    RGBA8uint,
+    RGBA8sint,
+    RGBA16uint,
+    RGBA16sint,
+    RGBA16float,
+    R32uint,
+    R32sint,
+    R32float,
+    RG32uint,
+    RG32sint,
+    RG32float,
+    RGBA32uint,
+    RGBA32sint,
+    RGBA32float,
+};
+
 namespace Types {
 
 #define FOR_EACH_PRIMITIVE_TYPE(f) \
@@ -63,6 +83,8 @@ namespace Types {
     f(Bool, "bool") \
     f(Sampler, "sampler") \
     f(TextureExternal, "texture_external") \
+    f(AccessMode, "access_mode") \
+    f(TexelFormat, "texel_format") \
 
 struct Primitive {
     enum Kind : uint8_t {
@@ -83,14 +105,23 @@ struct Texture {
         TextureCube,
         TextureCubeArray,
         TextureMultisampled2d,
-        TextureStorage1d,
+    };
+
+    const Type* element;
+    Kind kind;
+};
+
+struct TextureStorage {
+    enum class Kind : uint8_t {
+        TextureStorage1d = 1,
         TextureStorage2d,
         TextureStorage2dArray,
         TextureStorage3d,
     };
 
-    const Type* element;
     Kind kind;
+    TexelFormat format;
+    AccessMode access;
 };
 
 struct Vector {
@@ -143,6 +174,7 @@ struct Type : public std::variant<
     Types::Struct,
     Types::Function,
     Types::Texture,
+    Types::TextureStorage,
     Types::Reference,
     Types::TypeConstructor,
     Types::Bottom
@@ -155,6 +187,7 @@ struct Type : public std::variant<
         Types::Struct,
         Types::Function,
         Types::Texture,
+        Types::TextureStorage,
         Types::Reference,
         Types::TypeConstructor,
         Types::Bottom

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -116,6 +116,11 @@ var te: texture_external;
 var tc: texture_cube<f32>;
 var tca: texture_cube_array<f32>;
 
+var ts1d: texture_storage_2d<rgba8unorm, read>;
+var ts2d: texture_storage_2d<rgba16uint, write>;
+var ts2da: texture_storage_2d<r32sint, read_write>;
+var ts3d: texture_storage_2d<rgba32float, write>;
+
 fn testTextureSample() {
   {
     _ = textureSample(t1d, s, 1);


### PR DESCRIPTION
#### 51203d9ac9e8fe78cc8eae7a1034619efa9bcea1
<pre>
[WGSL] Add support for texture_storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=261465">https://bugs.webkit.org/show_bug.cgi?id=261465</a>
rdar://115363616

Reviewed by Dan Glastonbury.

Introduce a new TextureStorage type and new primitive types for texel format and
access mode.

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::bindingMemberForGlobal):
(WGSL::RewriteGlobalVariables::usesOverride):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WTF::printInternal):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::allocateTextureStorageConstructor):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::VectorKey::encode const):
(WGSL::MatrixKey::encode const):
(WGSL::ArrayKey::encode const):
(WGSL::TextureKey::encode const):
(WGSL::TextureStorageKey::encode const):
(WGSL::ReferenceKey::extra const):
(WGSL::ReferenceKey::encode const):
(WGSL::TypeCache::find const):
(WGSL::TypeCache::insert):
(WGSL::TypeStore::TypeStore):
(WGSL::TypeStore::textureType):
(WGSL::TypeStore::textureStorageType):
(WGSL::VectorKey::extra const): Deleted.
(WGSL::MatrixKey::extra const): Deleted.
(WGSL::ArrayKey::extra const): Deleted.
(WGSL::TextureKey::extra const): Deleted.
(WGSL::TypeStore::TypeCache::find const): Deleted.
(WGSL::TypeStore::TypeCache::insert): Deleted.
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::accessModeType const):
(WGSL::TypeStore::texelFormatType const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/267983@main">https://commits.webkit.org/267983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2883483bf681926d115ee83dea212ecbc7c335b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17099 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20992 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15923 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23157 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21047 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17397 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16495 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4351 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->