### PR TITLE
REGRESSION(267786@main): Nullptr crash under resolveComputedStyle when there is no render tree

### DIFF
--- a/LayoutTests/fast/css/computed-style-no-render-tree-crash-expected.txt
+++ b/LayoutTests/fast/css/computed-style-no-render-tree-crash-expected.txt
@@ -1,0 +1,1 @@
+ This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/computed-style-no-render-tree-crash.html
+++ b/LayoutTests/fast/css/computed-style-no-render-tree-crash.html
@@ -1,0 +1,21 @@
+<iframe id=iframe></iframe>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+iframe.srcdoc = `<script>onbeforeunload = async () => {
+    await clientInformation.storage.persist();
+    document.designMode = 'off';
+    document.title = 'x';
+};</scri`+`pt>`;
+iframe.onload = () => {
+    iframe.onload = () => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    };
+    iframe.srcdoc = "foo";
+};
+</script>
+This test passes if it doesn't crash.

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2361,7 +2361,7 @@ std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets
     ASSERT(Style::postResolutionCallbacksAreSuspended());
 
     std::optional<RenderStyle> updatedDocumentStyle;
-    if (!parentStyle && m_needsFullStyleRebuild) {
+    if (!parentStyle && m_needsFullStyleRebuild && hasLivingRenderTree()) {
         updatedDocumentStyle.emplace(Style::resolveForDocument(*this));
         parentStyle = &*updatedDocumentStyle;
     }


### PR DESCRIPTION
#### 7642333842d2e1878af6949a67fac4d8861b73f2
<pre>
REGRESSION(267786@main): Nullptr crash under resolveComputedStyle when there is no render tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=261509">https://bugs.webkit.org/show_bug.cgi?id=261509</a>
rdar://115348354

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/computed-style-no-render-tree-crash-expected.txt: Added.
* LayoutTests/fast/css/computed-style-no-render-tree-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::styleForElementIgnoringPendingStylesheets):

Render tree may not be present during navigations.

Canonical link: <a href="https://commits.webkit.org/267952@main">https://commits.webkit.org/267952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18a33471703e13f811661fb493eec9558de43f89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18648 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20875 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23075 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20958 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16404 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4320 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->