### PR TITLE
[GStreamer] WebCodecs gardening

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1127,10 +1127,6 @@ webkit.org/b/239750 media/media-source/media-mp4-xhe-aac.html [ Skip ]
 media/media-hevc-video-as-img.html [ ImageOnlyFailure ]
 
 # Temporal scalability support
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?h264_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?h264_avc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker.html?h264_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker.html?h264_avc [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?h264 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -19,7 +19,7 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height i
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd sized frames for H264
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -19,7 +19,7 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Height i
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Odd sized frames for H264
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future H264 codec string
-FAIL Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string assert_false: expected false got true
+PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
 FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {


### PR DESCRIPTION
#### 6c4458b35259a70d20146a0c511d72a538e5f670
<pre>
[GStreamer] WebCodecs gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=261499">https://bugs.webkit.org/show_bug.cgi?id=261499</a>

Unreviewed, WebCodecs rebaseline and expectations updates.

* LayoutTests/platform/glib/TestExpectations: reconfiguring-encoder* tests passing after 267865@main
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
Rebaseline after 267403@main
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/267939@main">https://commits.webkit.org/267939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecfffb09ab3c1c3e01364a8d4ae7b79ec0afa45d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/18137 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/18470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/19038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/19976 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/16976 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/21767 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/18628 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/19976 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/18357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/21767 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/19038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20854 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/21767 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/19038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/20854 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/21767 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/19038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/20854 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17283 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/18628 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16373 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/19038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4315 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20735 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17131 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->