### PR TITLE
Add support for full GC during opportunistically scheduled tasks

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -328,6 +328,7 @@ public:
     JS_EXPORT_PRIVATE GCActivityCallback* fullActivityCallback();
     JS_EXPORT_PRIVATE GCActivityCallback* edenActivityCallback();
     JS_EXPORT_PRIVATE void setGarbageCollectionTimerEnabled(bool);
+    JS_EXPORT_PRIVATE void scheduleOpportunisticFullCollectionIfNeeded();
 
     JS_EXPORT_PRIVATE IncrementalSweeper& sweeper();
 
@@ -770,10 +771,13 @@ private:
     size_t m_maxEdenSize;
     size_t m_maxEdenSizeWhenCritical;
     size_t m_maxHeapSize;
+    size_t m_totalBytesVisitedAfterLastFullCollect { 0 };
     size_t m_totalBytesVisited { 0 };
     size_t m_totalBytesVisitedThisCycle { 0 };
     double m_incrementBalance { 0 };
     
+    bool m_shouldDoOpportunisticFullCollection { false };
+    bool m_isInOpportunisticTask { false };
     bool m_shouldDoFullCollection { false };
     Markable<CollectionScope, EnumMarkableTraits<CollectionScope>> m_collectionScope;
     Markable<CollectionScope, EnumMarkableTraits<CollectionScope>> m_lastCollectionScope;
@@ -906,6 +910,7 @@ private:
     MonotonicTime m_lastGCStartTime;
     MonotonicTime m_lastGCEndTime;
     MonotonicTime m_currentGCStartTime;
+    MonotonicTime m_lastFullGCEndTime;
     Seconds m_totalGCTime;
     
     uintptr_t m_barriersExecuted { 0 };

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -250,6 +250,12 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
                 ownerDocument->decrementLoadEventDelayCount();
             };
         }
+
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame); localFrame && localFrame->loader().isComplete()) {
+            if (auto* page = localFrame->page())
+                page->willChangeLocationInCompletelyLoadedSubframe();
+        }
+
         frame->navigationScheduler().scheduleLocationChange(initiatingDocument, initiatingDocument.securityOrigin(), upgradedRequestURL, m_frame.loader().outgoingReferrer(), lockHistory, lockBackForwardList, WTFMove(stopDelayingLoadEvent));
     } else
         frame = loadSubframe(ownerElement, upgradedRequestURL, frameName, m_frame.loader().outgoingReferrer());

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4540,6 +4540,11 @@ void Page::opportunisticallyRunIdleCallbacks()
     });
 }
 
+void Page::willChangeLocationInCompletelyLoadedSubframe()
+{
+    commonVM().heap.scheduleOpportunisticFullCollectionIfNeeded();
+}
+
 void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
 {
     OptionSet<JSC::VM::SchedulerOptions> options;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -480,6 +480,8 @@ public:
     void didCommitLoad();
     void didFinishLoad();
 
+    void willChangeLocationInCompletelyLoadedSubframe();
+
     bool delegatesScaling() const { return m_delegatesScaling; }
     WEBCORE_EXPORT void setDelegatesScaling(bool);
 


### PR DESCRIPTION
#### c8e9c0c0c8605b26d8225c67cd5afdf5598feb37
<pre>
Add support for full GC during opportunistically scheduled tasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=261491">https://bugs.webkit.org/show_bug.cgi?id=261491</a>
rdar://113241499

Reviewed by Yusuke Suzuki.

Add support for triggering full GC during opportunistically scheduled tasks. This is similar to the
previous work done for eden GC in 267893@main, only (generally) more restrictive:

1.  We use `m_totalBytesVisited`, `m_totalBytesVisitedAfterLastFullCollect`, and the duration of the
    last GC to (more accurately) estimate the cost of a full GC.

2.  We only attempt full GC here if `m_shouldDoOpportunisticFullCollection` is `true`; this flag is
    only set when changing the location of a subframe, which has previously finished loading content
    (see below for more details).

3.  Instead of a 10 ms hysteresis, we add an extended hysteresis such that we don&apos;t trigger
    opportunistic full GC if we&apos;ve already finished a full GC in the last 30 ms.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::updateObjectCounts):

Keep track of `m_totalBytesVisitedAfterLastFullCollect` here (that is — `m_totalBytesVisited`, but
for the last full GC).

(JSC::Heap::runEndPhase):

Update the new `m_lastFullGCEndTime` alongside `m_lastGCEndTime`, only if we&apos;re ending a full GC
cycle.

(JSC::Heap::willStartCollection):
(JSC::Heap::updateAllocationLimits):
(JSC::Heap::scheduleOpportunisticFullCollectionIfNeeded):

Add a hook into `JSC::Heap` to set the `m_shouldDoOpportunisticFullCollection` flag only in the case
where `shouldDoFullCollection()` is set. See call site below in `Page`.

* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::performOpportunisticallyScheduledTasks):

Add logic to conditionally trigger full opportunistic GC. We also refactor this to use an inline
lambda block, so that we can make the code a bit easier to follow with early returns. This also
allows us to fall back to an eden GC in the case where we don&apos;t have enough time budget for a full
GC cycle.

* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):

Add a hook to call into `Page` when changing the location of a subframe, only if that subframe had
previously finished loading prior content.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::willChangeLocationInCompletelyLoadedSubframe):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/268039@main">https://commits.webkit.org/268039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2eb8ebbecdeaa8e41c41785c7529789b1500ab0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19119 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21106 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23246 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21133 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17662 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14853 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21738 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16589 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5319 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4393 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20955 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22978 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17345 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5167 "Passed tests") | 
<!--EWS-Status-Bubble-End-->