### PR TITLE
Basic support for CSS based Ruby in IFC

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -903,6 +903,20 @@ CSS3DTransformInteroperabilityEnabled:
     WebCore:
       default: true
 
+CSSBasedRubyEnabled:
+  type: bool
+  status: unstable
+  category: css
+  humanReadableName: "CSS based Ruby implementation in IFC"
+  humanReadableDescription: "CSS based Ruby implementation in IFC"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSCascadeLayersEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1836,6 +1836,7 @@ set(WebCore_USER_AGENT_STYLE_SHEETS
     ${WEBCORE_DIR}/css/plugIns.css
     ${WEBCORE_DIR}/css/popover.css
     ${WEBCORE_DIR}/css/quirks.css
+    ${WEBCORE_DIR}/css/ruby.css
     ${WEBCORE_DIR}/css/svg.css
     ${WEBCORE_DIR}/html/shadow/attachmentElementShadow.css
     ${WEBCORE_DIR}/html/shadow/imageOverlay.css

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1235,6 +1235,7 @@ $(PROJECT_DIR)/css/popover.css
 $(PROJECT_DIR)/css/process-css-properties.py
 $(PROJECT_DIR)/css/process-css-values.py
 $(PROJECT_DIR)/css/quirks.css
+$(PROJECT_DIR)/css/ruby.css
 $(PROJECT_DIR)/css/svg.css
 $(PROJECT_DIR)/css/typedom/CSSKeywordValue.idl
 $(PROJECT_DIR)/css/typedom/CSSNumericValue.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1962,6 +1962,7 @@ USER_AGENT_STYLE_SHEETS = \
     $(WebCore)/css/plugIns.css \
     $(WebCore)/css/popover.css \
     $(WebCore)/css/quirks.css \
+    $(WebCore)/css/ruby.css \
     $(WebCore)/css/svg.css \
     $(WebCore)/html/shadow/mac/imageControlsMac.css \
     $(WebCore)/html/shadow/attachmentElementShadow.css \

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -736,6 +736,14 @@ constexpr CSSValueID toCSSValueID(DisplayType e)
         return CSSValueContents;
     case DisplayType::FlowRoot:
         return CSSValueFlowRoot;
+    case DisplayType::Ruby:
+        return CSSValueRuby;
+    case DisplayType::RubyBlock:
+        return CSSValueBlockRuby;
+    case DisplayType::RubyBase:
+        return CSSValueRubyBase;
+    case DisplayType::RubyAnnotation:
+        return CSSValueRubyText;
     }
     ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
     return CSSValueInvalid;
@@ -743,12 +751,66 @@ constexpr CSSValueID toCSSValueID(DisplayType e)
 
 template<> constexpr DisplayType fromCSSValueID(CSSValueID valueID)
 {
-    if (valueID == CSSValueNone)
+    switch (valueID) {
+    case CSSValueInline:
+        return DisplayType::Inline;
+    case CSSValueBlock:
+        return DisplayType::Block;
+    case CSSValueListItem:
+        return DisplayType::ListItem;
+    case CSSValueInlineBlock:
+        return DisplayType::InlineBlock;
+    case CSSValueTable:
+        return DisplayType::Table;
+    case CSSValueInlineTable:
+        return DisplayType::InlineTable;
+    case CSSValueTableRowGroup:
+        return DisplayType::TableRowGroup;
+    case CSSValueTableHeaderGroup:
+        return DisplayType::TableHeaderGroup;
+    case CSSValueTableFooterGroup:
+        return DisplayType::TableFooterGroup;
+    case CSSValueTableRow:
+        return DisplayType::TableRow;
+    case CSSValueTableColumnGroup:
+        return DisplayType::TableColumnGroup;
+    case CSSValueTableColumn:
+        return DisplayType::TableColumn;
+    case CSSValueTableCell:
+        return DisplayType::TableCell;
+    case CSSValueTableCaption:
+        return DisplayType::TableCaption;
+    case CSSValueWebkitBox:
+        return DisplayType::Box;
+    case CSSValueWebkitInlineBox:
+        return DisplayType::InlineBox;
+    case CSSValueFlex:
+        return DisplayType::Flex;
+    case CSSValueInlineFlex:
+        return DisplayType::InlineFlex;
+    case CSSValueGrid:
+        return DisplayType::Grid;
+    case CSSValueInlineGrid:
+        return DisplayType::InlineGrid;
+    case CSSValueNone:
         return DisplayType::None;
-
-    DisplayType display = static_cast<DisplayType>(valueID - CSSValueInline);
-    ASSERT(display >= DisplayType::Inline && display <= DisplayType::None);
-    return display;
+    case CSSValueContents:
+        return DisplayType::Contents;
+    case CSSValueFlowRoot:
+        return DisplayType::FlowRoot;
+    case CSSValueRuby:
+        return DisplayType::Ruby;
+    case CSSValueBlockRuby:
+        return DisplayType::RubyBlock;
+    case CSSValueRubyBase:
+        return DisplayType::RubyBase;
+    case CSSValueRubyText:
+        return DisplayType::RubyAnnotation;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+    return DisplayType::Inline;
 }
 
 #define TYPE EmptyCell

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -476,6 +476,7 @@
             "codegen-properties": {
                 "high-priority": true,
                 "parser-function": "consumeDisplay",
+                "parser-function-requires-context-mode": true,
                 "parser-grammar-unused": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <-webkit-display>",
                 "parser-grammar-unused-reason": "Needs support for '||' groups and '&& groups."
             },

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -533,7 +533,11 @@ flow-root
 flow
 -webkit-inline-flex
 -webkit-flex
-//none
+// ruby
+block-ruby
+ruby-base
+ruby-text
+// none
 //
 // CSS_PROP_CURSOR:
 // The order here must match the order of the CursorType enum in RenderStyleConstants.h.

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -219,7 +219,7 @@ bool isGridBreadthIdent(CSSValueID);
 
 RefPtr<CSSValueList> consumeAlignTracks(CSSParserTokenRange&);
 RefPtr<CSSValueList> consumeJustifyTracks(CSSParserTokenRange&);
-RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeWillChange(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeQuotes(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange&);

--- a/Source/WebCore/css/ruby.css
+++ b/Source/WebCore/css/ruby.css
@@ -1,0 +1,10 @@
+@namespace "http://www.w3.org/1999/xhtml";
+
+ruby {
+    display: ruby;
+}
+ruby > rt {
+    display: ruby-text;
+    white-space: nowrap;
+    line-height: 1;
+}

--- a/Source/WebCore/html/RubyElement.cpp
+++ b/Source/WebCore/html/RubyElement.cpp
@@ -53,10 +53,12 @@ Ref<RubyElement> RubyElement::create(Document& document)
 
 RenderPtr<RenderElement> RubyElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
-    if (style.display() == DisplayType::Inline)
-        return createRenderer<RenderRubyAsInline>(*this, WTFMove(style));
-    if (style.display() == DisplayType::Block || style.display() == DisplayType::InlineBlock)
-        return createRenderer<RenderRubyAsBlock>(*this, WTFMove(style));
+    if (!document().settings().cssBasedRubyEnabled()) {
+        if (style.display() == DisplayType::Inline)
+            return createRenderer<RenderRubyAsInline>(*this, WTFMove(style));
+        if (style.display() == DisplayType::Block || style.display() == DisplayType::InlineBlock)
+            return createRenderer<RenderRubyAsBlock>(*this, WTFMove(style));
+    }
     return HTMLElement::createElementRenderer(WTFMove(style), insertionPosition);
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -257,6 +257,8 @@ void InlineItemsBuilder::collectInlineItems(InlineItems& inlineItems, InlineItem
             else if (layoutBox->isFloatingPositioned()) {
                 inlineItems.append({ layoutBox, InlineItem::Type::Float });
                 m_isNonBidiTextAndForcedLineBreakOnlyContent = false;
+            } else if (layoutBox->isRubyAnnotationBox()) {
+                // Does not participate in inline layout.
             } else
                 ASSERT_NOT_REACHED();
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -62,6 +62,7 @@ private:
     void appendInlineBoxDisplayBox(const Line::Run&, const InlineLevelBox&, const InlineRect&, bool linehasContent, InlineDisplay::Boxes&);
     void appendSpanningInlineBoxDisplayBox(const Line::Run&, const InlineLevelBox&, const InlineRect&, bool linehasContent, InlineDisplay::Boxes&);
     void appendInlineDisplayBoxAtBidiBoundary(const Box&, InlineDisplay::Boxes&);
+    void appendAssociatedRubyAnnotationBoxIfNeeded(const Box&, const InlineRect& inlineBoxBorderBox, InlineDisplay::Boxes&);
 
     void setInlineBoxGeometry(const Box&, const InlineRect&, bool isFirstInlineBoxFragment);
     void adjustVisualGeometryForDisplayBox(size_t displayBoxNodeIndex, InlineLayoutUnit& accumulatedOffset, InlineLayoutUnit lineBoxLogicalTop, const DisplayBoxTree&, InlineDisplay::Boxes&, const LineBox&, const HashMap<const Box*, IsFirstLastIndex>&);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -616,7 +616,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
 
         auto& layoutBox = box.layoutBox();
 
-        if (!layoutBox.isAtomicInlineLevelBox())
+        if (!layoutBox.isAtomicInlineLevelBox() && !layoutBox.isRubyAnnotationBox())
             continue;
 
         auto& renderer = downcast<RenderBox>(m_boxTree.rendererForLayoutBox(layoutBox));

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -130,6 +130,8 @@ public:
     bool isInitialContainingBlock() const { return baseTypeFlags().contains(InitialContainingBlockFlag); }
     bool isLayoutContainmentBox() const;
     bool isSizeContainmentBox() const;
+    bool isInternalRubyBox() const;
+    bool isRubyAnnotationBox() const;
 
     bool isDocumentBox() const { return m_nodeType == NodeType::DocumentElement; }
     bool isBodyBox() const { return m_nodeType == NodeType::Body; }
@@ -148,7 +150,6 @@ public:
     bool isFlexItem() const;
     bool isIFrame() const { return m_nodeType == NodeType::IFrame; }
     bool isImage() const { return m_nodeType == NodeType::Image; }
-    bool isInternalRubyBox() const { return false; }
     bool isLineBreakBox() const { return m_nodeType == NodeType::LineBreak || m_nodeType == NodeType::WordBreakOpportunity; }
     bool isWordBreakOpportunity() const { return m_nodeType == NodeType::WordBreakOpportunity; }
     bool isListMarkerBox() const { return m_nodeType == NodeType::ListMarker; }
@@ -197,6 +198,8 @@ public:
 
     const RubyAdjustments* rubyAdjustments() const;
     void setRubyAdjustments(std::unique_ptr<RubyAdjustments>);
+
+    const ElementBox* associatedRubyAnnotationBox() const;
 
     bool canCacheForLayoutState(const LayoutState&) const;
     BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -209,6 +209,15 @@ RenderPtr<RenderElement> RenderElement::createFor(Element& element, RenderStyle&
     case DisplayType::Box:
     case DisplayType::InlineBox:
         return createRenderer<RenderDeprecatedFlexibleBox>(element, WTFMove(style));
+    case DisplayType::RubyBase:
+        return createRenderer<RenderInline>(element, WTFMove(style));
+    case DisplayType::RubyAnnotation:
+        return createRenderer<RenderBlockFlow>(element, WTFMove(style));
+    case DisplayType::Ruby:
+        return createRenderer<RenderInline>(element, WTFMove(style));
+    case DisplayType::RubyBlock:
+        return createRenderer<RenderBlockFlow>(element, WTFMove(style));
+
     default: {
         if (style.isDisplayTableOrTablePart() && rendererTypeOverride.contains(ConstructBlockLevelRendererFor::TableOrTablePart))
             return createRenderer<RenderBlockFlow>(element, WTFMove(style));

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -409,6 +409,10 @@ TextStream& operator<<(TextStream& ts, DisplayType display)
     case DisplayType::Grid: ts << "grid"; break;
     case DisplayType::InlineGrid: ts << "inline-grid"; break;
     case DisplayType::FlowRoot: ts << "flow-root"; break;
+    case DisplayType::Ruby: ts << "ruby"; break;
+    case DisplayType::RubyBlock: ts << "block ruby"; break;
+    case DisplayType::RubyBase: ts << "ruby-base"; break;
+    case DisplayType::RubyAnnotation: ts << "ruby-text"; break;
     case DisplayType::None: ts << "none"; break;
     }
     return ts;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -819,7 +819,6 @@ enum class CursorVisibility : bool {
 };
 #endif
 
-// The order of this enum must match the order of the display values in CSSValueKeywords.in.
 enum class DisplayType : uint8_t {
     Inline,
     Block,
@@ -843,6 +842,10 @@ enum class DisplayType : uint8_t {
     Grid,
     InlineGrid,
     FlowRoot,
+    Ruby,
+    RubyBlock,
+    RubyBase,
+    RubyAnnotation,
     None
 };
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -864,7 +864,8 @@ constexpr bool RenderStyle::isDisplayBlockType(DisplayType display)
         || display == DisplayType::FlowRoot
         || display == DisplayType::Grid
         || display == DisplayType::ListItem
-        || display == DisplayType::Table;
+        || display == DisplayType::Table
+        || display == DisplayType::RubyBlock;
 }
 
 constexpr bool RenderStyle::isDisplayInlineType(DisplayType display)
@@ -874,7 +875,10 @@ constexpr bool RenderStyle::isDisplayInlineType(DisplayType display)
         || display == DisplayType::InlineBox
         || display == DisplayType::InlineFlex
         || display == DisplayType::InlineGrid
-        || display == DisplayType::InlineTable;
+        || display == DisplayType::InlineTable
+        || display == DisplayType::Ruby
+        || display == DisplayType::RubyBase
+        || display == DisplayType::RubyAnnotation;
 }
 
 constexpr bool RenderStyle::isDisplayRegionType() const

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -317,6 +317,11 @@ void RenderTreeBuilder::attachInternal(RenderElement& parent, RenderPtr<RenderOb
         return;
     }
 
+    if (parent.style().display() == DisplayType::Ruby || parent.style().display() == DisplayType::RubyBlock) {
+        insertRecursiveIfNeeded(rubyBuilder().findOrCreateParentForStyleBasedRubyChild(parent, *child, beforeChild));
+        return;
+    }
+
     if (is<RenderBlockFlow>(parent)) {
         blockFlowBuilder().attach(downcast<RenderBlockFlow>(parent), WTFMove(child), beforeChild);
         return;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -326,7 +326,7 @@ void RenderTreeBuilder::Inline::splitInlines(RenderInline& parent, RenderBlock* 
     unsigned splitDepth = 1;
     const unsigned cMaxSplitDepth = 200;
     while (current && current != fromBlock) {
-        if (splitDepth < cMaxSplitDepth) {
+        if (splitDepth < cMaxSplitDepth && !current->isAnonymous()) {
             // Create a new clone.
             RenderPtr<RenderInline> cloneChild = WTFMove(cloneInline);
             cloneInline = cloneAsContinuation(downcast<RenderInline>(*current));

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h
@@ -51,6 +51,7 @@ public:
 
     RenderElement& findOrCreateParentForChild(RenderRubyAsBlock& parent, const RenderObject& child, RenderObject*& beforeChild);
     RenderElement& findOrCreateParentForChild(RenderRubyAsInline& parent, const RenderObject& child, RenderObject*& beforeChild);
+    RenderElement& findOrCreateParentForStyleBasedRubyChild(RenderElement& parent, const RenderObject& child, RenderObject*& beforeChild);
 
 private:
     void moveInlineChildren(RenderRubyBase& from, RenderRubyBase& to, RenderObject* beforeChild);

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -84,6 +84,7 @@ StyleSheetContents* UserAgentStyle::popoverStyleSheet;
 StyleSheetContents* UserAgentStyle::plugInsStyleSheet;
 StyleSheetContents* UserAgentStyle::horizontalFormControlsStyleSheet;
 StyleSheetContents* UserAgentStyle::counterStylesStyleSheet;
+StyleSheetContents* UserAgentStyle::rubyStyleSheet;
 #if ENABLE(FULLSCREEN_API)
 StyleSheetContents* UserAgentStyle::fullscreenStyleSheet;
 #endif
@@ -253,6 +254,11 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
     if (!counterStylesStyleSheet) {
         counterStylesStyleSheet = parseUASheet(StringImpl::createWithoutCopying(counterStylesUserAgentStyleSheet, sizeof(counterStylesUserAgentStyleSheet)));
         addToCounterStyleRegistry(*counterStylesStyleSheet);
+    }
+
+    if (!rubyStyleSheet && element.document().settings().cssBasedRubyEnabled()) {
+        rubyStyleSheet = parseUASheet(StringImpl::createWithoutCopying(rubyUserAgentStyleSheet, sizeof(rubyUserAgentStyleSheet)));
+        addToDefaultStyle(*rubyStyleSheet);
     }
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/style/UserAgentStyle.h
+++ b/Source/WebCore/style/UserAgentStyle.h
@@ -49,6 +49,7 @@ public:
     static StyleSheetContents* plugInsStyleSheet;
     static StyleSheetContents* popoverStyleSheet;
     static StyleSheetContents* counterStylesStyleSheet;
+    static StyleSheetContents* rubyStyleSheet;
 #if ENABLE(FULLSCREEN_API)
     static StyleSheetContents* fullscreenStyleSheet;
 #endif


### PR DESCRIPTION
#### 44bf0d71007ce85571ea893edef23a9b3935f7a8
<pre>
Basic support for CSS based Ruby in IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=261468">https://bugs.webkit.org/show_bug.cgi?id=261468</a>
rdar://115370429

Reviewed by Alan Baradlay.

The current Ruby implementation uses special elements and renderers.

This patch implements basic support for CSS based ruby in IFC:
- Adds display property values &apos;ruby&apos;, &apos;block-ruby&apos;, &apos;ruby-base&apos; and &apos;ruby-text&apos; but does not expose them outside the user
agent stylesheet.
- Adds render tree building support for these values.
- Sketches an IFC implementation that is able to generate annotation boxes in the simple case. Layout is not affected.

The feature is behind a flag and is disabled by default.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add a setting.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):

Use switch for robustness and readability.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeDisplay):

Pass the parsing mode so we can limit the new properties to the UA sheet.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/ruby.css: Added.

Add a UA stylesheet that sets the display property values for HTML ruby elements.

* Source/WebCore/html/RubyElement.cpp:
(WebCore::RubyElement::createElementRenderer):

Skip the special case renderer generation if enabled.

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::collectInlineItems):

Skip over ruby annotation boxes when collecting inline items.
Ruby bases simply map to inline boxes.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendInlineBoxDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::appendAssociatedRubyAnnotationBoxIfNeeded):

If an inline box has an associated ruby box it is actually a ruby base.
Generate an annotation box and place it above the base.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Place the annotation box renderer after layout.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isInlineLevelBox const):
(WebCore::Layout::Box::isInlineBox const):
(WebCore::Layout::Box::isBlockContainer const):
(WebCore::Layout::Box::isRubyAnnotationBox const):
(WebCore::Layout::Box::isInternalRubyBox const):
(WebCore::Layout::Box::associatedRubyAnnotationBox const):

Find the annotation if any.

* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::isImage const):
(WebCore::Layout::Box::isInternalRubyBox const): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::createFor):

Use generic renderers for ruby display values.

* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isDisplayBlockType):
(WebCore::RenderStyle::isDisplayInlineType):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachInternal):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::splitInlines):

With ruby we may find anonymous inlines when splitting inlines for continuations. Just ignore them, they provide no styling.

* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):

Generate anonymous boxes for ruby so we get structure like

&lt;ruby&gt;&lt;ruby-base&gt;base content&lt;/ruby-base&gt;&lt;ruby-annotation&gt;annotation content&lt;/ruby-annotation&gt;&lt;/ruby&gt;

* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::equivalentBlockDisplay):
(WebCore::Style::equivalentInlineDisplay):

Add inlinification function.

(WebCore::Style::shouldInlinifyForRuby):
(WebCore::Style::Adjuster::adjust const):

Inlinify children of ruby boxes.

* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):

Include ruby.css if enabled.

* Source/WebCore/style/UserAgentStyle.h:

Canonical link: <a href="https://commits.webkit.org/267937@main">https://commits.webkit.org/267937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15356e4572522bbfb1fae2ce01e77b0e30da2818

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20846 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16536 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/15704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20929 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/17407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17275 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21484 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5267 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4311 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20727 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22718 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17123 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5114 "Passed tests") | 
<!--EWS-Status-Bubble-End-->