### PR TITLE
Use more std::span<uint8_t> in IPC::Decoder

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -208,6 +208,14 @@ Ref<ArrayBuffer> ArrayBuffer::create(const void* source, size_t byteLength)
     return buffer.releaseNonNull();
 }
 
+Ref<ArrayBuffer> ArrayBuffer::create(std::span<uint8_t> span)
+{
+    auto buffer = tryCreate(span);
+    if (!buffer)
+        CRASH();
+    return buffer.releaseNonNull();
+}
+
 Ref<ArrayBuffer> ArrayBuffer::create(ArrayBufferContents&& contents)
 {
     return adoptRef(*new ArrayBuffer(WTFMove(contents)));
@@ -266,6 +274,11 @@ RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(const void* source, size_t byteLength
     if (!contents.m_data)
         return nullptr;
     return createInternal(WTFMove(contents), source, byteLength);
+}
+
+RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(std::span<uint8_t> span)
+{
+    return tryCreate(span.data(), span.size_bytes());
 }
 
 Ref<ArrayBuffer> ArrayBuffer::createUninitialized(size_t numElements, unsigned elementByteSize)

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -261,6 +261,7 @@ public:
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(size_t numElements, unsigned elementByteSize);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(ArrayBuffer&);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(const void* source, size_t byteLength);
+    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(std::span<uint8_t>);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(ArrayBufferContents&&);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(const Vector<uint8_t>&);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createAdopted(const void* data, size_t byteLength);
@@ -269,6 +270,7 @@ public:
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength = std::nullopt);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(ArrayBuffer&);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(const void* source, size_t byteLength);
+    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(std::span<uint8_t>);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreateShared(VM&, size_t numElements, unsigned elementByteSize, size_t maxByteLength);
 
     // Only for use by Uint8ClampedArray::tryCreateUninitialized and FragmentedSharedBuffer::tryCreateArrayBuffer.

--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,6 +24,10 @@
  */
 
 #pragma once
+
+#include <cstring>
+#include <span>
+#include <wtf/Assertions.h>
 
 namespace WTF {
 
@@ -54,5 +58,15 @@ bool allOf(ContainerType&& container, AllOfFunction allOfFunction)
     return true;
 }
 
+template<typename T, typename U>
+std::span<T> spanReinterpretCast(std::span<U> span)
+{
+    RELEASE_ASSERT(!(span.size_bytes() % sizeof(T)));
+    static_assert(std::is_const_v<T> || (!std::is_const_v<T> && !std::is_const_v<U>), "spanCast will not remove constness from source");
+    return std::span<T> { reinterpret_cast<T*>(const_cast<std::remove_const_t<U>*>(span.data())), span.size_bytes() / sizeof(T) };
 }
+
+} // namespace WTF
+
+using WTF::spanReinterpretCast;
 

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,7 +80,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
 
         size_t dataSize { 0 };
         const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebPushD::protocolEncodedMessageKey, &dataSize));
-        auto decoder = IPC::Decoder::create(data, dataSize, { });
+        auto decoder = IPC::Decoder::create({ data, dataSize }, { });
         ASSERT(decoder);
 
         completionHandler(decoder.get());

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,8 +26,10 @@
 #pragma once
 
 #include "Attachment.h"
+#include "DataReference.h"
 #include "MessageNames.h"
 #include "ReceiverMatcher.h"
+#include <wtf/Algorithms.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Function.h>
 #include <wtf/OptionSet.h>
@@ -49,13 +51,14 @@ template<typename, typename, typename> struct HasModernDecoder;
 class Decoder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<Decoder> create(const uint8_t* buffer, size_t bufferSize, Vector<Attachment>&&);
-    using BufferDeallocator = Function<void(const uint8_t*, size_t)>;
-    static std::unique_ptr<Decoder> create(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&&, Vector<Attachment>&&);
-    Decoder(const uint8_t* stream, size_t streamSize, uint64_t destinationID);
+    static std::unique_ptr<Decoder> create(DataReference buffer, Vector<Attachment>&&);
+    using BufferDeallocator = Function<void(DataReference)>;
+    static std::unique_ptr<Decoder> create(DataReference buffer, BufferDeallocator&&, Vector<Attachment>&&);
+    Decoder(DataReference stream, uint64_t destinationID);
 
     ~Decoder();
 
+    Decoder() = delete;
     Decoder(const Decoder&) = delete;
     Decoder(Decoder&&) = delete;
     Decoder& operator=(const Decoder&) = delete;
@@ -80,12 +83,16 @@ public:
 
     static std::unique_ptr<Decoder> unwrapForTesting(Decoder&);
 
-    const uint8_t* buffer() const { return m_buffer; }
-    size_t currentBufferPosition() const { return m_bufferPos - m_buffer; }
-    size_t length() const { return m_bufferEnd - m_buffer; }
+    DataReference buffer() const { return m_buffer; }
+    size_t currentBufferOffset() const { return static_cast<size_t>(std::distance(m_buffer.begin(), m_bufferPosition)); }
 
-    WARN_UNUSED_RETURN bool isValid() const { return m_bufferPos != nullptr; }
-    void markInvalid() { m_bufferPos = nullptr; }
+    WARN_UNUSED_RETURN bool isValid() const { return !!m_buffer.data(); }
+    void markInvalid()
+    {
+        auto buffer = std::exchange(m_buffer, { });
+        if (m_bufferDeallocator)
+            m_bufferDeallocator(WTFMove(buffer));
+    }
 
     template<typename T>
     WARN_UNUSED_RETURN std::span<const T> decodeSpan(size_t);
@@ -121,7 +128,7 @@ public:
     }
 
     // The preferred decode() function. Can decode T which is not default constructible when T
-    // has a  modern decoder, e.g decoding function that returns std::optional.
+    // has a modern decoder, e.g decoding function that returns std::optional.
     template<typename T>
     std::optional<T> decode()
     {
@@ -145,33 +152,32 @@ public:
     static constexpr bool isIPCDecoder = true;
 
 private:
-    Decoder(const uint8_t* buffer, size_t bufferSize, BufferDeallocator&&, Vector<Attachment>&&);
+    Decoder(DataReference buffer, BufferDeallocator&&, Vector<Attachment>&&);
 
-    const uint8_t* m_buffer;
-    const uint8_t* m_bufferPos;
-    const uint8_t* m_bufferEnd;
+    DataReference m_buffer;
+    DataReference::iterator m_bufferPosition;
     BufferDeallocator m_bufferDeallocator;
 
     Vector<Attachment> m_attachments;
 
     OptionSet<MessageFlags> m_messageFlags;
-    MessageName m_messageName;
-
-    uint64_t m_destinationID;
     bool m_isAllowedWhenWaitingForSyncReplyOverride { false };
+    MessageName m_messageName { MessageName::Invalid };
 
 #if PLATFORM(MAC)
     ImportanceAssertion m_importanceAssertion;
 #endif
+
+    uint64_t m_destinationID;
 };
 
-inline bool alignedBufferIsLargeEnoughToContain(const uint8_t* alignedPosition, const uint8_t* bufferStart, const uint8_t* bufferEnd, size_t size)
+inline bool alignedBufferIsLargeEnoughToContain(size_t bufferSize, const size_t alignedBufferPosition, size_t bytesNeeded)
 {
-    // When size == 0 for the last argument and it's a variable length byte array,
-    // bufferStart == alignedPosition == bufferEnd, so checking (bufferEnd >= alignedPosition)
-    // is not an off-by-one error since (static_cast<size_t>(bufferEnd - alignedPosition) >= size)
-    // will catch issues when size != 0.
-    return bufferEnd >= alignedPosition && bufferStart <= alignedPosition && static_cast<size_t>(bufferEnd - alignedPosition) >= size;
+    // When bytesNeeded == 0 for the last argument and it's a variable length byte array,
+    // alignedBufferPosition == bufferSize, so checking (bufferSize >= alignedBufferPosition)
+    // is not an off-by-one error since (bufferSize - alignedBufferPosition) >= bytesNeeded)
+    // will catch issues when bytesNeeded > 0.
+    return (bufferSize >= alignedBufferPosition) && ((bufferSize - alignedBufferPosition) >= bytesNeeded);
 }
 
 template<typename T>
@@ -180,14 +186,15 @@ inline std::span<const T> Decoder::decodeSpan(size_t size)
     if (size > std::numeric_limits<size_t>::max() / sizeof(T))
         return { };
 
-    const uint8_t* alignedPosition = roundUpToMultipleOf<alignof(T)>(m_bufferPos);
-    if (UNLIKELY(!alignedBufferIsLargeEnoughToContain(alignedPosition, m_buffer, m_bufferEnd, size * sizeof(T)))) {
+    const size_t alignedBufferPosition = static_cast<size_t>(std::distance(m_buffer.data(), roundUpToMultipleOf<alignof(T)>(std::to_address(m_bufferPosition))));
+    const size_t bytesNeeded = size * sizeof(T);
+    if (UNLIKELY(!alignedBufferIsLargeEnoughToContain(m_buffer.size_bytes(), alignedBufferPosition, bytesNeeded))) {
         markInvalid();
         return { };
     }
 
-    m_bufferPos = alignedPosition + size * sizeof(T);
-    return { reinterpret_cast<const T*>(alignedPosition), size };
+    m_bufferPosition = m_buffer.begin() + alignedBufferPosition + bytesNeeded;
+    return spanReinterpretCast<const T>(m_buffer.subspan(alignedBufferPosition, bytesNeeded));
 }
 
 template<typename T>

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.cpp
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.cpp
@@ -194,12 +194,12 @@ JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, W
     return jsValueForDecodedArgumentRect(globalObject, value, "FloatRect"_s);
 }
 
-bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalObject* globalObject, JSC::JSArray* array, unsigned index, JSC::JSValue value, const uint8_t* buffer, size_t length)
+bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalObject* globalObject, JSC::JSArray* array, unsigned index, JSC::JSValue value, DataReference buffer)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     if (value.isUndefined()) {
-        auto arrayBuffer = JSC::ArrayBuffer::create(buffer, length);
+        auto arrayBuffer = JSC::ArrayBuffer::create(buffer);
         if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
             value = JSC::JSArrayBuffer::create(globalObject->vm(), structure, WTFMove(arrayBuffer));
     }

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -122,7 +122,7 @@ JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, O
     return result;
 }
 
-bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalObject*, JSC::JSArray*, unsigned index, JSC::JSValue, const uint8_t* buffer, size_t length);
+bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalObject*, JSC::JSArray*, unsigned index, JSC::JSValue, DataReference buffer);
 
 template<typename... Elements>
 std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObject*, IPC::Decoder&, JSC::JSArray*, size_t currentIndex, std::tuple<Elements...>*);
@@ -136,7 +136,7 @@ inline std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlo
 template<typename T, typename... Elements>
 std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObject* globalObject, IPC::Decoder& decoder, JSC::JSArray* array, size_t currentIndex, std::tuple<T, Elements...>*)
 {
-    auto startingBufferPosition = decoder.currentBufferPosition();
+    auto startingBufferOffset = decoder.currentBufferOffset();
     std::optional<T> value;
     decoder >> value;
     if (!value)
@@ -146,8 +146,8 @@ std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObje
     if (jsValue.isEmpty())
         return jsValue;
 
-    putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(globalObject, array, currentIndex, jsValue,
-        decoder.buffer() + startingBufferPosition, decoder.currentBufferPosition() - startingBufferPosition);
+    auto span = decoder.buffer().subspan(startingBufferOffset, decoder.currentBufferOffset() - startingBufferOffset);
+    putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(globalObject, array, currentIndex, jsValue, span);
 
     std::tuple<Elements...>* dummyArguments = nullptr;
     return putJSValueForDecodeArgumentInArray<Elements...>(globalObject, decoder, array, currentIndex + 1, dummyArguments);

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -245,7 +245,7 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
             if (!replySpan)
                 return Connection::DecoderOrError { Error::FailedToAcquireReplyBufferSpan };
 
-            auto decoder = std::unique_ptr<Decoder> { new Decoder(replySpan->data(), replySpan->size(), m_currentDestinationID) };
+            auto decoder = std::unique_ptr<Decoder> { new Decoder(*replySpan, m_currentDestinationID) };
             if (decoder->messageName() != MessageName::ProcessOutOfStreamMessage) {
                 ASSERT(decoder->messageName() == MessageName::SyncMessageReply);
                 return Connection::DecoderOrError { WTFMove(decoder) };

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -205,7 +205,7 @@ bool Connection::processMessage()
     if (messageInfo.isBodyOutOfLine())
         messageBody = reinterpret_cast<uint8_t*>(oolMessageBody->data());
 
-    auto decoder = Decoder::create(messageBody, messageInfo.bodySize(), WTFMove(attachments));
+    auto decoder = Decoder::create({ messageBody, messageInfo.bodySize() }, WTFMove(attachments));
     ASSERT(decoder);
     if (!decoder)
         return false;

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -142,7 +142,7 @@ void Connection::readEventHandler()
 
         if (!m_readBuffer.isEmpty()) {
             // We have a message, let's dispatch it.
-            auto decoder = Decoder::create(m_readBuffer.data(), m_readBuffer.size(), { });
+            auto decoder = Decoder::create(m_readBuffer.span(), { });
             ASSERT(decoder);
             if (!decoder)
                 return;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1263,6 +1263,7 @@ def generate_message_names_header(receivers):
         if condition:
             result.append('#endif\n')
     result.append('    Count,\n')
+    result.append('    Invalid = Count,\n')
     result.append('    Last = Count - 1\n')
     result.append('};\n')
     result.append('\n')

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -203,6 +203,7 @@ enum class MessageName : uint16_t {
     TestWithoutAttributes_TestMultipleAttributes,
     WrappedAsyncMessageForTesting,
     Count,
+    Invalid = Count,
     Last = Count - 1
 };
 

--- a/Source/WebKit/UIProcess/LegacySessionStateCodingNone.cpp
+++ b/Source/WebKit/UIProcess/LegacySessionStateCodingNone.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
 
 bool decodeLegacySessionState(const uint8_t* data, size_t dataSize, SessionState& sessionState)
 {
-    auto decoder = IPC::Decoder::create(data, dataSize, { });
+    auto decoder = IPC::Decoder::create({ data, dataSize }, { });
     if (!decoder)
         return false;
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -539,7 +539,7 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
     if (message.encoder->messageName() == IPC::MessageName::WebPage_LoadRequestWaitingForProcessLaunch) {
         auto buffer = message.encoder->buffer();
         auto bufferSize = message.encoder->bufferSize();
-        auto decoder = IPC::Decoder::create(buffer, bufferSize, { });
+        auto decoder = IPC::Decoder::create({ buffer, bufferSize }, { });
         ASSERT(decoder);
         if (!decoder)
             return false;
@@ -559,7 +559,7 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
     } else if (message.encoder->messageName() == IPC::MessageName::WebPage_GoToBackForwardItemWaitingForProcessLaunch) {
         auto buffer = message.encoder->buffer();
         auto bufferSize = message.encoder->bufferSize();
-        auto decoder = IPC::Decoder::create(buffer, bufferSize, { });
+        auto decoder = IPC::Decoder::create({ buffer, bufferSize }, { });
         ASSERT(decoder);
         if (!decoder)
             return false;

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2338,7 +2338,7 @@ static JSC::JSObject* jsResultFromReplyDecoder(JSC::JSGlobalObject* globalObject
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto arrayBuffer = JSC::ArrayBuffer::create(decoder.buffer(), decoder.length());
+    auto arrayBuffer = JSC::ArrayBuffer::create(decoder.buffer());
     JSC::JSArrayBuffer* jsArrayBuffer = nullptr;
     if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
         jsArrayBuffer = JSC::JSArrayBuffer::create(vm, structure, WTFMove(arrayBuffer));
@@ -2864,7 +2864,7 @@ void JSMessageListener::didReceiveMessage(const IPC::Decoder& decoder)
     auto* globalObject = toJS(m_context);
     JSC::JSLockHolder lock(globalObject->vm());
 
-    auto mutableDecoder = IPC::Decoder::create(decoder.buffer(), decoder.length(), { });
+    auto mutableDecoder = IPC::Decoder::create(decoder.buffer(), { });
     auto* description = jsDescriptionFromDecoder(globalObject, *mutableDecoder);
 
     JSValueRef arguments[] = { description ? toRef(globalObject, description) : JSValueMakeUndefined(m_context) };
@@ -2881,7 +2881,7 @@ void JSMessageListener::willSendMessage(const IPC::Encoder& encoder, OptionSet<I
     auto* globalObject = toJS(m_context);
     JSC::JSLockHolder lock(globalObject->vm());
 
-    auto decoder = IPC::Decoder::create(encoder.buffer(), encoder.bufferSize(), { });
+    auto decoder = IPC::Decoder::create({ encoder.buffer(), encoder.bufferSize() }, { });
     auto* description = jsDescriptionFromDecoder(globalObject, *decoder);
 
     JSValueRef arguments[] = { description ? toRef(globalObject, description) : JSValueMakeUndefined(m_context) };
@@ -2912,7 +2912,7 @@ JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* 
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
     }
-    auto arrayBuffer = JSC::ArrayBuffer::create(decoder.buffer(), decoder.length());
+    auto arrayBuffer = JSC::ArrayBuffer::create(decoder.buffer());
     if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode())) {
         if (auto* jsArrayBuffer = JSC::JSArrayBuffer::create(vm, structure, WTFMove(arrayBuffer))) {
             jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "buffer"_s), jsArrayBuffer);

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -187,7 +187,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
         return;
     }
 
-    auto decoder = IPC::Decoder::create(data, dataSize, { });
+    auto decoder = IPC::Decoder::create({ data, dataSize }, { });
     if (!decoder) {
         RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - Failed to create decoder for xpc messasge");
         tryCloseRequestConnection(request);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -231,7 +231,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
 
         size_t dataSize { 0 };
         const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebKit::WebPushD::protocolEncodedMessageKey, &dataSize));
-        auto decoder = IPC::Decoder::create(data, dataSize, { });
+        auto decoder = IPC::Decoder::create({ data, dataSize }, { });
         ASSERT(decoder);
 
         completionHandler(decoder.get());

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +74,7 @@ public:
 
     std::unique_ptr<IPC::Decoder> createDecoder() const
     {
-        return IPC::Decoder::create(m_encoder->buffer(), m_encoder->bufferSize(), { });
+        return IPC::Decoder::create({ m_encoder->buffer(), m_encoder->bufferSize() }, { });
     }
 
 private:
@@ -95,7 +96,7 @@ public:
 
     std::unique_ptr<IPC::Decoder> createDecoder() const
     {
-        auto decoder = makeUnique<IPC::Decoder>(m_impl->buffer.data(), m_impl->buffer.size(), 0);
+        auto decoder = makeUnique<IPC::Decoder>(IPC::DataReference { m_impl->buffer.data(), m_impl->buffer.size() }, 0);
         return decoder;
     }
 
@@ -609,19 +610,19 @@ TYPED_TEST_P(ArgumentCoderSpanTest, AlignedSpan)
     }
 
     auto decoder = TestFixture::createDecoder();
-    ASSERT_EQ(decoder->currentBufferPosition(), TestFixture::headerSize());
+    ASSERT_EQ(decoder->currentBufferOffset(), TestFixture::headerSize());
     {
         auto byte = decoder->template decode<uint8_t>();
         ASSERT_TRUE(!!byte);
         ASSERT_EQ(*byte, 42);
-        ASSERT_EQ(decoder->currentBufferPosition(), calculateEncodedSize(TestFixture::headerSize(), EncodedValue<uint8_t, 1> { }));
+        ASSERT_EQ(decoder->currentBufferOffset(), calculateEncodedSize(TestFixture::headerSize(), EncodedValue<uint8_t, 1> { }));
     }
     {
         auto alignedData = decoder->template decode<std::span<const AlignedStructure>>();
         ASSERT_TRUE(!!alignedData);
         ASSERT_NE(alignedData->data(), nullptr);
         ASSERT_EQ(alignedData->size(), 2u);
-        ASSERT_EQ(decoder->currentBufferPosition(), calculateEncodedSize(TestFixture::headerSize(),
+        ASSERT_EQ(decoder->currentBufferOffset(), calculateEncodedSize(TestFixture::headerSize(),
             EncodedValue<uint8_t, 1> { }, EncodedValue<uint64_t, 1> { }, EncodedValue<AlignedStructure, 2> { }));
     }
 }
@@ -643,20 +644,20 @@ TYPED_TEST_P(ArgumentCoderSpanTest, AlignedEmptySpan)
     }
 
     auto decoder = TestFixture::createDecoder();
-    ASSERT_EQ(decoder->currentBufferPosition(), TestFixture::headerSize());
+    ASSERT_EQ(decoder->currentBufferOffset(), TestFixture::headerSize());
     {
         // A valid but empty span should be decoded, meaning a null data pointer and 0 size.
         auto alignedData = decoder->template decode<std::span<const AlignedStructure>>();
         ASSERT_TRUE(!!alignedData);
         ASSERT_EQ(alignedData->data(), nullptr);
         ASSERT_EQ(alignedData->size(), 0u);
-        ASSERT_EQ(decoder->currentBufferPosition(), calculateEncodedSize(TestFixture::headerSize(), EncodedValue<uint64_t, 1> { }));
+        ASSERT_EQ(decoder->currentBufferOffset(), calculateEncodedSize(TestFixture::headerSize(), EncodedValue<uint64_t, 1> { }));
     }
     {
         auto byte = decoder->template decode<uint8_t>();
         ASSERT_TRUE(!!byte);
         ASSERT_EQ(*byte, 42);
-        ASSERT_EQ(decoder->currentBufferPosition(), calculateEncodedSize(TestFixture::headerSize(), EncodedValue<uint64_t, 1> { }, EncodedValue<uint8_t, 1> { }));
+        ASSERT_EQ(decoder->currentBufferOffset(), calculateEncodedSize(TestFixture::headerSize(), EncodedValue<uint64_t, 1> { }, EncodedValue<uint8_t, 1> { }));
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -37,7 +37,7 @@ std::optional<T> copyViaEncoder(const T& o)
 {
     IPC::Encoder encoder(static_cast<IPC::MessageName>(78), 0);
     encoder << o;
-    auto decoder = IPC::Decoder::create(encoder.buffer(), encoder.bufferSize(), encoder.releaseAttachments());
+    auto decoder = IPC::Decoder::create({ encoder.buffer(), encoder.bufferSize() }, encoder.releaseAttachments());
     return decoder->decode<T>();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -237,7 +237,7 @@ bool WebPushXPCConnectionMessageSender::performSendWithAsyncReplyWithoutUsingIPC
 
         size_t dataSize { 0 };
         const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebKit::WebPushD::protocolEncodedMessageKey, &dataSize));
-        auto decoder = IPC::Decoder::create(data, dataSize, { });
+        auto decoder = IPC::Decoder::create({ data, dataSize }, { });
         ASSERT(decoder);
 
         completionHandler(decoder.get());


### PR DESCRIPTION
#### 1e7b936a641ccf787c0362a26d984a65463429ca
<pre>
Use more std::span&lt;uint8_t&gt; in IPC::Decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=261228">https://bugs.webkit.org/show_bug.cgi?id=261228</a>
&lt;rdar://115075685&gt;

Reviewed by Chris Dumez.

Switch IPC::Decoder to use DataReference (std::span&lt;const uint8_t&gt;).

Other changes of note:
- Add support for std::span&lt;uint8_t&gt; when creating JSC::ArrayBuffer.
- Add a utility method for std::span to &lt;wtf/Algorithms.h&gt;.
- Introduce MessageName::Invalid and initialize
  IPC::Decoder::m_message_name to that value.
- IPC::Decoder objects now fit in 64 bytes.
- IPC::Decoder now calls m_bufferDeallocator when marked invalid,
  and clears m_buffer.

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::create): Add.
(JSC::ArrayBuffer::tryCreate): Add.
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
(JSC::ArrayBuffer::create): Add.
(JSC::ArrayBuffer::tryCreate): Add.

* Source/WTF/wtf/Algorithms.h:
(WTF::spanReinterpretCast): Add.

* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::copyBuffer):
(IPC::Decoder::create):
- Remove duplicate code for one overloaded method.
(IPC::Decoder::Decoder):
- Delete default constructor.
(IPC::Decoder::~Decoder):
(IPC::Decoder::unwrapForTesting):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::buffer const): Switch to return DataReference.
(IPC::Decoder::currentBufferPosition const): Delete.
- Rename to currentBufferOffset() since this returns an offset from the
  start of the buffer.
(IPC::Decoder::currentBufferOffset const):
(IPC::Decoder::length const): Delete.
(IPC::Decoder::isValid const):
(IPC::Decoder::markInvalid):
- Now calls m_bufferDeallocator and clear m_buffer on invalidation.
(IPC::alignedBufferIsLargeEnoughToContain):
- Simplify logic because we are no longer using two pointer addresses.
(IPC::Decoder::decodeSpan):
* Source/WebKit/Platform/IPC/JSIPCBinding.cpp:
(IPC::putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined):
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::putJSValueForDecodeArgumentInArray):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::dispatchOutOfStreamMessage):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::createMessageDecoder):
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::processMessage):
* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
(IPC::Connection::readEventHandler):
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_names_header):
- Add MessageName::Invalid.
* Source/WebKit/Scripts/webkit/tests/MessageNames.h: Ditto.
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::defaultTestDriver):
(WebKit::sendTestMessage):
* Source/WebKit/UIProcess/LegacySessionStateCodingNone.cpp:
(WebKit::decodeLegacySessionState):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::didReceiveMessage):
(WebKit::IPCTestingAPI::JSMessageListener::willSendMessage):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::Encoder&gt;::createDecoder const):
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::StreamConnectionEncoder&gt;::createDecoder const):
(TestWebKitAPI::TYPED_TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
(TestWebKitAPI::copyViaEncoder):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):

Canonical link: <a href="https://commits.webkit.org/267956@main">https://commits.webkit.org/267956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34264b4a9698800d9a7bc1e64d775836850bf31e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18164 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18656 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20883 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18322 "Found 1 webkitpy python3 test failure: webkitpy.w3c.test_converter_unittest.W3CTestConverterTest.test_convert_prefixed_properties") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16569 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15741 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20968 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17450 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14666 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21520 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16399 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5271 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20763 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22753 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2228 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17158 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5118 "Passed tests") | 
<!--EWS-Status-Bubble-End-->