### PR TITLE
[JSC] Expand InByVal ICs to cover integer indices as well

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -140,6 +140,32 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case IndexedResizableTypedArrayUint32Store:
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
         RELEASE_ASSERT(!prototypeAccessChain);
         break;
     case Load:
@@ -404,6 +430,31 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case IndexedResizableTypedArrayUint32Store:
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
         return false;
     case Load:
     case Miss:
@@ -412,6 +463,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case DeleteMiss:
     case Replace:
     case IndexedNoIndexingMiss:
+    case IndexedNoIndexingInMiss:
     case Transition:
     case GetGetter:
     case Getter:
@@ -518,6 +570,32 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case IndexedResizableTypedArrayUint32Store:
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
         return false;
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -610,99 +688,32 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case IndexedResizableTypedArrayUint32Store:
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
-        return true;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-bool AccessCase::needsScratchFPR() const
-{
-    switch (m_type) {
-    case Load:
-    case LoadMegamorphic:
-    case StoreMegamorphic:
-    case Transition:
-    case Delete:
-    case DeleteNonConfigurable:
-    case DeleteMiss:
-    case Replace: 
-    case Miss:
-    case GetGetter:
-    case Getter:
-    case Setter:
-    case CustomValueGetter:
-    case CustomAccessorGetter:
-    case CustomValueSetter:
-    case CustomAccessorSetter:
-    case InHit:
-    case InMiss:
-    case CheckPrivateBrand:
-    case SetPrivateBrand:
-    case ArrayLength:
-    case StringLength:
-    case DirectArgumentsLength:
-    case ScopedArgumentsLength:
-    case ModuleNamespaceLoad:
-    case ProxyObjectHas:
-    case ProxyObjectLoad:
-    case ProxyObjectStore:
-    case InstanceOfHit:
-    case InstanceOfMiss:
-    case InstanceOfGeneric:
-    case IndexedProxyObjectLoad:
-    case IndexedMegamorphicLoad:
-    case IndexedMegamorphicStore:
-    case IndexedInt32Load:
-    case IndexedContiguousLoad:
-    case IndexedArrayStorageLoad:
-    case IndexedScopedArgumentsLoad:
-    case IndexedDirectArgumentsLoad:
-    case IndexedTypedArrayInt8Load:
-    case IndexedTypedArrayUint8Load:
-    case IndexedTypedArrayUint8ClampedLoad:
-    case IndexedTypedArrayInt16Load:
-    case IndexedTypedArrayUint16Load:
-    case IndexedTypedArrayInt32Load:
-    case IndexedResizableTypedArrayInt8Load:
-    case IndexedResizableTypedArrayUint8Load:
-    case IndexedResizableTypedArrayUint8ClampedLoad:
-    case IndexedResizableTypedArrayInt16Load:
-    case IndexedResizableTypedArrayUint16Load:
-    case IndexedResizableTypedArrayInt32Load:
-    case IndexedStringLoad:
-    case IndexedNoIndexingMiss:
-    case IndexedInt32Store:
-    case IndexedContiguousStore:
-    case IndexedArrayStorageStore:
-    case IndexedTypedArrayInt8Store:
-    case IndexedTypedArrayUint8Store:
-    case IndexedTypedArrayUint8ClampedStore:
-    case IndexedTypedArrayInt16Store:
-    case IndexedTypedArrayUint16Store:
-    case IndexedTypedArrayInt32Store:
-    case IndexedResizableTypedArrayInt8Store:
-    case IndexedResizableTypedArrayUint8Store:
-    case IndexedResizableTypedArrayUint8ClampedStore:
-    case IndexedResizableTypedArrayInt16Store:
-    case IndexedResizableTypedArrayUint16Store:
-    case IndexedResizableTypedArrayInt32Store:
-        return false;
-    case IndexedDoubleLoad:
-    case IndexedTypedArrayFloat32Load:
-    case IndexedTypedArrayFloat64Load:
-    case IndexedTypedArrayUint32Load:
-    case IndexedResizableTypedArrayFloat32Load:
-    case IndexedResizableTypedArrayFloat64Load:
-    case IndexedResizableTypedArrayUint32Load:
-    case IndexedDoubleStore:
-    case IndexedTypedArrayUint32Store:
-    case IndexedTypedArrayFloat32Store:
-    case IndexedTypedArrayFloat64Store:
-    case IndexedResizableTypedArrayUint32Store:
-    case IndexedResizableTypedArrayFloat32Store:
-    case IndexedResizableTypedArrayFloat64Store:
-    // Used by TypedArrayLength/TypedArrayByteOffset in the process of boxing their result as a double
-    case IntrinsicGetter:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
         return true;
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -833,6 +844,32 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     case IndexedResizableTypedArrayUint32Store:
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
         break;
     }
 }
@@ -930,6 +967,32 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case IndexedResizableTypedArrayUint32Store:
     case IndexedResizableTypedArrayFloat32Store:
     case IndexedResizableTypedArrayFloat64Store:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
         doesCalls = false;
         break;
     case Replace:
@@ -1050,6 +1113,31 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case ProxyObjectLoad:
     case ProxyObjectStore:
     case IndexedProxyObjectLoad:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
         return other.type() == type();
 
     case ModuleNamespaceLoad: {
@@ -1099,6 +1187,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case CheckPrivateBrand:
     case SetPrivateBrand:
     case IndexedNoIndexingMiss:
+    case IndexedNoIndexingInMiss:
         if (other.type() != type())
             return false;
 
@@ -1268,6 +1357,32 @@ inline void AccessCase::runWithDowncast(const Func& func)
     case IndexedResizableTypedArrayFloat64Store:
     case IndexedStringLoad:
     case IndexedNoIndexingMiss:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
     case InstanceOfGeneric:
         func(static_cast<AccessCase*>(this));
         break;
@@ -1412,6 +1527,32 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case IndexedResizableTypedArrayFloat64Store:
     case IndexedStringLoad:
     case IndexedNoIndexingMiss:
+    case IndexedInt32InHit:
+    case IndexedDoubleInHit:
+    case IndexedContiguousInHit:
+    case IndexedArrayStorageInHit:
+    case IndexedScopedArgumentsInHit:
+    case IndexedDirectArgumentsInHit:
+    case IndexedTypedArrayInt8InHit:
+    case IndexedTypedArrayUint8InHit:
+    case IndexedTypedArrayUint8ClampedInHit:
+    case IndexedTypedArrayInt16InHit:
+    case IndexedTypedArrayUint16InHit:
+    case IndexedTypedArrayInt32InHit:
+    case IndexedTypedArrayUint32InHit:
+    case IndexedTypedArrayFloat32InHit:
+    case IndexedTypedArrayFloat64InHit:
+    case IndexedResizableTypedArrayInt8InHit:
+    case IndexedResizableTypedArrayUint8InHit:
+    case IndexedResizableTypedArrayUint8ClampedInHit:
+    case IndexedResizableTypedArrayInt16InHit:
+    case IndexedResizableTypedArrayUint16InHit:
+    case IndexedResizableTypedArrayInt32InHit:
+    case IndexedResizableTypedArrayUint32InHit:
+    case IndexedResizableTypedArrayFloat32InHit:
+    case IndexedResizableTypedArrayFloat64InHit:
+    case IndexedStringInHit:
+    case IndexedNoIndexingInMiss:
     case InstanceOfGeneric:
         return true;
 

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -175,6 +175,32 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(IndexedResizableTypedArrayUint32Store) \
     macro(IndexedResizableTypedArrayFloat32Store) \
     macro(IndexedResizableTypedArrayFloat64Store) \
+    macro(IndexedInt32InHit) \
+    macro(IndexedDoubleInHit) \
+    macro(IndexedContiguousInHit) \
+    macro(IndexedArrayStorageInHit) \
+    macro(IndexedScopedArgumentsInHit) \
+    macro(IndexedDirectArgumentsInHit) \
+    macro(IndexedTypedArrayInt8InHit) \
+    macro(IndexedTypedArrayUint8InHit) \
+    macro(IndexedTypedArrayUint8ClampedInHit) \
+    macro(IndexedTypedArrayInt16InHit) \
+    macro(IndexedTypedArrayUint16InHit) \
+    macro(IndexedTypedArrayInt32InHit) \
+    macro(IndexedTypedArrayUint32InHit) \
+    macro(IndexedTypedArrayFloat32InHit) \
+    macro(IndexedTypedArrayFloat64InHit) \
+    macro(IndexedResizableTypedArrayInt8InHit) \
+    macro(IndexedResizableTypedArrayUint8InHit) \
+    macro(IndexedResizableTypedArrayUint8ClampedInHit) \
+    macro(IndexedResizableTypedArrayInt16InHit) \
+    macro(IndexedResizableTypedArrayUint16InHit) \
+    macro(IndexedResizableTypedArrayInt32InHit) \
+    macro(IndexedResizableTypedArrayUint32InHit) \
+    macro(IndexedResizableTypedArrayFloat32InHit) \
+    macro(IndexedResizableTypedArrayFloat64InHit) \
+    macro(IndexedStringInHit) \
+    macro(IndexedNoIndexingInMiss) \
 
 
 class AccessCase : public ThreadSafeRefCounted<AccessCase> {

--- a/Source/JavaScriptCore/bytecode/InByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/InByStatus.cpp
@@ -169,6 +169,13 @@ InByStatus InByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurren
             if (access.usesPolyProto())
                 return InByStatus(TakesSlowPath);
 
+            if (!access.requiresIdentifierNameMatch()) {
+                // FIXME: We could use this for indexed loads in the future. This is pretty solid profiling
+                // information, and probably better than ArrayProfile when it's available.
+                // https://bugs.webkit.org/show_bug.cgi?id=204215
+                return InByStatus(TakesSlowPath);
+            }
+
             Structure* structure = access.structure();
             if (!structure) {
                 // The null structure cases arise due to array.length. We have no way of creating a

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -84,48 +84,66 @@ static TypedArrayType toTypedArrayType(AccessCase::AccessType accessType)
     switch (accessType) {
     case AccessCase::IndexedTypedArrayInt8Load:
     case AccessCase::IndexedTypedArrayInt8Store:
+    case AccessCase::IndexedTypedArrayInt8InHit:
     case AccessCase::IndexedResizableTypedArrayInt8Load:
     case AccessCase::IndexedResizableTypedArrayInt8Store:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
         return TypeInt8;
     case AccessCase::IndexedTypedArrayUint8Load:
     case AccessCase::IndexedTypedArrayUint8Store:
+    case AccessCase::IndexedTypedArrayUint8InHit:
     case AccessCase::IndexedResizableTypedArrayUint8Load:
     case AccessCase::IndexedResizableTypedArrayUint8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
         return TypeUint8;
     case AccessCase::IndexedTypedArrayUint8ClampedLoad:
     case AccessCase::IndexedTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
     case AccessCase::IndexedResizableTypedArrayUint8ClampedLoad:
     case AccessCase::IndexedResizableTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
         return TypeUint8Clamped;
     case AccessCase::IndexedTypedArrayInt16Load:
     case AccessCase::IndexedTypedArrayInt16Store:
+    case AccessCase::IndexedTypedArrayInt16InHit:
     case AccessCase::IndexedResizableTypedArrayInt16Load:
     case AccessCase::IndexedResizableTypedArrayInt16Store:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
         return TypeInt16;
     case AccessCase::IndexedTypedArrayUint16Load:
     case AccessCase::IndexedTypedArrayUint16Store:
+    case AccessCase::IndexedTypedArrayUint16InHit:
     case AccessCase::IndexedResizableTypedArrayUint16Load:
     case AccessCase::IndexedResizableTypedArrayUint16Store:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
         return TypeUint16;
     case AccessCase::IndexedTypedArrayInt32Load:
     case AccessCase::IndexedTypedArrayInt32Store:
+    case AccessCase::IndexedTypedArrayInt32InHit:
     case AccessCase::IndexedResizableTypedArrayInt32Load:
     case AccessCase::IndexedResizableTypedArrayInt32Store:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
         return TypeInt32;
     case AccessCase::IndexedTypedArrayUint32Load:
     case AccessCase::IndexedTypedArrayUint32Store:
+    case AccessCase::IndexedTypedArrayUint32InHit:
     case AccessCase::IndexedResizableTypedArrayUint32Load:
     case AccessCase::IndexedResizableTypedArrayUint32Store:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
         return TypeUint32;
     case AccessCase::IndexedTypedArrayFloat32Load:
     case AccessCase::IndexedTypedArrayFloat32Store:
+    case AccessCase::IndexedTypedArrayFloat32InHit:
     case AccessCase::IndexedResizableTypedArrayFloat32Load:
     case AccessCase::IndexedResizableTypedArrayFloat32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
         return TypeFloat32;
     case AccessCase::IndexedTypedArrayFloat64Load:
     case AccessCase::IndexedTypedArrayFloat64Store:
+    case AccessCase::IndexedTypedArrayFloat64InHit:
     case AccessCase::IndexedResizableTypedArrayFloat64Load:
     case AccessCase::IndexedResizableTypedArrayFloat64Store:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
         return TypeFloat64;
     default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -153,11 +171,260 @@ static bool forResizableTypedArray(AccessCase::AccessType accessType)
     case AccessCase::IndexedResizableTypedArrayUint32Store:
     case AccessCase::IndexedResizableTypedArrayFloat32Store:
     case AccessCase::IndexedResizableTypedArrayFloat64Store:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
         return true;
     default:
         return false;
     }
 }
+
+static bool needsScratchFPR(AccessCase::AccessType type)
+{
+    switch (type) {
+    case AccessCase::Load:
+    case AccessCase::LoadMegamorphic:
+    case AccessCase::StoreMegamorphic:
+    case AccessCase::Transition:
+    case AccessCase::Delete:
+    case AccessCase::DeleteNonConfigurable:
+    case AccessCase::DeleteMiss:
+    case AccessCase::Replace:
+    case AccessCase::Miss:
+    case AccessCase::GetGetter:
+    case AccessCase::Getter:
+    case AccessCase::Setter:
+    case AccessCase::CustomValueGetter:
+    case AccessCase::CustomAccessorGetter:
+    case AccessCase::CustomValueSetter:
+    case AccessCase::CustomAccessorSetter:
+    case AccessCase::InHit:
+    case AccessCase::InMiss:
+    case AccessCase::CheckPrivateBrand:
+    case AccessCase::SetPrivateBrand:
+    case AccessCase::ArrayLength:
+    case AccessCase::StringLength:
+    case AccessCase::DirectArgumentsLength:
+    case AccessCase::ScopedArgumentsLength:
+    case AccessCase::ModuleNamespaceLoad:
+    case AccessCase::ProxyObjectHas:
+    case AccessCase::ProxyObjectLoad:
+    case AccessCase::ProxyObjectStore:
+    case AccessCase::InstanceOfHit:
+    case AccessCase::InstanceOfMiss:
+    case AccessCase::InstanceOfGeneric:
+    case AccessCase::IndexedProxyObjectLoad:
+    case AccessCase::IndexedMegamorphicLoad:
+    case AccessCase::IndexedMegamorphicStore:
+    case AccessCase::IndexedInt32Load:
+    case AccessCase::IndexedContiguousLoad:
+    case AccessCase::IndexedArrayStorageLoad:
+    case AccessCase::IndexedScopedArgumentsLoad:
+    case AccessCase::IndexedDirectArgumentsLoad:
+    case AccessCase::IndexedTypedArrayInt8Load:
+    case AccessCase::IndexedTypedArrayUint8Load:
+    case AccessCase::IndexedTypedArrayUint8ClampedLoad:
+    case AccessCase::IndexedTypedArrayInt16Load:
+    case AccessCase::IndexedTypedArrayUint16Load:
+    case AccessCase::IndexedTypedArrayInt32Load:
+    case AccessCase::IndexedResizableTypedArrayInt8Load:
+    case AccessCase::IndexedResizableTypedArrayUint8Load:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedLoad:
+    case AccessCase::IndexedResizableTypedArrayInt16Load:
+    case AccessCase::IndexedResizableTypedArrayUint16Load:
+    case AccessCase::IndexedResizableTypedArrayInt32Load:
+    case AccessCase::IndexedStringLoad:
+    case AccessCase::IndexedNoIndexingMiss:
+    case AccessCase::IndexedInt32Store:
+    case AccessCase::IndexedContiguousStore:
+    case AccessCase::IndexedArrayStorageStore:
+    case AccessCase::IndexedTypedArrayInt8Store:
+    case AccessCase::IndexedTypedArrayUint8Store:
+    case AccessCase::IndexedTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedTypedArrayInt16Store:
+    case AccessCase::IndexedTypedArrayUint16Store:
+    case AccessCase::IndexedTypedArrayInt32Store:
+    case AccessCase::IndexedResizableTypedArrayInt8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedResizableTypedArrayInt16Store:
+    case AccessCase::IndexedResizableTypedArrayUint16Store:
+    case AccessCase::IndexedResizableTypedArrayInt32Store:
+    case AccessCase::IndexedInt32InHit:
+    case AccessCase::IndexedContiguousInHit:
+    case AccessCase::IndexedArrayStorageInHit:
+    case AccessCase::IndexedScopedArgumentsInHit:
+    case AccessCase::IndexedDirectArgumentsInHit:
+    case AccessCase::IndexedTypedArrayInt8InHit:
+    case AccessCase::IndexedTypedArrayUint8InHit:
+    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedTypedArrayInt16InHit:
+    case AccessCase::IndexedTypedArrayUint16InHit:
+    case AccessCase::IndexedTypedArrayInt32InHit:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
+    case AccessCase::IndexedStringInHit:
+    case AccessCase::IndexedNoIndexingInMiss:
+    // Indexed TypedArray InHit does not need FPR since it does not load a value.
+    case AccessCase::IndexedTypedArrayUint32InHit:
+    case AccessCase::IndexedTypedArrayFloat32InHit:
+    case AccessCase::IndexedTypedArrayFloat64InHit:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
+        return false;
+    case AccessCase::IndexedDoubleLoad:
+    case AccessCase::IndexedTypedArrayFloat32Load:
+    case AccessCase::IndexedTypedArrayFloat64Load:
+    case AccessCase::IndexedTypedArrayUint32Load:
+    case AccessCase::IndexedResizableTypedArrayFloat32Load:
+    case AccessCase::IndexedResizableTypedArrayFloat64Load:
+    case AccessCase::IndexedResizableTypedArrayUint32Load:
+    case AccessCase::IndexedDoubleStore:
+    case AccessCase::IndexedTypedArrayUint32Store:
+    case AccessCase::IndexedTypedArrayFloat32Store:
+    case AccessCase::IndexedTypedArrayFloat64Store:
+    case AccessCase::IndexedResizableTypedArrayUint32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat64Store:
+    case AccessCase::IndexedDoubleInHit:
+    // Used by TypedArrayLength/TypedArrayByteOffset in the process of boxing their result as a double
+    case AccessCase::IntrinsicGetter:
+        return true;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static bool forInBy(AccessCase::AccessType type)
+{
+    switch (type) {
+    case AccessCase::Load:
+    case AccessCase::LoadMegamorphic:
+    case AccessCase::StoreMegamorphic:
+    case AccessCase::Transition:
+    case AccessCase::Delete:
+    case AccessCase::DeleteNonConfigurable:
+    case AccessCase::DeleteMiss:
+    case AccessCase::Replace:
+    case AccessCase::Miss:
+    case AccessCase::GetGetter:
+    case AccessCase::ArrayLength:
+    case AccessCase::StringLength:
+    case AccessCase::DirectArgumentsLength:
+    case AccessCase::ScopedArgumentsLength:
+    case AccessCase::CheckPrivateBrand:
+    case AccessCase::SetPrivateBrand:
+    case AccessCase::IndexedMegamorphicLoad:
+    case AccessCase::IndexedMegamorphicStore:
+    case AccessCase::IndexedInt32Load:
+    case AccessCase::IndexedDoubleLoad:
+    case AccessCase::IndexedContiguousLoad:
+    case AccessCase::IndexedArrayStorageLoad:
+    case AccessCase::IndexedScopedArgumentsLoad:
+    case AccessCase::IndexedDirectArgumentsLoad:
+    case AccessCase::IndexedTypedArrayInt8Load:
+    case AccessCase::IndexedTypedArrayUint8Load:
+    case AccessCase::IndexedTypedArrayUint8ClampedLoad:
+    case AccessCase::IndexedTypedArrayInt16Load:
+    case AccessCase::IndexedTypedArrayUint16Load:
+    case AccessCase::IndexedTypedArrayInt32Load:
+    case AccessCase::IndexedTypedArrayUint32Load:
+    case AccessCase::IndexedTypedArrayFloat32Load:
+    case AccessCase::IndexedTypedArrayFloat64Load:
+    case AccessCase::IndexedResizableTypedArrayInt8Load:
+    case AccessCase::IndexedResizableTypedArrayUint8Load:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedLoad:
+    case AccessCase::IndexedResizableTypedArrayInt16Load:
+    case AccessCase::IndexedResizableTypedArrayUint16Load:
+    case AccessCase::IndexedResizableTypedArrayInt32Load:
+    case AccessCase::IndexedResizableTypedArrayUint32Load:
+    case AccessCase::IndexedResizableTypedArrayFloat32Load:
+    case AccessCase::IndexedResizableTypedArrayFloat64Load:
+    case AccessCase::IndexedInt32Store:
+    case AccessCase::IndexedDoubleStore:
+    case AccessCase::IndexedContiguousStore:
+    case AccessCase::IndexedArrayStorageStore:
+    case AccessCase::IndexedTypedArrayInt8Store:
+    case AccessCase::IndexedTypedArrayUint8Store:
+    case AccessCase::IndexedTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedTypedArrayInt16Store:
+    case AccessCase::IndexedTypedArrayUint16Store:
+    case AccessCase::IndexedTypedArrayInt32Store:
+    case AccessCase::IndexedTypedArrayUint32Store:
+    case AccessCase::IndexedTypedArrayFloat32Store:
+    case AccessCase::IndexedTypedArrayFloat64Store:
+    case AccessCase::IndexedResizableTypedArrayInt8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8Store:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedStore:
+    case AccessCase::IndexedResizableTypedArrayInt16Store:
+    case AccessCase::IndexedResizableTypedArrayUint16Store:
+    case AccessCase::IndexedResizableTypedArrayInt32Store:
+    case AccessCase::IndexedResizableTypedArrayUint32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat32Store:
+    case AccessCase::IndexedResizableTypedArrayFloat64Store:
+    case AccessCase::IndexedStringLoad:
+    case AccessCase::IndexedNoIndexingMiss:
+    case AccessCase::InstanceOfGeneric:
+    case AccessCase::Getter:
+    case AccessCase::Setter:
+    case AccessCase::ProxyObjectHas:
+    case AccessCase::ProxyObjectLoad:
+    case AccessCase::ProxyObjectStore:
+    case AccessCase::IndexedProxyObjectLoad:
+    case AccessCase::CustomValueGetter:
+    case AccessCase::CustomAccessorGetter:
+    case AccessCase::CustomValueSetter:
+    case AccessCase::CustomAccessorSetter:
+    case AccessCase::IntrinsicGetter:
+    case AccessCase::ModuleNamespaceLoad:
+    case AccessCase::InstanceOfHit:
+    case AccessCase::InstanceOfMiss:
+        return false;
+    case AccessCase::InHit:
+    case AccessCase::InMiss:
+    case AccessCase::IndexedInt32InHit:
+    case AccessCase::IndexedDoubleInHit:
+    case AccessCase::IndexedContiguousInHit:
+    case AccessCase::IndexedArrayStorageInHit:
+    case AccessCase::IndexedScopedArgumentsInHit:
+    case AccessCase::IndexedDirectArgumentsInHit:
+    case AccessCase::IndexedTypedArrayInt8InHit:
+    case AccessCase::IndexedTypedArrayUint8InHit:
+    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedTypedArrayInt16InHit:
+    case AccessCase::IndexedTypedArrayUint16InHit:
+    case AccessCase::IndexedTypedArrayInt32InHit:
+    case AccessCase::IndexedTypedArrayUint32InHit:
+    case AccessCase::IndexedTypedArrayFloat32InHit:
+    case AccessCase::IndexedTypedArrayFloat64InHit:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
+    case AccessCase::IndexedStringInHit:
+    case AccessCase::IndexedNoIndexingInMiss:
+        return true;
+    }
+    return false;
+}
+
+
 
 void InlineCacheCompiler::installWatchpoint(CodeBlock* codeBlock, const ObjectPropertyCondition& condition)
 {
@@ -541,7 +808,8 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
         return;
     }
 
-    case AccessCase::IndexedScopedArgumentsLoad: {
+    case AccessCase::IndexedScopedArgumentsLoad:
+    case AccessCase::IndexedScopedArgumentsInHit: {
         ASSERT(!accessCase.viaGlobalProxy());
         // This code is written such that the result could alias with the base or the property.
         GPRReg propertyGPR = stubInfo.propertyGPR();
@@ -580,12 +848,19 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 #if USE(JSVALUE64)
         jit.loadValue(CCallHelpers::BaseIndex(scratch3GPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratchGPR));
         failAndIgnore.append(jit.branchIfEmpty(scratchGPR));
-        jit.move(scratchGPR, valueRegs.payloadGPR());
+        if (forInBy(accessCase.m_type))
+            jit.moveTrustedValue(jsBoolean(true), valueRegs);
+        else
+            jit.move(scratchGPR, valueRegs.payloadGPR());
 #else
         jit.loadValue(CCallHelpers::BaseIndex(scratch3GPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratch2GPR, scratchGPR));
         failAndIgnore.append(jit.branchIfEmpty(scratch2GPR));
-        jit.move(scratchGPR, valueRegs.payloadGPR());
-        jit.move(scratch2GPR, valueRegs.tagGPR());
+        if (forInBy(accessCase.m_type))
+            jit.moveTrustedValue(jsBoolean(true), valueRegs);
+        else {
+            jit.move(scratchGPR, valueRegs.payloadGPR());
+            jit.move(scratch2GPR, valueRegs.tagGPR());
+        }
 #endif
 
         done.link(&jit);
@@ -603,7 +878,8 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
         return;
     }
 
-    case AccessCase::IndexedDirectArgumentsLoad: {
+    case AccessCase::IndexedDirectArgumentsLoad:
+    case AccessCase::IndexedDirectArgumentsInHit: {
         ASSERT(!accessCase.viaGlobalProxy());
         // This code is written such that the result could alias with the base or the property.
         GPRReg propertyGPR = stubInfo.propertyGPR();
@@ -613,8 +889,12 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
         jit.load32(CCallHelpers::Address(baseGPR, DirectArguments::offsetOfLength()), scratchGPR);
         m_failAndRepatch.append(jit.branch32(CCallHelpers::AboveOrEqual, propertyGPR, scratchGPR));
         m_failAndRepatch.append(jit.branchTestPtr(CCallHelpers::NonZero, CCallHelpers::Address(baseGPR, DirectArguments::offsetOfMappedArguments())));
-        jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
-        jit.loadValue(CCallHelpers::BaseIndex(baseGPR, scratchGPR, CCallHelpers::TimesEight, DirectArguments::storageOffset()), valueRegs);
+        if (forInBy(accessCase.m_type))
+            jit.moveTrustedValue(jsBoolean(true), valueRegs);
+        else {
+            jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
+            jit.loadValue(CCallHelpers::BaseIndex(baseGPR, scratchGPR, CCallHelpers::TimesEight, DirectArguments::storageOffset()), valueRegs);
+        }
         succeed();
         return;
     }
@@ -636,7 +916,25 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
     case AccessCase::IndexedResizableTypedArrayInt32Load:
     case AccessCase::IndexedResizableTypedArrayUint32Load:
     case AccessCase::IndexedResizableTypedArrayFloat32Load:
-    case AccessCase::IndexedResizableTypedArrayFloat64Load: {
+    case AccessCase::IndexedResizableTypedArrayFloat64Load:
+    case AccessCase::IndexedTypedArrayInt8InHit:
+    case AccessCase::IndexedTypedArrayUint8InHit:
+    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedTypedArrayInt16InHit:
+    case AccessCase::IndexedTypedArrayUint16InHit:
+    case AccessCase::IndexedTypedArrayInt32InHit:
+    case AccessCase::IndexedTypedArrayUint32InHit:
+    case AccessCase::IndexedTypedArrayFloat32InHit:
+    case AccessCase::IndexedTypedArrayFloat64InHit:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit: {
         ASSERT(!accessCase.viaGlobalProxy());
         // This code is written such that the result could alias with the base or the property.
 
@@ -677,68 +975,72 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 #endif
         }
 
+        if (forInBy(accessCase.m_type))
+            jit.moveTrustedValue(jsBoolean(true), valueRegs);
+        else {
 #if USE(LARGE_TYPED_ARRAYS)
-        jit.load64(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfLength()), scratchGPR);
+            jit.load64(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfLength()), scratchGPR);
 #else
-        jit.load32(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfLength()), scratchGPR);
+            jit.load32(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfLength()), scratchGPR);
 #endif
-        jit.loadPtr(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfVector()), scratch2GPR);
-        jit.cageConditionallyAndUntag(Gigacage::Primitive, scratch2GPR, scratchGPR, scratchGPR, false);
-        jit.signExtend32ToPtr(propertyGPR, scratchGPR);
-        if (isInt(type)) {
-            switch (elementSize(type)) {
-            case 1:
-                if (JSC::isSigned(type))
-                    jit.load8SignedExtendTo32(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne), valueRegs.payloadGPR());
-                else
-                    jit.load8(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne), valueRegs.payloadGPR());
-                break;
-            case 2:
-                if (JSC::isSigned(type))
-                    jit.load16SignedExtendTo32(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesTwo), valueRegs.payloadGPR());
-                else
-                    jit.load16(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesTwo), valueRegs.payloadGPR());
-                break;
-            case 4:
-                jit.load32(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesFour), valueRegs.payloadGPR());
-                break;
-            default:
-                CRASH();
-            }
+            jit.loadPtr(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfVector()), scratch2GPR);
+            jit.cageConditionallyAndUntag(Gigacage::Primitive, scratch2GPR, scratchGPR, scratchGPR, false);
+            jit.signExtend32ToPtr(propertyGPR, scratchGPR);
+            if (isInt(type)) {
+                switch (elementSize(type)) {
+                case 1:
+                    if (JSC::isSigned(type))
+                        jit.load8SignedExtendTo32(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne), valueRegs.payloadGPR());
+                    else
+                        jit.load8(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne), valueRegs.payloadGPR());
+                    break;
+                case 2:
+                    if (JSC::isSigned(type))
+                        jit.load16SignedExtendTo32(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesTwo), valueRegs.payloadGPR());
+                    else
+                        jit.load16(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesTwo), valueRegs.payloadGPR());
+                    break;
+                case 4:
+                    jit.load32(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesFour), valueRegs.payloadGPR());
+                    break;
+                default:
+                    CRASH();
+                }
 
-            CCallHelpers::Jump done;
-            if (type == TypeUint32) {
+                CCallHelpers::Jump done;
+                if (type == TypeUint32) {
+                    RELEASE_ASSERT(m_scratchFPR != InvalidFPRReg);
+                    auto canBeInt = jit.branch32(CCallHelpers::GreaterThanOrEqual, valueRegs.payloadGPR(), CCallHelpers::TrustedImm32(0));
+
+                    jit.convertInt32ToDouble(valueRegs.payloadGPR(), m_scratchFPR);
+                    jit.addDouble(CCallHelpers::AbsoluteAddress(&CCallHelpers::twoToThe32), m_scratchFPR);
+                    jit.boxDouble(m_scratchFPR, valueRegs);
+                    done = jit.jump();
+                    canBeInt.link(&jit);
+                }
+
+                jit.boxInt32(valueRegs.payloadGPR(), valueRegs);
+                if (done.isSet())
+                    done.link(&jit);
+            } else {
+                ASSERT(isFloat(type));
                 RELEASE_ASSERT(m_scratchFPR != InvalidFPRReg);
-                auto canBeInt = jit.branch32(CCallHelpers::GreaterThanOrEqual, valueRegs.payloadGPR(), CCallHelpers::TrustedImm32(0));
+                switch (elementSize(type)) {
+                case 4:
+                    jit.loadFloat(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesFour), m_scratchFPR);
+                    jit.convertFloatToDouble(m_scratchFPR, m_scratchFPR);
+                    break;
+                case 8: {
+                    jit.loadDouble(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesEight), m_scratchFPR);
+                    break;
+                }
+                default:
+                    CRASH();
+                }
 
-                jit.convertInt32ToDouble(valueRegs.payloadGPR(), m_scratchFPR);
-                jit.addDouble(CCallHelpers::AbsoluteAddress(&CCallHelpers::twoToThe32), m_scratchFPR);
+                jit.purifyNaN(m_scratchFPR);
                 jit.boxDouble(m_scratchFPR, valueRegs);
-                done = jit.jump();
-                canBeInt.link(&jit);
             }
-
-            jit.boxInt32(valueRegs.payloadGPR(), valueRegs);
-            if (done.isSet())
-                done.link(&jit);
-        } else {
-            ASSERT(isFloat(type));
-            RELEASE_ASSERT(m_scratchFPR != InvalidFPRReg);
-            switch (elementSize(type)) {
-            case 4:
-                jit.loadFloat(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesFour), m_scratchFPR);
-                jit.convertFloatToDouble(m_scratchFPR, m_scratchFPR);
-                break;
-            case 8: {
-                jit.loadDouble(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesEight), m_scratchFPR);
-                break;
-            }
-            default:
-                CRASH();
-            }
-
-            jit.purifyNaN(m_scratchFPR);
-            jit.boxDouble(m_scratchFPR, valueRegs);
         }
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
@@ -752,7 +1054,8 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
         return;
     }
 
-    case AccessCase::IndexedStringLoad: {
+    case AccessCase::IndexedStringLoad:
+    case AccessCase::IndexedStringInHit: {
         ASSERT(!accessCase.viaGlobalProxy());
         // This code is written such that the result could alias with the base or the property.
         GPRReg propertyGPR = stubInfo.propertyGPR();
@@ -773,21 +1076,26 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 
         failAndIgnore.append(jit.branch32(CCallHelpers::AboveOrEqual, propertyGPR, scratchGPR));
 
-        jit.load32(CCallHelpers::Address(scratch2GPR, StringImpl::flagsOffset()), scratchGPR);
-        jit.loadPtr(CCallHelpers::Address(scratch2GPR, StringImpl::dataOffset()), scratch2GPR);
-        auto is16Bit = jit.branchTest32(CCallHelpers::Zero, scratchGPR, CCallHelpers::TrustedImm32(StringImpl::flagIs8Bit()));
-        jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
-        jit.load8(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne, 0), scratch2GPR);
-        auto is8BitLoadDone = jit.jump();
-        is16Bit.link(&jit);
-        jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
-        jit.load16(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesTwo, 0), scratch2GPR);
-        is8BitLoadDone.link(&jit);
+        if (forInBy(accessCase.m_type))
+            jit.moveTrustedValue(jsBoolean(true), valueRegs);
+        else {
+            jit.load32(CCallHelpers::Address(scratch2GPR, StringImpl::flagsOffset()), scratchGPR);
+            jit.loadPtr(CCallHelpers::Address(scratch2GPR, StringImpl::dataOffset()), scratch2GPR);
+            auto is16Bit = jit.branchTest32(CCallHelpers::Zero, scratchGPR, CCallHelpers::TrustedImm32(StringImpl::flagIs8Bit()));
+            jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
+            jit.load8(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesOne, 0), scratch2GPR);
+            auto is8BitLoadDone = jit.jump();
+            is16Bit.link(&jit);
+            jit.zeroExtend32ToWord(propertyGPR, scratchGPR);
+            jit.load16(CCallHelpers::BaseIndex(scratch2GPR, scratchGPR, CCallHelpers::TimesTwo, 0), scratch2GPR);
+            is8BitLoadDone.link(&jit);
 
-        failAndIgnore.append(jit.branch32(CCallHelpers::Above, scratch2GPR, CCallHelpers::TrustedImm32(maxSingleCharacterString)));
-        jit.move(CCallHelpers::TrustedImmPtr(vm.smallStrings.singleCharacterStrings()), scratchGPR);
-        jit.loadPtr(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::ScalePtr, 0), valueRegs.payloadGPR());
-        jit.boxCell(valueRegs.payloadGPR(), valueRegs);
+            failAndIgnore.append(jit.branch32(CCallHelpers::Above, scratch2GPR, CCallHelpers::TrustedImm32(maxSingleCharacterString)));
+            jit.move(CCallHelpers::TrustedImmPtr(vm.smallStrings.singleCharacterStrings()), scratchGPR);
+            jit.loadPtr(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::ScalePtr, 0), valueRegs.payloadGPR());
+            jit.boxCell(valueRegs.payloadGPR(), valueRegs);
+        }
+
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
 
@@ -801,7 +1109,8 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
         return;
     }
 
-    case AccessCase::IndexedNoIndexingMiss: {
+    case AccessCase::IndexedNoIndexingMiss:
+    case AccessCase::IndexedNoIndexingInMiss: {
         emitDefaultGuard();
         GPRReg propertyGPR = stubInfo.propertyGPR();
         m_failAndIgnore.append(jit.branch32(CCallHelpers::LessThan, propertyGPR, CCallHelpers::TrustedImm32(0)));
@@ -811,7 +1120,11 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
     case AccessCase::IndexedInt32Load:
     case AccessCase::IndexedDoubleLoad:
     case AccessCase::IndexedContiguousLoad:
-    case AccessCase::IndexedArrayStorageLoad: {
+    case AccessCase::IndexedArrayStorageLoad:
+    case AccessCase::IndexedInt32InHit:
+    case AccessCase::IndexedDoubleInHit:
+    case AccessCase::IndexedContiguousInHit:
+    case AccessCase::IndexedArrayStorageInHit: {
         ASSERT(!accessCase.viaGlobalProxy());
         // This code is written such that the result could alias with the base or the property.
         GPRReg propertyGPR = stubInfo.propertyGPR();
@@ -833,7 +1146,7 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
             preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
         };
 
-        if (accessCase.m_type == AccessCase::IndexedArrayStorageLoad) {
+        if (accessCase.m_type == AccessCase::IndexedArrayStorageLoad || accessCase.m_type == AccessCase::IndexedArrayStorageInHit) {
             jit.add32(CCallHelpers::TrustedImm32(-ArrayStorageShape), scratchGPR, scratchGPR);
             fallThrough.append(jit.branch32(CCallHelpers::Above, scratchGPR, CCallHelpers::TrustedImm32(SlowPutArrayStorageShape - ArrayStorageShape)));
 
@@ -846,24 +1159,34 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 #if USE(JSVALUE64)
             jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight, ArrayStorage::vectorOffset()), JSValueRegs(scratchGPR));
             failAndIgnore.append(jit.branchIfEmpty(scratchGPR));
-            jit.move(scratchGPR, valueRegs.payloadGPR());
+            if (forInBy(accessCase.m_type))
+                jit.moveTrustedValue(jsBoolean(true), valueRegs);
+            else
+                jit.move(scratchGPR, valueRegs.payloadGPR());
 #else
             jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight, ArrayStorage::vectorOffset()), JSValueRegs(scratch3GPR, scratchGPR));
             failAndIgnore.append(jit.branchIfEmpty(scratch3GPR));
-            jit.move(scratchGPR, valueRegs.payloadGPR());
-            jit.move(scratch3GPR, valueRegs.tagGPR());
+            if (forInBy(accessCase.m_type))
+                jit.moveTrustedValue(jsBoolean(true), valueRegs);
+            else {
+                jit.move(scratchGPR, valueRegs.payloadGPR());
+                jit.move(scratch3GPR, valueRegs.tagGPR());
+            }
 #endif
         } else {
             IndexingType expectedShape;
             switch (accessCase.m_type) {
             case AccessCase::IndexedInt32Load:
+            case AccessCase::IndexedInt32InHit:
                 expectedShape = Int32Shape;
                 break;
             case AccessCase::IndexedDoubleLoad:
+            case AccessCase::IndexedDoubleInHit:
                 ASSERT(Options::allowDoubleShape());
                 expectedShape = DoubleShape;
                 break;
             case AccessCase::IndexedContiguousLoad:
+            case AccessCase::IndexedContiguousInHit:
                 expectedShape = ContiguousShape;
                 break;
             default:
@@ -878,21 +1201,31 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
             jit.loadPtr(CCallHelpers::Address(baseGPR, JSObject::butterflyOffset()), scratchGPR);
             failAndIgnore.append(jit.branch32(CCallHelpers::AboveOrEqual, propertyGPR, CCallHelpers::Address(scratchGPR, Butterfly::offsetOfPublicLength())));
             jit.zeroExtend32ToWord(propertyGPR, scratch2GPR);
-            if (accessCase.m_type == AccessCase::IndexedDoubleLoad) {
+            if (accessCase.m_type == AccessCase::IndexedDoubleLoad || accessCase.m_type == AccessCase::IndexedDoubleInHit) {
                 RELEASE_ASSERT(m_scratchFPR != InvalidFPRReg);
                 jit.loadDouble(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), m_scratchFPR);
                 failAndIgnore.append(jit.branchIfNaN(m_scratchFPR));
-                jit.boxDouble(m_scratchFPR, valueRegs);
+                if (forInBy(accessCase.m_type))
+                    jit.moveTrustedValue(jsBoolean(true), valueRegs);
+                else
+                    jit.boxDouble(m_scratchFPR, valueRegs);
             } else {
 #if USE(JSVALUE64)
                 jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratchGPR));
                 failAndIgnore.append(jit.branchIfEmpty(scratchGPR));
-                jit.move(scratchGPR, valueRegs.payloadGPR());
+                if (forInBy(accessCase.m_type))
+                    jit.moveTrustedValue(jsBoolean(true), valueRegs);
+                else
+                    jit.move(scratchGPR, valueRegs.payloadGPR());
 #else
                 jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratch3GPR, scratchGPR));
                 failAndIgnore.append(jit.branchIfEmpty(scratch3GPR));
-                jit.move(scratchGPR, valueRegs.payloadGPR());
-                jit.move(scratch3GPR, valueRegs.tagGPR());
+                if (forInBy(accessCase.m_type))
+                    jit.moveTrustedValue(jsBoolean(true), valueRegs);
+                else {
+                    jit.move(scratchGPR, valueRegs.payloadGPR());
+                    jit.move(scratch3GPR, valueRegs.tagGPR());
+                }
 #endif
             }
         }
@@ -2159,6 +2492,11 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
         succeed();
         return;
 
+    case AccessCase::IndexedNoIndexingInMiss:
+        jit.moveTrustedValue(jsBoolean(false), valueRegs);
+        succeed();
+        return;
+
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::ModuleNamespaceLoad:
@@ -2219,6 +2557,31 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
     case AccessCase::IndexedResizableTypedArrayUint32Store:
     case AccessCase::IndexedResizableTypedArrayFloat32Store:
     case AccessCase::IndexedResizableTypedArrayFloat64Store:
+    case AccessCase::IndexedInt32InHit:
+    case AccessCase::IndexedDoubleInHit:
+    case AccessCase::IndexedContiguousInHit:
+    case AccessCase::IndexedArrayStorageInHit:
+    case AccessCase::IndexedScopedArgumentsInHit:
+    case AccessCase::IndexedDirectArgumentsInHit:
+    case AccessCase::IndexedTypedArrayInt8InHit:
+    case AccessCase::IndexedTypedArrayUint8InHit:
+    case AccessCase::IndexedTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedTypedArrayInt16InHit:
+    case AccessCase::IndexedTypedArrayUint16InHit:
+    case AccessCase::IndexedTypedArrayInt32InHit:
+    case AccessCase::IndexedTypedArrayUint32InHit:
+    case AccessCase::IndexedTypedArrayFloat32InHit:
+    case AccessCase::IndexedTypedArrayFloat64InHit:
+    case AccessCase::IndexedResizableTypedArrayInt8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8InHit:
+    case AccessCase::IndexedResizableTypedArrayUint8ClampedInHit:
+    case AccessCase::IndexedResizableTypedArrayInt16InHit:
+    case AccessCase::IndexedResizableTypedArrayUint16InHit:
+    case AccessCase::IndexedResizableTypedArrayInt32InHit:
+    case AccessCase::IndexedResizableTypedArrayUint32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat32InHit:
+    case AccessCase::IndexedResizableTypedArrayFloat64InHit:
+    case AccessCase::IndexedStringInHit:
         // These need to be handled by generateWithGuard(), since the guard is part of the
         // algorithm. We can be sure that nobody will call generate() directly for these since they
         // are not guarded by structure checks.
@@ -2950,7 +3313,7 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
     m_scratchGPR = allocator.allocateScratchGPR();
 
     for (auto& accessCase : cases) {
-        if (accessCase->needsScratchFPR()) {
+        if (needsScratchFPR(accessCase->m_type)) {
             m_scratchFPR = allocator.allocateScratchFPR();
             break;
         }

--- a/Source/JavaScriptCore/bytecode/Repatch.h
+++ b/Source/JavaScriptCore/bytecode/Repatch.h
@@ -78,6 +78,7 @@ void repatchGetBy(JSGlobalObject*, CodeBlock*, JSValue, CacheableIdentifier, con
 void repatchArrayPutByVal(JSGlobalObject*, CodeBlock*, JSValue base, JSValue index, StructureStubInfo&, PutByKind);
 void repatchPutBy(JSGlobalObject*, CodeBlock*, JSValue, Structure*, CacheableIdentifier, const PutPropertySlot&, StructureStubInfo&, PutByKind);
 void repatchDeleteBy(JSGlobalObject*, CodeBlock*, DeletePropertySlot&, JSValue, Structure*, CacheableIdentifier, StructureStubInfo&, DelByKind, ECMAMode);
+void repatchArrayInByVal(JSGlobalObject*, CodeBlock*, JSValue base, JSValue index, StructureStubInfo&, InByKind);
 void repatchInBy(JSGlobalObject*, CodeBlock*, JSObject*, CacheableIdentifier, bool wasFound, const PropertySlot&, StructureStubInfo&, InByKind);
 void repatchHasPrivateBrand(JSGlobalObject*, CodeBlock*, JSObject*, CacheableIdentifier, bool wasFound,  StructureStubInfo&);
 void repatchCheckPrivateBrand(JSGlobalObject*, CodeBlock*, JSObject*, CacheableIdentifier, StructureStubInfo&);

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -108,9 +108,6 @@ inline bool opInByVal(JSGlobalObject* globalObject, JSValue baseVal, JSValue pro
     }
 
     JSObject* baseObj = asObject(baseVal);
-    if (arrayProfile)
-        arrayProfile->observeStructure(baseObj->structure());
-
     uint32_t i;
     if (propName.getUInt32(i)) {
         if (arrayProfile)


### PR DESCRIPTION
#### 17e3401e8e8ec94c6d94fa97c76104c0f1022b90
<pre>
[JSC] Expand InByVal ICs to cover integer indices as well
<a href="https://bugs.webkit.org/show_bug.cgi?id=226619">https://bugs.webkit.org/show_bug.cgi?id=226619</a>
rdar://79172384

Reviewed by Keith Miller.

Inline Cache for InByVal should cover indexed accesses too so that we can handle multiple indexed-shaped arrays efficiently at one InByVal site.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
(JSC::AccessCase::needsScratchFPR const): Deleted.
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
(JSC::InByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::toTypedArrayType):
(JSC::forResizableTypedArray):
(JSC::needsScratchFPR):
(JSC::forInBy):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayInByVal):
(JSC::repatchArrayInByVal):
* Source/JavaScriptCore/bytecode/Repatch.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/CommonSlowPaths.h:
(JSC::CommonSlowPaths::opInByVal):

Canonical link: <a href="https://commits.webkit.org/267991@main">https://commits.webkit.org/267991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58b65d8538876af5d299d10be87f520670f00fba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18224 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17056 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18999 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20946 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23118 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21002 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16454 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20814 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2243 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->