### PR TITLE
[WGSL] Fix source locations

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -52,7 +52,6 @@ public:
 
     Vector<Token> lex();
     bool isAtEndOfFile() const;
-    SourcePosition currentPosition() const { return m_currentPosition; }
 
 private:
     Token nextToken();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -66,10 +66,10 @@ struct TemplateTypes<TT> {
 };
 
 #define START_PARSE() \
-    auto _startOfElementPosition = m_lexer.currentPosition();
+    auto _startOfElementPosition = m_currentPosition;
 
 #define CURRENT_SOURCE_SPAN() \
-    SourceSpan(_startOfElementPosition, m_lexer.currentPosition())
+    SourceSpan(_startOfElementPosition, m_currentPosition)
 
 #define MAKE_ARENA_NODE(type, ...) \
     m_builder.construct<AST::type>(CURRENT_SOURCE_SPAN() __VA_OPT__(,) __VA_ARGS__) /* NOLINT */
@@ -345,6 +345,7 @@ void Parser<Lexer>::consume()
 {
     do {
         m_current = m_tokens[++m_currentTokenIndex];
+        m_currentPosition = SourcePosition { m_current.span.line, m_current.span.lineOffset, m_current.span.offset };
     } while (m_current.type == TokenType::Placeholder);
 }
 
@@ -1327,7 +1328,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePostfixExpression(AST::Expressi
             PARSE(arrayIndex, Expression);
             CONSUME_TYPE(BracketRight);
             // FIXME: Replace with NODE_REF(...)
-            SourceSpan span(startPosition, m_lexer.currentPosition());
+            SourceSpan span(startPosition, m_currentPosition);
             expr = m_builder.construct<AST::IndexAccessExpression>(span, WTFMove(expr), WTFMove(arrayIndex));
             break;
         }
@@ -1336,7 +1337,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePostfixExpression(AST::Expressi
             consume();
             PARSE(fieldName, Identifier);
             // FIXME: Replace with NODE_REF(...)
-            SourceSpan span(startPosition, m_lexer.currentPosition());
+            SourceSpan span(startPosition, m_currentPosition);
             expr = m_builder.construct<AST::FieldAccessExpression>(span, WTFMove(expr), WTFMove(fieldName));
             break;
         }

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -50,6 +50,7 @@ public:
         , m_lexer(lexer)
         , m_tokens(m_lexer.lex())
         , m_current(m_tokens[0])
+        , m_currentPosition({ m_current.span.line, m_current.span.lineOffset, m_current.span.offset })
     {
     }
 
@@ -113,6 +114,7 @@ private:
     Vector<Token> m_tokens;
     unsigned m_currentTokenIndex { 0 };
     Token m_current;
+    SourcePosition m_currentPosition;
 };
 
 } // namespace WGSL

--- a/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
@@ -28,6 +28,7 @@
 #include "AST.h"
 #include "ParserPrivate.h"
 #include "WGSLShaderModule.h"
+#include <wtf/DataLog.h>
 
 static Expected<std::pair<WGSL::ShaderModule, WGSL::AST::Expression::Ref>, WGSL::Error> parseLCharPrimaryExpression(const String& input)
 {
@@ -68,7 +69,7 @@ TEST(WGSLConstLiteralTests, BoolLiteral)
         const auto& intLiteral = downcast<AST::BoolLiteral>(expr);
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(intLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
+        EXPECT_EQ(intLiteral.span(), SourceSpan(1, 0, 0, inputLength));
     }
 }
 
@@ -92,7 +93,7 @@ TEST(WGSLConstLiteralTests, AbstractIntegerLiteralDecimal)
         const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr);
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(intLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
+        EXPECT_EQ(intLiteral.span(), SourceSpan(1, 0, 0, inputLength));
     }
 }
 
@@ -116,7 +117,7 @@ TEST(WGSLConstLiteralTests, AbstractIntegerLiteralHex)
         const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr);
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(intLiteral.span(), WGSL::SourceSpan(1, inputLength, inputLength, 0));
+        EXPECT_EQ(intLiteral.span(), WGSL::SourceSpan(1, 0, 0, inputLength));
     }
 }
 
@@ -145,7 +146,7 @@ TEST(WGSLConstLiteralTests, AbstractFloatLiteralDec)
         const auto& floatLiteral = downcast<AST::AbstractFloatLiteral>(expr);
         EXPECT_EQ(floatLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
-        EXPECT_EQ(floatLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
+        EXPECT_EQ(floatLiteral.span(), SourceSpan(1, 0, 0, inputLength));
     }
 }
 


### PR DESCRIPTION
#### 0c11a59de5ef49334ab3c619753ca3f482018e17
<pre>
[WGSL] Fix source locations
<a href="https://bugs.webkit.org/show_bug.cgi?id=261521">https://bugs.webkit.org/show_bug.cgi?id=261521</a>
rdar://115438296

Reviewed by Dan Glastonbury.

In 267855@main I implemented template disambiguation, which required changing how
we handle tokens: instead of consuming them progressively as we parse, we now need
to generate a list of tokens upfront. However, the parser was still using the lexer&apos;s
current position in order to assign source locations to AST nodes, but since all the
lexing was done upfront the current location was always the end of the file. In order
to fix it we keep track of the current location in the parser itself, instead of
consulting the lexer.

* Source/WebGPU/WGSL/Lexer.h:
(WGSL::Lexer::currentPosition const): Deleted.
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::consume):
(WGSL::Parser&lt;Lexer&gt;::parsePostfixExpression):
* Source/WebGPU/WGSL/ParserPrivate.h:

Canonical link: <a href="https://commits.webkit.org/267985@main">https://commits.webkit.org/267985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33b2981f04ad2b134bb4525690255950b69d9663

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18276 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19039 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20999 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23163 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21053 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14763 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16501 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4353 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->