### PR TITLE
Use more smart pointers in Source/WebKit

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4937,9 +4937,8 @@ bool Document::setFocusedElement(Element* element)
     return setFocusedElement(element, { });
 }
 
-bool Document::setFocusedElement(Element* element, const FocusOptions& options)
+bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions& options)
 {
-    RefPtr<Element> newFocusedElement = element;
     // Make sure newFocusedElement is actually in this document
     if (newFocusedElement && (&newFocusedElement->document() != this))
         return true;
@@ -4970,7 +4969,7 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
             }
 
             // Dispatch the blur event and let the node do any other blur related activities (important for text fields)
-            oldFocusedElement->dispatchBlurEvent(newFocusedElement.copyRef());
+            oldFocusedElement->dispatchBlurEvent(newFocusedElement);
 
             if (m_focusedElement) {
                 // handler shifted focus
@@ -4978,7 +4977,7 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
                 newFocusedElement = nullptr;
             }
 
-            oldFocusedElement->dispatchFocusOutEventIfNeeded(newFocusedElement.copyRef()); // DOM level 3 bubbling blur event.
+            oldFocusedElement->dispatchFocusOutEventIfNeeded(newFocusedElement); // DOM level 3 bubbling blur event.
 
             if (m_focusedElement) {
                 // handler shifted focus
@@ -5092,7 +5091,7 @@ bool Document::setFocusedElement(Element* element, const FocusOptions& options)
 #else
         if (auto* cache = existingAXObjectCache())
 #endif
-            cache->onFocusChange(oldFocusedElement.get(), newFocusedElement.get());
+            cache->onFocusChange(oldFocusedElement.get(), newFocusedElement);
     }
 
     if (page())

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3528,7 +3528,7 @@ void Element::focus(const FocusOptions& options)
 
     document->updateContentRelevancyForScrollIfNeeded(*this);
 
-    RefPtr<Element> newTarget = this;
+    RefPtr newTarget { this };
 
     // If we don't have renderer yet, isFocusable will compute it without style update.
     // FIXME: Expand it to avoid style update in all cases.

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2352,14 +2352,12 @@ void FrameSelection::setCaretVisibility(CaretVisibility visibility, ShouldUpdate
 
 // Helper function that tells whether a particular node is an element that has an entire
 // Frame and FrameView, a <frame>, <iframe>, or <object>.
-static bool isFrameElement(const Node* n)
+static bool isFrameElement(const Node& node)
 {
-    if (!n)
+    auto* renderer = dynamicDowncast<RenderWidget>(node.renderer());
+    if (!renderer)
         return false;
-    RenderObject* renderer = n->renderer();
-    if (!is<RenderWidget>(renderer))
-        return false;
-    Widget* widget = downcast<RenderWidget>(*renderer).widget();
+    auto* widget = renderer->widget();
     return widget && widget->isLocalFrameView();
 }
 
@@ -2377,14 +2375,14 @@ void FrameSelection::setFocusedElementIfNeeded()
         }
     }
 
-    if (Element* target = m_selection.rootEditableElement()) {
+    if (RefPtr target = m_selection.rootEditableElement()) {
         // Walk up the DOM tree to search for an element to focus.
         while (target) {
             // We don't want to set focus on a subframe when selecting in a parent frame,
             // so add the !isFrameElement check here. There's probably a better way to make this
             // work in the long term, but this is the safest fix at this time.
-            if (target->isMouseFocusable() && !isFrameElement(target)) {
-                CheckedRef(m_document->page()->focusController())->setFocusedElement(target, *m_document->frame());
+            if (target->isMouseFocusable() && !isFrameElement(*target)) {
+                CheckedRef(m_document->page()->focusController())->setFocusedElement(target.get(), *m_document->frame());
                 return;
             }
             target = target->parentOrShadowHostElement();

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -307,11 +307,11 @@ void Editor::confirmMarkedText()
 {
     // FIXME: This is a hacky workaround for the keyboard calling this method too late -
     // after the selection and focus have already changed. See <rdar://problem/5975559>.
-    Element* focused = document().focusedElement();
-    Node* composition = compositionNode();
-    if (composition && focused && focused != composition && !composition->isDescendantOrShadowDescendantOf(focused)) {
+    RefPtr focused = document().focusedElement();
+    RefPtr composition = compositionNode();
+    if (composition && focused && !composition->isDescendantOrShadowDescendantOf(*focused)) {
         cancelComposition();
-        document().setFocusedElement(focused);
+        document().setFocusedElement(focused.get());
     } else
         confirmComposition();
 }

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -144,7 +144,7 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
         // Look for more radio buttons.
         if (!is<HTMLInputElement>(*node))
             continue;
-        RefPtr<HTMLInputElement> inputElement = downcast<HTMLInputElement>(node.get());
+        RefPtr inputElement = downcast<HTMLInputElement>(node);
         if (inputElement->form() != element()->form())
             break;
         if (inputElement->isRadioButton() && inputElement->name() == element()->name() && inputElement->isFocusable()) {

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2618,9 +2618,9 @@ void EventHandler::clearDragState()
 
 #endif // ENABLE(DRAG_SUPPORT)
 
-void EventHandler::setCapturingMouseEventsElement(Element* element)
+void EventHandler::setCapturingMouseEventsElement(RefPtr<Element>&& element)
 {
-    m_capturingMouseEventsElement = element;
+    m_capturingMouseEventsElement = WTFMove(element);
     m_eventHandlerWillResetCapturingMouseEventsElement = false;
 }
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -164,7 +164,7 @@ public:
     bool mousePressed() const { return m_mousePressed; }
     Node* mousePressNode() const { return m_mousePressNode.get(); }
 
-    WEBCORE_EXPORT void setCapturingMouseEventsElement(Element*);
+    WEBCORE_EXPORT void setCapturingMouseEventsElement(RefPtr<Element>&&);
     void pointerCaptureElementDidChange(Element*);
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -931,7 +931,7 @@ bool FocusController::setFocusedElement(Element* element, LocalFrame& newFocused
     RefPtr oldFocusedFrame { focusedFrame() };
     RefPtr oldDocument = oldFocusedFrame ? oldFocusedFrame->document() : nullptr;
     
-    Element* oldFocusedElement = oldDocument ? oldDocument->focusedElement() : nullptr;
+    RefPtr oldFocusedElement = oldDocument ? oldDocument->focusedElement() : nullptr;
     if (oldFocusedElement == element) {
         if (element)
             m_page.chrome().client().elementDidRefocus(*element, options);
@@ -944,7 +944,7 @@ bool FocusController::setFocusedElement(Element* element, LocalFrame& newFocused
 
     m_page.editorClient().willSetInputMethodState();
 
-    if (shouldClearSelectionWhenChangingFocusedElement(m_page, oldFocusedElement, element))
+    if (shouldClearSelectionWhenChangingFocusedElement(m_page, WTFMove(oldFocusedElement), element))
         clearSelectionIfNeeded(oldFocusedFrame.get(), &newFocusedFrame, element);
 
     if (!element) {
@@ -954,7 +954,7 @@ bool FocusController::setFocusedElement(Element* element, LocalFrame& newFocused
         return true;
     }
 
-    Ref<Document> newDocument(element->document());
+    Ref newDocument(element->document());
 
     if (newDocument->focusedElement() == element) {
         m_page.editorClient().setInputMethodState(element);
@@ -969,8 +969,6 @@ bool FocusController::setFocusedElement(Element* element, LocalFrame& newFocused
         return false;
     }
     setFocusedFrame(&newFocusedFrame);
-
-    Ref<Element> protect(*element);
 
     bool successfullyFocused = newDocument->setFocusedElement(element, options);
     if (!successfullyFocused)

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -416,32 +416,32 @@ void RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent(Event* event)
     if (!is<MouseEvent>(*event))
         return;
 
-    MouseEvent& mouseEvent = downcast<MouseEvent>(*event);
-    HTMLPlugInElement& element = downcast<HTMLPlugInElement>(frameOwnerElement());
-    if (mouseEvent.type() == eventNames().mousedownEvent && mouseEvent.button() == LeftButton) {
+    Ref mouseEvent = downcast<MouseEvent>(*event);
+    Ref element = downcast<HTMLPlugInElement>(frameOwnerElement());
+    if (mouseEvent->type() == eventNames().mousedownEvent && mouseEvent->button() == LeftButton) {
         m_mouseDownWasInUnavailablePluginIndicator = isInUnavailablePluginIndicator(mouseEvent);
         if (m_mouseDownWasInUnavailablePluginIndicator) {
-            frame().eventHandler().setCapturingMouseEventsElement(&element);
-            element.setIsCapturingMouseEvents(true);
+            frame().eventHandler().setCapturingMouseEventsElement(element.copyRef());
+            element->setIsCapturingMouseEvents(true);
             setUnavailablePluginIndicatorIsPressed(true);
         }
-        mouseEvent.setDefaultHandled();
+        mouseEvent->setDefaultHandled();
     }
-    if (mouseEvent.type() == eventNames().mouseupEvent && mouseEvent.button() == LeftButton) {
+    if (mouseEvent->type() == eventNames().mouseupEvent && mouseEvent->button() == LeftButton) {
         if (m_unavailablePluginIndicatorIsPressed) {
             frame().eventHandler().setCapturingMouseEventsElement(nullptr);
-            element.setIsCapturingMouseEvents(false);
+            element->setIsCapturingMouseEvents(false);
             setUnavailablePluginIndicatorIsPressed(false);
         }
         if (m_mouseDownWasInUnavailablePluginIndicator && isInUnavailablePluginIndicator(mouseEvent)) {
-            page().chrome().client().unavailablePluginButtonClicked(element, m_pluginUnavailabilityReason);
+            page().chrome().client().unavailablePluginButtonClicked(element.get(), m_pluginUnavailabilityReason);
         }
         m_mouseDownWasInUnavailablePluginIndicator = false;
         event->setDefaultHandled();
     }
-    if (mouseEvent.type() == eventNames().mousemoveEvent) {
+    if (mouseEvent->type() == eventNames().mousemoveEvent) {
         setUnavailablePluginIndicatorIsPressed(m_mouseDownWasInUnavailablePluginIndicator && isInUnavailablePluginIndicator(mouseEvent));
-        mouseEvent.setDefaultHandled();
+        mouseEvent->setDefaultHandled();
     }
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExecutionContextIdentifier identifier)
 {
-    auto* document = Document::allDocumentsMap().get(identifier);
+    RefPtr document = Document::allDocumentsMap().get(identifier);
     if (!document)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -60,6 +60,15 @@ private:
     }
 };
 
+LibWebRTCProvider::LibWebRTCProvider(WebPage& webPage)
+    : m_webPage(webPage)
+{
+    m_useNetworkThreadWithSocketServer = false;
+    m_supportsMDNS = true;
+}
+
+LibWebRTCProvider::~LibWebRTCProvider() = default;
+
 rtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::createPeerConnection(ScriptExecutionContextIdentifier identifier, webrtc::PeerConnectionObserver& observer, rtc::PacketSocketFactory* socketFactory, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration)
 {
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA) && !PLATFORM(MACCATALYST)
@@ -155,9 +164,10 @@ void LibWebRTCProvider::startedNetworkThread()
 
 std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::createSocketFactory(String&& userAgent, ScriptExecutionContextIdentifier identifier, bool isFirstParty, RegistrableDomain&& domain)
 {
-    auto factory = makeUnique<RTCSocketFactory>(m_webPage.webPageProxyIdentifier(), WTFMove(userAgent), identifier, isFirstParty, WTFMove(domain));
+    Ref webPage { m_webPage.get() };
+    auto factory = makeUnique<RTCSocketFactory>(webPage->webPageProxyIdentifier(), WTFMove(userAgent), identifier, isFirstParty, WTFMove(domain));
 
-    auto* page = m_webPage.corePage();
+    auto* page = webPage->corePage();
     if (!page || !page->settings().webRTCSocketsProxyingEnabled())
         factory->disableRelay();
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -33,6 +33,8 @@
 
 #if USE(LIBWEBRTC)
 
+#include <wtf/CheckedRef.h>
+
 #if PLATFORM(COCOA)
 #include <WebCore/LibWebRTCProviderCocoa.h>
 #elif USE(GSTREAMER)
@@ -61,6 +63,7 @@ using LibWebRTCProviderBase = WebCore::LibWebRTCProvider;
 class LibWebRTCProvider final : public LibWebRTCProviderBase {
 public:
     explicit LibWebRTCProvider(WebPage&);
+    ~LibWebRTCProvider();
 
 private:
     std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, WebCore::ScriptExecutionContextIdentifier, bool /* isFirstParty */, WebCore::RegistrableDomain&&) final;
@@ -74,15 +77,8 @@ private:
 
     void willCreatePeerConnectionFactory() final;
 
-    WebPage& m_webPage;
+    CheckedRef<WebPage> m_webPage;
 };
-
-inline LibWebRTCProvider::LibWebRTCProvider(WebPage& webPage)
-    : m_webPage(webPage)
-{
-    m_useNetworkThreadWithSocketServer = false;
-    m_supportsMDNS = true;
-}
 
 inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage& page)
 {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -40,7 +40,8 @@ namespace WebKit {
 void LibWebRTCResolver::sendOnMainThread(Function<void(IPC::Connection&)>&& callback)
 {
     callOnMainRunLoop([callback = WTFMove(callback)]() {
-        callback(WebProcess::singleton().ensureNetworkProcessConnection().connection());
+        Ref networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        callback(networkProcessConnection);
     });
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -124,7 +124,7 @@ int LibWebRTCSocket::SendTo(const void *value, size_t size, const rtc::SocketAdd
 
 int LibWebRTCSocket::Close()
 {
-    auto* connection = m_factory.connection();
+    RefPtr connection = m_factory.connection();
     if (!connection || m_state == STATE_CLOSED)
         return 0;
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -50,15 +50,15 @@ static inline rtc::SocketAddress prepareSocketAddress(const rtc::SocketAddress& 
 void LibWebRTCSocketFactory::setConnection(RefPtr<IPC::Connection>&& connection)
 {
     ASSERT(!WTF::isMainRunLoop());
-    m_connection = WTFMove(connection);
+    m_connection = connection.copyRef();
     if (!m_connection)
         return;
 
-    m_connection->send(Messages::NetworkRTCProvider::SetPlatformTCPSocketsEnabled(DeprecatedGlobalSettings::webRTCPlatformTCPSocketsEnabled()), 0);
-    m_connection->send(Messages::NetworkRTCProvider::SetPlatformUDPSocketsEnabled(DeprecatedGlobalSettings::webRTCPlatformUDPSocketsEnabled()), 0);
+    connection->send(Messages::NetworkRTCProvider::SetPlatformTCPSocketsEnabled(DeprecatedGlobalSettings::webRTCPlatformTCPSocketsEnabled()), 0);
+    connection->send(Messages::NetworkRTCProvider::SetPlatformUDPSocketsEnabled(DeprecatedGlobalSettings::webRTCPlatformUDPSocketsEnabled()), 0);
 
     while (!m_pendingMessageTasks.isEmpty())
-        m_pendingMessageTasks.takeFirst()(*m_connection);
+        m_pendingMessageTasks.takeFirst()(*connection);
 }
 
 IPC::Connection* LibWebRTCSocketFactory::connection()

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -58,8 +58,10 @@ using namespace WebCore;
 static bool sendMessage(WebPage* page, const Function<bool(IPC::Connection&, uint64_t)>& sendMessage)
 {
 #if ENABLE(BUILT_IN_NOTIFICATIONS)
-    if (DeprecatedGlobalSettings::builtInNotificationsEnabled())
-        return sendMessage(WebProcess::singleton().ensureNetworkProcessConnection().connection(), WebProcess::singleton().sessionID().toUInt64());
+    if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
+        Ref networkProcessConnection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        return sendMessage(networkProcessConnection, WebProcess::singleton().sessionID().toUInt64());
+    }
 #endif
 
     std::optional<WebCore::PageIdentifier> pageIdentifier;
@@ -74,7 +76,8 @@ static bool sendMessage(WebPage* page, const Function<bool(IPC::Connection&, uin
 #endif
 
     ASSERT(pageIdentifier);
-    return sendMessage(*WebProcess::singleton().parentProcessConnection(), pageIdentifier->toUInt64());
+    Ref parentConnection = *WebProcess::singleton().parentProcessConnection();
+    return sendMessage(parentConnection, pageIdentifier->toUInt64());
 }
 
 template<typename U> static bool sendNotificationMessage(U&& message, WebPage* page)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -31,10 +31,12 @@
 #include <WebCore/EventListener.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class Document;
 class Element;
+class WeakPtrImplWithEventTargetData;
 }
 
 OBJC_CLASS PDFAnnotation;
@@ -60,15 +62,14 @@ public:
 
 protected:
     PDFPluginAnnotation(PDFAnnotation *annotation, PDFLayerController *pdfLayerController, PDFPlugin* plugin)
-        : m_parent(0)
-        , m_annotation(annotation)
+        : m_annotation(annotation)
         , m_eventListener(PDFPluginAnnotationEventListener::create(this))
         , m_pdfLayerController(pdfLayerController)
         , m_plugin(plugin)
     {
     }
 
-    WebCore::Element* parent() const { return m_parent; }
+    WebCore::Element* parent() const { return m_parent.get(); }
     PDFLayerController *pdfLayerController() const { return m_pdfLayerController; }
     WebCore::EventListener* eventListener() const { return m_eventListener.get(); }
 
@@ -99,7 +100,7 @@ private:
         PDFPluginAnnotation* m_annotation;
     };
 
-    WebCore::Element* m_parent;
+    WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_parent;
 
     RefPtr<WebCore::Element> m_element;
     RetainPtr<PDFAnnotation> m_annotation;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -67,19 +67,20 @@ void PDFPluginAnnotation::attach(Element* parent)
     ASSERT(!m_parent);
 
     m_parent = parent;
-    m_element = createAnnotationElement();
+    Ref element = createAnnotationElement();
+    m_element = element.copyRef();
 
-    m_element->setAttributeWithoutSynchronization(classAttr, "annotation"_s);
-    m_element->setAttributeWithoutSynchronization(x_apple_pdf_annotationAttr, "true"_s);
-    m_element->addEventListener(eventNames().changeEvent, *m_eventListener, false);
-    m_element->addEventListener(eventNames().blurEvent, *m_eventListener, false);
+    element->setAttributeWithoutSynchronization(classAttr, "annotation"_s);
+    element->setAttributeWithoutSynchronization(x_apple_pdf_annotationAttr, "true"_s);
+    element->addEventListener(eventNames().changeEvent, *m_eventListener, false);
+    element->addEventListener(eventNames().blurEvent, *m_eventListener, false);
 
     updateGeometry();
 
-    m_parent->appendChild(*m_element);
+    RefPtr { m_parent.get() }->appendChild(element);
 
     // FIXME: The text cursor doesn't blink after this. Why?
-    m_element->focus();
+    element->focus();
 }
 
 void PDFPluginAnnotation::commit()

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -53,7 +53,7 @@ void PDFPluginChoiceAnnotation::updateGeometry()
 {
     PDFPluginAnnotation::updateGeometry();
 
-    StyledElement* styledElement = static_cast<StyledElement*>(element());
+    RefPtr styledElement = downcast<StyledElement>(element());
     styledElement->setInlineStyleProperty(CSSPropertyFontSize, choiceAnnotation().font.pointSize * pdfLayerController().contentScaleFactor, CSSUnitType::CSS_PX);
 }
 
@@ -66,31 +66,29 @@ void PDFPluginChoiceAnnotation::commit()
 
 Ref<Element> PDFPluginChoiceAnnotation::createAnnotationElement()
 {
-    Document& document = parent()->document();
+    Ref document = parent()->document();
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     PDFAnnotationChoiceWidget *choiceAnnotation = this->choiceAnnotation();
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    auto element = document.createElement(selectTag, false);
-
-    auto& styledElement = downcast<StyledElement>(element.get());
+    Ref element = downcast<StyledElement>(document->createElement(selectTag, false));
 
     // FIXME: Match font weight and style as well?
-    styledElement.setInlineStyleProperty(CSSPropertyColor, serializationForHTML(colorFromCocoaColor(choiceAnnotation.fontColor)));
-    styledElement.setInlineStyleProperty(CSSPropertyFontFamily, choiceAnnotation.font.familyName);
+    element->setInlineStyleProperty(CSSPropertyColor, serializationForHTML(colorFromCocoaColor(choiceAnnotation.fontColor)));
+    element->setInlineStyleProperty(CSSPropertyFontFamily, choiceAnnotation.font.familyName);
 
     NSArray *choices = choiceAnnotation.choices;
     NSString *selectedChoice = choiceAnnotation.stringValue;
 
     for (NSString *choice in choices) {
-        auto choiceOption = document.createElement(optionTag, false);
+        auto choiceOption = document->createElement(optionTag, false);
         choiceOption->setAttributeWithoutSynchronization(valueAttr, choice);
         choiceOption->setTextContent(choice);
 
         if (choice == selectedChoice)
             choiceOption->setAttributeWithoutSynchronization(selectedAttr, "selected"_s);
 
-        styledElement.appendChild(choiceOption);
+        element->appendChild(choiceOption);
     }
 
     return element;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -203,7 +203,7 @@ void SpeechRecognitionRealtimeMediaSourceManager::createSource(RealtimeMediaSour
     }
 
     ASSERT(!m_sources.contains(identifier));
-    m_sources.add(identifier, makeUnique<Source>(identifier, result.source(), *messageSenderConnection()));
+    m_sources.add(identifier, makeUnique<Source>(identifier, result.source(), m_connection.copyRef()));
 }
 
 void SpeechRecognitionRealtimeMediaSourceManager::deleteSource(RealtimeMediaSourceIdentifier identifier)

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -396,7 +396,7 @@ void WebSWClientConnection::notifyRecordResponseBodyEnd(RetrieveRecordResponseBo
 
 void WebSWClientConnection::focusServiceWorkerClient(ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(std::optional<ServiceWorkerClientData>&&)>&& callback)
 {
-    auto* client = Document::allDocumentsMap().get(clientIdentifier);
+    RefPtr client = Document::allDocumentsMap().get(clientIdentifier);
     auto* page = client ? client->page() : nullptr;
     if (!page) {
         callback({ });
@@ -404,14 +404,14 @@ void WebSWClientConnection::focusServiceWorkerClient(ScriptExecutionContextIdent
     }
 
     WebPage::fromCorePage(*page)->sendWithAsyncReply(Messages::WebPageProxy::FocusFromServiceWorker { }, [clientIdentifier, callback = WTFMove(callback)]() mutable {
-        auto* client = Document::allDocumentsMap().get(clientIdentifier);
-        auto* frame = client ? client->frame() : nullptr;
+        RefPtr client = Document::allDocumentsMap().get(clientIdentifier);
+        RefPtr frame = client ? client->frame() : nullptr;
         auto* page = frame ? frame->page() : nullptr;
         if (!page) {
             callback({ });
             return;
         }
-        page->focusController().setFocusedFrame(frame);
+        page->focusController().setFocusedFrame(frame.get());
         callback(ServiceWorkerClientData::from(*client));
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5095,7 +5095,7 @@ void WebPage::textInputContextsInRect(FloatRect searchRect, CompletionHandler<vo
 
 void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementContext, const IntPoint& point, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto target = elementForContext(elementContext);
+    RefPtr target = elementForContext(elementContext);
     if (!target) {
         completionHandler(false);
         return;

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -3767,7 +3767,7 @@ static RetainPtr<NSArray> customMenuFromDefaultItems(WebView *webView, const Web
     if (!document)
         return;
     
-    document->setFocusedElement(0);
+    document->setFocusedElement(nullptr);
 }
 
 - (BOOL)isOpaque
@@ -4602,7 +4602,7 @@ static RefPtr<WebCore::KeyboardEvent> currentKeyboardEvent(WebCore::LocalFrame* 
         return YES;
 
     if (auto* document = frame->document())
-        document->setFocusedElement(0);
+        document->setFocusedElement(nullptr);
     page->focusController().setInitialFocus(direction == NSSelectingNext ? WebCore::FocusDirection::Forward : WebCore::FocusDirection::Backward,
                                              currentKeyboardEvent(frame).get());
     return YES;


### PR DESCRIPTION
#### 7763e295bcf62a0fd798c716a36684bcab236162
<pre>
Use more smart pointers in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261518">https://bugs.webkit.org/show_bug.cgi?id=261518</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focus):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setFocusedElementIfNeeded):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::confirmMarkedText):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::handleKeydownEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::setCapturingMouseEventsElement):
(WebCore::EventHandler::dispatchMouseEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedElement):
* Source/WebCore/page/FocusController.h:
(WebCore::FocusController::setFocusedElement):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragmentInternal):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::getOrCreate):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::createSocketFactory):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
(WebKit::LibWebRTCResolver::sendOnMainThread):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::Close):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::setConnection):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendMessage):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject parent]):
(-[WKPDFPluginAccessibilityObject accessibilityFocusedUIElement]):
(-[WKPDFPluginAccessibilityObject accessibilityAssociatedControlForAnnotation:]):
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::getResourceBytesAtPosition):
(WebKit::PDFPlugin::jsPDFDocPrint):
(WebKit::PDFPlugin::handleContextMenuEvent):
(WebKit::PDFPlugin::isFullFramePlugin const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
(WebKit::PDFPluginAnnotation::PDFPluginAnnotation):
(WebKit::PDFPluginAnnotation::parent const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::attach):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::updateGeometry):
(WebKit::PDFPluginChoiceAnnotation::createAnnotationElement):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::handleEvent):
(WebKit::PluginView::clipRectInWindowCoordinates const):
(WebKit::PluginView::focusPluginElement):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::createSource):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::focusServiceWorkerClient):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView clearFocus]):
(-[WebHTMLView becomeFirstResponder]):

Canonical link: <a href="https://commits.webkit.org/267992@main">https://commits.webkit.org/267992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf55e15fb24d9bb4f133aa8bcdebdbd6be2d249

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18770 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21005 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23170 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21059 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17411 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16507 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4361 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->