### PR TITLE
[Xcode] WebKitSwift is not built by WebKit.xcworkspace schemes

### DIFF
--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to MiniBrowser.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to MiniBrowser.xcscheme
@@ -126,9 +126,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1A50DB38110A3C13000D3FE5"
-               BuildableName = "Framework, XPC Services, and daemons"
-               BlueprintName = "Framework, XPC Services, and daemons"
+               BlueprintIdentifier = "CD0C36D52639D39A004E35D8"
+               BuildableName = "Everything"
+               BlueprintName = "Everything"
                ReferencedContainer = "container:Source/WebKit/WebKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
@@ -126,9 +126,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1A50DB38110A3C13000D3FE5"
-               BuildableName = "Framework, XPC Services, and daemons"
-               BlueprintName = "Framework, XPC Services, and daemons"
+               BlueprintIdentifier = "CD0C36D52639D39A004E35D8"
+               BuildableName = "Everything"
+               BlueprintName = "Everything"
                ReferencedContainer = "container:Source/WebKit/WebKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
@@ -126,9 +126,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1A50DB38110A3C13000D3FE5"
-               BuildableName = "Framework, XPC Services, and daemons"
-               BlueprintName = "Framework, XPC Services, and daemons"
+               BlueprintIdentifier = "CD0C36D52639D39A004E35D8"
+               BuildableName = "Everything"
+               BlueprintName = "Everything"
                ReferencedContainer = "container:Source/WebKit/WebKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>


### PR DESCRIPTION
#### aa9569b3f0cb61bd4d1452b9508b76d8660060bd
<pre>
[Xcode] WebKitSwift is not built by WebKit.xcworkspace schemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261476">https://bugs.webkit.org/show_bug.cgi?id=261476</a>
rdar://115386183

Reviewed by Elliott Williams.

For reasons only relevant to Apple&apos;s Production build, the WebKit project’s default
&quot;Framework, XPC Services, and daemons&quot; aggregate target does not build the WebKitSwift target. As a
result, this target is not built by any of WebKit.xcworkspace&apos;s schemes. Resolved this by changing
the aggregate target used to build WebKit by WebKit.xcworkspace&apos;s schemes from
&quot;Framework, XPC Services, and daemons&quot; to &quot;Everything&quot;, the latter of which includes the former plus
WebKitSwift.

* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to MiniBrowser.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme:

Canonical link: <a href="https://commits.webkit.org/267927@main">https://commits.webkit.org/267927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb4a3935989773bd00bf7bd02b3558964dc82489

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20776 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22999 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16310 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4304 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->