### PR TITLE
Opacity and root element background image doesn't render.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6682,3 +6682,5 @@ imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-f
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-first-003.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-002.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-003.html [ Pass Failure ]
+
+webkit.org/b/245032 imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <style>
+      html {
+        background-color: white;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+        background: url(support/transform-triangle-left.svg) top left;
+        opacity: 0.5;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <style>
+      html {
+        background-color: white;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+        background: url(support/transform-triangle-left.svg) top left;
+        opacity: 0.5;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg);
+        opacity: 0.5;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <style>
+      html {
+        background-color: white;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+        background: url(support/transform-triangle-left.svg) top left;
+        opacity: 0.5;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg) fixed;
+        opacity: 0.5;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-003-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <style>
+      html {
+        background-color: white;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+        background: url(support/transform-triangle-left.svg) top left;
+        opacity: 0.5;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-237600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg);
+        opacity: 0.5;
+        will-change: opacity;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <style>
+      html {
+        background-color: white;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+        background: url(support/transform-triangle-left.svg) top left;
+        opacity: 0.5;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Opacity on Root Element With background image</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+    <link rel="help" href="https://drafts.fxtf.org/compositing/#pagebackdrop">
+    <meta name="assert" content="The background image should have opacity applied to
+    it as part of the Root Element Group">
+    <link rel="match" href="root-element-background-image-transparency-001-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-237600" />
+    <style>
+      html {
+        background: url(support/transform-triangle-left.svg) fixed;
+        opacity: 0.5;
+        will-change: opacity;
+      }
+      body {
+        /* The default 8px margin makes the background not line up exactly */
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/support/transform-triangle-left.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/support/transform-triangle-left.svg
@@ -1,0 +1,4 @@
+<svg height="100px" width="100px" viewBox="0 0 100 100"
+xmlns="http://www.w3.org/2000/svg">
+<polygon fill="blue" points="0,50 100,100 100,0" />
+</svg>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2079,6 +2079,13 @@ bool RenderBox::repaintLayerRectsForImage(WrappedImagePtr image, const FillLayer
                         -layerRenderer->marginTop(),
                         std::max(layerRenderer->width() + layerRenderer->horizontalMarginExtent() + layerRenderer->borderLeft() + layerRenderer->borderRight(), rw),
                         std::max(layerRenderer->height() + layerRenderer->verticalMarginExtent() + layerRenderer->borderTop() + layerRenderer->borderBottom(), rh));
+
+                    // If we're drawing the root background, then we want to use the bounds of the view
+                    // (since root backgrounds cover the canvas, not just the element). If the root element
+                    // is composited though, we need to issue the repaint to that root element.
+                    auto documentElementRenderer = downcast<RenderBox>(document().documentElement()->renderer());
+                    if (documentElementRenderer->layer()->isComposited())
+                        layerRenderer = documentElementRenderer;
                 } else {
                     layerRenderer = this;
                     rendererRect = borderBoxRect();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -691,6 +691,7 @@ public:
         IncludeCompositedDescendants            = 1 << 6,
         UseFragmentBoxesExcludingCompositing    = 1 << 7,
         UseFragmentBoxesIncludingCompositing    = 1 << 8,
+        IncludeRootBackgroundPaintingArea       = 1 << 9,
     };
     static constexpr OptionSet<CalculateLayerBoundsFlag> defaultCalculateLayerBoundsFlags() { return { IncludeSelfTransform, UseLocalClipRectIfPossible, IncludePaintedFilterOutsets, UseFragmentBoxesExcludingCompositing }; }
 


### PR DESCRIPTION
#### 80a5258521a832779b46bdd6bb04368f36882e5c
<pre>
Opacity and root element background image doesn&apos;t render.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261486">https://bugs.webkit.org/show_bug.cgi?id=261486</a>
&lt;rdar://115396444&gt;

Reviewed by Simon Fraser.

There are two bugs fixed here:

One is that transparencyClipBox doesn&apos;t account for the background rendering area of the root element when computing the clip
to push for the opacity group.

The other is that repaintLayerRectsForImage always issued a repaint request to the RenderView if the background image on the root
element changed, which is incorrect if the root element is composited.

The remaining test failure is because we don&apos;t apply opacity when we have background-attachment:fixed, and the root element is
composited. Bug 245032 should fix that in the near future.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/compositing/support/transform-triangle-left.svg: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::repaintLayerRectsForImage):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::transparencyClipBox):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/268156@main">https://commits.webkit.org/268156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e25cdbf4420bf846d388001238c894d3eef089e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19345 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19092 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21620 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17199 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17472 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21547 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4481 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21391 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->