### PR TITLE
Disable opportunistic tasks until page load completes

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5930,11 +5930,8 @@ void LocalFrameView::firePaintRelatedMilestonesIfNeeded()
     if (m_milestonesPendingPaint & LayoutMilestone::DidFirstMeaningfulPaint) {
         if (page->requestedLayoutMilestones() & LayoutMilestone::DidFirstMeaningfulPaint)
             milestonesAchieved.add(LayoutMilestone::DidFirstMeaningfulPaint);
-        if (m_frame->isMainFrame()) {
+        if (m_frame->isMainFrame())
             WTFEmitSignpost(m_frame->document(), "Page Load: First Meaningful Paint");
-            if (auto* page = m_frame->page())
-                page->didFirstMeaningfulPaint();
-        }
     }
 
     m_milestonesPendingPaint = { };

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -62,7 +62,7 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     if (UNLIKELY(!page))
         return;
 
-    if (page->isWaitingForFirstMeaningfulPaint())
+    if (page->isWaitingForLoadToFinish() || !page->isVisibleAndActive())
         return;
 
     auto currentTime = ApproximateTime::now();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1491,12 +1491,7 @@ void Page::didCommitLoad()
         geolocationController->didNavigatePage();
 #endif
 
-    m_isWaitingForFirstMeaningfulPaint = true;
-}
-
-void Page::didFirstMeaningfulPaint()
-{
-    m_isWaitingForFirstMeaningfulPaint = false;
+    m_isWaitingForLoadToFinish = true;
 }
 
 void Page::didFinishLoad()
@@ -1507,6 +1502,8 @@ void Page::didFinishLoad()
         m_performanceMonitor->didFinishLoad();
 
     setLoadSchedulingMode(LoadSchedulingMode::Direct);
+
+    m_isWaitingForLoadToFinish = false;
 }
 
 bool Page::isOnlyNonUtilityPage() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -479,7 +479,6 @@ public:
     void didStartProvisionalLoad();
     void didCommitLoad();
     void didFinishLoad();
-    void didFirstMeaningfulPaint();
 
     bool delegatesScaling() const { return m_delegatesScaling; }
     WEBCORE_EXPORT void setDelegatesScaling(bool);
@@ -1057,7 +1056,7 @@ public:
     void opportunisticallyRunIdleCallbacks();
     void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
 
-    bool isWaitingForFirstMeaningfulPaint() const { return m_isWaitingForFirstMeaningfulPaint; }
+    bool isWaitingForLoadToFinish() const { return m_isWaitingForLoadToFinish; }
 
 private:
     struct Navigation {
@@ -1415,7 +1414,7 @@ private:
     std::unique_ptr<AttachmentElementClient> m_attachmentElementClient;
 #endif
 
-    bool m_isWaitingForFirstMeaningfulPaint { false };
+    bool m_isWaitingForLoadToFinish { false };
     Ref<OpportunisticTaskScheduler> m_opportunisticTaskScheduler;
 
 #if ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### 7966e09d3699967276d8214e84698fab778546f3
<pre>
Disable opportunistic tasks until page load completes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261489">https://bugs.webkit.org/show_bug.cgi?id=261489</a>
rdar://115404985

Reviewed by Richard Robinson.

Adjust the opportunistic task scheduler to duck out of the way during page load, and also for web
pages that are not visible (or are not in the active window). This is a speculative mitigation for a
recent increase in memory use on Membuster5, which may have been caused by the adjustments in
&lt;<a href="https://commits.webkit.org/267818@main">https://commits.webkit.org/267818@main</a>&gt;.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::firePaintRelatedMilestonesIfNeeded):
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::didFinishLoad):
(WebCore::Page::didFirstMeaningfulPaint): Deleted.

Replace the &quot;waiting for first meaningful paint&quot; flag with a &quot;waiting for page load&quot; flag instead.

* Source/WebCore/page/Page.h:
(WebCore::Page::isWaitingForLoadToFinish const):
(WebCore::Page::isWaitingForFirstMeaningfulPaint const): Deleted.

Canonical link: <a href="https://commits.webkit.org/267950@main">https://commits.webkit.org/267950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ff604cfbc2bcfa0742f218abbc0c4e7536f5f36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16952 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18918 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20827 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23033 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20912 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17258 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14620 "4 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16350 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4324 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->