### PR TITLE
Use more smart pointers in rendering code

### DIFF
--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -146,7 +146,7 @@ public:
             return *this;
         }
 
-        WeakListHashSetIterator& operator--()
+        WeakListHashSetConstIterator& operator--()
         {
             Base::advanceBackwards();
             return *this;
@@ -184,7 +184,7 @@ public:
         increaseOperationCountSinceLastCleanup();
         auto& weakPtrImpl = value.weakPtrFactory().m_impl;
         if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return WeakListHashSetIterator(*this, m_set.find(*pointer));
+            return WeakListHashSetConstIterator(*this, m_set.find(*pointer));
         return end();
     }
 
@@ -308,6 +308,34 @@ public:
         }
         cleanupHappened();
         return didRemove;
+    }
+
+    T& first()
+    {
+        auto it = begin();
+        ASSERT(it != end());
+        return *it;
+    }
+
+    const T& first() const
+    {
+        auto it = begin();
+        ASSERT(it != end());
+        return *it;
+    }
+
+    T& last()
+    {
+        auto it = end();
+        --it;
+        return *it;
+    }
+
+    const T& last() const
+    {
+        auto it = end();
+        --it;
+        return *it;
     }
 
 private:

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -140,8 +140,8 @@ void InlineContentPainter::paint()
     if (lastBoxLineIndex)
         paintEllipsis(*lastBoxLineIndex);
 
-    for (auto* renderInline : m_outlineObjects)
-        renderInline->paintOutline(m_paintInfo, m_paintOffset);
+    for (auto& renderInline : m_outlineObjects)
+        renderInline.paintOutline(m_paintInfo, m_paintOffset);
 }
 
 LayoutPoint InlineContentPainter::flippedContentOffsetIfNeeded(const RenderBox& childRenderer) const

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -68,7 +68,7 @@ private:
     const RenderInline* m_layerRenderer { nullptr };
     const InlineContent& m_inlineContent;
     const BoxTree& m_boxTree;
-    ListHashSet<RenderInline*> m_outlineObjects;
+    WeakListHashSet<RenderInline> m_outlineObjects;
 };
 
 class LayerPaintScope {

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -95,7 +95,7 @@ void InlineBoxPainter::paint()
             // paint us atomically.
             containingBlock->addContinuationWithOutline(downcast<RenderInline>(renderer().element()->renderer()));
         } else if (!inlineFlow.isContinuation())
-            m_paintInfo.outlineObjects->add(&inlineFlow);
+            m_paintInfo.outlineObjects->add(inlineFlow);
 
         return;
     }

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -213,13 +213,13 @@ RenderFragmentContainer* LegacyRootInlineBox::containingFragment() const
 {
     ContainingFragmentMap& fragmentMap = containingFragmentMap(blockFlow());
     bool hasContainingFragment = fragmentMap.contains(this);
-    RenderFragmentContainer* fragment = hasContainingFragment ? fragmentMap.get(this) : nullptr;
+    RenderFragmentContainer* fragment = hasContainingFragment ? fragmentMap.get(this).get() : nullptr;
 
 #ifndef NDEBUG
     if (hasContainingFragment) {
         RenderFragmentedFlow* fragmentedFlow = blockFlow().enclosingFragmentedFlow();
         const RenderFragmentContainerList& fragmentList = fragmentedFlow->renderFragmentContainerList();
-        ASSERT_WITH_SECURITY_IMPLICATION(fragmentList.contains(fragment));
+        ASSERT_WITH_SECURITY_IMPLICATION(fragmentList.contains(*fragment));
     }
 #endif
 

--- a/Source/WebCore/rendering/PaintInfo.h
+++ b/Source/WebCore/rendering/PaintInfo.h
@@ -34,8 +34,8 @@
 #include "PaintPhase.h"
 #include <limits>
 #include <wtf/HashMap.h>
-#include <wtf/ListHashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/WeakListHashSet.h>
 
 namespace WebCore {
 
@@ -53,7 +53,7 @@ typedef HashMap<OverlapTestRequestClient*, IntRect> OverlapTestRequestMap;
  */
 struct PaintInfo {
     PaintInfo(GraphicsContext& newContext, const LayoutRect& newRect, PaintPhase newPhase, OptionSet<PaintBehavior> newPaintBehavior,
-        RenderObject* newSubtreePaintRoot = nullptr, ListHashSet<RenderInline*>* newOutlineObjects = nullptr,
+        RenderObject* newSubtreePaintRoot = nullptr, WeakListHashSet<RenderInline>* newOutlineObjects = nullptr,
         OverlapTestRequestMap* overlapTestRequests = nullptr, const RenderLayerModelObject* newPaintContainer = nullptr,
         const RenderLayer* enclosingSelfPaintingLayer = nullptr, bool newRequireSecurityOriginAccessForWidgets = false)
             : rect(newRect)
@@ -129,7 +129,7 @@ struct PaintInfo {
     PaintPhase phase;
     OptionSet<PaintBehavior> paintBehavior;
     RenderObject* subtreePaintRoot; // used to draw just one element and its visual children
-    ListHashSet<RenderInline*>* outlineObjects; // used to list outlines that should be painted by a block with inline children
+    WeakListHashSet<RenderInline>* outlineObjects; // used to list outlines that should be painted by a block with inline children
     OverlapTestRequestMap* overlapTestRequests;
     const RenderLayerModelObject* paintContainer; // the layer object that originates the current painting
     bool requireSecurityOriginAccessForWidgets { false };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -227,7 +227,7 @@ bool RenderBox::hasFragmentRangeInFragmentedFlow() const
     return fragmentedFlow->hasCachedFragmentRangeForBox(*this);
 }
 
-LayoutRect RenderBox::clientBoxRectInFragment(RenderFragmentContainer* fragment) const
+LayoutRect RenderBox::clientBoxRectInFragment(const RenderFragmentContainer* fragment) const
 {
     if (!fragment)
         return clientBoxRect();
@@ -239,7 +239,7 @@ LayoutRect RenderBox::clientBoxRectInFragment(RenderFragmentContainer* fragment)
     return clientBox;
 }
 
-LayoutRect RenderBox::borderBoxRectInFragment(RenderFragmentContainer*, RenderBoxFragmentInfoFlags) const
+LayoutRect RenderBox::borderBoxRectInFragment(const RenderFragmentContainer*, RenderBoxFragmentInfoFlags) const
 {
     return borderBoxRect();
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -354,8 +354,8 @@ public:
     void computeAndSetBlockDirectionMargins(const RenderBlock& containingBlock);
 
     enum RenderBoxFragmentInfoFlags { CacheRenderBoxFragmentInfo, DoNotCacheRenderBoxFragmentInfo };
-    LayoutRect borderBoxRectInFragment(RenderFragmentContainer*, RenderBoxFragmentInfoFlags = CacheRenderBoxFragmentInfo) const;
-    LayoutRect clientBoxRectInFragment(RenderFragmentContainer*) const;
+    LayoutRect borderBoxRectInFragment(const RenderFragmentContainer*, RenderBoxFragmentInfoFlags = CacheRenderBoxFragmentInfo) const;
+    LayoutRect clientBoxRectInFragment(const RenderFragmentContainer*) const;
     RenderFragmentContainer* clampToStartAndEndFragments(RenderFragmentContainer*) const;
     bool hasFragmentRangeInFragmentedFlow() const;
     virtual LayoutUnit offsetFromLogicalTopOfFirstPage() const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -900,9 +900,9 @@ void RenderFlexibleBox::initializeMarginTrimState()
     auto marginTrim = style().marginTrim();
     auto isRowsFlexbox = isHorizontalFlow();
     if (auto child = firstInFlowChildBox(); child && marginTrim.contains(MarginTrimType::InlineStart))
-        isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineStart.add(child) : m_marginTrimItems.m_itemsOnFirstFlexLine.add(child);
+        isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineStart.add(*child) : m_marginTrimItems.m_itemsOnFirstFlexLine.add(*child);
     if (auto child = lastInFlowChildBox(); child && marginTrim.contains(MarginTrimType::InlineEnd))
-        isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineEnd.add(child) : m_marginTrimItems.m_itemsOnLastFlexLine.add(child);
+        isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineEnd.add(*child) : m_marginTrimItems.m_itemsOnLastFlexLine.add(*child);
 }
 
 LayoutUnit RenderFlexibleBox::mainAxisMarginExtentForChild(const RenderBox& child) const
@@ -942,8 +942,8 @@ bool RenderFlexibleBox::isChildEligibleForMarginTrim(MarginTrimType marginTrimTy
         return marginTrimType == MarginTrimType::InlineStart || marginTrimType == MarginTrimType::InlineEnd;
     };
     if (isMarginParallelWithMainAxis(marginTrimType))
-        return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsOnFirstFlexLine.contains(&child) : m_marginTrimItems.m_itemsOnLastFlexLine.contains(&child);
-    return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsAtFlexLineStart.contains(&child) : m_marginTrimItems.m_itemsAtFlexLineEnd.contains(&child);
+        return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsOnFirstFlexLine.contains(child) : m_marginTrimItems.m_itemsOnLastFlexLine.contains(child);
+    return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsAtFlexLineStart.contains(child) : m_marginTrimItems.m_itemsAtFlexLineEnd.contains(child);
 }
 
 bool RenderFlexibleBox::shouldTrimMainAxisMarginStart() const
@@ -982,7 +982,7 @@ void RenderFlexibleBox::trimMainAxisMarginStart(const FlexItem& flexItem)
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::InlineStart);
     else
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::BlockStart);
-    m_marginTrimItems.m_itemsAtFlexLineStart.add(&flexItem.box);
+    m_marginTrimItems.m_itemsAtFlexLineStart.add(flexItem.box);
 }
 
 void RenderFlexibleBox::trimMainAxisMarginEnd(const FlexItem& flexItem)
@@ -993,7 +993,7 @@ void RenderFlexibleBox::trimMainAxisMarginEnd(const FlexItem& flexItem)
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::InlineEnd);
     else
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::BlockEnd);
-    m_marginTrimItems.m_itemsAtFlexLineEnd.add(&flexItem.box);
+    m_marginTrimItems.m_itemsAtFlexLineEnd.add(flexItem.box);
 }
 
 void RenderFlexibleBox::trimCrossAxisMarginStart(const FlexItem& flexItem)
@@ -1002,7 +1002,7 @@ void RenderFlexibleBox::trimCrossAxisMarginStart(const FlexItem& flexItem)
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::BlockStart);
     else
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::InlineStart);
-    m_marginTrimItems.m_itemsOnFirstFlexLine.add(&flexItem.box);
+    m_marginTrimItems.m_itemsOnFirstFlexLine.add(flexItem.box);
 }
 
 void RenderFlexibleBox::trimCrossAxisMarginEnd(const FlexItem& flexItem)
@@ -1011,7 +1011,7 @@ void RenderFlexibleBox::trimCrossAxisMarginEnd(const FlexItem& flexItem)
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::BlockEnd);
     else
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::InlineEnd);
-    m_marginTrimItems.m_itemsOnLastFlexLine.add(&flexItem.box);
+    m_marginTrimItems.m_itemsOnLastFlexLine.add(flexItem.box);
 }
 
 LayoutUnit RenderFlexibleBox::crossAxisScrollbarExtent() const
@@ -1211,7 +1211,7 @@ void RenderFlexibleBox::cacheChildMainSize(const RenderBox& child)
     }
   
     m_intrinsicSizeAlongMainAxis.set(&child, mainSize);
-    m_relaidOutChildren.add(&child);
+    m_relaidOutChildren.add(child);
 }
 
 void RenderFlexibleBox::clearCachedMainSizeForChild(const RenderBox& child)
@@ -2198,7 +2198,7 @@ void RenderFlexibleBox::layoutAndPlaceChildren(LayoutUnit& crossAxisOffset, Flex
         }
         // We may have already forced relayout for orthogonal flowing children in
         // computeInnerFlexBaseSizeForChild.
-        bool forceChildRelayout = relayoutChildren && !m_relaidOutChildren.contains(&child);
+        bool forceChildRelayout = relayoutChildren && !m_relaidOutChildren.contains(child);
         if (!forceChildRelayout && childHasPercentHeightDescendants(child)) {
             // Have to force another relayout even though the child is sized
             // correctly, because its descendants are not sized correctly yet. Our
@@ -2210,7 +2210,7 @@ void RenderFlexibleBox::layoutAndPlaceChildren(LayoutUnit& crossAxisOffset, Flex
         if (!child.needsLayout())
             child.markForPaginationRelayoutIfNeeded();
         if (child.needsLayout())
-            m_relaidOutChildren.add(&child);
+            m_relaidOutChildren.add(child);
         child.layoutIfNeeded();
         if (!flexItem.everHadLayout && child.checkForRepaintDuringLayout()) {
             child.repaint();
@@ -2491,7 +2491,7 @@ void RenderFlexibleBox::applyStretchAlignmentToChild(RenderBox& child, LayoutUni
         
         // FIXME: Can avoid laying out here in some cases. See https://webkit.org/b/87905.
         bool childNeedsRelayout = desiredLogicalHeight != child.logicalHeight();
-        if (child.isRenderBlock() && downcast<RenderBlock>(child).hasPercentHeightDescendants() && m_relaidOutChildren.contains(&child)) {
+        if (child.isRenderBlock() && downcast<RenderBlock>(child).hasPercentHeightDescendants() && m_relaidOutChildren.contains(child)) {
             // Have to force another relayout even though the child is sized
             // correctly, because its descendants are not sized correctly yet. Our
             // previous layout of the child was done without an override height set.

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -33,6 +33,7 @@
 #include "OrderIterator.h"
 #include "RenderBlock.h"
 #include "RenderStyleInlines.h"
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -277,17 +278,17 @@ private:
     // need an additional layout pass for correct stretch alignment handling, as
     // the first layout likely did not use the correct value for percentage
     // sizing of children.
-    HashSet<const RenderBox*> m_relaidOutChildren;
+    WeakHashSet<const RenderBox> m_relaidOutChildren;
 
     mutable OrderIterator m_orderIterator { *this };
     std::optional<size_t> m_numberOfInFlowChildrenOnFirstLine { };
     std::optional<size_t> m_numberOfInFlowChildrenOnLastLine { };
 
     struct MarginTrimItems {
-        HashSet<const RenderBox*> m_itemsAtFlexLineStart;
-        HashSet<const RenderBox*> m_itemsAtFlexLineEnd;
-        HashSet<const RenderBox*> m_itemsOnFirstFlexLine;
-        HashSet<const RenderBox*> m_itemsOnLastFlexLine;
+        WeakHashSet<const RenderBox> m_itemsAtFlexLineStart;
+        WeakHashSet<const RenderBox> m_itemsAtFlexLineEnd;
+        WeakHashSet<const RenderBox> m_itemsOnFirstFlexLine;
+        WeakHashSet<const RenderBox> m_itemsOnLastFlexLine;
     } m_marginTrimItems;
 
     // This is SizeIsUnknown outside of layoutBlock()

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -131,7 +131,7 @@ LayoutUnit RenderFragmentContainer::logicalHeightOfAllFragmentedFlowContent() co
     return pageLogicalHeight();
 }
 
-LayoutRect RenderFragmentContainer::fragmentedFlowPortionOverflowRect()
+LayoutRect RenderFragmentContainer::fragmentedFlowPortionOverflowRect() const
 {
     return overflowRectForFragmentedFlowPortion(fragmentedFlowPortionRect(), isFirstFragment(), isLastFragment());
 }
@@ -151,7 +151,7 @@ LayoutPoint RenderFragmentContainer::fragmentedFlowPortionLocation() const
     return portionLocation;
 }
 
-LayoutRect RenderFragmentContainer::overflowRectForFragmentedFlowPortion(const LayoutRect& fragmentedFlowPortionRect, bool isFirstPortion, bool isLastPortion)
+LayoutRect RenderFragmentContainer::overflowRectForFragmentedFlowPortion(const LayoutRect& fragmentedFlowPortionRect, bool isFirstPortion, bool isLastPortion) const
 {
     ASSERT(isValid());
     if (shouldClipFragmentedFlowContent())
@@ -212,12 +212,12 @@ void RenderFragmentContainer::styleDidChange(StyleDifference diff, const RenderS
         m_fragmentedFlow->fragmentChangedWritingMode(this);
 }
 
-void RenderFragmentContainer::repaintFragmentedFlowContent(const LayoutRect& repaintRect)
+void RenderFragmentContainer::repaintFragmentedFlowContent(const LayoutRect& repaintRect) const
 {
     repaintFragmentedFlowContentRectangle(repaintRect, fragmentedFlowPortionRect(), contentBoxRect().location());
 }
 
-void RenderFragmentContainer::repaintFragmentedFlowContentRectangle(const LayoutRect& repaintRect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect)
+void RenderFragmentContainer::repaintFragmentedFlowContentRectangle(const LayoutRect& repaintRect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect) const
 {
     ASSERT(isValid());
 
@@ -246,7 +246,7 @@ void RenderFragmentContainer::repaintFragmentedFlowContentRectangle(const Layout
     repaintRectangle(clippedRect);
 }
 
-LayoutRect RenderFragmentContainer::fragmentedFlowContentRectangle(const LayoutRect& rect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect)
+LayoutRect RenderFragmentContainer::fragmentedFlowContentRectangle(const LayoutRect& rect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect) const
 {
     auto clippedRect = rect;
 
@@ -268,7 +268,7 @@ LayoutRect RenderFragmentContainer::fragmentedFlowContentRectangle(const LayoutR
     return clippedRect;
 }
 
-Vector<LayoutRect> RenderFragmentContainer::fragmentRectsForFlowContentRect(const LayoutRect& contentRect)
+Vector<LayoutRect> RenderFragmentContainer::fragmentRectsForFlowContentRect(const LayoutRect& contentRect) const
 {
     auto portionRect = fragmentedFlowPortionRect();
     auto fragmentLocation = contentBoxRect().location();
@@ -312,7 +312,7 @@ void RenderFragmentContainer::attachFragment()
 void RenderFragmentContainer::detachFragment()
 {
     if (m_fragmentedFlow)
-        m_fragmentedFlow->removeFragmentFromThread(this);
+        m_fragmentedFlow->removeFragmentFromThread(*this);
     m_fragmentedFlow = nullptr;
 }
 
@@ -406,9 +406,9 @@ void RenderFragmentContainer::computePreferredLogicalWidths()
     setPreferredLogicalWidthsDirty(false);
 }
 
-void RenderFragmentContainer::ensureOverflowForBox(const RenderBox* box, RefPtr<RenderOverflow>& overflow, bool forceCreation)
+void RenderFragmentContainer::ensureOverflowForBox(const RenderBox* box, RefPtr<RenderOverflow>& overflow, bool forceCreation) const
 {
-    ASSERT(m_fragmentedFlow->renderFragmentContainerList().contains(this));
+    ASSERT(m_fragmentedFlow->renderFragmentContainerList().contains(*this));
     ASSERT(isValid());
 
     RenderBoxFragmentInfo* boxInfo = renderBoxFragmentInfo(box);
@@ -494,7 +494,7 @@ void RenderFragmentContainer::addVisualOverflowForBox(const RenderBox* box, cons
     fragmentOverflow->addVisualOverflow(flippedRect);
 }
 
-LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBoxModelObject& box)
+LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBoxModelObject& box) const
 {
     if (is<RenderInline>(box)) {
         const RenderInline& inlineBox = downcast<RenderInline>(box);

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -48,7 +48,7 @@ public:
 
     void setFragmentedFlowPortionRect(const LayoutRect& rect) { m_fragmentedFlowPortionRect = rect; }
     LayoutRect fragmentedFlowPortionRect() const { return m_fragmentedFlowPortionRect; }
-    LayoutRect fragmentedFlowPortionOverflowRect();
+    LayoutRect fragmentedFlowPortionOverflowRect() const;
 
     LayoutPoint fragmentedFlowPortionLocation() const;
 
@@ -97,13 +97,13 @@ public:
     // Whether or not this fragment is a set.
     virtual bool isRenderFragmentContainerSet() const { return false; }
     
-    virtual void repaintFragmentedFlowContent(const LayoutRect& repaintRect);
+    virtual void repaintFragmentedFlowContent(const LayoutRect& repaintRect) const;
 
     virtual void collectLayerFragments(LayerFragments&, const LayoutRect&, const LayoutRect&) { }
 
     void addLayoutOverflowForBox(const RenderBox*, const LayoutRect&);
     void addVisualOverflowForBox(const RenderBox*, const LayoutRect&);
-    LayoutRect visualOverflowRectForBox(const RenderBoxModelObject&);
+    LayoutRect visualOverflowRectForBox(const RenderBoxModelObject&) const;
     LayoutRect layoutOverflowRectForBoxForPropagation(const RenderBox*);
     LayoutRect visualOverflowRectForBoxForPropagation(const RenderBoxModelObject&);
 
@@ -116,21 +116,21 @@ public:
     bool canHaveGeneratedChildren() const override { return true; }
     VisiblePosition positionForPoint(const LayoutPoint&, const RenderFragmentContainer*) override;
 
-    virtual Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&);
+    virtual Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) const;
 
 protected:
     RenderFragmentContainer(Element&, RenderStyle&&, RenderFragmentedFlow*);
     RenderFragmentContainer(Document&, RenderStyle&&, RenderFragmentedFlow*);
 
-    void ensureOverflowForBox(const RenderBox*, RefPtr<RenderOverflow>&, bool);
+    void ensureOverflowForBox(const RenderBox*, RefPtr<RenderOverflow>&, bool) const;
 
     void computePreferredLogicalWidths() override;
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
 
-    LayoutRect overflowRectForFragmentedFlowPortion(const LayoutRect& fragmentedFlowPortionRect, bool isFirstPortion, bool isLastPortion);
-    void repaintFragmentedFlowContentRectangle(const LayoutRect& repaintRect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect = 0);
+    LayoutRect overflowRectForFragmentedFlowPortion(const LayoutRect& fragmentedFlowPortionRect, bool isFirstPortion, bool isLastPortion) const;
+    void repaintFragmentedFlowContentRectangle(const LayoutRect& repaintRect, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect = 0) const;
 
-    LayoutRect fragmentedFlowContentRectangle(const LayoutRect&, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect = 0);
+    LayoutRect fragmentedFlowContentRectangle(const LayoutRect&, const LayoutRect& fragmentedFlowPortionRect, const LayoutPoint& fragmentLocation, const LayoutRect* fragmentedFlowPortionClipRect = 0) const;
 
 private:
     bool isRenderFragmentContainer() const final { return true; }

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -82,10 +82,9 @@ void RenderFragmentedFlow::removeFlowChildInfo(RenderElement& child)
         removeRenderBoxFragmentInfo(downcast<RenderBox>(child));
 }
 
-void RenderFragmentedFlow::removeFragmentFromThread(RenderFragmentContainer* RenderFragmentContainer)
+void RenderFragmentedFlow::removeFragmentFromThread(RenderFragmentContainer& renderFragmentContainer)
 {
-    ASSERT(RenderFragmentContainer);
-    m_fragmentList.remove(RenderFragmentContainer);
+    m_fragmentList.remove(renderFragmentContainer);
 }
 
 void RenderFragmentedFlow::invalidateFragments(MarkingBehavior markingParents)
@@ -118,12 +117,12 @@ void RenderFragmentedFlow::validateFragments()
             bool firstFragmentVisited = false;
             
             for (auto& fragment : m_fragmentList) {
-                ASSERT(!fragment->needsLayout() || fragment->isRenderFragmentContainerSet());
+                ASSERT(!fragment.needsLayout() || fragment.isRenderFragmentContainerSet());
 
-                fragment->deleteAllRenderBoxFragmentInfo();
+                fragment.deleteAllRenderBoxFragmentInfo();
 
-                LayoutUnit fragmentLogicalWidth = fragment->pageLogicalWidth();
-                LayoutUnit fragmentLogicalHeight = fragment->pageLogicalHeight();
+                LayoutUnit fragmentLogicalWidth = fragment.pageLogicalWidth();
+                LayoutUnit fragmentLogicalHeight = fragment.pageLogicalHeight();
 
                 if (!firstFragmentVisited)
                     firstFragmentVisited = true;
@@ -137,7 +136,7 @@ void RenderFragmentedFlow::validateFragments()
                 previousFragmentLogicalWidth = fragmentLogicalWidth;
             }
 
-            setFragmentRangeForBox(*this, m_fragmentList.first(), m_fragmentList.last());
+            setFragmentRangeForBox(*this, &m_fragmentList.first(), &m_fragmentList.last());
         }
     }
 
@@ -162,16 +161,16 @@ void RenderFragmentedFlow::updateLogicalWidth()
 {
     LayoutUnit logicalWidth = initialLogicalWidth();
     for (auto& fragment : m_fragmentList) {
-        ASSERT(!fragment->needsLayout() || fragment->isRenderFragmentContainerSet());
-        logicalWidth = std::max(fragment->pageLogicalWidth(), logicalWidth);
+        ASSERT(!fragment.needsLayout() || fragment.isRenderFragmentContainerSet());
+        logicalWidth = std::max(fragment.pageLogicalWidth(), logicalWidth);
     }
     setLogicalWidth(logicalWidth);
 
     // If the fragments have non-uniform logical widths, then insert inset information for the RenderFragmentedFlow.
     for (auto& fragment : m_fragmentList) {
-        LayoutUnit fragmentLogicalWidth = fragment->pageLogicalWidth();
+        LayoutUnit fragmentLogicalWidth = fragment.pageLogicalWidth();
         LayoutUnit logicalLeft = style().direction() == TextDirection::LTR ? 0_lu : logicalWidth - fragmentLogicalWidth;
-        fragment->setRenderBoxFragmentInfo(this, logicalLeft, fragmentLogicalWidth, false);
+        fragment.setRenderBoxFragmentInfo(this, logicalLeft, fragmentLogicalWidth, false);
     }
 }
 
@@ -183,10 +182,10 @@ RenderBox::LogicalExtentComputedValues RenderFragmentedFlow::computeLogicalHeigh
 
     const LayoutUnit maxFlowSize = RenderFragmentedFlow::maxLogicalHeight();
     for (auto& fragment : m_fragmentList) {
-        ASSERT(!fragment->needsLayout() || fragment->isRenderFragmentContainerSet());
+        ASSERT(!fragment.needsLayout() || fragment.isRenderFragmentContainerSet());
 
         LayoutUnit distanceToMaxSize = maxFlowSize - computedValues.m_extent;
-        computedValues.m_extent += std::min(distanceToMaxSize, fragment->logicalHeightOfAllFragmentedFlowContent());
+        computedValues.m_extent += std::min(distanceToMaxSize, fragment.logicalHeightOfAllFragmentedFlowContent());
 
         // If we reached the maximum size there's no point in going further.
         if (computedValues.m_extent == maxFlowSize)
@@ -218,7 +217,7 @@ void RenderFragmentedFlow::repaintRectangleInFragments(const LayoutRect& repaint
     LayoutStateDisabler layoutStateDisabler(view().frameView().layoutContext()); // We can't use layout state to repaint, since the fragments are somewhere else.
 
     for (auto& fragment : m_fragmentList)
-        fragment->repaintFragmentedFlowContent(repaintRect);
+        fragment.repaintFragmentedFlowContent(repaintRect);
 }
 
 bool RenderFragmentedFlow::absoluteQuadsForBox(Vector<FloatQuad>& quads, bool* wasFixed, const RenderBox* box) const
@@ -234,15 +233,15 @@ bool RenderFragmentedFlow::absoluteQuadsForBox(Vector<FloatQuad>& quads, bool* w
     if (!computedFragmentRangeForBox(box, startFragment, endFragment))
         return false;
 
-    for (auto it = m_fragmentList.find(startFragment), end = m_fragmentList.end(); it != end; ++it) {
-        auto* fragment = *it;
-        auto rectsInFragment = fragment->fragmentRectsForFlowContentRect(boxRectInFlowCoordinates);
+    for (auto it = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); it != end; ++it) {
+        auto& fragment = *it;
+        auto rectsInFragment = fragment.fragmentRectsForFlowContentRect(boxRectInFlowCoordinates);
         for (auto rect : rectsInFragment) {
-            auto absoluteQuad = fragment->localToAbsoluteQuad(FloatRect(rect), UseTransforms, wasFixed);
+            auto absoluteQuad = fragment.localToAbsoluteQuad(FloatRect(rect), UseTransforms, wasFixed);
             quads.append(absoluteQuad);
         }
 
-        if (fragment == endFragment)
+        if (&fragment == endFragment)
             break;
     }
 
@@ -278,18 +277,18 @@ RenderFragmentContainer* RenderFragmentedFlow::fragmentAtBlockOffset(const Rende
 {
     ASSERT(!m_fragmentsInvalidated);
 
-    if (m_fragmentList.isEmpty())
+    if (m_fragmentList.isEmptyIgnoringNullReferences())
         return nullptr;
 
-    if (m_fragmentList.size() == 1 && extendLastFragment)
-        return m_fragmentList.first();
+    if (m_fragmentList.computeSize() == 1 && extendLastFragment)
+        return const_cast<RenderFragmentContainer*>(&m_fragmentList.first());
 
     auto clamp = [clampBox](RenderFragmentContainer* fragment)  {
         return clampBox ? clampBox->clampToStartAndEndFragments(fragment) : fragment;
     };
 
     if (offset <= 0)
-        return clamp(m_fragmentList.first());
+        return clamp(const_cast<RenderFragmentContainer*>(&m_fragmentList.first()));
 
     FragmentSearchAdapter adapter(offset);
     m_fragmentIntervalTree.allOverlapsWithAdapter(adapter);
@@ -298,8 +297,8 @@ RenderFragmentContainer* RenderFragmentedFlow::fragmentAtBlockOffset(const Rende
 
     // If no fragment was found, the offset is in the flow thread overflow.
     // The last fragment will contain the offset if extendLastFragment is set or if the last fragment is a set.
-    if (extendLastFragment || m_fragmentList.last()->isRenderFragmentContainerSet())
-        return clamp(m_fragmentList.last());
+    if (extendLastFragment || m_fragmentList.last().isRenderFragmentContainerSet())
+        return clamp(const_cast<RenderFragmentContainer*>(&m_fragmentList.last()));
 
     return nullptr;
 }
@@ -468,10 +467,10 @@ void RenderFragmentedFlow::removeRenderBoxFragmentInfo(RenderBox& box)
     RenderFragmentContainer* startFragment = nullptr;
     RenderFragmentContainer* endFragment = nullptr;
     if (getFragmentRangeForBox(&box, startFragment, endFragment)) {
-        for (auto it = m_fragmentList.find(startFragment), end = m_fragmentList.end(); it != end; ++it) {
-            RenderFragmentContainer* fragment = *it;
-            fragment->removeRenderBoxFragmentInfo(box);
-            if (fragment == endFragment)
+        for (auto it = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); it != end; ++it) {
+            RenderFragmentContainer& fragment = *it;
+            fragment.removeRenderBoxFragmentInfo(box);
+            if (&fragment == endFragment)
                 break;
         }
     }
@@ -479,7 +478,7 @@ void RenderFragmentedFlow::removeRenderBoxFragmentInfo(RenderBox& box)
 #ifndef NDEBUG
     // We have to make sure we did not leave any RenderBoxFragmentInfo attached.
     for (auto& fragment : m_fragmentList)
-        ASSERT_UNUSED(fragment, !fragment->renderBoxFragmentInfo(&box));
+        ASSERT_UNUSED(fragment, !fragment.renderBoxFragmentInfo(&box));
 #endif
 
     m_fragmentRangeMap.remove(&box);
@@ -526,25 +525,25 @@ void RenderFragmentedFlow::logicalWidthChangedInFragmentsForBlock(const RenderBl
     if (!getFragmentRangeForBox(block, startFragment, endFragment))
         return;
 
-    for (auto it = m_fragmentList.find(startFragment), end = m_fragmentList.end(); it != end; ++it) {
-        RenderFragmentContainer* fragment = *it;
-        ASSERT(!fragment->needsLayout() || fragment->isRenderFragmentContainerSet());
+    for (auto it = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); it != end; ++it) {
+        RenderFragmentContainer& fragment = *it;
+        ASSERT(!fragment.needsLayout() || fragment.isRenderFragmentContainerSet());
 
         // We have no information computed for this fragment so we need to do it.
-        std::unique_ptr<RenderBoxFragmentInfo> oldInfo = fragment->takeRenderBoxFragmentInfo(block);
+        std::unique_ptr<RenderBoxFragmentInfo> oldInfo = fragment.takeRenderBoxFragmentInfo(block);
         if (!oldInfo) {
             relayoutChildren = rangeInvalidated;
             return;
         }
 
         LayoutUnit oldLogicalWidth = oldInfo->logicalWidth();
-        RenderBoxFragmentInfo* newInfo = block->renderBoxFragmentInfo(fragment);
+        RenderBoxFragmentInfo* newInfo = block->renderBoxFragmentInfo(&fragment);
         if (!newInfo || newInfo->logicalWidth() != oldLogicalWidth) {
             relayoutChildren = true;
             return;
         }
 
-        if (fragment == endFragment)
+        if (&fragment == endFragment)
             break;
     }
 }
@@ -577,14 +576,14 @@ RenderFragmentContainer* RenderFragmentedFlow::firstFragment() const
 {
     if (!hasFragments())
         return nullptr;
-    return m_fragmentList.first();
+    return const_cast<RenderFragmentContainer*>(&m_fragmentList.first());
 }
 
 RenderFragmentContainer* RenderFragmentedFlow::lastFragment() const
 {
     if (!hasFragments())
         return nullptr;
-    return m_fragmentList.last();
+    return const_cast<RenderFragmentContainer*>(&m_fragmentList.last());
 }
 
 void RenderFragmentedFlow::clearRenderBoxFragmentInfoAndCustomStyle(const RenderBox& box,
@@ -596,19 +595,19 @@ void RenderFragmentedFlow::clearRenderBoxFragmentInfoAndCustomStyle(const Render
     bool insideOldFragmentRange = false;
     bool insideNewFragmentRange = false;
     for (auto& fragment : m_fragmentList) {
-        if (oldStartFragment == fragment)
+        if (oldStartFragment == &fragment)
             insideOldFragmentRange = true;
-        if (newStartFragment == fragment)
+        if (newStartFragment == &fragment)
             insideNewFragmentRange = true;
 
         if (!(insideOldFragmentRange && insideNewFragmentRange)) {
-            if (fragment->renderBoxFragmentInfo(&box))
-                fragment->removeRenderBoxFragmentInfo(box);
+            if (fragment.renderBoxFragmentInfo(&box))
+                fragment.removeRenderBoxFragmentInfo(box);
         }
 
-        if (oldEndFragment == fragment)
+        if (oldEndFragment == &fragment)
             insideOldFragmentRange = false;
-        if (newEndFragment == fragment)
+        if (newEndFragment == &fragment)
             insideNewFragmentRange = false;
     }
 }
@@ -644,7 +643,7 @@ bool RenderFragmentedFlow::getFragmentRangeForBoxFromCachedInfo(const RenderBox*
         const RenderFragmentContainerRange& range = it->value;
         startFragment = range.startFragment();
         endFragment = range.endFragment();
-        ASSERT(m_fragmentList.contains(startFragment) && m_fragmentList.contains(endFragment));
+        ASSERT(m_fragmentList.contains(*startFragment) && m_fragmentList.contains(*endFragment));
         return true;
     }
 
@@ -659,8 +658,8 @@ bool RenderFragmentedFlow::getFragmentRangeForBox(const RenderBox* box, RenderFr
     if (!hasValidFragmentInfo()) // We clear the ranges when we invalidate the fragments.
         return false;
 
-    if (m_fragmentList.size() == 1) {
-        startFragment = endFragment = m_fragmentList.first();
+    if (m_fragmentList.computeSize() == 1) {
+        startFragment = endFragment = const_cast<RenderFragmentContainer*>(&m_fragmentList.first());
         return true;
     }
 
@@ -687,7 +686,7 @@ bool RenderFragmentedFlow::computedFragmentRangeForBox(const RenderBox* box, Ren
         LegacyInlineElementBox* boxWrapper = containingBlock->inlineBoxWrapper();
         if (boxWrapper && boxWrapper->root().containingFragment()) {
             startFragment = endFragment = boxWrapper->root().containingFragment();
-            ASSERT(m_fragmentList.contains(startFragment));
+            ASSERT(m_fragmentList.contains(*startFragment));
             return true;
         }
 
@@ -713,11 +712,11 @@ bool RenderFragmentedFlow::fragmentInRange(const RenderFragmentContainer* target
 {
     ASSERT(targetFragment);
 
-    for (auto it = m_fragmentList.find(const_cast<RenderFragmentContainer*>(startFragment)), end = m_fragmentList.end(); it != end; ++it) {
-        const RenderFragmentContainer* currFragment = *it;
-        if (targetFragment == currFragment)
+    for (auto it = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); it != end; ++it) {
+        const RenderFragmentContainer& currFragment = *it;
+        if (targetFragment == &currFragment)
             return true;
-        if (currFragment == endFragment)
+        if (&currFragment == endFragment)
             break;
     }
 
@@ -733,7 +732,7 @@ bool RenderFragmentedFlow::objectShouldFragmentInFlowFragment(const RenderObject
     if (fragmentedFlow != this)
         return false;
 
-    if (!m_fragmentList.contains(const_cast<RenderFragmentContainer*>(fragment)))
+    if (!m_fragmentList.contains(*fragment))
         return false;
     
     RenderFragmentContainer* enclosingBoxStartFragment = nullptr;
@@ -756,7 +755,7 @@ bool RenderFragmentedFlow::objectInFlowFragment(const RenderObject* object, cons
     if (fragmentedFlow != this)
         return false;
 
-    if (!m_fragmentList.contains(const_cast<RenderFragmentContainer*>(fragment)))
+    if (!m_fragmentList.contains(*fragment))
         return false;
 
     RenderFragmentContainer* enclosingBoxStartFragment = nullptr;
@@ -781,11 +780,11 @@ bool RenderFragmentedFlow::objectInFlowFragment(const RenderObject* object, cons
     if (fragment == lastFragment()) {
         // If the object does not intersect any of the enclosing box fragments
         // then the object is in last fragment.
-        for (auto it = m_fragmentList.find(enclosingBoxStartFragment), end = m_fragmentList.end(); it != end; ++it) {
-            const RenderFragmentContainer* currFragment = *it;
-            if (currFragment == fragment)
+        for (auto it = m_fragmentList.find(*enclosingBoxStartFragment), end = m_fragmentList.end(); it != end; ++it) {
+            const RenderFragmentContainer& currFragment = *it;
+            if (&currFragment == fragment)
                 break;
-            if (objectABBRect.intersects(currFragment->absoluteBoundingBoxRect(true)))
+            if (objectABBRect.intersects(currFragment.absoluteBoundingBoxRect(true)))
                 return false;
         }
         return true;
@@ -802,7 +801,7 @@ bool RenderFragmentedFlow::checkLinesConsistency(const RenderBlockFlow& removedB
 
     for (auto& linePair : *m_lineToFragmentMap.get()) {
         const LegacyRootInlineBox* line = linePair.key;
-        RenderFragmentContainer* fragment = linePair.value;
+        RenderFragmentContainer& fragment = *linePair.value;
         if (&line->blockFlow() == &removedBlock)
             return false;
         if (line->blockFlow().fragmentedFlowState() == NotInsideFragmentedFlow)
@@ -839,7 +838,7 @@ void RenderFragmentedFlow::markFragmentsForOverflowLayoutIfNeeded()
         return;
 
     for (auto& fragment : m_fragmentList)
-        fragment->setNeedsSimplifiedNormalFlowLayout();
+        fragment.setNeedsSimplifiedNormalFlowLayout();
 }
 
 void RenderFragmentedFlow::updateFragmentsFragmentedFlowPortionRect()
@@ -848,14 +847,14 @@ void RenderFragmentedFlow::updateFragmentsFragmentedFlowPortionRect()
     // FIXME: Optimize not to clear the interval tree all the time. This would involve manually managing the tree nodes' lifecycle.
     m_fragmentIntervalTree.clear();
     for (auto& fragment : m_fragmentList) {
-        LayoutUnit fragmentLogicalWidth = fragment->pageLogicalWidth();
-        LayoutUnit fragmentLogicalHeight = std::min<LayoutUnit>(RenderFragmentedFlow::maxLogicalHeight() - logicalHeight, fragment->logicalHeightOfAllFragmentedFlowContent());
+        LayoutUnit fragmentLogicalWidth = fragment.pageLogicalWidth();
+        LayoutUnit fragmentLogicalHeight = std::min<LayoutUnit>(RenderFragmentedFlow::maxLogicalHeight() - logicalHeight, fragment.logicalHeightOfAllFragmentedFlowContent());
 
         LayoutRect fragmentRect(style().direction() == TextDirection::LTR ? 0_lu : logicalWidth() - fragmentLogicalWidth, logicalHeight, fragmentLogicalWidth, fragmentLogicalHeight);
 
-        fragment->setFragmentedFlowPortionRect(isHorizontalWritingMode() ? fragmentRect : fragmentRect.transposedRect());
+        fragment.setFragmentedFlowPortionRect(isHorizontalWritingMode() ? fragmentRect : fragmentRect.transposedRect());
 
-        m_fragmentIntervalTree.add({ logicalHeight, logicalHeight + fragmentLogicalHeight, fragment });
+        m_fragmentIntervalTree.add({ logicalHeight, logicalHeight + fragmentLogicalHeight, &fragment });
 
         logicalHeight += fragmentLogicalHeight;
     }
@@ -891,7 +890,7 @@ void RenderFragmentedFlow::collectLayerFragments(LayerFragments& layerFragments,
     ASSERT(!m_fragmentsInvalidated);
     
     for (auto& fragment : m_fragmentList)
-        fragment->collectLayerFragments(layerFragments, layerBoundingBox, dirtyRect);
+        fragment.collectLayerFragments(layerFragments, layerBoundingBox, dirtyRect);
 }
 
 LayoutRect RenderFragmentedFlow::fragmentsBoundingBox(const LayoutRect& layerBoundingBox)
@@ -901,7 +900,7 @@ LayoutRect RenderFragmentedFlow::fragmentsBoundingBox(const LayoutRect& layerBou
     LayoutRect result;
     for (auto& fragment : m_fragmentList) {
         LayerFragments fragments;
-        fragment->collectLayerFragments(fragments, layerBoundingBox, LayoutRect::infiniteRect());
+        fragment.collectLayerFragments(fragments, layerBoundingBox, LayoutRect::infiniteRect());
         for (const auto& fragment : fragments) {
             LayoutRect fragmentRect(layerBoundingBox);
             fragmentRect.intersect(fragment.paginationClip);
@@ -1035,15 +1034,15 @@ void RenderFragmentedFlow::addFragmentsVisualEffectOverflow(const RenderBox* box
     if (!getFragmentRangeForBox(box, startFragment, endFragment))
         return;
 
-    for (auto iter = m_fragmentList.find(startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
-        RenderFragmentContainer* fragment = *iter;
+    for (auto iter = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
+        RenderFragmentContainer& fragment = *iter;
 
-        LayoutRect borderBox = box->borderBoxRectInFragment(fragment);
+        LayoutRect borderBox = box->borderBoxRectInFragment(&fragment);
         borderBox = box->applyVisualEffectOverflow(borderBox);
-        borderBox = fragment->rectFlowPortionForBox(box, borderBox);
+        borderBox = fragment.rectFlowPortionForBox(box, borderBox);
 
-        fragment->addVisualOverflowForBox(box, borderBox);
-        if (fragment == endFragment)
+        fragment.addVisualOverflowForBox(box, borderBox);
+        if (&fragment == endFragment)
             break;
     }
 }
@@ -1055,17 +1054,17 @@ void RenderFragmentedFlow::addFragmentsVisualOverflowFromTheme(const RenderBlock
     if (!getFragmentRangeForBox(block, startFragment, endFragment))
         return;
 
-    for (auto iter = m_fragmentList.find(startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
-        RenderFragmentContainer* fragment = *iter;
+    for (auto iter = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
+        RenderFragmentContainer& fragment = *iter;
 
-        LayoutRect borderBox = block->borderBoxRectInFragment(fragment);
-        borderBox = fragment->rectFlowPortionForBox(block, borderBox);
+        LayoutRect borderBox = block->borderBoxRectInFragment(&fragment);
+        borderBox = fragment.rectFlowPortionForBox(block, borderBox);
 
         FloatRect inflatedRect = borderBox;
         block->theme().adjustRepaintRect(*block, inflatedRect);
 
-        fragment->addVisualOverflowForBox(block, snappedIntRect(LayoutRect(inflatedRect)));
-        if (fragment == endFragment)
+        fragment.addVisualOverflowForBox(block, snappedIntRect(LayoutRect(inflatedRect)));
+        if (&fragment == endFragment)
             break;
     }
 }
@@ -1082,29 +1081,29 @@ void RenderFragmentedFlow::addFragmentsOverflowFromChild(const RenderBox* box, c
     if (!getFragmentRangeForBox(box, containerStartFragment, containerEndFragment))
         return;
 
-    for (auto iter = m_fragmentList.find(startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
-        RenderFragmentContainer* fragment = *iter;
-        if (!fragmentInRange(fragment, containerStartFragment, containerEndFragment)) {
-            if (fragment == endFragment)
+    for (auto iter = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
+        RenderFragmentContainer& fragment = *iter;
+        if (!fragmentInRange(&fragment, containerStartFragment, containerEndFragment)) {
+            if (&fragment == endFragment)
                 break;
             continue;
         }
 
-        LayoutRect childLayoutOverflowRect = fragment->layoutOverflowRectForBoxForPropagation(child);
+        LayoutRect childLayoutOverflowRect = fragment.layoutOverflowRectForBoxForPropagation(child);
         childLayoutOverflowRect.move(delta);
         
-        fragment->addLayoutOverflowForBox(box, childLayoutOverflowRect);
+        fragment.addLayoutOverflowForBox(box, childLayoutOverflowRect);
 
         if (child->hasSelfPaintingLayer() || box->hasNonVisibleOverflow()) {
-            if (fragment == endFragment)
+            if (&fragment == endFragment)
                 break;
             continue;
         }
-        LayoutRect childVisualOverflowRect = fragment->visualOverflowRectForBoxForPropagation(*child);
+        LayoutRect childVisualOverflowRect = fragment.visualOverflowRectForBoxForPropagation(*child);
         childVisualOverflowRect.move(delta);
-        fragment->addVisualOverflowForBox(box, childVisualOverflowRect);
+        fragment.addVisualOverflowForBox(box, childVisualOverflowRect);
 
-        if (fragment == endFragment)
+        if (&fragment == endFragment)
             break;
     }
 }
@@ -1116,13 +1115,13 @@ void RenderFragmentedFlow::addFragmentsLayoutOverflow(const RenderBox* box, cons
     if (!getFragmentRangeForBox(box, startFragment, endFragment))
         return;
 
-    for (auto iter = m_fragmentList.find(startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
-        RenderFragmentContainer* fragment = *iter;
-        LayoutRect layoutOverflowInFragment = fragment->rectFlowPortionForBox(box, layoutOverflow);
+    for (auto iter = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
+        RenderFragmentContainer& fragment = *iter;
+        LayoutRect layoutOverflowInFragment = fragment.rectFlowPortionForBox(box, layoutOverflow);
 
-        fragment->addLayoutOverflowForBox(box, layoutOverflowInFragment);
+        fragment.addLayoutOverflowForBox(box, layoutOverflowInFragment);
 
-        if (fragment == endFragment)
+        if (&fragment == endFragment)
             break;
     }
 }
@@ -1134,13 +1133,13 @@ void RenderFragmentedFlow::addFragmentsVisualOverflow(const RenderBox* box, cons
     if (!getFragmentRangeForBox(box, startFragment, endFragment))
         return;
     
-    for (RenderFragmentContainerList::iterator iter = m_fragmentList.find(startFragment); iter != m_fragmentList.end(); ++iter) {
-        RenderFragmentContainer* fragment = *iter;
-        LayoutRect visualOverflowInFragment = fragment->rectFlowPortionForBox(box, visualOverflow);
+    for (RenderFragmentContainerList::iterator iter = m_fragmentList.find(*startFragment); iter != m_fragmentList.end(); ++iter) {
+        RenderFragmentContainer& fragment = *iter;
+        LayoutRect visualOverflowInFragment = fragment.rectFlowPortionForBox(box, visualOverflow);
         
-        fragment->addVisualOverflowForBox(box, visualOverflowInFragment);
+        fragment.addVisualOverflowForBox(box, visualOverflowInFragment);
         
-        if (fragment == endFragment)
+        if (&fragment == endFragment)
             break;
     }
 }
@@ -1152,13 +1151,13 @@ void RenderFragmentedFlow::clearFragmentsOverflow(const RenderBox* box)
     if (!getFragmentRangeForBox(box, startFragment, endFragment))
         return;
 
-    for (auto iter = m_fragmentList.find(startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
-        RenderFragmentContainer* fragment = *iter;
-        RenderBoxFragmentInfo* boxInfo = fragment->renderBoxFragmentInfo(box);
+    for (auto iter = m_fragmentList.find(*startFragment), end = m_fragmentList.end(); iter != end; ++iter) {
+        RenderFragmentContainer& fragment = *iter;
+        RenderBoxFragmentInfo* boxInfo = fragment.renderBoxFragmentInfo(box);
         if (boxInfo && boxInfo->overflow())
             boxInfo->clearOverflow();
 
-        if (fragment == endFragment)
+        if (&fragment == endFragment)
             break;
     }
 }

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -33,7 +33,7 @@
 #include "PODIntervalTree.h"
 #include "RenderBlockFlow.h"
 #include "RenderFragmentContainer.h"
-#include <wtf/ListHashSet.h>
+#include <wtf/WeakListHashSet.h>
 
 namespace WebCore {
 
@@ -43,9 +43,9 @@ class RenderStyle;
 class RenderFragmentContainer;
 class LegacyRootInlineBox;
 
-typedef ListHashSet<RenderFragmentContainer*> RenderFragmentContainerList;
-typedef Vector<RenderLayer*> RenderLayerList;
-typedef HashMap<const LegacyRootInlineBox*, RenderFragmentContainer*> ContainingFragmentMap;
+typedef WeakListHashSet<RenderFragmentContainer> RenderFragmentContainerList;
+typedef Vector<WeakPtr<RenderLayer>> RenderLayerList;
+typedef HashMap<const LegacyRootInlineBox*, WeakPtr<RenderFragmentContainer>> ContainingFragmentMap;
 
 // RenderFragmentedFlow is used to collect all the render objects that participate in a
 // flow thread. It will also help in doing the layout. However, it will not render
@@ -70,7 +70,7 @@ public:
     void deleteLines() override;
 
     virtual void addFragmentToThread(RenderFragmentContainer*) = 0;
-    virtual void removeFragmentFromThread(RenderFragmentContainer*);
+    void removeFragmentFromThread(RenderFragmentContainer&);
     const RenderFragmentContainerList& renderFragmentContainerList() const { return m_fragmentList; }
 
     void updateLogicalWidth() final;
@@ -78,12 +78,12 @@ public:
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
-    bool hasFragments() const { return m_fragmentList.size(); }
+    bool hasFragments() const { return !m_fragmentList.isEmptyIgnoringNullReferences(); }
     virtual void fragmentChangedWritingMode(RenderFragmentContainer*) { }
 
     void validateFragments();
     void invalidateFragments(MarkingBehavior = MarkContainingBlockChain);
-    bool hasValidFragmentInfo() const { return !m_fragmentsInvalidated && !m_fragmentList.isEmpty(); }
+    bool hasValidFragmentInfo() const { return !m_fragmentsInvalidated && !m_fragmentList.isEmptyIgnoringNullReferences(); }
     
     // Called when a descendant box's layout is finished and it has been positioned within its container.
     virtual void fragmentedFlowDescendantBoxLaidOut(RenderBox*) { }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2359,12 +2359,12 @@ static RenderLayer* findCommonAncestor(const RenderLayer& firstLayer, const Rend
     if (&firstLayer == &secondLayer)
         return const_cast<RenderLayer*>(&firstLayer);
 
-    HashSet<const RenderLayer*> ancestorChain;
+    WeakHashSet<const RenderLayer> ancestorChain;
     for (auto* currLayer = &firstLayer; currLayer; currLayer = currLayer->parent())
-        ancestorChain.add(currLayer);
+        ancestorChain.add(*currLayer);
 
     for (auto* currLayer = &secondLayer; currLayer; currLayer = currLayer->parent()) {
-        if (ancestorChain.contains(currLayer))
+        if (ancestorChain.contains(*currLayer))
             return const_cast<RenderLayer*>(currLayer);
     }
     return nullptr;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5367,24 +5367,24 @@ void LegacyWebKitScrollingLayerCoordinator::registerAllViewportConstrainedLayers
     LayerMap layerMap;
     StickyContainerMap stickyContainerMap;
 
-    for (auto* layer : m_viewportConstrainedLayers) {
-        ASSERT(layer->isComposited());
+    for (auto& layer : m_viewportConstrainedLayers) {
+        ASSERT(layer.isComposited());
 
         std::unique_ptr<ViewportConstraints> constraints;
-        if (layer->renderer().isStickilyPositioned()) {
-            constraints = makeUnique<StickyPositionViewportConstraints>(compositor.computeStickyViewportConstraints(*layer));
+        if (layer.renderer().isStickilyPositioned()) {
+            constraints = makeUnique<StickyPositionViewportConstraints>(compositor.computeStickyViewportConstraints(layer));
             const RenderLayer* enclosingTouchScrollableLayer = nullptr;
-            if (compositor.isAsyncScrollableStickyLayer(*layer, &enclosingTouchScrollableLayer) && enclosingTouchScrollableLayer) {
+            if (compositor.isAsyncScrollableStickyLayer(layer, &enclosingTouchScrollableLayer) && enclosingTouchScrollableLayer) {
                 ASSERT(enclosingTouchScrollableLayer->isComposited());
                 // what
-                stickyContainerMap.add(layer->backing()->graphicsLayer()->platformLayer(), enclosingTouchScrollableLayer->backing()->scrollContainerLayer()->platformLayer());
+                stickyContainerMap.add(layer.backing()->graphicsLayer()->platformLayer(), enclosingTouchScrollableLayer->backing()->scrollContainerLayer()->platformLayer());
             }
-        } else if (layer->renderer().isFixedPositioned())
-            constraints = makeUnique<FixedPositionViewportConstraints>(compositor.computeFixedViewportConstraints(*layer));
+        } else if (layer.renderer().isFixedPositioned())
+            constraints = makeUnique<FixedPositionViewportConstraints>(compositor.computeFixedViewportConstraints(layer));
         else
             continue;
 
-        layerMap.add(layer->backing()->graphicsLayer()->platformLayer(), WTFMove(constraints));
+        layerMap.add(layer.backing()->graphicsLayer()->platformLayer(), WTFMove(constraints));
     }
     
     m_chromeClient.updateViewportConstrainedLayers(layerMap, stickyContainerMap);
@@ -5416,27 +5416,27 @@ void LegacyWebKitScrollingLayerCoordinator::updateScrollingLayer(RenderLayer& la
 
 void LegacyWebKitScrollingLayerCoordinator::registerAllScrollingLayers()
 {
-    for (auto* layer : m_scrollingLayers)
-        updateScrollingLayer(*layer);
+    for (auto& layer : m_scrollingLayers)
+        updateScrollingLayer(layer);
 }
 
 void LegacyWebKitScrollingLayerCoordinator::unregisterAllScrollingLayers()
 {
-    for (auto* layer : m_scrollingLayers) {
-        auto* backing = layer->backing();
+    for (auto& layer : m_scrollingLayers) {
+        auto* backing = layer.backing();
         ASSERT(backing);
-        m_chromeClient.removeScrollingLayer(layer->renderer().element(), backing->scrollContainerLayer()->platformLayer(), backing->scrolledContentsLayer()->platformLayer());
+        m_chromeClient.removeScrollingLayer(layer.renderer().element(), backing->scrollContainerLayer()->platformLayer(), backing->scrolledContentsLayer()->platformLayer());
     }
 }
 
 void LegacyWebKitScrollingLayerCoordinator::addScrollingLayer(RenderLayer& layer)
 {
-    m_scrollingLayers.add(&layer);
+    m_scrollingLayers.add(layer);
 }
 
 void LegacyWebKitScrollingLayerCoordinator::removeScrollingLayer(RenderLayer& layer, RenderLayerBacking& backing)
 {
-    if (m_scrollingLayers.remove(&layer)) {
+    if (m_scrollingLayers.remove(layer)) {
         auto* scrollContainerLayer = backing.scrollContainerLayer()->platformLayer();
         auto* scrolledContentsLayer = backing.scrolledContentsLayer()->platformLayer();
         m_chromeClient.removeScrollingLayer(layer.renderer().element(), scrollContainerLayer, scrolledContentsLayer);
@@ -5448,17 +5448,17 @@ void LegacyWebKitScrollingLayerCoordinator::removeLayer(RenderLayer& layer)
     removeScrollingLayer(layer, *layer.backing());
 
     // We'll put the new set of layers to the client via registerAllViewportConstrainedLayers() at flush time.
-    m_viewportConstrainedLayers.remove(&layer);
+    m_viewportConstrainedLayers.remove(layer);
 }
 
 void LegacyWebKitScrollingLayerCoordinator::addViewportConstrainedLayer(RenderLayer& layer)
 {
-    m_viewportConstrainedLayers.add(&layer);
+    m_viewportConstrainedLayers.add(layer);
 }
 
 void LegacyWebKitScrollingLayerCoordinator::removeViewportConstrainedLayer(RenderLayer& layer)
 {
-    m_viewportConstrainedLayers.remove(&layer);
+    m_viewportConstrainedLayers.remove(layer);
 }
 
 #endif

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -32,6 +32,7 @@
 #include <pal/HysteresisActivity.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -132,8 +133,8 @@ private:
 
     ChromeClient& m_chromeClient;
 
-    HashSet<RenderLayer*> m_scrollingLayers;
-    HashSet<RenderLayer*> m_viewportConstrainedLayers;
+    WeakHashSet<RenderLayer> m_scrollingLayers;
+    WeakHashSet<RenderLayer> m_viewportConstrainedLayers;
 
     const bool m_coordinateViewportConstrainedLayers;
 };

--- a/Source/WebCore/rendering/RenderLineBoxList.cpp
+++ b/Source/WebCore/rendering/RenderLineBoxList.cpp
@@ -222,7 +222,7 @@ void RenderLineBoxList::paint(RenderBoxModelObject* renderer, PaintInfo& paintIn
         return;
 
     PaintInfo info(paintInfo);
-    ListHashSet<RenderInline*> outlineObjects;
+    WeakListHashSet<RenderInline> outlineObjects;
     info.outlineObjects = &outlineObjects;
 
     // See if our root lines intersect with the dirty rect.  If so, then we paint
@@ -263,10 +263,10 @@ void RenderLineBoxList::paint(RenderBoxModelObject* renderer, PaintInfo& paintIn
     }
 
     if (info.phase == PaintPhase::Outline || info.phase == PaintPhase::SelfOutline || info.phase == PaintPhase::ChildOutlines) {
-        ListHashSet<RenderInline*>::iterator end = info.outlineObjects->end();
-        for (ListHashSet<RenderInline*>::iterator it = info.outlineObjects->begin(); it != end; ++it) {
-            RenderInline* flow = *it;
-            flow->paintOutline(info, paintOffset);
+        auto end = info.outlineObjects->end();
+        for (auto it = info.outlineObjects->begin(); it != end; ++it) {
+            RenderInline& flow = *it;
+            flow.paintOutline(info, paintOffset);
         }
         info.outlineObjects->clear();
     }

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -134,11 +134,11 @@ void RenderMultiColumnFlow::addFragmentToThread(RenderFragmentContainer* fragmen
 {
     auto* columnSet = downcast<RenderMultiColumnSet>(fragmentContainer);
     if (RenderMultiColumnSet* nextSet = columnSet->nextSiblingMultiColumnSet()) {
-        RenderFragmentContainerList::iterator it = m_fragmentList.find(nextSet);
+        auto it = m_fragmentList.find(*nextSet);
         ASSERT(it != m_fragmentList.end());
-        m_fragmentList.insertBefore(it, columnSet);
+        m_fragmentList.insertBefore(it, *columnSet);
     } else
-        m_fragmentList.add(columnSet);
+        m_fragmentList.add(*columnSet);
     fragmentContainer->setIsValid(true);
 }
 

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -576,7 +576,7 @@ LayoutRect RenderMultiColumnSet::fragmentedFlowPortionRectAt(unsigned index) con
     return portionRect;
 }
 
-LayoutRect RenderMultiColumnSet::fragmentedFlowPortionOverflowRect(const LayoutRect& portionRect, unsigned index, unsigned colCount, LayoutUnit colGap)
+LayoutRect RenderMultiColumnSet::fragmentedFlowPortionOverflowRect(const LayoutRect& portionRect, unsigned index, unsigned colCount, LayoutUnit colGap) const
 {
     // This function determines the portion of the flow thread that paints for the column. Along the inline axis, columns are
     // unclipped at outside edges (i.e., the first and last column in the set), and they clip to half the column
@@ -702,7 +702,7 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     }
 }
 
-void RenderMultiColumnSet::repaintFragmentedFlowContent(const LayoutRect& repaintRect)
+void RenderMultiColumnSet::repaintFragmentedFlowContent(const LayoutRect& repaintRect) const
 {
     // Figure out the start and end columns and only check within that range so that we don't walk the
     // entire column set. Put the repaint rect into flow thread coordinates by flipping it first.
@@ -742,7 +742,7 @@ void RenderMultiColumnSet::repaintFragmentedFlowContent(const LayoutRect& repain
     }
 }
 
-Vector<LayoutRect> RenderMultiColumnSet::fragmentRectsForFlowContentRect(const LayoutRect& rect)
+Vector<LayoutRect> RenderMultiColumnSet::fragmentRectsForFlowContentRect(const LayoutRect& rect) const
 {
     auto fragmentedFlowRect = rect;
     fragmentedFlow()->flipForWritingMode(fragmentedFlowRect);

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -159,11 +159,11 @@ private:
 
     LayoutUnit logicalHeightOfAllFragmentedFlowContent() const override { return logicalHeightInFragmentedFlow(); }
 
-    void repaintFragmentedFlowContent(const LayoutRect& repaintRect) override;
+    void repaintFragmentedFlowContent(const LayoutRect& repaintRect) const override;
 
     void collectLayerFragments(LayerFragments&, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) override;
 
-    Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) final;
+    Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) const final;
 
     VisiblePosition positionForPoint(const LayoutPoint&, const RenderFragmentContainer*) override;
 
@@ -175,7 +175,7 @@ private:
     LayoutUnit columnLogicalTop(unsigned) const;
 
     LayoutRect fragmentedFlowPortionRectAt(unsigned index) const;
-    LayoutRect fragmentedFlowPortionOverflowRect(const LayoutRect& fragmentedFlowPortion, unsigned index, unsigned colCount, LayoutUnit colGap);
+    LayoutRect fragmentedFlowPortionOverflowRect(const LayoutRect& fragmentedFlowPortion, unsigned index, unsigned colCount, LayoutUnit colGap) const;
 
     LayoutUnit initialBlockOffsetForPainting() const;
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -911,8 +911,8 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
     // FIXME: We should really propagate only when the child renderer sticks out.
     bool repaintRectNeedsConverting = false;
     // Issue repaint on the renderer with outline: auto.
-    for (const auto* renderer = this; renderer; renderer = renderer->parent()) {
-        const auto* originalRenderer = renderer;
+    for (auto* renderer = this; renderer; renderer = renderer->parent()) {
+        auto* originalRenderer = renderer;
         if (is<RenderMultiColumnSet>(renderer->previousSibling()) && !renderer->isLegend()) {
             auto previousMultiColumnSet = downcast<RenderMultiColumnSet>(renderer->previousSibling());
             auto enclosingMultiColumnFlow = previousMultiColumnSet->multiColumnFlow();
@@ -936,7 +936,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
         if (!repaintRectNeedsConverting)
             repaintContainer.repaintRectangle(adjustedRepaintRect);
         else if (is<RenderLayerModelObject>(originalRenderer)) {
-            const auto& rendererWithOutline = downcast<RenderLayerModelObject>(*originalRenderer);
+            auto& rendererWithOutline = downcast<RenderLayerModelObject>(*originalRenderer);
             adjustedRepaintRect = LayoutRect(repaintContainer.localToContainerQuad(FloatRect(adjustedRepaintRect), &rendererWithOutline).boundingBox());
             rendererWithOutline.repaintRectangle(adjustedRepaintRect);
         }
@@ -1181,11 +1181,11 @@ void RenderObject::outputRegionsInformation(TextStream& stream) const
 
         stream << " [fragment containers ";
         bool first = true;
-        for (const auto* fragment : fragmentContainers) {
+        for (const auto& fragment : fragmentContainers) {
             if (!first)
                 stream << ", ";
             first = false;
-            stream << fragment;
+            stream << &fragment;
         }
         stream << "]";
     }
@@ -2266,7 +2266,7 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
 
     bool useVisibleBounds = behavior.contains(RenderObject::BoundingRectBehavior::UseVisibleBounds);
 
-    HashSet<Element*> selectedElementsSet;
+    HashSet<RefPtr<Element>> selectedElementsSet;
     for (auto& node : intersectingNodesWithDeprecatedZeroOffsetStartQuirk(range)) {
         if (is<Element>(node))
             selectedElementsSet.add(&downcast<Element>(node));

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -671,8 +671,8 @@ void RenderTableSection::computeOverflowFromCells(unsigned totalRows, unsigned n
             hasOverflowingCell |= cell->hasVisualOverflow();
 #endif
             if (cell->hasVisualOverflow() && !m_forceSlowPaintPathWithOverflowingCell) {
-                m_overflowingCells.add(cell);
-                if (m_overflowingCells.size() > maxAllowedOverflowingCellsCount) {
+                m_overflowingCells.add(*cell);
+                if (m_overflowingCells.computeSize() > maxAllowedOverflowingCellsCount) {
                     // We need to set m_forcesSlowPaintPath only if there is a least one overflowing cells as the hit testing code rely on this information.
                     m_forceSlowPaintPathWithOverflowingCell = true;
                     // The slow path does not make any use of the overflowing cells info, don't hold on to the memory.
@@ -944,14 +944,14 @@ void RenderTableSection::paint(PaintInfo& paintInfo, const LayoutPoint& paintOff
         paintOutline(paintInfo, LayoutRect(adjustedPaintOffset, size()));
 }
 
-static inline bool compareCellPositions(RenderTableCell* elem1, RenderTableCell* elem2)
+static inline bool compareCellPositions(const WeakPtr<RenderTableCell>& elem1, const WeakPtr<RenderTableCell>& elem2)
 {
     return elem1->rowIndex() < elem2->rowIndex();
 }
 
 // This comparison is used only when we have overflowing cells as we have an unsorted array to sort. We thus need
 // to sort both on rows and columns to properly repaint.
-static inline bool compareCellPositionsWithOverflowingCells(RenderTableCell* elem1, RenderTableCell* elem2)
+static inline bool compareCellPositionsWithOverflowingCells(const WeakPtr<RenderTableCell>& elem1, const WeakPtr<RenderTableCell>& elem2)
 {
     if (elem1->rowIndex() != elem2->rowIndex())
         return elem1->rowIndex() < elem2->rowIndex();
@@ -1223,7 +1223,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
     CellSpan dirtiedColumns = this->dirtiedColumns(tableAlignedRect);
 
     if (dirtiedColumns.start < dirtiedColumns.end) {
-        if (!m_hasMultipleCellLevels && !m_overflowingCells.size()) {
+        if (!m_hasMultipleCellLevels && m_overflowingCells.isEmptyIgnoringNullReferences()) {
             if (paintInfo.phase == PaintPhase::CollapsedTableBorders) {
                 // Collapsed borders are painted from the bottom right to the top left so that precedence
                 // due to cell position is respected. We need to paint one row beyond the topmost dirtied
@@ -1281,7 +1281,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
 #if ASSERT_ENABLED
             unsigned totalRows = m_grid.size();
             unsigned totalCols = table()->columns().size();
-            ASSERT(m_overflowingCells.size() < totalRows * totalCols * gMaxAllowedOverflowingCellRatioForFastPaintPath);
+            ASSERT(m_overflowingCells.computeSize() < totalRows * totalCols * gMaxAllowedOverflowingCellRatioForFastPaintPath);
 #endif
 
             // To make sure we properly repaint the section, we repaint all the overflowing cells that we collected.
@@ -1298,7 +1298,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
                     if (!current.hasCells())
                         continue;
                     for (unsigned i = 0; i < current.cells.size(); ++i) {
-                        if (m_overflowingCells.contains(current.cells[i]))
+                        if (m_overflowingCells.contains(*current.cells[i]))
                             continue;
 
                         if (current.cells[i]->rowSpan() > 1 || current.cells[i]->colSpan() > 1) {
@@ -1312,7 +1312,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             }
 
             // Sort the dirty cells by paint order.
-            if (!m_overflowingCells.size())
+            if (m_overflowingCells.isEmptyIgnoringNullReferences())
                 std::stable_sort(cells.begin(), cells.end(), compareCellPositions);
             else
                 std::sort(cells.begin(), cells.end(), compareCellPositionsWithOverflowingCells);
@@ -1324,7 +1324,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
                 }
             } else {
                 for (unsigned i = 0; i < cells.size(); ++i)
-                    paintCell(cells[i], paintInfo, paintOffset);
+                    paintCell(cells[i].get(), paintInfo, paintOffset);
             }
         }
     }

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -193,7 +193,7 @@ private:
     void distributeExtraLogicalHeightToAutoRows(LayoutUnit& extraLogicalHeight, unsigned autoRowsCount);
     void distributeRemainingExtraLogicalHeight(LayoutUnit& extraLogicalHeight);
 
-    bool hasOverflowingCell() const { return m_overflowingCells.size() || m_forceSlowPaintPathWithOverflowingCell; }
+    bool hasOverflowingCell() const { return m_overflowingCells.computeSize() || m_forceSlowPaintPathWithOverflowingCell; }
     void computeOverflowFromCells(unsigned totalRows, unsigned nEffCols);
 
     CellSpan fullTableRowSpan() const;
@@ -234,7 +234,7 @@ private:
     // This HashSet holds the overflowing cells for faster painting.
     // If we have more than gMaxAllowedOverflowingCellRatio * total cells, it will be empty
     // and m_forceSlowPaintPathWithOverflowingCell will be set to save memory.
-    HashSet<RenderTableCell*> m_overflowingCells;
+    WeakHashSet<RenderTableCell> m_overflowingCells;
 
     // This map holds the collapsed border values for cells with collapsed borders.
     // It is held at RenderTableSection level to spare memory consumption by table cells.


### PR DESCRIPTION
#### c0f8683a027790d6bc3887dcd0f0b2637f4c789c
<pre>
Use more smart pointers in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=261490">https://bugs.webkit.org/show_bug.cgi?id=261490</a>

Reviewed by Alan Baradlay.

* Source/WTF/wtf/WeakListHashSet.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paint):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paint):
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::containingFragment const):
* Source/WebCore/rendering/PaintInfo.h:
(WebCore::PaintInfo::PaintInfo):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::clientBoxRectInFragment const):
(WebCore::RenderBox::borderBoxRectInFragment const):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::initializeMarginTrimState):
(WebCore::RenderFlexibleBox::isChildEligibleForMarginTrim const):
(WebCore::RenderFlexibleBox::trimMainAxisMarginStart):
(WebCore::RenderFlexibleBox::trimMainAxisMarginEnd):
(WebCore::RenderFlexibleBox::trimCrossAxisMarginStart):
(WebCore::RenderFlexibleBox::trimCrossAxisMarginEnd):
(WebCore::RenderFlexibleBox::cacheChildMainSize):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):
(WebCore::RenderFlexibleBox::applyStretchAlignmentToChild):
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::overflowRectForFragmentedFlowPortion const):
(WebCore::RenderFragmentContainer::fragmentedFlowContentRectangle const):
(WebCore::RenderFragmentContainer::fragmentRectsForFlowContentRect const):
(WebCore::RenderFragmentContainer::detachFragment):
(WebCore::RenderFragmentContainer::ensureOverflowForBox const):
(WebCore::RenderFragmentContainer::visualOverflowRectForBox const):
(WebCore::RenderFragmentContainer::overflowRectForFragmentedFlowPortion): Deleted.
(WebCore::RenderFragmentContainer::fragmentedFlowContentRectangle): Deleted.
(WebCore::RenderFragmentContainer::fragmentRectsForFlowContentRect): Deleted.
(WebCore::RenderFragmentContainer::ensureOverflowForBox): Deleted.
(WebCore::RenderFragmentContainer::visualOverflowRectForBox): Deleted.
* Source/WebCore/rendering/RenderFragmentContainer.h:
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::removeFragmentFromThread):
(WebCore::RenderFragmentedFlow::validateFragments):
(WebCore::RenderFragmentedFlow::updateLogicalWidth):
(WebCore::RenderFragmentedFlow::computeLogicalHeight const):
(WebCore::RenderFragmentedFlow::repaintRectangleInFragments const):
(WebCore::RenderFragmentedFlow::absoluteQuadsForBox const):
(WebCore::RenderFragmentedFlow::fragmentAtBlockOffset const):
(WebCore::RenderFragmentedFlow::removeRenderBoxFragmentInfo):
(WebCore::RenderFragmentedFlow::logicalWidthChangedInFragmentsForBlock):
(WebCore::RenderFragmentedFlow::firstFragment const):
(WebCore::RenderFragmentedFlow::lastFragment const):
(WebCore::RenderFragmentedFlow::clearRenderBoxFragmentInfoAndCustomStyle):
(WebCore::RenderFragmentedFlow::getFragmentRangeForBoxFromCachedInfo const):
(WebCore::RenderFragmentedFlow::getFragmentRangeForBox const):
(WebCore::RenderFragmentedFlow::computedFragmentRangeForBox const):
(WebCore::RenderFragmentedFlow::fragmentInRange const):
(WebCore::RenderFragmentedFlow::objectShouldFragmentInFlowFragment const):
(WebCore::RenderFragmentedFlow::objectInFlowFragment const):
(WebCore::RenderFragmentedFlow::checkLinesConsistency const):
(WebCore::RenderFragmentedFlow::markFragmentsForOverflowLayoutIfNeeded):
(WebCore::RenderFragmentedFlow::updateFragmentsFragmentedFlowPortionRect):
(WebCore::RenderFragmentedFlow::collectLayerFragments):
(WebCore::RenderFragmentedFlow::fragmentsBoundingBox):
(WebCore::RenderFragmentedFlow::addFragmentsVisualEffectOverflow):
(WebCore::RenderFragmentedFlow::addFragmentsVisualOverflowFromTheme):
(WebCore::RenderFragmentedFlow::addFragmentsOverflowFromChild):
(WebCore::RenderFragmentedFlow::addFragmentsLayoutOverflow):
(WebCore::RenderFragmentedFlow::addFragmentsVisualOverflow):
(WebCore::RenderFragmentedFlow::clearFragmentsOverflow):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::findCommonAncestor):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::LegacyWebKitScrollingLayerCoordinator::registerAllViewportConstrainedLayers):
(WebCore::LegacyWebKitScrollingLayerCoordinator::registerAllScrollingLayers):
(WebCore::LegacyWebKitScrollingLayerCoordinator::unregisterAllScrollingLayers):
(WebCore::LegacyWebKitScrollingLayerCoordinator::addScrollingLayer):
(WebCore::LegacyWebKitScrollingLayerCoordinator::removeScrollingLayer):
(WebCore::LegacyWebKitScrollingLayerCoordinator::removeLayer):
(WebCore::LegacyWebKitScrollingLayerCoordinator::addViewportConstrainedLayer):
(WebCore::LegacyWebKitScrollingLayerCoordinator::removeViewportConstrainedLayer):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLineBoxList.cpp:
(WebCore::RenderLineBoxList::paint const):
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::addFragmentToThread):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::fragmentedFlowPortionOverflowRect const):
(WebCore::RenderMultiColumnSet::fragmentRectsForFlowContentRect const):
(WebCore::RenderMultiColumnSet::fragmentedFlowPortionOverflowRect): Deleted.
(WebCore::RenderMultiColumnSet::fragmentRectsForFlowContentRect): Deleted.
* Source/WebCore/rendering/RenderMultiColumnSet.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::outputRegionsInformation const):
(WebCore::borderAndTextRects):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::computeOverflowFromCells):
(WebCore::compareCellPositions):
(WebCore::compareCellPositionsWithOverflowingCells):
(WebCore::RenderTableSection::paintObject):
* Source/WebCore/rendering/RenderTableSection.h:

Canonical link: <a href="https://commits.webkit.org/267973@main">https://commits.webkit.org/267973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8646888bf9ca46fd707d9f5b84dd3df9153bb49c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18199 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18690 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20922 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23110 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15772 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20993 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17482 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14699 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21556 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16429 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4339 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20794 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22789 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17186 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5126 "Found 1 jsc stress test failure: microbenchmarks/array-from-object-func.js.lockdown") | 
<!--EWS-Status-Bubble-End-->