### PR TITLE
Remove special renderer based IFC ruby code

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.cpp
@@ -364,12 +364,6 @@ InlineLayoutUnit InlineFormattingGeometry::inlineItemWidth(const InlineItem& inl
     if (inlineItem.isOpaque())
         return { };
 
-    // FIXME: The overhang should be computed to not overlap the neighboring runs or overflow the line.
-    if (auto* rubyAdjustments = layoutBox.rubyAdjustments()) {
-        auto& overhang = useFirstLineStyle ? rubyAdjustments->firstLineOverhang : rubyAdjustments->overhang;
-        return boxGeometry.marginBoxWidth() - (overhang.start + overhang.end);
-    }
-
     // Non-replaced inline box (e.g. inline-block)
     return boxGeometry.marginBoxWidth();
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -44,10 +44,6 @@ inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const RenderStyle& s
         m_style.verticalAlignment.baselineOffset = floatValueForLength(style.verticalAlignLength(), preferredLineHeight());
 
     auto setAnnotationIfApplicable = [&] {
-        if (auto* rubyAdjustments = layoutBox.rubyAdjustments()) {
-            m_annotation = { rubyAdjustments->annotationAbove, rubyAdjustments->annotationBelow };
-            return;
-        }
         // Generic, non-inline box inline-level content (e.g. replaced elements) can't have text-emphasis annotations.
         if (!isRootInlineBox() && !isInlineBox())
             return;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
@@ -113,10 +113,6 @@ InlineRect LineBox::logicalBorderBoxForAtomicInlineLevelBox(const Box& layoutBox
     auto verticalMargin = boxGeometry.marginBefore() + boxGeometry.marginAfter();
     logicalRect.expandVertically(-verticalMargin);
 
-    // FIXME: The overhang adjustment should be based on the computed value.
-    if (auto* rubyAdjustments = layoutBox.rubyAdjustments())
-        logicalRect.moveHorizontally(-rubyAdjustments->overhang.start);
-
     return logicalRect;
 }
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -57,9 +57,6 @@
 #include <pal/Logging.h>
 #include <wtf/OptionSet.h>
 
-#define ALLOW_RUBY 0
-#define ALLOW_RUBY_BASE_AND_TEXT 0
-
 #ifndef NDEBUG
 #define SET_REASON_AND_RETURN_IF_NEEDED(reason, reasons, includeReasons) { \
         reasons.add(AvoidanceReason::reason); \
@@ -296,10 +293,8 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
         return reasons;
 
     auto& renderer = downcast<RenderElement>(child);
-#if !ALLOW_RUBY
     if (renderer.isRubyRun())
         SET_REASON_AND_RETURN_IF_NEEDED(ContentIsRuby, reasons, includeReasons);
-#endif
 
     if (is<RenderBlockFlow>(renderer)
         || is<RenderGrid>(renderer)
@@ -317,10 +312,8 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
     if (is<RenderInline>(renderer)) {
         if (renderer.isSVGInline())
             SET_REASON_AND_RETURN_IF_NEEDED(ContentIsSVG, reasons, includeReasons);
-#if !ALLOW_RUBY
         if (renderer.isRubyInline())
             SET_REASON_AND_RETURN_IF_NEEDED(ContentIsRuby, reasons, includeReasons);
-#endif
         return reasons;
     }
 
@@ -348,10 +341,8 @@ OptionSet<AvoidanceReason> canUseForLineLayoutWithReason(const RenderBlockFlow& 
         ASSERT(is<RenderSVGBlock>(flow));
         SET_REASON_AND_RETURN_IF_NEEDED(ContentIsSVG, reasons, includeReasons);
     }
-#if !ALLOW_RUBY || !ALLOW_RUBY_BASE_AND_TEXT
     if (flow.isRubyText() || flow.isRubyBase())
         SET_REASON_AND_RETURN_IF_NEEDED(ContentIsRuby, reasons, includeReasons);
-#endif
     for (auto walker = InlineWalker(flow); !walker.atEnd(); walker.advance()) {
         auto& child = *walker.current();
         if (auto childReasons = canUseForChild(flow, child, includeReasons))

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -65,7 +65,6 @@
 #include "RenderListItem.h"
 #include "RenderListMarker.h"
 #include "RenderMathMLBlock.h"
-#include "RenderRubyRun.h"
 #include "RenderSlider.h"
 #include "RenderTable.h"
 #include "RenderTextControlMultiLine.h"
@@ -393,11 +392,10 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
 #if ENABLE(ATTACHMENT_ELEMENT)
             || is<RenderAttachment>(replacedOrInlineBlock)
 #endif
-            || is<RenderButton>(replacedOrInlineBlock)
 #if ENABLE(MATHML)
             || is<RenderMathMLBlock>(replacedOrInlineBlock)
 #endif
-            || is<RenderRubyRun>(replacedOrInlineBlock)) {
+            || is<RenderButton>(replacedOrInlineBlock)) {
             // These are special RenderBlock renderers that override the default baseline position behavior of the inline block box.
             return true;
         }
@@ -414,16 +412,6 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
 
     if (auto* shapeOutsideInfo = replacedOrInlineBlock.shapeOutsideInfo())
         layoutBox.setShape(&shapeOutsideInfo->computedShape());
-
-    if (auto* rubyRun = dynamicDowncast<RenderRubyRun>(replacedOrInlineBlock)) {
-        auto adjustments = makeUnique<Layout::RubyAdjustments>();
-
-        std::tie(adjustments->annotationAbove, adjustments->annotationBelow) = rubyRun->annotationsAboveAndBelow();
-        std::tie(adjustments->overhang.start, adjustments->overhang.end) = rubyRun->startAndEndOverhang(false);
-        std::tie(adjustments->firstLineOverhang.start, adjustments->firstLineOverhang.end) = rubyRun->startAndEndOverhang(true);
-
-        layoutBox.setRubyAdjustments(WTFMove(adjustments));
-    }
 }
 
 void LineLayout::updateLineBreakBoxDimensions(const RenderLineBreak& lineBreakBox)

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -470,18 +470,6 @@ void Box::setShape(RefPtr<const Shape> shape)
     ensureRareData().shape = WTFMove(shape);
 }
 
-const RubyAdjustments* Box::rubyAdjustments() const
-{
-    if (!hasRareData())
-        return nullptr;
-    return rareData().rubyAdjustments.get();
-}
-
-void Box::setRubyAdjustments(std::unique_ptr<RubyAdjustments> rubyAdjustments)
-{
-    ensureRareData().rubyAdjustments = WTFMove(rubyAdjustments);
-}
-
 const ElementBox* Box::associatedRubyAnnotationBox() const
 {
     if (style().display() != DisplayType::RubyBase)

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -43,19 +43,6 @@ class InitialContainingBlock;
 class LayoutState;
 class TreeBuilder;
 
-struct RubyAdjustments {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-    LayoutUnit annotationAbove;
-    LayoutUnit annotationBelow;
-    struct Overhang {
-        LayoutUnit start;
-        LayoutUnit end;
-    };
-    Overhang firstLineOverhang;
-    Overhang overhang;
-};
-
 class Box : public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(Box);
 public:
@@ -196,9 +183,6 @@ public:
     const Shape* shape() const;
     void setShape(RefPtr<const Shape>);
 
-    const RubyAdjustments* rubyAdjustments() const;
-    void setRubyAdjustments(std::unique_ptr<RubyAdjustments>);
-
     const ElementBox* associatedRubyAnnotationBox() const;
 
     bool canCacheForLayoutState(const LayoutState&) const;
@@ -225,7 +209,6 @@ private:
         std::optional<LayoutUnit> columnWidth;
         std::unique_ptr<RenderStyle> firstLineStyle;
         RefPtr<const Shape> shape;
-        std::unique_ptr<RubyAdjustments> rubyAdjustments;
     };
 
     bool hasRareData() const { return m_hasRareData; }


### PR DESCRIPTION
#### ab71719ed2ffeac0a2ce51fb6e10d5b4c40f20f3
<pre>
Remove special renderer based IFC ruby code
<a href="https://bugs.webkit.org/show_bug.cgi?id=261496">https://bugs.webkit.org/show_bug.cgi?id=261496</a>
rdar://115413576

Reviewed by Alan Baradlay.

We are going to implement proper IFC ruby.

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.cpp:
(WebCore::Layout::InlineFormattingGeometry::inlineItemWidth const):
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp:
(WebCore::Layout::LineBox::logicalBorderBoxForAtomicInlineLevelBox const):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForChild):
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateLayoutBoxDimensions):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::rubyAdjustments const): Deleted.
(WebCore::Layout::Box::setRubyAdjustments): Deleted.
* Source/WebCore/layout/layouttree/LayoutBox.h:

Canonical link: <a href="https://commits.webkit.org/267962@main">https://commits.webkit.org/267962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3aac2d04d46859c58f1323743a1f138576d0089

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18941 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20858 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23058 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20940 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14641 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16377 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4332 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->