### PR TITLE
[webkitpy] Detection of GTK4 is broken

### DIFF
--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -199,13 +199,13 @@ class GtkPort(GLibPort):
     def _is_gtk4_build(self):
         try:
             libdir = self._build_path('lib')
-            candidates = self._filesystem.glob(os.path.join(libdir, 'libwebkit2gtk-*.so'))
+            candidates = self._filesystem.glob(os.path.join(libdir, 'libwebkit*gtk-*.so'))
             if not candidates:
                 return False
             if len(candidates) > 1:
                 _log.warning("Multiple WebKit2GTK libraries found. Skipping GTK4 detection.")
                 return False
-            return os.path.basename(candidates[0]) == 'libwebkit2gtk-5.0.so'
+            return os.path.basename(candidates[0]) == 'libwebkitgtk-6.0.so'
 
         except (webkitpy.common.system.executive.ScriptError, IOError, OSError):
             return False

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -102,7 +102,7 @@ class GtkPortTest(port_testcase.PortTestCase):
     def test_gtk4_expectations_binary_only(self):
         port = self.make_port()
         port._filesystem = MockFileSystem({
-            "/mock-build/lib/libwebkit2gtk-5.0.so": ""
+            "/mock-build/lib/libwebkitgtk-6.0.so": ""
         })
         with OutputCapture() as _:
             self.assertEqual(port.expectations_files(),
@@ -129,7 +129,7 @@ class GtkPortTest(port_testcase.PortTestCase):
         port = self.make_port()
         port._filesystem = MockFileSystem({
             "/mock-build/lib/libwebkit2gtk-4.0.so": "",
-            "/mock-build/lib/libwebkit2gtk-5.0.so": ""
+            "/mock-build/lib/libwebkitgtk-6.0.so": ""
         })
 
         with OutputCapture() as captured:


### PR DESCRIPTION
#### bc011e53e91781e58ab5fc3a91795eba69d836ea
<pre>
[webkitpy] Detection of GTK4 is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=261503">https://bugs.webkit.org/show_bug.cgi?id=261503</a>

Reviewed by Adrian Perez de Castro.

The name of the current binary for the gtk4 library is different,
update the method to actually find all library binaries.

 * Tools/Scripts/webkitpy/port/gtk.py:
 (GtkPort._is_gtk4_build):
 * Tools/Scripts/webkitpy/port/gtk_unittest.py:
 (GtkPortTest.test_gtk4_expectations_binary_only):
 (GtkPortTest.test_gtk_expectations_both_binaries):

Canonical link: <a href="https://commits.webkit.org/267946@main">https://commits.webkit.org/267946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d07729ea7dbd8932613bcf8583c2fce4655bf6fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18642 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20868 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18311 "Found 1 webkitpy python3 test failure: webkitpy.w3c.test_converter_unittest.W3CTestConverterTest.test_convert_prefixed_properties") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23068 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20950 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14651 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16387 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4318 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20749 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->