### PR TITLE
Block SYS_sigaltstack in sandboxes

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -1266,7 +1266,9 @@
         SYS_sendto
         SYS_setrlimit
         SYS_setsockopt
+#if ASAN_ENABLED
         SYS_sigaltstack
+#endif
         SYS_sigprocmask
 #if !PLATFORM(MAC)
         SYS_shared_region_map_and_slide_2_np

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -722,7 +722,9 @@
         SYS_shared_region_map_and_slide_2_np
 #endif
         SYS_sigaction
+#if ASAN_ENABLED
         SYS_sigaltstack
+#endif
         SYS_sigprocmask
         SYS_sigreturn
         SYS_socketpair

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -865,7 +865,9 @@
         SYS_shm_open
         SYS_shutdown
         SYS_sigaction
+#if ASAN_ENABLED
         SYS_sigaltstack
+#endif
         SYS_sigprocmask
         SYS_socket
         SYS_socketpair

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1103,6 +1103,9 @@
         SYS_getxattr
         SYS_iopolicysys
         SYS_openat_nocancel
+#if ASAN_ENABLED
+        SYS_sigaltstack
+#endif
         SYS_sigprocmask
         SYS_umask
         SYS_unlink
@@ -1122,7 +1125,6 @@
         SYS_rmdir
         SYS_sendto
         SYS_setrlimit
-        SYS_sigaltstack
 #if PLATFORM(WATCHOS)
         SYS_sigreturn
 #endif

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1933,7 +1933,9 @@
         SYS_readlink
         SYS_rename
         SYS_sendto
+#if ASAN_ENABLED
         SYS_sigaltstack
+#endif
         SYS_stat64
         SYS_statfs64
         SYS_sysctl


### PR DESCRIPTION
#### 2826247972777dec008c4111558f24b930e828fa
<pre>
Block SYS_sigaltstack in sandboxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261481">https://bugs.webkit.org/show_bug.cgi?id=261481</a>
rdar://114840732

Reviewed by Brent Fulgham.

Block SYS_sigaltstack in sandboxes when ASAN is not enabled.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/267951@main">https://commits.webkit.org/267951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/416236daa3527ad66de445e8dd25b87d7c4fa5ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16918 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20785 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15764 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23007 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20881 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14597 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16317 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4325 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->