### PR TITLE
[GTK][WPE] Test `/webkit/WebKitWebExtension/form-submission-steps` times out in the bots

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
@@ -372,7 +372,6 @@ static void testWebProcessExtensionFormSubmissionSteps(FormSubmissionTest* test,
     test->loadHtml("<form id=\"" FORM_SUBMISSION_TEST_ID "\" target=\"target_frame\">"
         "<input type=\"text\" name=\"foo\" value=\"first\">"
         "<input type=\"text\" name=\"bar\" value=\"second\">"
-        "<input type=\"submit\" id=\"submit_button\">"
         "</form>"
         "<iframe name=\"target_frame\"></iframe>", nullptr);
     test->waitUntilLoadFinished();
@@ -387,6 +386,14 @@ static void testWebProcessExtensionFormSubmissionSteps(FormSubmissionTest* test,
     g_assert_true(test->m_willCompleteCallbackExecuted);
     test->m_willCompleteCallbackExecuted = false;
 
+    test->loadHtml("<form id=\"" FORM_SUBMISSION_TEST_ID "\" target=\"target_frame\">"
+        "<input type=\"text\" name=\"foo\" value=\"first\">"
+        "<input type=\"text\" name=\"bar\" value=\"second\">"
+        "<input type=\"submit\" id=\"submit_button\">"
+        "</form>"
+        "<iframe name=\"target_frame\"></iframe>", nullptr);
+    test->waitUntilLoadFinished();
+
     static const char* manuallySubmitFormScript =
         "var button = document.getElementById(\"submit_button\");"
         "button.click();";
@@ -395,11 +402,6 @@ static void testWebProcessExtensionFormSubmissionSteps(FormSubmissionTest* test,
     g_assert_true(test->m_willCompleteCallbackExecuted);
     test->m_willSendDOMEventCallbackExecuted = false;
     test->m_willCompleteCallbackExecuted = false;
-
-    test->loadHtml("<form id=\"" FORM_SUBMISSION_TEST_ID "\" target=\"target_frame\">"
-        "</form>"
-        "<iframe name=\"target_frame\"></iframe>", nullptr);
-    test->waitUntilLoadFinished();
 }
 
 static void webViewPageIDChanged(WebKitWebView* webView, GParamSpec*, bool* pageIDChangedEmitted)

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -62,13 +62,6 @@
             }
         }
     },
-    "TestWebProcessExtensions": {
-        "subtests": {
-            "/webkit/WebKitWebProcessExtension/form-submission-steps": {
-                "expected": {"all": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205333"}}
-            }
-        }
-    },
     "TestWebKitWebView": {
         "subtests": {
             "/webkit/WebKitWebView/is-web-process-responsive": {


### PR DESCRIPTION
#### b8bd4de0bf5cd9bc3ab89baed85fbc9eb0457f54
<pre>
[GTK][WPE] Test `/webkit/WebKitWebExtension/form-submission-steps` times out in the bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=205333">https://bugs.webkit.org/show_bug.cgi?id=205333</a>

Reviewed by Michael Catanzaro.

In this test, we submit a form on the same page twice. In some
circumstances, the first submission can cancel the second one.
When this happens, the test will time out.

The best way to prevent it is to reload the page before the second
submission.

Also, at the end of the test, we reload a page with no good reason.
This patch removes this piece of code.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp:
(testWebProcessExtensionFormSubmissionSteps):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/267949@main">https://commits.webkit.org/267949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29bf99f3bdde8dff9ebc0492552168f2088989b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20872 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16559 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14656 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16391 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4321 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->