### PR TITLE
WPT lint tool fails if run from outside the repo.

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -29,9 +29,8 @@ import subprocess
 
 class WPTLinter(object):
     def __init__(self, repository_directory, filesystem):
-        self.wpt_path = filesystem.join(repository_directory, 'wpt')
+        self.wpt_path = repository_directory
 
     def lint(self):
-        cmd = [self.wpt_path, 'lint']
-        proc = subprocess.Popen(cmd)
+        proc = subprocess.Popen(['./wpt', 'lint'], cwd=self.wpt_path)
         return proc.wait()


### PR DESCRIPTION
#### 97f8f55121164c5fc2b8f7630c1360a22c8f88cf
<pre>
WPT lint tool fails if run from outside the repo.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261488">https://bugs.webkit.org/show_bug.cgi?id=261488</a>
&lt;rdar://115400766&gt;

Reviewed by Tim Nguyen.

Running export-w3c-tests fails for me with a bunch of lint errors of the form &apos;file matches an ignore filter in .gitignore&apos;.

It seems that for some reason it ends up passing our new test files to `git check-ignore --stdin&apos; such that the contents of the test file is interpreted as a list of files to check against the ignore list.

Using the web-platform-tests directory as the CWD fixes this issue.

* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter.__init__):
(WPTLinter.lint):

Canonical link: <a href="https://commits.webkit.org/267967@main">https://commits.webkit.org/267967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cd8add40b0c15415ccbdcff29ac325a5cf9025a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20817 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18257 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23023 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20900 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14611 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20702 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2235 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->