### PR TITLE
Fix `Expected(unexpect, ...)`

### DIFF
--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -445,7 +445,7 @@ public:
     constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).value()) { }
     template<class Err> constexpr expected(const unexpected<Err>& u) : base(__expected_detail::error_tag, u.value()) { }
     template<class Err> constexpr expected(unexpected<Err>&& u) : base(__expected_detail::error_tag, std::forward<Err>(u.value())) { }
-    template<class... Args> constexpr explicit expected(unexpected_t, Args&&... args) : base(__expected_detail::value_tag, unexpected_type(std::forward<Args>(args)...)) { }
+    template<class... Args> constexpr explicit expected(unexpected_t, Args&&... args) : base(__expected_detail::error_tag, error_type(std::forward<Args>(args)...)) { }
     // template<class U, class... Args> constexpr explicit expected(unexpected_t, std::initializer_list<U>, Args&&...);
 
     ~expected() = default;

--- a/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
@@ -162,7 +162,19 @@ TEST(WTF_Expected, expected)
         EXPECT_EQ(u.value_or(3.14), 3);
     }
     {
+        auto u = E(unexpect, oops);
+        EXPECT_FALSE(u.has_value());
+        EXPECT_EQ(u.error(), oops);
+        EXPECT_EQ(u.value_or(3.14), 3);
+    }
+    {
         auto uv = EV(makeUnexpected(oops));
+        EXPECT_FALSE(uv.has_value());
+        EXPECT_EQ(uv.error(), oops);
+        EXPECT_EQ(uv.value_or(3.14), 3);
+    }
+    {
+        auto uv = EV(unexpect, oops);
         EXPECT_FALSE(uv.has_value());
         EXPECT_EQ(uv.error(), oops);
         EXPECT_EQ(uv.value_or(3.14), 3);


### PR DESCRIPTION
#### 95191e8f4045e7fa3895a72da063e6c6b04ae053
<pre>
Fix `Expected(unexpect, ...)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=261485">https://bugs.webkit.org/show_bug.cgi?id=261485</a>
rdar://problem/115401559

Reviewed by Cameron McCormack.

The constructor taking `unexpect` was using the wrong `value_tag`, in most cases it would
just fail to build (which could explain why it&apos;s not used anywhere yet). In the worst
case, it could have built an apparent &quot;expected&quot; result in unexpected situations.

And even after using the correct `error_tag`, the constructor was not passing the correct
argument type to the base constructor.

* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::expected::expected):
* Tools/TestWebKitAPI/Tests/WTF/Expected.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/267931@main">https://commits.webkit.org/267931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68e48acbb5eeafbefcf1a7052a3d872e0ee4bfd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18600 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16515 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15689 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20908 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17389 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21464 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16348 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5261 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4309 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20709 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22699 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17104 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5107 "Passed tests") | 
<!--EWS-Status-Bubble-End-->