### PR TITLE
[webkitbugspy] Handle Radar rate limits

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.13.1',
+    version='0.13.2',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 13, 1)
+version = Version(0, 13, 2)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -137,7 +137,7 @@ MILESTONES = [
     dict(
         name='October',
         isProtected=True,
-        protectedAccessGroup='Managers,Integrators',
+        protectedAccessGroups=['Managers', 'Integrators'],
         categories=['Test Development', 'Tentpole Feature Work', 'Escape / Regression in the Build'],
         events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Convergence'],
         tentpoles=['Scrolling', 'SVG'],

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -120,8 +120,8 @@ class RadarModel(object):
         def __init__(
             self, name,
             isClosed=False,
-            isRestricted=False, restrictedAccessGroup='',
-            isProtected=False, protectedAccessGroup='',
+            isRestricted=False, restrictedAccessGroups=None,
+            isProtected=False, protectedAccessGroups=None,
             isCategoryRequired=False, categories=None,
             isEventRequired=False, events=None,
             isTentpoleRequired=False, tentpoles=None,
@@ -129,9 +129,9 @@ class RadarModel(object):
             self.name = name
             self.isClosed = isClosed
             self.isRestricted = isRestricted
-            self.restrictedAccessGroup = restrictedAccessGroup
+            self.restrictedAccessGroups = [RadarModel.RadarGroup(name) for name in restrictedAccessGroups or []]
             self.isProtected = isProtected
-            self.protectedAccessGroup = protectedAccessGroup
+            self.protectedAccessGroups = [RadarModel.RadarGroup(name) for name in protectedAccessGroups or []]
 
             self._isCategoryRequired = isCategoryRequired
             self._categories = [RadarModel.Category(category) for category in (categories or [])]
@@ -141,6 +141,7 @@ class RadarModel(object):
 
             self._isTentpoleRequired = isTentpoleRequired
             self._tentpoles = [RadarModel.Tentpole(tentpole) for tentpole in (tentpoles or [])]
+
 
     class Category(object):
         def __init__(self, name):
@@ -166,6 +167,10 @@ class RadarModel(object):
     class Keyword(object):
         def __init__(self, name):
             self.name = name
+
+    class RadarGroup(object):
+        def __init__(self, id):
+            self.id = id
 
     def __init__(self, client, issue):
         from datetime import datetime, timedelta
@@ -434,6 +439,9 @@ class Radar(Base, ContextStack):
         class UnsuccessfulResponseException(Exception):
             pass
 
+    class RetryPolicy(object):
+        pass
+
     @classmethod
     def transform_user(cls, user):
         return User(
@@ -459,7 +467,7 @@ class Radar(Base, ContextStack):
             self.milestones[ms.name] = ms
 
         self.AppleDirectoryQuery = AppleDirectoryQuery(self)
-        self.RadarClient = lambda authentication_strategy, client_system_identifier: RadarClient(self, authentication_strategy)
+        self.RadarClient = lambda authentication_strategy, client_system_identifier, retry_policy=None: RadarClient(self, authentication_strategy)
 
         from mock import patch
         self.patches.append(patch('webkitbugspy.radar.Tracker.radarclient', new=lambda s=None: self))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -113,6 +113,7 @@ class Tracker(GenericTracker):
         if authentication:
             self.client = self.library.RadarClient(
                 authentication, self.library.ClientSystemIdentifier(library_name, str(library_version)),
+                retry_policy=self.radarclient().RetryPolicy(),
             )
         else:
             self.client = None

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.11',
+    version='6.6.12',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 11)
+version = Version(6, 6, 12)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
@@ -158,16 +158,16 @@ class Clone(Command):
                 milestone = None
                 continue
             if milestone.isRestricted:
-                for group in milestone.restrictedAccessGroup.split(','):
-                    if rdar.me().username in rdar.library.AppleDirectoryQuery.member_dsid_list_for_group_name(group):
+                for group in milestone.restrictedAccessGroups:
+                    if rdar.me().username in rdar.library.AppleDirectoryQuery.member_dsid_list_for_group_name(group.id):
                         break
                 else:
                     sys.stderr.write("You do not have read access to '{}', pick another\n".format(milestone.name))
                     milestone = None
                     continue
             if milestone.isProtected:
-                for group in milestone.protectedAccessGroup.split(','):
-                    if rdar.me().username in rdar.library.AppleDirectoryQuery.member_dsid_list_for_group_name(group):
+                for group in milestone.protectedAccessGroups:
+                    if rdar.me().username in rdar.library.AppleDirectoryQuery.member_dsid_list_for_group_name(group.id):
                         break
                 else:
                     sys.stderr.write("You do not have write access to '{}', pick another\n".format(milestone.name))


### PR DESCRIPTION
#### 6ba3165c0feb1c202795e5c8bd05c47b87264f3a
<pre>
[webkitbugspy] Handle Radar rate limits
<a href="https://bugs.webkit.org/show_bug.cgi?id=261469">https://bugs.webkit.org/show_bug.cgi?id=261469</a>
rdar://115370971

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: protectedAccessGroups is a list.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.Milestone): Update function call with AccessGroups.
(RadarModel.RadarGroup): Added.
(Radar.RetryPolicy): Added.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.__init__): Add retry policy.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py:
(Clone.main): Use new AccessGroups.

Canonical link: <a href="https://commits.webkit.org/267913@main">https://commits.webkit.org/267913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77ef5fa5071be23d5f19cd6a0af6a99819aa4a2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18526 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18257 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/18513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20751 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18192 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/15740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/16454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/16756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/20859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/17884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20648 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2211 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->