### PR TITLE
Regression(262976@main) Images do not show in Microsoft Word Online

### DIFF
--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -200,7 +200,7 @@ static std::optional<Vector<uint8_t, 0, CrashOnOverflow, 16, Malloc>> base64Deco
                 if (equalsSignCount)
                     return std::nullopt;
                 destination[destinationLength++] = decodedCharacter;
-            } else if (mode != Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace || !isASCIIWhitespace(ch))
+            } else if ((mode != Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace && mode != Base64DecodeMode::DefaultIgnoreWhitespaceForQuirk) || !isASCIIWhitespace(ch))
                 return std::nullopt;
         }
     }

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -42,7 +42,9 @@ enum class Base64EncodeMode : bool { Default, URL };
 //   enforce a correct number of trailing equal signs in the input.
 // - ::DefaultValidatePaddingAndIgnoreWhitespace ignores ASCII whitespace in
 //   the input. It matches <https://infra.spec.whatwg.org/#forgiving-base64>.
-enum class Base64DecodeMode { DefaultIgnorePadding, DefaultValidatePadding, DefaultValidatePaddingAndIgnoreWhitespace, URL };
+// - ::DefaultIgnoreWhitespaceForQuirk, URL ignores ASCII whitespace in the
+//   input but doesn't validate padding. It is currently only used for quirks.
+enum class Base64DecodeMode { DefaultIgnorePadding, DefaultValidatePadding, DefaultValidatePaddingAndIgnoreWhitespace, DefaultIgnoreWhitespaceForQuirk, URL };
 
 struct Base64Specification {
     std::span<const std::byte> input;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1568,4 +1568,15 @@ bool Quirks::shouldStarBeFeaturePolicyDefaultValue() const
     return *m_shouldStarBeFeaturePolicyDefaultValueQuirk;
 }
 
+// Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
+bool Quirks::shouldDisableDataURLPaddingValidation() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldDisableDataURLPaddingValidation)
+        m_shouldDisableDataURLPaddingValidation = m_document->url().host().endsWith("officeapps.live.com"_s);
+    return *m_shouldDisableDataURLPaddingValidation;
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -173,6 +173,7 @@ public:
     bool needsResettingTransitionCancelsRunningTransitionQuirk() const;
 
     bool shouldStarBeFeaturePolicyDefaultValue() const;
+    bool shouldDisableDataURLPaddingValidation() const;
 
 private:
     bool needsQuirks() const;
@@ -235,6 +236,7 @@ private:
     bool m_needsConfigurableIndexedPropertiesQuirk { false };
     bool m_needsToCopyUserSelectNoneQuirk { false };
     mutable std::optional<bool> m_shouldStarBeFeaturePolicyDefaultValueQuirk;
+    mutable std::optional<bool> m_shouldDisableDataURLPaddingValidation;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/DataURLDecoder.h
+++ b/Source/WebCore/platform/network/DataURLDecoder.h
@@ -51,8 +51,10 @@ struct ScheduleContext {
 #endif
 };
 
-WEBCORE_EXPORT void decode(const URL&, const ScheduleContext&, DecodeCompletionHandler&&);
-WEBCORE_EXPORT std::optional<Result> decode(const URL&);
+enum class ShouldValidatePadding : bool { No, Yes };
+
+WEBCORE_EXPORT void decode(const URL&, const ScheduleContext&, ShouldValidatePadding, DecodeCompletionHandler&&);
+WEBCORE_EXPORT std::optional<Result> decode(const URL&, ShouldValidatePadding = ShouldValidatePadding::Yes);
 
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -77,7 +77,7 @@ void NetworkDataTaskDataURL::resume()
 
     m_state = State::Running;
 
-    DataURLDecoder::decode(firstRequest().url(), { }, [this, protectedThis = Ref { *this }](auto decodeResult) mutable {
+    DataURLDecoder::decode(firstRequest().url(), { }, DataURLDecoder::ShouldValidatePadding::Yes, [this, protectedThis = Ref { *this }](auto decodeResult) mutable {
         if (m_state == State::Canceling || m_state == State::Completed)
             return;
 


### PR DESCRIPTION
#### 599c092f0fc9b57c1a68f5f35208d722adc762cb
<pre>
Regression(262976@main) Images do not show in Microsoft Word Online
<a href="https://bugs.webkit.org/show_bug.cgi?id=261524">https://bugs.webkit.org/show_bug.cgi?id=261524</a>
rdar://114573089

Reviewed by Brent Fulgham.

Images do not show in Microsoft Word Online since the data URL change in 262976@main.
It is a surprising since 262976@main was meant to align us with other browsers and yet
images show correctly in Chrome &amp; Firefox.

After some investigation, I found that the data URL used by Word Online for images in
Safari have incorrect padding, while the ones it uses in Chrome have correct padding.
As a result, it doesn&apos;t appear to be a WebKit bug but rather Safari getting served
different content than Chrome for some reason.

To address the issue, I am introducing a quirk to disable padding validation in data
URLs on Microsoft Word Online.

* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64DecodeInternal):
* Source/WTF/wtf/text/Base64.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::loadDataURL):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableDataURLPaddingValidation const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::DecodeTask::DecodeTask):
(WebCore::DataURLDecoder::createDecodeTask):
(WebCore::DataURLDecoder::decodeSynchronously):
(WebCore::DataURLDecoder::decode):
* Source/WebCore/platform/network/DataURLDecoder.h:

Canonical link: <a href="https://commits.webkit.org/267969@main">https://commits.webkit.org/267969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a60fb3055d4458a309e11c1a801d2942b47d49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18696 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20928 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16602 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15778 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20990 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21563 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16435 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5281 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4340 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20799 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22796 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17190 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5128 "Passed tests") | 
<!--EWS-Status-Bubble-End-->