### PR TITLE
Add Web Push and App Badge support to MiniBrowser for testing purposes

### DIFF
--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0FE643A4161FAC660059E3FF /* WK1BrowserWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FE643A3161FAC660059E3FF /* WK1BrowserWindowController.m */; };
 		256AC3DA0F4B6AC300CF3369 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 256AC3D90F4B6AC300CF3369 /* AppDelegate.m */; };
 		2DC37343198B62D300EC33E9 /* SettingsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DC37342198B62D300EC33E9 /* SettingsController.m */; };
+		511AAEB72A8C1E77007ECBEE /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 511AAEB62A8C1E77007ECBEE /* UserNotifications.framework */; };
 		51E244FA11EFCE07008228D1 /* MBToolbarItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 51E244F911EFCE07008228D1 /* MBToolbarItem.m */; };
 		5C9332AF24C1349C0036DECE /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9332AE24C1349C0036DECE /* SecurityInterface.framework */; };
 		72945D0229B7F204006ACF75 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72945D0129B7F204006ACF75 /* QuartzCore.framework */; };
@@ -62,6 +63,7 @@
 		2DC37341198B62D300EC33E9 /* SettingsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SettingsController.h; path = mac/SettingsController.h; sourceTree = "<group>"; };
 		2DC37342198B62D300EC33E9 /* SettingsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SettingsController.m; path = mac/SettingsController.m; sourceTree = "<group>"; };
 		37BAF90620218053000EA879 /* MiniBrowser.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MiniBrowser.entitlements; sourceTree = "<group>"; };
+		511AAEB62A8C1E77007ECBEE /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		51E244F811EFCE07008228D1 /* MBToolbarItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBToolbarItem.h; sourceTree = "<group>"; };
 		51E244F911EFCE07008228D1 /* MBToolbarItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBToolbarItem.m; sourceTree = "<group>"; };
 		5C9332AE24C1349C0036DECE /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = System/Library/Frameworks/SecurityInterface.framework; sourceTree = SDKROOT; };
@@ -88,6 +90,7 @@
 			files = (
 				72945D0229B7F204006ACF75 /* QuartzCore.framework in Frameworks */,
 				5C9332AF24C1349C0036DECE /* SecurityInterface.framework in Frameworks */,
+				511AAEB72A8C1E77007ECBEE /* UserNotifications.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -166,6 +169,7 @@
 				1AFFEF761860EE6800DA465E /* Cocoa.framework */,
 				72945D0129B7F204006ACF75 /* QuartzCore.framework */,
 				5C9332AE24C1349C0036DECE /* SecurityInterface.framework */,
+				511AAEB62A8C1E77007ECBEE /* UserNotifications.framework */,
 				DD403C5328500F6400D899FC /* WebKit.framework */,
 			);
 			name = Frameworks;

--- a/Tools/MiniBrowser/mac/AppDelegate.h
+++ b/Tools/MiniBrowser/mac/AppDelegate.h
@@ -23,11 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UserNotifications/UNUserNotificationCenter.h>
+#import <WebKit/_WKWebsiteDataStoreDelegate.h>
+
 @class BrowserWindowController;
 @class ExtensionManagerWindowController;
 @class SettingsController;
 
-@interface BrowserAppDelegate : NSObject <NSApplicationDelegate> {
+@interface BrowserAppDelegate : NSObject <NSApplicationDelegate, _WKWebsiteDataStoreDelegate, UNUserNotificationCenterDelegate> {
     NSMutableSet *_browserWindowControllers;
     SettingsController *_settingsController;
     ExtensionManagerWindowController *_extensionManagerWindowController;
@@ -46,6 +49,8 @@
 - (void)browserWindowWillClose:(NSWindow *)window;
 
 - (void)didChangeSettings;
+
++ (NSNumber *)currentBadge;
 
 @property (readonly, nonatomic) WKUserContentController *userContentContoller;
 @property (readonly, nonatomic) SettingsController *settingsController;

--- a/Tools/MiniBrowser/mac/BrowserWindowController.h
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.h
@@ -92,6 +92,8 @@
 
 - (CGFloat)pageScaleForMenuItemTag:(NSInteger)tag;
 
+- (void)updateTitleForBadgeChange;
+
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 - (IBAction)toggleEditable:(id)sender;
 

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -344,4 +344,9 @@ static CGRect coreGraphicsScreenRectForAppKitScreenRect(NSRect rect)
     return self.window;
 }
 
+- (void)updateTitleForBadgeChange
+{
+    // Only implemented in WebKit2
+}
+
 @end

--- a/Tools/MiniBrowser/mac/Info.plist
+++ b/Tools/MiniBrowser/mac/Info.plist
@@ -65,5 +65,16 @@
 	</dict>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Recognizing captured audio on behalf of websites</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>x-webkit-app-launch</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>none</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
#### d65ae5ea23a9dd813a65c5686600e77bf4256113
<pre>
Add Web Push and App Badge support to MiniBrowser for testing purposes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261482">https://bugs.webkit.org/show_bug.cgi?id=261482</a>
rdar://115394079

Reviewed by Andy Estes.

Fills in all the delegates and other support functionality for MiniBrowser to support Web Push from the testing service.

* Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/mac/AppDelegate.h:
* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate init]):
(-[BrowserAppDelegate persistentDataStore]):
(-[BrowserAppDelegate notificationPermissionsForWebsiteDataStore:]):
(-[BrowserAppDelegate userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:]):
(-[BrowserAppDelegate websiteDataStore:showNotification:]):
(+[BrowserAppDelegate currentBadge]):
(-[BrowserAppDelegate websiteDataStore:workerOrigin:updatedAppBadge:]):
(-[BrowserAppDelegate _processPendingPushMessages]):
(-[BrowserAppDelegate _handleURLEvent:withReplyEvent:]):
(-[BrowserAppDelegate awakeFromNib]):
(-[BrowserAppDelegate defaultConfiguration]):
(-[BrowserAppDelegate fetchDefaultStoreWebsiteData:]):
(-[BrowserAppDelegate fetchAndClearDefaultStoreWebsiteData:]):
(-[BrowserAppDelegate clearDefaultStoreWebsiteData:]):
(persistentDataStore): Deleted.
* Tools/MiniBrowser/mac/BrowserWindowController.h:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController updateTitleForBadgeChange]):
* Tools/MiniBrowser/mac/Info.plist:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController _webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:]):
(-[WK2BrowserWindowController updateTitleForBadgeChange]):
(-[WK2BrowserWindowController updateTitle:]):

Canonical link: <a href="https://commits.webkit.org/267928@main">https://commits.webkit.org/267928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/929f9ef5ff6d16a8fa46c64ee81f8173cd2628fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18101 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19937 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18559 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/15752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20815 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15784 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/16505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16802 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/16676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20898 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17247 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4306 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->