### PR TITLE
LinkDecorationFilteringData should use the new serialization format

### DIFF
--- a/Source/WebCore/page/LinkDecorationFilteringData.h
+++ b/Source/WebCore/page/LinkDecorationFilteringData.h
@@ -66,27 +66,6 @@ struct LinkDecorationFilteringData {
         linkDecoration = WTFMove(data.linkDecoration);
         return *this;
     }
-
-    template<class Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << domain;
-        encoder << linkDecoration;
-    }
-
-    template<class Decoder> static std::optional<LinkDecorationFilteringData> decode(Decoder& decoder)
-    {
-        std::optional<RegistrableDomain> domain;
-        decoder >> domain;
-        if (!domain)
-            return std::nullopt;
-
-        std::optional<String> linkDecoration;
-        decoder >> linkDecoration;
-        if (!linkDecoration)
-            return std::nullopt;
-
-        return { { WTFMove(*domain), WTFMove(*linkDecoration) } };
-    }
 };
 
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5885,8 +5885,12 @@ using WebCore::FontSelectionValue::BackingType = int16_t;
     std::optional<WebCore::FontSelectionRange> slope;
 };
 
-header: <WebCore/RemoteMouseEventData.h>
 struct WebCore::RemoteMouseEventData {
     WebCore::FrameIdentifier targetFrameID;
     WebCore::IntPoint transformedPoint;
+};
+
+struct WebCore::LinkDecorationFilteringData {
+    WebCore::RegistrableDomain domain;
+    String linkDecoration;
 };


### PR DESCRIPTION
#### 8c8f60c068a856727cdc79ac2bff45c70a20d230
<pre>
LinkDecorationFilteringData should use the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=261520">https://bugs.webkit.org/show_bug.cgi?id=261520</a>
rdar://115437892

Reviewed by Aditya Keerthi.

Also a drive by fix to remove the unnecessary header for the `RemoteMouseEventData` struct above.

* Source/WebCore/page/LinkDecorationFilteringData.h:
(WebCore::LinkDecorationFilteringData::operator=):
(WebCore::LinkDecorationFilteringData::encode const): Deleted.
(WebCore::LinkDecorationFilteringData::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/267974@main">https://commits.webkit.org/267974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39ca053e52700a7d806cd3869e5362ecec69e44f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20057 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20940 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18375 "Found 1 webkitpy python3 test failure: webkitpy.w3c.test_converter_unittest.W3CTestConverterTest.test_convert_prefixed_properties") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16612 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/16893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16783 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/18057 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16445 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20809 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->