### PR TITLE
Use more smart pointers in RenderView

### DIFF
--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -126,7 +126,7 @@ void RenderView::scheduleLazyRepaint(RenderBox& renderer)
     if (renderer.renderBoxNeedsLazyRepaint())
         return;
     renderer.setRenderBoxNeedsLazyRepaint(true);
-    m_renderersNeedingLazyRepaint.add(&renderer);
+    m_renderersNeedingLazyRepaint.add(renderer);
     if (!m_lazyRepaintTimer.isActive())
         m_lazyRepaintTimer.startOneShot(0_s);
 }
@@ -136,16 +136,16 @@ void RenderView::unscheduleLazyRepaint(RenderBox& renderer)
     if (!renderer.renderBoxNeedsLazyRepaint())
         return;
     renderer.setRenderBoxNeedsLazyRepaint(false);
-    m_renderersNeedingLazyRepaint.remove(&renderer);
-    if (m_renderersNeedingLazyRepaint.isEmpty())
+    m_renderersNeedingLazyRepaint.remove(renderer);
+    if (m_renderersNeedingLazyRepaint.isEmptyIgnoringNullReferences())
         m_lazyRepaintTimer.stop();
 }
 
 void RenderView::lazyRepaintTimerFired()
 {
     for (auto& renderer : m_renderersNeedingLazyRepaint) {
-        renderer->repaint();
-        renderer->setRenderBoxNeedsLazyRepaint(false);
+        renderer.repaint();
+        renderer.setRenderBoxNeedsLazyRepaint(false);
     }
     m_renderersNeedingLazyRepaint.clear();
 }
@@ -854,52 +854,52 @@ ImageQualityController& RenderView::imageQualityController()
 
 void RenderView::registerForVisibleInViewportCallback(RenderElement& renderer)
 {
-    ASSERT(!m_visibleInViewportRenderers.contains(&renderer));
-    m_visibleInViewportRenderers.add(&renderer);
+    ASSERT(!m_visibleInViewportRenderers.contains(renderer));
+    m_visibleInViewportRenderers.add(renderer);
 }
 
 void RenderView::unregisterForVisibleInViewportCallback(RenderElement& renderer)
 {
-    ASSERT(m_visibleInViewportRenderers.contains(&renderer));
-    m_visibleInViewportRenderers.remove(&renderer);
+    ASSERT(m_visibleInViewportRenderers.contains(renderer));
+    m_visibleInViewportRenderers.remove(renderer);
 }
 
 void RenderView::updateVisibleViewportRect(const IntRect& visibleRect)
 {
     resumePausedImageAnimationsIfNeeded(visibleRect);
 
-    for (auto* renderer : m_visibleInViewportRenderers) {
-        auto state = visibleRect.intersects(enclosingIntRect(renderer->absoluteClippedOverflowRectForRepaint())) ? VisibleInViewportState::Yes : VisibleInViewportState::No;
-        renderer->setVisibleInViewportState(state);
+    for (auto& renderer : m_visibleInViewportRenderers) {
+        auto state = visibleRect.intersects(enclosingIntRect(renderer.absoluteClippedOverflowRectForRepaint())) ? VisibleInViewportState::Yes : VisibleInViewportState::No;
+        renderer.setVisibleInViewportState(state);
     }
 }
 
 void RenderView::addRendererWithPausedImageAnimations(RenderElement& renderer, CachedImage& image)
 {
-    ASSERT(!renderer.hasPausedImageAnimations() || m_renderersWithPausedImageAnimation.contains(&renderer));
+    ASSERT(!renderer.hasPausedImageAnimations() || m_renderersWithPausedImageAnimation.contains(renderer));
 
     renderer.setHasPausedImageAnimations(true);
-    auto& images = m_renderersWithPausedImageAnimation.ensure(&renderer, [] {
-        return Vector<CachedImage*>();
+    auto& images = m_renderersWithPausedImageAnimation.ensure(renderer, [] {
+        return Vector<WeakPtr<CachedImage>>();
     }).iterator->value;
     if (!images.contains(&image))
-        images.append(&image);
+        images.append(image);
 }
 
 void RenderView::removeRendererWithPausedImageAnimations(RenderElement& renderer)
 {
     ASSERT(renderer.hasPausedImageAnimations());
-    ASSERT(m_renderersWithPausedImageAnimation.contains(&renderer));
+    ASSERT(m_renderersWithPausedImageAnimation.contains(renderer));
 
     renderer.setHasPausedImageAnimations(false);
-    m_renderersWithPausedImageAnimation.remove(&renderer);
+    m_renderersWithPausedImageAnimation.remove(renderer);
 }
 
 void RenderView::removeRendererWithPausedImageAnimations(RenderElement& renderer, CachedImage& image)
 {
     ASSERT(renderer.hasPausedImageAnimations());
 
-    auto it = m_renderersWithPausedImageAnimation.find(&renderer);
+    auto it = m_renderersWithPausedImageAnimation.find(renderer);
     ASSERT(it != m_renderersWithPausedImageAnimation.end());
 
     auto& images = it->value;
@@ -914,24 +914,24 @@ void RenderView::removeRendererWithPausedImageAnimations(RenderElement& renderer
 
 void RenderView::resumePausedImageAnimationsIfNeeded(const IntRect& visibleRect)
 {
-    Vector<std::pair<RenderElement*, CachedImage*>, 10> toRemove;
-    for (auto& it : m_renderersWithPausedImageAnimation) {
-        auto* renderer = it.key;
-        for (auto* image : it.value) {
-            if (renderer->repaintForPausedImageAnimationsIfNeeded(visibleRect, *image))
-                toRemove.append(std::make_pair(renderer, image));
+    Vector<std::pair<WeakPtr<RenderElement>, WeakPtr<CachedImage>>, 10> toRemove;
+    for (auto it : m_renderersWithPausedImageAnimation) {
+        auto& renderer = it.key;
+        for (auto& image : it.value) {
+            if (renderer.repaintForPausedImageAnimationsIfNeeded(visibleRect, *image))
+                toRemove.append({ renderer, image });
         }
     }
     for (auto& pair : toRemove)
         removeRendererWithPausedImageAnimations(*pair.first, *pair.second);
 
-    Vector<SVGSVGElement*> svgSvgElementsToRemove;
+    Vector<Ref<SVGSVGElement>> svgSvgElementsToRemove;
     m_SVGSVGElementsWithPausedImageAnimation.forEach([&] (WeakPtr<SVGSVGElement, WeakPtrImplWithEventTargetData> svgSvgElement) {
         if (svgSvgElement && svgSvgElement->resumePausedAnimationsIfNeeded(visibleRect))
-            svgSvgElementsToRemove.append(svgSvgElement.get());
+            svgSvgElementsToRemove.append(*svgSvgElement);
     });
     for (auto& svgSvgElement : svgSvgElementsToRemove)
-        m_SVGSVGElementsWithPausedImageAnimation.remove(*svgSvgElement);
+        m_SVGSVGElementsWithPausedImageAnimation.remove(svgSvgElement.get());
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -1092,12 +1092,12 @@ RenderLayer* RenderView::takeStyleChangeLayerTreeMutationRoot()
 
 void RenderView::registerBoxWithScrollSnapPositions(const RenderBox& box)
 {
-    m_boxesWithScrollSnapPositions.add(&box);
+    m_boxesWithScrollSnapPositions.add(box);
 }
 
 void RenderView::unregisterBoxWithScrollSnapPositions(const RenderBox& box)
 {
-    m_boxesWithScrollSnapPositions.remove(&box);
+    m_boxesWithScrollSnapPositions.remove(box);
 }
 
 void RenderView::registerContainerQueryBox(const RenderBox& box)

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -205,7 +205,7 @@ public:
 
     void registerBoxWithScrollSnapPositions(const RenderBox&);
     void unregisterBoxWithScrollSnapPositions(const RenderBox&);
-    const HashSet<const RenderBox*>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
+    const WeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
 
     void registerContainerQueryBox(const RenderBox&);
     void unregisterContainerQueryBox(const RenderBox&);
@@ -261,7 +261,7 @@ private:
     void lazyRepaintTimerFired();
 
     Timer m_lazyRepaintTimer;
-    HashSet<RenderBox*> m_renderersNeedingLazyRepaint;
+    WeakHashSet<RenderBox> m_renderersNeedingLazyRepaint;
 
     std::unique_ptr<ImageQualityController> m_imageQualityController;
     std::optional<LayoutSize> m_pageLogicalSize;
@@ -278,11 +278,11 @@ private:
     bool m_needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly { false };
     bool m_needsEventRegionUpdateForNonCompositedFrame { false };
 
-    HashMap<RenderElement*, Vector<CachedImage*>> m_renderersWithPausedImageAnimation;
+    WeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithPausedImageAnimation;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_SVGSVGElementsWithPausedImageAnimation;
-    HashSet<RenderElement*> m_visibleInViewportRenderers;
+    WeakHashSet<RenderElement> m_visibleInViewportRenderers;
 
-    HashSet<const RenderBox*> m_boxesWithScrollSnapPositions;
+    WeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     WeakHashSet<const RenderBox> m_containerQueryBoxes;
 };
 


### PR DESCRIPTION
#### a173bc8a3ff080345b8930ca48d38299bcd763e3
<pre>
Use more smart pointers in RenderView
<a href="https://bugs.webkit.org/show_bug.cgi?id=261479">https://bugs.webkit.org/show_bug.cgi?id=261479</a>

Reviewed by Alan Baradlay.

* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::updateSnapOffsetsForScrollableArea):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::scheduleLazyRepaint):
(WebCore::RenderView::unscheduleLazyRepaint):
(WebCore::RenderView::lazyRepaintTimerFired):
(WebCore::RenderView::registerForVisibleInViewportCallback):
(WebCore::RenderView::unregisterForVisibleInViewportCallback):
(WebCore::RenderView::updateVisibleViewportRect):
(WebCore::RenderView::addRendererWithPausedImageAnimations):
(WebCore::RenderView::removeRendererWithPausedImageAnimations):
(WebCore::RenderView::resumePausedImageAnimationsIfNeeded):
(WebCore::RenderView::registerBoxWithScrollSnapPositions):
(WebCore::RenderView::unregisterBoxWithScrollSnapPositions):
* Source/WebCore/rendering/RenderView.h:

Canonical link: <a href="https://commits.webkit.org/267929@main">https://commits.webkit.org/267929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29d56d7345794c90b829cc76383a35cec99ad859

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18892 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20779 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23001 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20872 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16313 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->