### PR TITLE
Use more smart pointers in WebUserContentController

### DIFF
--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -49,7 +49,7 @@ class WebCompiledContentRuleListData;
 class WebUserMessageHandlerDescriptorProxy;
 enum class InjectUserScriptImmediately : bool;
 
-class WebUserContentController final : public WebCore::UserContentProvider, private IPC::MessageReceiver {
+class WebUserContentController final : public WebCore::UserContentProvider, public IPC::MessageReceiver {
 public:
     static Ref<WebUserContentController> getOrCreate(UserContentControllerIdentifier);
     virtual ~WebUserContentController();


### PR DESCRIPTION
#### f15b34787013cca3a6dfe0d11983eac2b415a62d
<pre>
Use more smart pointers in WebUserContentController
<a href="https://bugs.webkit.org/show_bug.cgi?id=261515">https://bugs.webkit.org/show_bug.cgi?id=261515</a>

Reviewed by Brent Fulgham.

* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::userContentControllers):
(WebKit::worldMap):
(WebKit::WebUserContentController::worldForIdentifier):
(WebKit::WebUserContentController::addContentWorld):
(WebKit::WebUserContentController::addUserScripts):
(WebKit::WebUserContentController::removeUserScript):
(WebKit::WebUserContentController::removeAllUserScripts):
(WebKit::WebUserContentController::addUserStyleSheets):
(WebKit::WebUserContentController::removeUserStyleSheet):
(WebKit::WebUserContentController::removeAllUserStyleSheets):
(WebKit::WebUserContentController::addUserScriptMessageHandlers):
(WebKit::WebUserContentController::removeUserScriptMessageHandler):
(WebKit::WebUserContentController::removeAllUserScriptMessageHandlersForWorlds):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:

Canonical link: <a href="https://commits.webkit.org/267968@main">https://commits.webkit.org/267968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd806efd1e85b730e528516738a60b9e9f7812bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17009 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18970 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20888 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15845 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23082 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20965 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14670 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16403 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->