### PR TITLE
Use more smart pointers in Source/WebKit

### DIFF
--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -486,7 +486,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithOrdinal(WebCore::PageIdenti
         return;
     }
 
-    WebFrame* childFrame = WebFrame::fromCoreFrame(*coreChildFrame);
+    auto childFrame = WebFrame::fromCoreFrame(*coreChildFrame);
     if (!childFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;
@@ -536,7 +536,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithNodeHandle(WebCore::PageIde
         return;
     }
 
-    WebFrame* frameFromElement = WebFrame::fromCoreFrame(*coreFrameFromElement);
+    auto frameFromElement = WebFrame::fromCoreFrame(*coreFrameFromElement);
     if (!frameFromElement) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;
@@ -574,7 +574,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithName(WebCore::PageIdentifie
         return;
     }
 
-    WebFrame* childFrame = WebFrame::fromCoreFrame(*coreChildFrame);
+    auto childFrame = WebFrame::fromCoreFrame(*coreChildFrame);
     if (!childFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;
@@ -600,7 +600,7 @@ void WebAutomationSessionProxy::resolveParentFrame(WebCore::PageIdentifier pageI
         return;
     }
 
-    WebFrame* parentFrame = frame->parentFrame();
+    auto parentFrame = frame->parentFrame();
     if (!parentFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -81,7 +81,7 @@ void MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest(MediaKeyS
 
     m_ongoingMediaKeySystemRequests.add(userRequest.identifier(), userRequest);
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*frame);
+    auto webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
     auto* topLevelDocumentOrigin = userRequest.topLevelDocumentOrigin();

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -98,7 +98,7 @@ enum class NullOrEmptyString {
     NullStringAsEmptyString
 };
 
-inline WebFrame* toWebFrame(JSContextRef context)
+inline RefPtr<WebFrame> toWebFrame(JSContextRef context)
 {
     ASSERT(context);
     return WebFrame::frameForContext(JSContextGetGlobalContext(context));
@@ -107,7 +107,7 @@ inline WebFrame* toWebFrame(JSContextRef context)
 inline WebPage* toWebPage(JSContextRef context)
 {
     ASSERT(context);
-    auto* frame = toWebFrame(context);
+    auto frame = toWebFrame(context);
     return frame ? frame->page() : nullptr;
 }
 

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -65,7 +65,7 @@ void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation
     m_geolocationToIDMap.set(&geolocation, geolocationID);
     m_idToGeolocationMap.set(geolocationID, &geolocation);
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*frame);
+    auto webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
     m_page.send(Messages::WebPageProxy::RequestGeolocationPermissionForFrame(geolocationID, webFrame->info()));

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.cpp
@@ -44,7 +44,7 @@ WKBundleDOMWindowExtensionRef WKBundleDOMWindowExtensionCreate(WKBundleFrameRef 
 
 WKBundleFrameRef WKBundleDOMWindowExtensionGetFrame(WKBundleDOMWindowExtensionRef extension)
 {
-    return toAPI(WebKit::toImpl(extension)->frame());
+    return toAPI(WebKit::toImpl(extension)->frame().get());
 }
 
 WKBundleScriptWorldRef WKBundleDOMWindowExtensionGetScriptWorld(WKBundleDOMWindowExtensionRef extension)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -58,7 +58,7 @@ bool WKBundleFrameIsMainFrame(WKBundleFrameRef frameRef)
 
 WKBundleFrameRef WKBundleFrameGetParentFrame(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toImpl(frameRef)->parentFrame());
+    return toAPI(WebKit::toImpl(frameRef)->parentFrame().get());
 }
 
 WKURLRef WKBundleFrameCopyURL(WKBundleFrameRef frameRef)
@@ -102,7 +102,7 @@ JSGlobalContextRef WKBundleFrameGetJavaScriptContext(WKBundleFrameRef frameRef)
 
 WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
 {
-    return toAPI(WebKit::WebFrame::frameForContext(context));
+    return toAPI(WebKit::WebFrame::frameForContext(context).get());
 }
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContextForWorld(WKBundleFrameRef frameRef, WKBundleScriptWorldRef worldRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
@@ -52,12 +52,12 @@ WKBundleNodeHandleRef WKBundleHitTestResultCopyURLElementHandle(WKBundleHitTestR
 
 WKBundleFrameRef WKBundleHitTestResultGetFrame(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return toAPI(WebKit::toImpl(hitTestResultRef)->frame());
+    return toAPI(WebKit::toImpl(hitTestResultRef)->frame().get());
 }
 
 WKBundleFrameRef WKBundleHitTestResultGetTargetFrame(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return toAPI(WebKit::toImpl(hitTestResultRef)->targetFrame());
+    return toAPI(WebKit::toImpl(hitTestResultRef)->targetFrame().get());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteImageURL(WKBundleHitTestResultRef hitTestResultRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -69,7 +69,7 @@ InjectedBundleDOMWindowExtension::~InjectedBundleDOMWindowExtension()
     allExtensions().remove(m_coreExtension.get());
 }
 
-WebFrame* InjectedBundleDOMWindowExtension::frame() const
+RefPtr<WebFrame> InjectedBundleDOMWindowExtension::frame() const
 {
     auto* frame = m_coreExtension->frame();
     if (!frame)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
@@ -47,7 +47,7 @@ public:
 
     virtual ~InjectedBundleDOMWindowExtension();
     
-    WebFrame* frame() const;
+    RefPtr<WebFrame> frame() const;
     InjectedBundleScriptWorld* world() const;
 
 private:

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -59,7 +59,7 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::urlElementHandle()
     return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.URLElement());
 }
 
-WebFrame* InjectedBundleHitTestResult::frame() const
+RefPtr<WebFrame> InjectedBundleHitTestResult::frame() const
 {
     auto* node = m_hitTestResult.innerNonSharedNode();
     if (!node)
@@ -72,7 +72,7 @@ WebFrame* InjectedBundleHitTestResult::frame() const
     return WebFrame::fromCoreFrame(*frame);
 }
 
-WebFrame* InjectedBundleHitTestResult::targetFrame() const
+RefPtr<WebFrame> InjectedBundleHitTestResult::targetFrame() const
 {
     auto* frame = m_hitTestResult.targetFrame();
     if (!frame)
@@ -150,7 +150,7 @@ IntRect InjectedBundleHitTestResult::imageRect() const
         
     // The image rect in HitTestResult is in frame coordinates, but we need it in WKView
     // coordinates since WebKit2 clients don't have enough context to do the conversion themselves.
-    auto* webFrame = frame();
+    auto webFrame = frame();
     if (!webFrame)
         return imageRect;
     

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.h
@@ -47,8 +47,8 @@ public:
 
     RefPtr<InjectedBundleNodeHandle> nodeHandle() const;
     RefPtr<InjectedBundleNodeHandle> urlElementHandle() const;
-    WebFrame* frame() const;
-    WebFrame* targetFrame() const;
+    RefPtr<WebFrame> frame() const;
+    RefPtr<WebFrame> targetFrame() const;
 
     String absoluteImageURL() const;
     String absolutePDFURL() const;

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -79,7 +79,7 @@ void UserMediaPermissionRequestManager::sendUserMediaRequest(UserMediaRequest& u
 
     m_ongoingUserMediaRequests.add(userRequest.identifier(), userRequest);
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*frame);
+    auto webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
     auto* topLevelDocumentOrigin = userRequest.topLevelDocumentOrigin();

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -814,15 +814,15 @@ bool WebLoaderStrategy::usePingLoad() const
 
 void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& request, const HTTPHeaderMap& originalRequestHeaders, const FetchOptions& options, ContentSecurityPolicyImposition policyCheck, PingLoadCompletionHandler&& completionHandler)
 {
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
-    auto* document = frame.document();
+    auto webFrame = WebFrame::fromCoreFrame(frame);
+    RefPtr document = frame.document();
     if (!document || !webFrame) {
         if (completionHandler)
             completionHandler(internalError(request.url()), { });
         return;
     }
 
-    auto* webPage = webFrame->page();
+    RefPtr webPage = webFrame->page();
     if (!webPage) {
         if (completionHandler)
             completionHandler(internalError(request.url()), { });

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -202,7 +202,7 @@ RefPtr<PluginView> PluginView::create(HTMLPlugInElement& element, const URL& mai
     if (!coreFrame)
         return nullptr;
 
-    auto* frame = WebFrame::fromCoreFrame(*coreFrame);
+    auto frame = WebFrame::fromCoreFrame(*coreFrame);
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -278,11 +278,11 @@ private:
         if (!frame)
             return;
     
-        WebFrame* webFrame = WebFrame::fromCoreFrame(*frame);
+        auto webFrame = WebFrame::fromCoreFrame(*frame);
         if (!webFrame)
             return;
 
-        WebPage* webPage = webFrame->page();
+        RefPtr webPage = webFrame->page();
         if (!webPage)
             return;
 

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
@@ -68,7 +68,7 @@ WebAuthenticatorCoordinator::WebAuthenticatorCoordinator(WebPage& webPage)
 
 void WebAuthenticatorCoordinator::makeCredential(const LocalFrame& frame, const SecurityOrigin&, const Vector<uint8_t>& hash, const PublicKeyCredentialCreationOptions& options, RequestCompletionHandler&& handler)
 {
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     if (!webFrame)
         return;
 
@@ -78,7 +78,7 @@ void WebAuthenticatorCoordinator::makeCredential(const LocalFrame& frame, const 
 
 void WebAuthenticatorCoordinator::getAssertion(const LocalFrame& frame, const SecurityOrigin&, const Vector<uint8_t>& hash, const PublicKeyCredentialRequestOptions& options, MediationRequirement mediation, const ScopeAndCrossOriginParent& scopeAndCrossOriginParent, RequestCompletionHandler&& handler)
 {
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     if (!webFrame)
         return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -255,18 +255,18 @@ void WebChromeClient::takeFocus(FocusDirection direction)
 
 void WebChromeClient::focusedElementChanged(Element* element)
 {
-    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement || !inputElement->isText())
         return;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(*element->document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element->document().frame());
     ASSERT(webFrame);
-    m_page.injectedBundleFormClient().didFocusTextField(&m_page, *inputElement, webFrame);
+    m_page.injectedBundleFormClient().didFocusTextField(&m_page, *inputElement, webFrame.get());
 }
 
 void WebChromeClient::focusedFrameChanged(LocalFrame* frame)
 {
-    WebFrame* webFrame = frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
+    auto webFrame = frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), m_page.identifier());
 }
@@ -274,7 +274,7 @@ void WebChromeClient::focusedFrameChanged(LocalFrame* frame)
 Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
 {
 #if ENABLE(FULLSCREEN_API)
-    if (auto* document = frame.document())
+    if (RefPtr document = frame.document())
         document->fullscreenManager().cancelFullscreen();
 #endif
 
@@ -313,7 +313,7 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& win
 #endif
     };
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
 
     auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(webFrame->info(), webFrame->page()->webPageProxyIdentifier(), navigationAction.resourceRequest(), windowFeatures, navigationActionData), m_page.identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages, IPC::SendSyncOption::InformPlatformProcessWillSuspend });
     if (!sendResult.succeeded())
@@ -441,7 +441,7 @@ bool WebChromeClient::canRunBeforeUnloadConfirmPanel()
 
 bool WebChromeClient::runBeforeUnloadConfirmPanel(const String& message, LocalFrame& frame)
 {
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
 
     HangDetectionDisabler hangDetectionDisabler;
 
@@ -461,8 +461,8 @@ void WebChromeClient::closeWindow()
 
     m_page.corePage()->setGroupName(String());
 
-    auto& frame = m_page.mainWebFrame();
-    if (auto* coreFrame = frame.coreLocalFrame())
+    Ref frame = m_page.mainWebFrame();
+    if (RefPtr coreFrame = frame->coreLocalFrame())
         coreFrame->loader().stopForUserCancel();
 
     m_page.sendClose();
@@ -481,11 +481,11 @@ void WebChromeClient::runJavaScriptAlert(LocalFrame& frame, const String& alertT
     if (shouldSuppressJavaScriptDialogs(frame))
         return;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
 
     // Notify the bundle client.
-    m_page.injectedBundleUIClient().willRunJavaScriptAlert(&m_page, alertText, webFrame);
+    m_page.injectedBundleUIClient().willRunJavaScriptAlert(&m_page, alertText, webFrame.get());
     m_page.prepareToRunModalJavaScriptDialog();
 
     HangDetectionDisabler hangDetectionDisabler;
@@ -499,11 +499,11 @@ bool WebChromeClient::runJavaScriptConfirm(LocalFrame& frame, const String& mess
     if (shouldSuppressJavaScriptDialogs(frame))
         return false;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
 
     // Notify the bundle client.
-    m_page.injectedBundleUIClient().willRunJavaScriptConfirm(&m_page, message, webFrame);
+    m_page.injectedBundleUIClient().willRunJavaScriptConfirm(&m_page, message, webFrame.get());
     m_page.prepareToRunModalJavaScriptDialog();
 
     HangDetectionDisabler hangDetectionDisabler;
@@ -519,11 +519,11 @@ bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& messa
     if (shouldSuppressJavaScriptDialogs(frame))
         return false;
 
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
 
     // Notify the bundle client.
-    m_page.injectedBundleUIClient().willRunJavaScriptPrompt(&m_page, message, defaultValue, webFrame);
+    m_page.injectedBundleUIClient().willRunJavaScriptPrompt(&m_page, message, defaultValue, webFrame.get());
     m_page.prepareToRunModalJavaScriptDialog();
 
     HangDetectionDisabler hangDetectionDisabler;
@@ -592,11 +592,11 @@ void WebChromeClient::invalidateRootView(const IntRect&)
 
 void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.corePage()->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.corePage()->mainFrame());
     if (!localMainFrame)
         return;
 
-    if (Document* document = localMainFrame->document()) {
+    if (RefPtr document = localMainFrame->document()) {
         if (document->printing())
             return;
     }
@@ -606,18 +606,18 @@ void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 
 void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.corePage()->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.corePage()->mainFrame());
     if (!localMainFrame)
         return;
 
-    if (Document* document = localMainFrame->document()) {
+    if (RefPtr document = localMainFrame->document()) {
         if (document->printing())
             return;
     }
 
     m_page.pageDidScroll();
 #if USE(COORDINATED_GRAPHICS)
-    auto* frameView = m_page.localMainFrameView();
+    RefPtr frameView = m_page.localMainFrameView();
     if (frameView && frameView->delegatesScrolling()) {
         m_page.drawingArea()->scroll(rect, IntSize());
         return;
@@ -670,7 +670,7 @@ void WebChromeClient::intrinsicContentsSizeChanged(const IntSize& size) const
 
 void WebChromeClient::contentsSizeChanged(LocalFrame& frame, const IntSize& size) const
 {
-    auto* frameView = frame.view();
+    RefPtr frameView = frame.view();
 
     if (&frame.page()->mainFrame() != &frame)
         return;
@@ -746,7 +746,7 @@ static constexpr unsigned maxTitleLength = 1000; // Closest power of 10 above th
 
 void WebChromeClient::print(LocalFrame& frame, const StringWithDirection& title)
 {
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
 
     WebCore::FloatSize pdfFirstPageSize;
@@ -826,7 +826,7 @@ void WebChromeClient::runOpenPanel(LocalFrame& frame, FileChooser& fileChooser)
 
     m_page.setActiveOpenPanelResultListener(WebOpenPanelResultListener::create(m_page, fileChooser));
 
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
     m_page.send(Messages::WebPageProxy::RunOpenPanel(webFrame->frameID(), webFrame->info(), fileChooser.settings()));
 }
@@ -867,9 +867,9 @@ RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames
 
 void WebChromeClient::didAssociateFormControls(const Vector<RefPtr<Element>>& elements, WebCore::LocalFrame& frame)
 {
-    WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
-    return m_page.injectedBundleFormClient().didAssociateFormControls(&m_page, elements, webFrame);
+    return m_page.injectedBundleFormClient().didAssociateFormControls(&m_page, elements, webFrame.get());
 }
 
 bool WebChromeClient::shouldNotifyOnFormChanges()
@@ -1500,7 +1500,7 @@ void WebChromeClient::removePlaybackTargetPickerClient(PlaybackTargetClientConte
 
 void WebChromeClient::showPlaybackTargetPicker(PlaybackTargetClientContextIdentifier contextId, const IntPoint& position, bool isVideo)
 {
-    auto* frameView = m_page.localMainFrameView();
+    RefPtr frameView = m_page.localMainFrameView();
     if (!frameView)
         return;
 
@@ -1542,14 +1542,14 @@ void WebChromeClient::didInvalidateDocumentMarkerRects()
 #if ENABLE(TRACKING_PREVENTION)
 void WebChromeClient::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, LocalFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
     m_page.hasStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), *webFrame, WTFMove(completionHandler));
 }
 
 void WebChromeClient::requestStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, LocalFrame& frame, StorageAccessScope scope, CompletionHandler<void(RequestStorageAccessResult)>&& completionHandler)
 {
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
     m_page.requestStorageAccess(WTFMove(subFrameDomain), WTFMove(topFrameDomain), *webFrame, scope, WTFMove(completionHandler));
 }
@@ -1563,7 +1563,7 @@ bool WebChromeClient::hasPageLevelStorageAccess(const WebCore::RegistrableDomain
 #if ENABLE(DEVICE_ORIENTATION)
 void WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess(LocalFrame& frame, bool mayPrompt, CompletionHandler<void(DeviceOrientationOrMotionPermissionState)>&& callback)
 {
-    auto* webFrame = WebFrame::fromCoreFrame(frame);
+    auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);
     m_page.shouldAllowDeviceOrientationAndMotionAccess(webFrame->frameID(), webFrame->info(), mayPrompt, WTFMove(callback));
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -357,52 +357,52 @@ void WebEditorClient::handleInputMethodKeydown(KeyboardEvent&)
 
 void WebEditorClient::textFieldDidBeginEditing(Element& element)
 {
-    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
-    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page.get(), *inputElement, webFrame);
+    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page.get(), *inputElement, webFrame.get());
 }
 
 void WebEditorClient::textFieldDidEndEditing(Element& element)
 {
-    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
-    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page.get(), *inputElement, webFrame);
+    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page.get(), *inputElement, webFrame.get());
 }
 
 void WebEditorClient::textDidChangeInTextField(Element& element)
 {
-    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
     bool initiatedByUserTyping = UserTypingGestureIndicator::processingUserTypingGesture() && UserTypingGestureIndicator::focusedElementAtGestureStart() == inputElement;
 
-    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page.get(), *inputElement, webFrame, initiatedByUserTyping);
+    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page.get(), *inputElement, webFrame.get(), initiatedByUserTyping);
 }
 
 void WebEditorClient::textDidChangeInTextArea(Element& element)
 {
-    auto* textAreaElement = dynamicDowncast<HTMLTextAreaElement>(element);
+    RefPtr textAreaElement = dynamicDowncast<HTMLTextAreaElement>(element);
     if (!textAreaElement)
         return;
 
-    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page.get(), *textAreaElement, webFrame);
+    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page.get(), *textAreaElement, webFrame.get());
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -464,7 +464,7 @@ static API::InjectedBundle::FormClient::InputFieldAction toInputFieldAction(WKIn
 
 bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEvent* event)
 {
-    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement)
         return false;
 
@@ -472,22 +472,22 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     if (!getActionTypeForKeyEvent(event, actionType))
         return false;
 
-    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.get(), *inputElement, toInputFieldAction(actionType), webFrame);
+    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.get(), *inputElement, toInputFieldAction(actionType), webFrame.get());
 }
 
 void WebEditorClient::textWillBeDeletedInTextField(Element& element)
 {
-    auto* inputElement = dynamicDowncast<HTMLInputElement>(element);
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
-    auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.get(), *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame);
+    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.get(), *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame.get());
 }
 
 bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextCheckingType type) const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -88,11 +88,11 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
         return;
     }
 
-    auto* requestingFrame = WebProcess::singleton().webFrame(*requester.frameID);
+    RefPtr requestingFrame = WebProcess::singleton().webFrame(*requester.frameID);
 
     auto originatingFrameID = *requester.frameID;
     std::optional<WebCore::FrameIdentifier> parentFrameID;
-    if (auto* parentFrame = requestingFrame ? requestingFrame->parentFrame() : nullptr)
+    if (auto parentFrame = requestingFrame ? requestingFrame->parentFrame() : nullptr)
         parentFrameID = parentFrame->frameID();
 
     FrameInfoData originatingFrameInfoData {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -44,23 +44,23 @@ WebGeolocationClient::~WebGeolocationClient()
 
 void WebGeolocationClient::geolocationDestroyed()
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(m_page);
+    WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(m_page.get());
     delete this;
 }
 
 void WebGeolocationClient::startUpdating(const String& authorizationToken, bool needsHighAccuracy)
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->registerWebPage(m_page, authorizationToken, needsHighAccuracy);
+    WebProcess::singleton().supplement<WebGeolocationManager>()->registerWebPage(m_page.get(), authorizationToken, needsHighAccuracy);
 }
 
 void WebGeolocationClient::stopUpdating()
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(m_page);
+    WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(m_page.get());
 }
 
 void WebGeolocationClient::setEnableHighAccuracy(bool enabled)
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->setEnableHighAccuracyForPage(m_page, enabled);
+    WebProcess::singleton().supplement<WebGeolocationManager>()->setEnableHighAccuracyForPage(m_page.get(), enabled);
 }
 
 std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
@@ -70,17 +70,17 @@ std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
 
 void WebGeolocationClient::requestPermission(Geolocation& geolocation)
 {
-    m_page.geolocationPermissionRequestManager().startRequestForGeolocation(geolocation);
+    m_page.get().geolocationPermissionRequestManager().startRequestForGeolocation(geolocation);
 }
 
 void WebGeolocationClient::revokeAuthorizationToken(const String& authorizationToken)
 {
-    m_page.geolocationPermissionRequestManager().revokeAuthorizationToken(authorizationToken);
+    m_page.get().geolocationPermissionRequestManager().revokeAuthorizationToken(authorizationToken);
 }
 
 void WebGeolocationClient::cancelPermissionRequest(Geolocation& geolocation)
 {
-    m_page.geolocationPermissionRequestManager().cancelRequestForGeolocation(geolocation);
+    m_page.get().geolocationPermissionRequestManager().cancelRequestForGeolocation(geolocation);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/GeolocationClient.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebKit {
 
@@ -54,7 +55,7 @@ private:
     void requestPermission(WebCore::Geolocation&) final;
     void cancelPermissionRequest(WebCore::Geolocation&) final;
 
-    WebPage& m_page;
+    CheckedRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -150,7 +150,7 @@ void WebLocalFrameLoaderClient::setHasFrameSpecificStorageAccess(FrameSpecificSt
 
 void WebLocalFrameLoaderClient::didLoadFromRegistrableDomain(RegistrableDomain&& domain)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
     
@@ -159,7 +159,7 @@ void WebLocalFrameLoaderClient::didLoadFromRegistrableDomain(RegistrableDomain&&
 
 Vector<RegistrableDomain> WebLocalFrameLoaderClient::loadedSubresourceDomains() const
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return { };
 
@@ -195,7 +195,7 @@ void WebLocalFrameLoaderClient::setCopiesOnScroll()
 
 void WebLocalFrameLoaderClient::detachedFromParent2()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -220,7 +220,7 @@ void WebLocalFrameLoaderClient::detachedFromParent3()
 
 void WebLocalFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceRequest& request)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -239,7 +239,7 @@ void WebLocalFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderI
 
 void WebLocalFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier identifier, ResourceRequest& request, const ResourceResponse& redirectResponse)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -260,7 +260,7 @@ void WebLocalFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, Resourc
 
 bool WebLocalFrameLoaderClient::shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier identifier)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return true;
 
@@ -283,7 +283,7 @@ bool WebLocalFrameLoaderClient::canAuthenticateAgainstProtectionSpace(DocumentLo
 
 void WebLocalFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -296,7 +296,7 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, Reso
 
 void WebLocalFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier identifier, int dataLength)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -306,7 +306,7 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*,
 #if ENABLE(DATA_DETECTION)
 void WebLocalFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *detectionResults)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
     webPage->setDataDetectionResults(detectionResults);
@@ -315,7 +315,7 @@ void WebLocalFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *detectio
 
 void WebLocalFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier identifier)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -330,7 +330,7 @@ void WebLocalFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader*, Resour
 
 void WebLocalFrameLoaderClient::dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier identifier, const ResourceError& error)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -351,7 +351,7 @@ bool WebLocalFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentL
 
 void WebLocalFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -361,11 +361,11 @@ void WebLocalFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 
 void WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    WebDocumentLoader* documentLoader = static_cast<WebDocumentLoader*>(m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
+    RefPtr documentLoader = static_cast<WebDocumentLoader*>(m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
     if (!documentLoader) {
         WebLocalFrameLoaderClient_RELEASE_LOG_FAULT(Loading, "dispatchDidReceiveServerRedirectForProvisionalLoad: Called with no provisional DocumentLoader (frameState=%hhu, stateForDebugging=%i)", m_frame->coreLocalFrame()->loader().state(), m_frame->coreLocalFrame()->loader().stateMachine().stateForDebugging());
         return;
@@ -384,17 +384,17 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLo
 
 void WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    WebDocumentLoader& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
-    webPage->send(Messages::WebPageProxy::DidChangeProvisionalURLForFrame(m_frame->frameID(), documentLoader.navigationID(), documentLoader.url()));
+    Ref documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
+    webPage->send(Messages::WebPageProxy::DidChangeProvisionalURLForFrame(m_frame->frameID(), documentLoader->navigationID(), documentLoader->url()));
 }
 
 void WebLocalFrameLoaderClient::dispatchDidCancelClientRedirect()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -407,7 +407,7 @@ void WebLocalFrameLoaderClient::dispatchDidCancelClientRedirect()
 
 void WebLocalFrameLoaderClient::dispatchWillPerformClientRedirect(const URL& url, double interval, WallTime fireDate, LockBackForwardList lockBackForwardList)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -420,7 +420,7 @@ void WebLocalFrameLoaderClient::dispatchWillPerformClientRedirect(const URL& url
 
 void WebLocalFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -437,7 +437,7 @@ void WebLocalFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 
 void WebLocalFrameLoaderClient::dispatchDidChangeMainDocument()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -450,7 +450,7 @@ void WebLocalFrameLoaderClient::dispatchWillChangeDocument(const URL& currentURL
     if (m_frame->isMainFrame())
         return;
 
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -464,7 +464,7 @@ void WebLocalFrameLoaderClient::dispatchWillChangeDocument(const URL& currentURL
 
 void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocumentNavigationType navigationType)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -531,7 +531,7 @@ void WebLocalFrameLoaderClient::dispatchWillClose()
 
 void WebLocalFrameLoaderClient::dispatchDidExplicitOpen(const URL& url, const String& mimeType)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -541,7 +541,7 @@ void WebLocalFrameLoaderClient::dispatchDidExplicitOpen(const URL& url, const St
 
 void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -580,7 +580,7 @@ static constexpr unsigned maxTitleLength = 1000; // Closest power of 10 above th
 
 void WebLocalFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirection& title)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -598,11 +598,11 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirectio
 
 void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureContent> hasInsecureContent, std::optional<UsedLegacyTLS> usedLegacyTLSFromPageCache, std::optional<WasPrivateRelayed> wasPrivateRelayedFromPageCache)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    WebDocumentLoader& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
+    Ref documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
     RefPtr<API::Object> userData;
 
     // Notify the bundle client.
@@ -610,15 +610,15 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
 
     webPage->sandboxExtensionTracker().didCommitProvisionalLoad(m_frame.ptr());
 
-    bool usedLegacyTLS = documentLoader.response().usedLegacyTLS();
+    bool usedLegacyTLS = documentLoader->response().usedLegacyTLS();
     if (!usedLegacyTLS && usedLegacyTLSFromPageCache)
         usedLegacyTLS = usedLegacyTLSFromPageCache == UsedLegacyTLS::Yes;
 
-    bool wasPrivateRelayed = documentLoader.response().wasPrivateRelayed();
+    bool wasPrivateRelayed = documentLoader->response().wasPrivateRelayed();
     if (!wasPrivateRelayed && wasPrivateRelayedFromPageCache)
         wasPrivateRelayed = wasPrivateRelayedFromPageCache == WasPrivateRelayed::Yes;
 
-    auto certificateInfo = valueOrCompute(documentLoader.response().certificateInfo(), [] {
+    auto certificateInfo = valueOrCompute(documentLoader->response().certificateInfo(), [] {
         return CertificateInfo();
     });
     hasInsecureContent = hasInsecureContent ? *hasInsecureContent : (certificateInfo.containsNonRootSHA1SignedCertificate() ? HasInsecureContent::Yes : HasInsecureContent::No);
@@ -630,13 +630,13 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
 #endif
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader.request(), documentLoader.navigationID(), documentLoader.response().mimeType(), m_frameHasCustomContentProvider, m_frame->coreLocalFrame()->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, m_frame->coreLocalFrame()->document()->isPluginDocument(), *hasInsecureContent, documentLoader.mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader->request(), documentLoader->navigationID(), documentLoader->response().mimeType(), m_frameHasCustomContentProvider, m_frame->coreLocalFrame()->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, m_frame->coreLocalFrame()->document()->isPluginDocument(), *hasInsecureContent, documentLoader->mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
     webPage->didCommitLoad(m_frame.ptr());
 }
 
 void WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceError& error, WillContinueLoading willContinueLoading, WillInternallyHandleFailure willInternallyHandleFailure)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -681,7 +681,7 @@ void WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceErr
 
 void WebLocalFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -689,20 +689,20 @@ void WebLocalFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)
 
     RefPtr<API::Object> userData;
 
-    auto& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
-    auto navigationID = documentLoader.navigationID();
+    Ref documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
+    auto navigationID = documentLoader->navigationID();
 
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didFailLoadWithErrorForFrame(*webPage, m_frame, error, userData);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
     // Notify the extensions controller.
-    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+    if (RefPtr extensionControllerProxy = webPage->webExtensionControllerProxy())
         extensionControllerProxy->didFailLoadForFrame(*webPage, m_frame, m_frame->url());
 #endif
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidFailLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader.request(), navigationID, error, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidFailLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader->request(), navigationID, error, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 
     // If we have a load listener, notify it.
     if (WebFrame::LoadListener* loadListener = m_frame->loadListener())
@@ -711,7 +711,7 @@ void WebLocalFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)
 
 void WebLocalFrameLoaderClient::dispatchDidFinishDocumentLoad()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -730,7 +730,7 @@ void WebLocalFrameLoaderClient::dispatchDidFinishDocumentLoad()
 
 void WebLocalFrameLoaderClient::dispatchDidFinishLoad()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -763,7 +763,7 @@ void WebLocalFrameLoaderClient::completePageTransitionIfNeeded()
     if (m_didCompletePageTransition)
         return;
 
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -774,7 +774,7 @@ void WebLocalFrameLoaderClient::completePageTransitionIfNeeded()
 
 void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> milestones)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -838,7 +838,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState()
 
 void WebLocalFrameLoaderClient::dispatchDidLayout()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -863,7 +863,7 @@ void WebLocalFrameLoaderClient::dispatchDidLayout()
 
 LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction& navigationAction, NewFrameOpenerPolicy newFrameOpenerPolicy)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return nullptr;
 
@@ -883,7 +883,7 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
 
 void WebLocalFrameLoaderClient::dispatchShow()
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -892,7 +892,7 @@ void WebLocalFrameLoaderClient::dispatchShow()
 
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceResponse& response, const ResourceRequest& request, WebCore::PolicyCheckIdentifier identifier, const String& downloadAttribute, FramePolicyFunction&& function)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage) {
         WebLocalFrameLoaderClient_RELEASE_LOG(Network, "dispatchDecidePolicyForResponse: ignoring because there's no web page");
         function(PolicyAction::Ignore, identifier);
@@ -913,21 +913,21 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceRe
 
     bool canShowResponse = webPage->canShowResponse(response);
 
-    auto* coreFrame = m_frame->coreLocalFrame();
-    auto* policyDocumentLoader = coreFrame ? coreFrame->loader().provisionalDocumentLoader() : nullptr;
+    RefPtr coreFrame = m_frame->coreLocalFrame();
+    RefPtr policyDocumentLoader = coreFrame ? coreFrame->loader().provisionalDocumentLoader() : nullptr;
     auto navigationID = policyDocumentLoader ? static_cast<WebDocumentLoader&>(*policyDocumentLoader).navigationID() : 0;
 
-    auto protector = m_frame.copyRef();
-    uint64_t listenerID = m_frame->setUpPolicyListener(identifier, WTFMove(function), WebFrame::ForNavigationAction::No);
+    auto protectedFrame = m_frame.copyRef();
+    uint64_t listenerID = protectedFrame->setUpPolicyListener(identifier, WTFMove(function), WebFrame::ForNavigationAction::No);
 
-    webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(m_frame->info(), navigationID, response, request, canShowResponse, downloadAttribute), [frame = m_frame, listenerID, identifier] (PolicyDecision&& policyDecision) {
+    webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(protectedFrame->info(), navigationID, response, request, canShowResponse, downloadAttribute), [frame = protectedFrame, listenerID, identifier] (PolicyDecision&& policyDecision) {
         frame->didReceivePolicyDecision(listenerID, identifier, WTFMove(policyDecision));
     });
 }
 
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const NavigationAction& navigationAction, const ResourceRequest& request, FormState* formState, const String& frameName, WebCore::PolicyCheckIdentifier identifier, FramePolicyFunction&& function)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage) {
         function(PolicyAction::Ignore, identifier);
         return;
@@ -987,7 +987,7 @@ void WebLocalFrameLoaderClient::applyToDocumentLoader(WebsitePoliciesData&& webs
 
 WebCore::AllowsContentJavaScript WebLocalFrameLoaderClient::allowsContentJavaScriptFromMostRecentNavigation() const
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     return webPage ? webPage->allowsContentJavaScriptFromMostRecentNavigation() : WebCore::AllowsContentJavaScript::No;
 }
 
@@ -1008,40 +1008,40 @@ void WebLocalFrameLoaderClient::dispatchUnableToImplementPolicy(const ResourceEr
 
 void WebLocalFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<FormState>&& formState)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    auto& form = formState->form();
+    Ref form = formState->form();
 
     ASSERT(formState->sourceDocument().frame());
-    auto* sourceFrame = WebFrame::fromCoreFrame(*formState->sourceDocument().frame());
+    auto sourceFrame = WebFrame::fromCoreFrame(*formState->sourceDocument().frame());
     ASSERT(sourceFrame);
 
-    webPage->injectedBundleFormClient().willSendSubmitEvent(webPage, &form, m_frame.ptr(), sourceFrame, formState->textFieldValues());
+    webPage->injectedBundleFormClient().willSendSubmitEvent(webPage.get(), form.ptr(), m_frame.ptr(), sourceFrame.get(), formState->textFieldValues());
 }
 
 void WebLocalFrameLoaderClient::dispatchWillSubmitForm(FormState& formState, CompletionHandler<void()>&& completionHandler)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage) {
         completionHandler();
         return;
     }
 
-    auto& form = formState.form();
+    Ref form = formState.form();
 
-    auto* sourceCoreFrame = formState.sourceDocument().frame();
+    RefPtr sourceCoreFrame = formState.sourceDocument().frame();
     if (!sourceCoreFrame)
         return completionHandler();
-    auto* sourceFrame = WebFrame::fromCoreFrame(*sourceCoreFrame);
+    auto sourceFrame = WebFrame::fromCoreFrame(*sourceCoreFrame);
     if (!sourceFrame)
         return completionHandler();
 
     auto& values = formState.textFieldValues();
 
     RefPtr<API::Object> userData;
-    webPage->injectedBundleFormClient().willSubmitForm(webPage, &form, m_frame.ptr(), sourceFrame, values, userData);
+    webPage->injectedBundleFormClient().willSubmitForm(webPage.get(), form.ptr(), m_frame.ptr(), sourceFrame.get(), values, userData);
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::WillSubmitForm(m_frame->frameID(), sourceFrame->frameID(), values, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())), WTFMove(completionHandler));
 }
@@ -1094,7 +1094,7 @@ void WebLocalFrameLoaderClient::didChangeTitle(DocumentLoader*)
 
 void WebLocalFrameLoaderClient::willReplaceMultipartContent()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
     webPage->willReplaceMultipartContent(m_frame);
@@ -1102,7 +1102,7 @@ void WebLocalFrameLoaderClient::willReplaceMultipartContent()
 
 void WebLocalFrameLoaderClient::didReplaceMultipartContent()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
     webPage->didReplaceMultipartContent(m_frame);
@@ -1141,7 +1141,7 @@ void WebLocalFrameLoaderClient::committedLoad(DocumentLoader* loader, const Shar
 void WebLocalFrameLoaderClient::finishedLoading(DocumentLoader* loader)
 {
     if (m_frameHasCustomContentProvider) {
-        WebPage* webPage = m_frame->page();
+        RefPtr webPage = m_frame->page();
         if (!webPage)
             return;
 
@@ -1175,11 +1175,11 @@ void WebLocalFrameLoaderClient::finishedLoading(DocumentLoader* loader)
 
 void WebLocalFrameLoaderClient::updateGlobalHistory()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    DocumentLoader* loader = m_frame->coreLocalFrame()->loader().documentLoader();
+    RefPtr loader = m_frame->coreLocalFrame()->loader().documentLoader();
 
     WebNavigationDataStore data;
     data.url = loader->url().string();
@@ -1193,7 +1193,7 @@ void WebLocalFrameLoaderClient::updateGlobalHistory()
 
 void WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1215,7 +1215,7 @@ void WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks()
 
 bool WebLocalFrameLoaderClient::shouldGoToHistoryItem(HistoryItem& item) const
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return false;
     webPage->send(Messages::WebPageProxy::WillGoToBackForwardListItem(item.identifier(), item.isInBackForwardCache()));
@@ -1224,7 +1224,7 @@ bool WebLocalFrameLoaderClient::shouldGoToHistoryItem(HistoryItem& item) const
 
 void WebLocalFrameLoaderClient::didDisplayInsecureContent()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1237,7 +1237,7 @@ void WebLocalFrameLoaderClient::didDisplayInsecureContent()
 
 void WebLocalFrameLoaderClient::didRunInsecureContent(SecurityOrigin&, const URL&)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1394,7 +1394,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
 
 void WebLocalFrameLoaderClient::provisionalLoadStarted()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1428,7 +1428,7 @@ void WebLocalFrameLoaderClient::updateCachedDocumentLoader(WebCore::DocumentLoad
 
 void WebLocalFrameLoaderClient::setTitle(const StringWithDirection& title, const URL& url)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1438,7 +1438,7 @@ void WebLocalFrameLoaderClient::setTitle(const StringWithDirection& title, const
 
 String WebLocalFrameLoaderClient::userAgent(const URL& url) const
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return String();
 
@@ -1447,7 +1447,7 @@ String WebLocalFrameLoaderClient::userAgent(const URL& url) const
 
 String WebLocalFrameLoaderClient::overrideContentSecurityPolicy() const
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return String();
 
@@ -1467,7 +1467,7 @@ void WebLocalFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame
 
 void WebLocalFrameLoaderClient::transitionToCommittedForNewPage()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
 
     bool isMainFrame = m_frame->isMainFrame();
     bool shouldUseFixedLayout = isMainFrame && webPage->useFixedLayout();
@@ -1577,7 +1577,7 @@ void WebLocalFrameLoaderClient::convertMainResourceLoadToDownload(DocumentLoader
 
 RefPtr<LocalFrame> WebLocalFrameLoaderClient::createFrame(const AtomString& name, HTMLFrameOwnerElement& ownerElement)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     ASSERT(webPage);
     auto subframe = WebFrame::createSubframe(*webPage, m_frame, name, ownerElement);
     auto* coreSubframe = subframe->coreLocalFrame();
@@ -1639,7 +1639,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
         mimeType = MIMETypeRegistry::mimeTypeForExtension(extension);
         if (mimeType.isEmpty()) {
             // Check if there's a plug-in around that can handle the extension.
-            if (auto* webPage = m_frame->page()) {
+            if (RefPtr webPage = m_frame->page()) {
                 if (pluginSupportsExtension(webPage->corePage()->pluginData(), extension))
                     return ObjectContentType::PlugIn;
             }
@@ -1647,7 +1647,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
         }
     }
 #if ENABLE(PDFJS)
-    if (auto* webPage = m_frame->page()) {
+    if (RefPtr webPage = m_frame->page()) {
         if (webPage->corePage()->settings().pdfJSViewerEnabled() && MIMETypeRegistry::isPDFMIMEType(mimeType))
             return ObjectContentType::Frame;
     }
@@ -1655,7 +1655,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
     if (MIMETypeRegistry::isSupportedImageMIMEType(mimeType))
         return ObjectContentType::Image;
 
-    if (WebPage* webPage = m_frame->page()) {
+    if (RefPtr webPage = m_frame->page()) {
         auto allowedPluginTypes = webFrame().coreLocalFrame()->arePluginsEnabled()
             ? PluginData::AllPlugins : PluginData::OnlyApplicationPlugins;
         if (webPage->corePage()->pluginData().supportsMimeType(mimeType, allowedPluginTypes))
@@ -1684,7 +1684,7 @@ AtomString WebLocalFrameLoaderClient::overrideMediaType() const
 
 void WebLocalFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld& world)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1702,7 +1702,7 @@ void WebLocalFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWo
 
 void WebLocalFrameLoaderClient::dispatchGlobalObjectAvailable(DOMWrapperWorld& world)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1716,7 +1716,7 @@ void WebLocalFrameLoaderClient::dispatchGlobalObjectAvailable(DOMWrapperWorld& w
 
 void WebLocalFrameLoaderClient::dispatchServiceWorkerGlobalObjectAvailable(DOMWrapperWorld& world)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1730,7 +1730,7 @@ void WebLocalFrameLoaderClient::dispatchServiceWorkerGlobalObjectAvailable(DOMWr
 
 void WebLocalFrameLoaderClient::willInjectUserScript(DOMWrapperWorld& world)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1739,7 +1739,7 @@ void WebLocalFrameLoaderClient::willInjectUserScript(DOMWrapperWorld& world)
 
 void WebLocalFrameLoaderClient::dispatchWillDisconnectDOMWindowExtensionFromGlobalObject(WebCore::DOMWindowExtension* extension)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
         
@@ -1748,7 +1748,7 @@ void WebLocalFrameLoaderClient::dispatchWillDisconnectDOMWindowExtensionFromGlob
 
 void WebLocalFrameLoaderClient::dispatchDidReconnectDOMWindowExtensionToGlobalObject(WebCore::DOMWindowExtension* extension)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
         
@@ -1757,7 +1757,7 @@ void WebLocalFrameLoaderClient::dispatchDidReconnectDOMWindowExtensionToGlobalOb
 
 void WebLocalFrameLoaderClient::dispatchWillDestroyGlobalObjectForDOMWindowExtension(WebCore::DOMWindowExtension* extension)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
         
@@ -1768,7 +1768,7 @@ void WebLocalFrameLoaderClient::dispatchWillDestroyGlobalObjectForDOMWindowExten
     
 RemoteAXObjectRef WebLocalFrameLoaderClient::accessibilityRemoteObject()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return 0;
     
@@ -1779,14 +1779,14 @@ RemoteAXObjectRef WebLocalFrameLoaderClient::accessibilityRemoteObject()
 void WebLocalFrameLoaderClient::setAXIsolatedTreeRoot(WebCore::AXCoreObject* axObject)
 {
     ASSERT(isMainRunLoop());
-    if (auto* webPage = m_frame->page())
+    if (RefPtr webPage = m_frame->page())
         webPage->setAXIsolatedTreeRoot(axObject);
 }
 #endif
 
 void WebLocalFrameLoaderClient::willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier identifier, NSCachedURLResponse* response, CompletionHandler<void(NSCachedURLResponse *)>&& completionHandler) const
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return completionHandler(response);
 
@@ -1795,7 +1795,7 @@ void WebLocalFrameLoaderClient::willCacheResponse(DocumentLoader*, ResourceLoade
 
 std::optional<double> WebLocalFrameLoaderClient::dataDetectionReferenceDate()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return std::nullopt;
 
@@ -1806,7 +1806,7 @@ std::optional<double> WebLocalFrameLoaderClient::dataDetectionReferenceDate()
 
 void WebLocalFrameLoaderClient::didChangeScrollOffset()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1820,7 +1820,7 @@ bool WebLocalFrameLoaderClient::allowScript(bool enabledPerSettings)
 
 bool WebLocalFrameLoaderClient::shouldForceUniversalAccessFromLocalURL(const URL& url)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return false;
 
@@ -1855,7 +1855,7 @@ void WebLocalFrameLoaderClient::prefetchDNS(const String& hostname)
 
 void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler)
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return completionHandler(makeUnexpected(internalError(url)));
 
@@ -1879,7 +1879,7 @@ void WebLocalFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<voi
 
 void WebLocalFrameLoaderClient::didRestoreScrollPosition()
 {
-    WebPage* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1888,7 +1888,7 @@ void WebLocalFrameLoaderClient::didRestoreScrollPosition()
 
 void WebLocalFrameLoaderClient::getLoadDecisionForIcons(const Vector<std::pair<WebCore::LinkIcon&, uint64_t>>& icons)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1904,7 +1904,7 @@ void WebLocalFrameLoaderClient::broadcastFrameRemovalToOtherProcesses()
 #if ENABLE(SERVICE_WORKER)
 void WebLocalFrameLoaderClient::didFinishServiceWorkerPageRegistration(bool success)
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1923,7 +1923,7 @@ void WebLocalFrameLoaderClient::notifyPageOfAppBoundBehavior()
     if (!m_frame->isMainFrame())
         return;
 
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
@@ -1950,7 +1950,7 @@ bool WebLocalFrameLoaderClient::isParentProcessAFullWebBrowser() const
 #if ENABLE(ARKIT_INLINE_PREVIEW_MAC)
 void WebLocalFrameLoaderClient::modelInlinePreviewUUIDs(CompletionHandler<void(Vector<String>)>&& completionHandler) const
 {
-    auto* webPage = m_frame->page();
+    RefPtr webPage = m_frame->page();
     if (!webPage) {
         completionHandler({ });
         return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
@@ -43,8 +43,8 @@ WebValidationMessageClient::WebValidationMessageClient(WebPage& page)
 
 WebValidationMessageClient::~WebValidationMessageClient()
 {
-    if (m_currentAnchor)
-        hideValidationMessage(*m_currentAnchor);
+    if (RefPtr anchor = m_currentAnchor.get())
+        hideValidationMessage(*anchor);
 }
 
 void WebValidationMessageClient::documentDetached(Document& document)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
@@ -36,7 +36,7 @@ WebRemoteObjectRegistry::WebRemoteObjectRegistry(_WKRemoteObjectRegistry *remote
     : RemoteObjectRegistry(remoteObjectRegistry)
     , m_page(page)
 {
-    WebProcess::singleton().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page.identifier(), *this);
+    WebProcess::singleton().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), page.identifier(), *this);
     page.setRemoteObjectRegistry(this);
 }
 
@@ -47,20 +47,21 @@ WebRemoteObjectRegistry::~WebRemoteObjectRegistry()
 
 void WebRemoteObjectRegistry::close()
 {
-    if (m_page.remoteObjectRegistry() == this) {
-        WebProcess::singleton().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page.identifier());
-        m_page.setRemoteObjectRegistry(nullptr);
+    Ref page { m_page.get() };
+    if (page->remoteObjectRegistry() == this) {
+        WebProcess::singleton().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), page->identifier());
+        page->setRemoteObjectRegistry(nullptr);
     }
 }
 
 IPC::MessageSender& WebRemoteObjectRegistry::messageSender()
 {
-    return m_page;
+    return m_page.get();
 }
 
 uint64_t WebRemoteObjectRegistry::messageDestinationID()
 {
-    return m_page.webPageProxyIdentifier().toUInt64();
+    return m_page.get().webPageProxyIdentifier().toUInt64();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RemoteObjectRegistry.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebKit {
 
@@ -42,7 +43,7 @@ private:
     IPC::MessageSender& messageSender() final;
     uint64_t messageDestinationID() final;
 
-    WebPage& m_page;
+    CheckedRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
@@ -55,11 +55,12 @@ void WebDocumentLoader::setNavigationID(uint64_t navigationID)
 
 RefPtr<WebDocumentLoader> WebDocumentLoader::loaderForWebsitePolicies(const LocalFrame& frame, CanIncludeCurrentDocumentLoader canIncludeCurrentDocumentLoader)
 {
-    RefPtr loader = static_cast<WebDocumentLoader*>(frame.loader().policyDocumentLoader());
+    Ref protectedFrame { frame };
+    RefPtr loader = static_cast<WebDocumentLoader*>(protectedFrame->loader().policyDocumentLoader());
     if (!loader)
-        loader = static_cast<WebDocumentLoader*>(frame.loader().provisionalDocumentLoader());
+        loader = static_cast<WebDocumentLoader*>(protectedFrame->loader().provisionalDocumentLoader());
     if (!loader && canIncludeCurrentDocumentLoader == CanIncludeCurrentDocumentLoader::Yes)
-        loader = static_cast<WebDocumentLoader*>(frame.loader().documentLoader());
+        loader = static_cast<WebDocumentLoader*>(protectedFrame->loader().documentLoader());
     return loader;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -198,7 +198,7 @@ WebPage* WebFrame::page() const
     return page ? WebPage::fromCorePage(*page) : nullptr;
 }
 
-WebFrame* WebFrame::fromCoreFrame(const Frame& frame)
+RefPtr<WebFrame> WebFrame::fromCoreFrame(const Frame& frame)
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {
         auto* webLocalFrameLoaderClient = toWebLocalFrameLoaderClient(localFrame->loader().client());
@@ -693,7 +693,7 @@ String WebFrame::innerText() const
     return localFrame->document()->documentElement()->innerText();
 }
 
-WebFrame* WebFrame::parentFrame() const
+RefPtr<WebFrame> WebFrame::parentFrame() const
 {
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame || !localFrame->ownerElement())
@@ -965,13 +965,13 @@ void WebFrame::stopLoading()
     localFrame->loader().stopForUserCancel();
 }
 
-WebFrame* WebFrame::frameForContext(JSContextRef context)
+RefPtr<WebFrame> WebFrame::frameForContext(JSContextRef context)
 {
     RefPtr coreFrame = LocalFrame::fromJSContext(context);
     return coreFrame ? WebFrame::fromCoreFrame(*coreFrame) : nullptr;
 }
 
-WebFrame* WebFrame::contentFrameForWindowOrFrameElement(JSContextRef context, JSValueRef value)
+RefPtr<WebFrame> WebFrame::contentFrameForWindowOrFrameElement(JSContextRef context, JSValueRef value)
 {
     RefPtr coreFrame = LocalFrame::contentFrameFromWindowOrFrameElement(context, value);
     return coreFrame ? WebFrame::fromCoreFrame(*coreFrame) : nullptr;
@@ -1143,7 +1143,7 @@ bool WebFrame::shouldEnableInAppBrowserPrivacyProtections()
 
     bool treeHasNonAppBoundFrame = m_isNavigatingToAppBoundDomain && m_isNavigatingToAppBoundDomain == NavigatingToAppBoundDomain::No;
     if (!treeHasNonAppBoundFrame) {
-        for (WebFrame* frame = this; frame; frame = frame->parentFrame()) {
+        for (RefPtr frame = this; frame; frame = frame->parentFrame()) {
             if (frame->isNavigatingToAppBoundDomain() && frame->isNavigatingToAppBoundDomain() == NavigatingToAppBoundDomain::No) {
                 treeHasNonAppBoundFrame = true;
                 break;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -93,7 +93,7 @@ public:
 
     WebPage* page() const;
 
-    static WebFrame* fromCoreFrame(const WebCore::Frame&);
+    static RefPtr<WebFrame> fromCoreFrame(const WebCore::Frame&);
     WebCore::LocalFrame* coreLocalFrame() const;
     WebCore::RemoteFrame* coreRemoteFrame() const;
     WebCore::Frame* coreFrame() const;
@@ -134,7 +134,7 @@ public:
     WebCore::CertificateInfo certificateInfo() const;
     String innerText() const;
     bool isFrameSet() const;
-    WebFrame* parentFrame() const;
+    RefPtr<WebFrame> parentFrame() const;
     Ref<API::Array> childFrames();
     JSGlobalContextRef jsContext();
     JSGlobalContextRef jsContextForWorld(WebCore::DOMWrapperWorld&);
@@ -167,8 +167,8 @@ public:
     void stopLoading();
     void setAccessibleName(const AtomString&);
 
-    static WebFrame* frameForContext(JSContextRef);
-    static WebFrame* contentFrameForWindowOrFrameElement(JSContextRef, JSValueRef);
+    static RefPtr<WebFrame> frameForContext(JSContextRef);
+    static RefPtr<WebFrame> contentFrameForWindowOrFrameElement(JSContextRef, JSValueRef);
 
     JSValueRef jsWrapperForWorld(InjectedBundleCSSStyleDeclarationHandle*, InjectedBundleScriptWorld*);
     JSValueRef jsWrapperForWorld(InjectedBundleNodeHandle*, InjectedBundleScriptWorld*);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6795,7 +6795,7 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
 
         RefPtr<API::Object> userData;
 
-        m_formClient->willBeginInputSession(this, &element, WebFrame::fromCoreFrame(*element.document().frame()), m_userIsInteracting, userData);
+        m_formClient->willBeginInputSession(this, &element, WebFrame::fromCoreFrame(*element.document().frame()).get(), m_userIsInteracting, userData);
 
         information->preventScroll = options.preventScroll;
         send(Messages::WebPageProxy::ElementDidFocus(information.value(), m_userIsInteracting, m_recentlyBlurredElement, m_lastActivityStateChanges, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));


### PR DESCRIPTION
#### bd0e96182943cd6e05b1f15f771ca926832e42d3
<pre>
Use more smart pointers in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261474">https://bugs.webkit.org/show_bug.cgi?id=261474</a>

Reviewed by Brent Fulgham.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::focusedElementChanged):
(WebKit::WebChromeClient::focusedFrameChanged):
(WebKit::WebChromeClient::createWindow):
(WebKit::WebChromeClient::runBeforeUnloadConfirmPanel):
(WebKit::WebChromeClient::closeWindow):
(WebKit::WebChromeClient::runJavaScriptAlert):
(WebKit::WebChromeClient::runJavaScriptConfirm):
(WebKit::WebChromeClient::runJavaScriptPrompt):
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
(WebKit::WebChromeClient::contentsSizeChanged const):
(WebKit::WebChromeClient::print):
(WebKit::WebChromeClient::runOpenPanel):
(WebKit::WebChromeClient::didAssociateFormControls):
(WebKit::WebChromeClient::showPlaybackTargetPicker):
(WebKit::WebChromeClient::hasStorageAccess):
(WebKit::WebChromeClient::requestStorageAccess):
(WebKit::WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::textFieldDidBeginEditing):
(WebKit::WebEditorClient::textFieldDidEndEditing):
(WebKit::WebEditorClient::textDidChangeInTextField):
(WebKit::WebEditorClient::textDidChangeInTextArea):
(WebKit::WebEditorClient::doTextFieldCommandFromEvent):
(WebKit::WebEditorClient::textWillBeDeletedInTextField):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
(WebKit::WebGeolocationClient::geolocationDestroyed):
(WebKit::WebGeolocationClient::startUpdating):
(WebKit::WebGeolocationClient::stopUpdating):
(WebKit::WebGeolocationClient::setEnableHighAccuracy):
(WebKit::WebGeolocationClient::requestPermission):
(WebKit::WebGeolocationClient::revokeAuthorizationToken):
(WebKit::WebGeolocationClient::cancelPermissionRequest):
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didLoadFromRegistrableDomain):
(WebKit::WebLocalFrameLoaderClient::loadedSubresourceDomains const):
(WebKit::WebLocalFrameLoaderClient::detachedFromParent2):
(WebKit::WebLocalFrameLoaderClient::assignIdentifierToInitialRequest):
(WebKit::WebLocalFrameLoaderClient::dispatchWillSendRequest):
(WebKit::WebLocalFrameLoaderClient::shouldUseCredentialStorage):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReceiveResponse):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReceiveContentLength):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishDataDetection):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishLoading):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailLoading):
(WebKit::WebLocalFrameLoaderClient::dispatchDidDispatchOnloadEvents):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL):
(WebKit::WebLocalFrameLoaderClient::dispatchDidCancelClientRedirect):
(WebKit::WebLocalFrameLoaderClient::dispatchWillPerformClientRedirect):
(WebKit::WebLocalFrameLoaderClient::dispatchDidChangeLocationWithinPage):
(WebKit::WebLocalFrameLoaderClient::dispatchDidChangeMainDocument):
(WebKit::WebLocalFrameLoaderClient::dispatchWillChangeDocument):
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebLocalFrameLoaderClient::dispatchDidExplicitOpen):
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReceiveTitle):
(WebKit::WebLocalFrameLoaderClient::dispatchDidCommitLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishDocumentLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishLoad):
(WebKit::WebLocalFrameLoaderClient::completePageTransitionIfNeeded):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone):
(WebKit::WebLocalFrameLoaderClient::dispatchDidLayout):
(WebKit::WebLocalFrameLoaderClient::dispatchCreatePage):
(WebKit::WebLocalFrameLoaderClient::dispatchShow):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebKit::WebLocalFrameLoaderClient::allowsContentJavaScriptFromMostRecentNavigation const):
(WebKit::WebLocalFrameLoaderClient::dispatchWillSendSubmitEvent):
(WebKit::WebLocalFrameLoaderClient::dispatchWillSubmitForm):
(WebKit::WebLocalFrameLoaderClient::willReplaceMultipartContent):
(WebKit::WebLocalFrameLoaderClient::didReplaceMultipartContent):
(WebKit::WebLocalFrameLoaderClient::finishedLoading):
(WebKit::WebLocalFrameLoaderClient::updateGlobalHistory):
(WebKit::WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks):
(WebKit::WebLocalFrameLoaderClient::shouldGoToHistoryItem const):
(WebKit::WebLocalFrameLoaderClient::didDisplayInsecureContent):
(WebKit::WebLocalFrameLoaderClient::didRunInsecureContent):
(WebKit::WebLocalFrameLoaderClient::provisionalLoadStarted):
(WebKit::WebLocalFrameLoaderClient::setTitle):
(WebKit::WebLocalFrameLoaderClient::userAgent const):
(WebKit::WebLocalFrameLoaderClient::overrideContentSecurityPolicy const):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedForNewPage):
(WebKit::WebLocalFrameLoaderClient::createFrame):
(WebKit::WebLocalFrameLoaderClient::objectContentType):
(WebKit::WebLocalFrameLoaderClient::dispatchDidClearWindowObjectInWorld):
(WebKit::WebLocalFrameLoaderClient::dispatchGlobalObjectAvailable):
(WebKit::WebLocalFrameLoaderClient::dispatchServiceWorkerGlobalObjectAvailable):
(WebKit::WebLocalFrameLoaderClient::willInjectUserScript):
(WebKit::WebLocalFrameLoaderClient::dispatchWillDisconnectDOMWindowExtensionFromGlobalObject):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReconnectDOMWindowExtensionToGlobalObject):
(WebKit::WebLocalFrameLoaderClient::dispatchWillDestroyGlobalObjectForDOMWindowExtension):
(WebKit::WebLocalFrameLoaderClient::accessibilityRemoteObject):
(WebKit::WebLocalFrameLoaderClient::setAXIsolatedTreeRoot):
(WebKit::WebLocalFrameLoaderClient::willCacheResponse const):
(WebKit::WebLocalFrameLoaderClient::dataDetectionReferenceDate):
(WebKit::WebLocalFrameLoaderClient::didChangeScrollOffset):
(WebKit::WebLocalFrameLoaderClient::shouldForceUniversalAccessFromLocalURL):
(WebKit::WebLocalFrameLoaderClient::sendH2Ping):
(WebKit::WebLocalFrameLoaderClient::didRestoreScrollPosition):
(WebKit::WebLocalFrameLoaderClient::getLoadDecisionForIcons):
(WebKit::WebLocalFrameLoaderClient::didFinishServiceWorkerPageRegistration):
(WebKit::WebLocalFrameLoaderClient::notifyPageOfAppBoundBehavior):
(WebKit::WebLocalFrameLoaderClient::modelInlinePreviewUUIDs const):
* Source/WebKit/WebProcess/WebCoreSupport/WebValidationMessageClient.cpp:
(WebKit::WebValidationMessageClient::~WebValidationMessageClient):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp:
(WebKit::WebRemoteObjectRegistry::WebRemoteObjectRegistry):
(WebKit::WebRemoteObjectRegistry::close):
(WebKit::WebRemoteObjectRegistry::messageSender):
(WebKit::WebRemoteObjectRegistry::messageDestinationID):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h:
* Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp:
(WebKit::WebDocumentLoader::loaderForWebsitePolicies):

Canonical link: <a href="https://commits.webkit.org/267945@main">https://commits.webkit.org/267945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09f7e49d699a80e4397e2a67fa8388e4efc19f52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16959 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18924 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20836 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15802 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23037 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20918 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17266 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16357 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->