### PR TITLE
visionOS: Text jumps by subpixel increments when repainting

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -64,7 +64,7 @@ protected:
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
-    mutable std::unique_ptr<WebCore::GraphicsContext> m_context;
+    mutable std::unique_ptr<WebCore::GraphicsContextCG> m_context;
     RetainPtr<id> m_resourceCache;
     WebCore::RenderingMode m_renderingMode;
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -182,7 +182,7 @@ public:
 private:
     RemoteLayerBackingStoreCollection* backingStoreCollection() const;
 
-    void drawInContext(WebCore::GraphicsContext&, WTF::Function<void()>&& additionalContextSetupCallback = nullptr);
+    void drawInContext(WebCore::GraphicsContext&);
 
     struct Buffer {
         RefPtr<WebCore::ImageBuffer> imageBuffer;


### PR DESCRIPTION
#### 7eb6ed02a5ba9ad174481b97bc76954169ca3608
<pre>
visionOS: Text jumps by subpixel increments when repainting
<a href="https://bugs.webkit.org/show_bug.cgi?id=261472">https://bugs.webkit.org/show_bug.cgi?id=261472</a>
rdar://109372324

Reviewed by Mike Wyrzykowski, Richard Robinson and Dean Jackson.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
(WebKit::CGDisplayListImageBufferBackend::context):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::paintContents):
(WebKit::RemoteLayerBackingStore::drawInContext):
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer):
Now that it is possible to specify the resolution at which a dynamic content
scaling display list is recorded, plumb the backing store scale to that mechanism,
and remove all of our workarounds from the days when it was only recorded at 1x.

This fixes a bug where the integer rounding of the backing store size coupled
with subpixel CTMs would make text quantization cause glyphs to land at different
quantized positions between the 2x tiles and the 1x recorded display list.

Canonical link: <a href="https://commits.webkit.org/268107@main">https://commits.webkit.org/268107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9d6e5388e564daecc32d4ee84afc295bb57009a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19188 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21449 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16303 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17821 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16880 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4446 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->