### PR TITLE
[WebGPU] GPU process should not crash when shader fails to compile

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -419,7 +419,7 @@ static MTLResourceUsage resourceUsageForBindingAcccess(BindGroupLayout::BindingA
 
 Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor)
 {
-    if (descriptor.nextInChain)
+    if (descriptor.nextInChain || !descriptor.layout)
         return BindGroup::createInvalid(*this);
 
     // FIXME: We have to validate that the bind group is compatible with the bind group layout.

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -122,7 +122,7 @@ public:
     bool hasUnifiedMemory() const { return m_device.hasUnifiedMemory; }
 
     uint32_t maxBuffersPlusVertexBuffersForVertexStage() const;
-    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
+    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex, uint32_t maxIndex = 0) const;
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -311,9 +311,9 @@ uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
     return 8;
 }
 
-uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const
+uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex, uint32_t maxIndex) const
 {
-    auto maxIndex = maxBuffersPlusVertexBuffersForVertexStage();
+    maxIndex = maxIndex ?: maxBuffersPlusVertexBuffersForVertexStage();
     return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxIndex);
 }
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -92,6 +92,7 @@ private:
     uint64_t m_debugGroupStackSize { 0 };
     uint64_t m_currentCommandIndex { 0 };
     id<MTLBuffer> m_indexBuffer { nil };
+    id<MTLRenderPipelineState> m_currentPipelineState { nil };
     MTLPrimitiveType m_primitiveType { MTLPrimitiveTypeTriangle };
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -237,7 +237,6 @@ void RemoteDevice::createPipelineLayout(const WebGPU::PipelineLayoutDescriptor& 
 void RemoteDevice::createBindGroup(const WebGPU::BindGroupDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
-    ASSERT(convertedDescriptor);
     if (!convertedDescriptor)
         return;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -125,7 +125,6 @@ void RemoteRenderPassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebGP
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     auto convertedBindGroup = m_objectHeap.convertBindGroupFromBacking(bindGroup);
-    ASSERT(convertedBindGroup);
     if (!convertedBindGroup)
         return;
 


### PR DESCRIPTION
#### cc77505dc54cc15993d477ec88ce1d73014c7e72
<pre>
[WebGPU] GPU process should not crash when shader fails to compile
<a href="https://bugs.webkit.org/show_bug.cgi?id=261484">https://bugs.webkit.org/show_bug.cgi?id=261484</a>
&lt;radar://115395840&gt;

Reviewed by Dan Glastonbury.

Cleanup some invalid assertions and logic so we can open all
of the samples in a debug build without crashes or assertions triggering.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
Bind group creation can fail if resources are not valid, don&apos;t assert.

* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::vertexBufferIndexForBindGroup const):
Allow passing a maximum vertex buffer count for ICB commands.

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::Device::createRenderBundleEncoder):
Settings inheritPipelineState to YES was wrong as setPipelineState
is called.

(WebGPU::RenderBundleEncoder::finish):
Ensure the pipeline state was set during ICB creation.

(WebGPU::RenderBundleEncoder::setBindGroup):
Use the max vertex buffer count instead of the default.

(WebGPU::RenderBundleEncoder::setPipeline):
Ensure the pipeline state is valid.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::createBindGroup):
Bind group creation can fail if resources are not valid, don&apos;t assert.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::setBindGroup):
Bind group creation can fail if resources are not valid, don&apos;t assert.

Canonical link: <a href="https://commits.webkit.org/267947@main">https://commits.webkit.org/267947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402671d2c3858af47cda52e8ffc00ffa05a69fe2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16946 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20821 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15790 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23026 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20904 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14660 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16344 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4322 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->