### PR TITLE
[css-grid] getBaselineChild should consider both first and last baseline aligned grid items.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-001-expected.txt
@@ -3,13 +3,9 @@ PASS .target > * 1
 PASS .target > * 2
 PASS .target > * 3
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-y="55"><span></span></div>
-offsetTop expected 55 but got 25
+PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-y="115"><span></span></div>
-offsetTop expected 115 but got 90
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt
@@ -5,13 +5,11 @@ FAIL .target > * 3 assert_equals:
 <div data-offset-x="48"><span></span></div>
 offsetLeft expected 48 but got 47
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-x="90"><span></span></div>
-offsetLeft expected 90 but got 115
+PASS .target > * 5
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 52
+offsetLeft expected 33 but got 32
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt
@@ -5,13 +5,11 @@ FAIL .target > * 3 assert_equals:
 <div data-offset-x="93"><span></span></div>
 offsetLeft expected 93 but got 92
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-x="50"><span></span></div>
-offsetLeft expected 50 but got 25
+PASS .target > * 5
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="108"><span></span></div>
-offsetLeft expected 108 but got 87
+offsetLeft expected 108 but got 107
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001-expected.txt
@@ -3,13 +3,9 @@ PASS .target > * 1
 PASS .target > * 2
 PASS .target > * 3
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-y="55"><span></span></div>
-offsetTop expected 55 but got 25
+PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-y="115"><span></span></div>
-offsetTop expected 115 but got 90
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt
@@ -5,13 +5,11 @@ FAIL .target > * 3 assert_equals:
 <div data-offset-x="48"><span></span></div>
 offsetLeft expected 48 but got 47
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-x="90"><span></span></div>
-offsetLeft expected 90 but got 115
+PASS .target > * 5
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="33"><span></span></div>
-offsetLeft expected 33 but got 52
+offsetLeft expected 33 but got 32
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt
@@ -5,13 +5,11 @@ FAIL .target > * 3 assert_equals:
 <div data-offset-x="93"><span></span></div>
 offsetLeft expected 93 but got 92
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-x="50"><span></span></div>
-offsetLeft expected 50 but got 25
+PASS .target > * 5
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="108"><span></span></div>
-offsetLeft expected 108 but got 87
+offsetLeft expected 108 but got 107
 PASS .target > * 8
 PASS .target > * 9
 PASS .target > * 10

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -30,6 +30,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderGrid.h"
+#include "RenderStyleConstants.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {
@@ -192,6 +193,14 @@ bool isSubgridReversedDirection(const RenderGrid& grid, GridTrackSizingDirection
     GridTrackSizingDirection childDirection = flowAwareDirectionForChild(grid, subgrid, outerDirection);
     ASSERT(subgrid.isSubgrid(childDirection));
     return isFlippedDirection(grid, outerDirection) != isFlippedDirection(subgrid, childDirection);
+}
+
+unsigned alignmentContextForBaselineAlignment(const GridSpan& span, const ItemPosition& alignment)
+{
+    ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
+    if (alignment == ItemPosition::Baseline)
+        return span.startLine();
+    return span.endLine() - 1;
 }
 
 } // namespace GridLayoutFunctions

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+enum class ItemPosition : uint8_t;
 class RenderBox;
 class RenderElement;
 class RenderGrid;
@@ -54,6 +55,8 @@ std::optional<LayoutUnit> overridingContainingBlockContentSizeForChild(const Ren
 bool isFlippedDirection(const RenderGrid&, GridTrackSizingDirection);
 bool isSubgridReversedDirection(const RenderGrid&, GridTrackSizingDirection outerDirection, const RenderGrid& subgrid);
 LayoutUnit extraMarginForSubgridAncestors(GridTrackSizingDirection, const RenderBox& child);
+
+unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPosition& alignment);
 
 }
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -961,14 +961,6 @@ bool GridTrackSizingAlgorithm::participateInBaselineAlignment(const RenderBox& c
     return baselineAxis == GridColumnAxis ? m_columnBaselineItemsMap.get(&child) : m_rowBaselineItemsMap.get(&child);
 }
 
-static unsigned alignmentContextForBaselineAlignment(const GridSpan& span, const ItemPosition& alignment)
-{
-    ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
-    if (alignment == ItemPosition::Baseline)
-        return span.startLine();
-    return span.endLine() - 1;
-}
-
 void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& child, GridAxis baselineAxis)
 {
     ASSERT(wasSetup());
@@ -976,7 +968,7 @@ void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& c
 
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
-    auto alignmentContext = alignmentContextForBaselineAlignment(span, align);
+    auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
     m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, child, baselineAxis);
 }
 
@@ -992,7 +984,7 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& chi
 
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
-    auto alignmentContext = alignmentContextForBaselineAlignment(span, align);
+    auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
     return m_baselineAlignment.baselineOffsetForChild(align, alignmentContext, child, baselineAxis);
 }
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1806,20 +1806,20 @@ WeakPtr<RenderBox> RenderGrid::getBaselineChild(ItemPosition alignment) const
     ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
     const RenderBox* baselineChild = nullptr;
     unsigned numColumns = currentGrid().numTracks(ForColumns);
-    unsigned numRows = currentGrid().numTracks(ForRows);
-
+    auto rowIndexDeterminingBaseline = alignment == ItemPosition::Baseline ? 0 : currentGrid().numTracks(ForRows) - 1;
     for (size_t column = 0; column < numColumns; column++) {
-        auto cell = currentGrid().cell(0, column);
-        if (alignment == ItemPosition::LastBaseline)
-            cell = currentGrid().cell(numRows - 1, numColumns - column - 1);
+        auto cell = currentGrid().cell(rowIndexDeterminingBaseline, alignment == ItemPosition::Baseline ? column : numColumns - column - 1);
 
         for (auto& child : cell) {
             ASSERT(child.get());
             // If an item participates in baseline alignment, we select such item.
-            if (isBaselineAlignmentForChild(*child, GridColumnAxis, AllowedBaseLine::FirstLine)) {
-                // FIXME: self-baseline and content-baseline alignment not implemented yet.
-                baselineChild = child.get();
-                break;
+            if (isBaselineAlignmentForChild(*child, GridColumnAxis, AllowedBaseLine::BothLines)) {
+                auto gridItemAlignment = selfAlignmentForChild(GridAxis::GridColumnAxis, *child).position();
+                if (rowIndexDeterminingBaseline == GridLayoutFunctions::alignmentContextForBaselineAlignment(gridSpanForChild(*child, ForRows), gridItemAlignment)) {
+                    // FIXME: self-baseline and content-baseline alignment not implemented yet.
+                    baselineChild = child.get();
+                    break;
+                }
             }
             if (!baselineChild)
                 baselineChild = child.get();


### PR DESCRIPTION
#### b508fd690c0973b5824b82e26e6013e2b73b6470
<pre>
[css-grid] getBaselineChild should consider both first and last baseline aligned grid items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261523.">https://bugs.webkit.org/show_bug.cgi?id=261523.</a>
rdar://115441833.

Reviewed by Matt Woodrow.

getbaselineChild is responsible for selecting the correct grid item to
use when determining the baseline for the grid itself. The spec states:

The first (last) baselines of a grid container are determined as follows:
    1.) Find the first (last) row of the grid container containing at
        least one grid item.

    If any of the grid items intersecting this row participate in
    baseline alignment in that row, the grid containers baseline set is
    generated from the shared alignment baseline of those grid items.

Since the spec states that we should look for any grid items that
&quot;participate in baseline alignment in that row&quot; it seems like we should
also look at items that are being last baseline aligned.

In the case that an item spans multiple rows, we need to double check
the alignment context that it is participating in (which row) is the
same as the row we are using to determine the baseline (first row for
first baseline and last row for last baseline).

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-grid-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003-expected.txt:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::alignmentContextForBaselineAlignment):
* Source/WebCore/rendering/GridLayoutFunctions.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::updateBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForChild const):
(WebCore::alignmentContextForBaselineAlignment): Deleted.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::getBaselineChild const):

Canonical link: <a href="https://commits.webkit.org/268029@main">https://commits.webkit.org/268029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d0b072f23b657cc5f47e4f4349c9fde098c782

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20197 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18576 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18775 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21077 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23228 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21114 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14837 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16567 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4386 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->