### PR TITLE
[macOS] Support rendering native <progress> in vertical writing mode

### DIFF
--- a/LayoutTests/fast/forms/vertical-writing-mode/progress-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/progress-expected.html
@@ -1,0 +1,10 @@
+<style>
+
+progress {
+    transform: rotate(90deg) translate(0, -100%);
+    transform-origin: left top;
+}
+
+</style>
+<progress value="20" max="100"></progress>
+

--- a/LayoutTests/fast/forms/vertical-writing-mode/progress.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/progress.html
@@ -1,0 +1,9 @@
+<meta name="fuzzy" content="maxDifference=0-8; totalPixels=0-1"/>
+<style>
+
+progress {
+    writing-mode: vertical-lr;
+}
+
+</style>
+<progress value="20" max="100"></progress>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
@@ -1,6 +1,6 @@
 
 
 FAIL progress[style="writing-mode: horizontal-tb"] block size should match height and inline should match width assert_equals: expected "16px" but got "21px"
-PASS progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width
-PASS progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width
+FAIL progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width assert_equals: expected "16px" but got "21px"
+FAIL progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width assert_equals: expected "16px" but got "21px"
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -722,6 +722,8 @@ webkit.org/b/216853 css3/font-synthesis-small-caps.html [ ImageOnlyFailure ]
 webkit.org/b/221308 [ Debug ] fast/selectors/matches-backtracking.html [ Timeout ]
 webkit.org/b/221308 [ Debug ] fast/selectors/is-backtracking.html [ Timeout ]
 
+fast/forms/vertical-writing-mode/progress.html [ ImageOnlyFailure ]
+
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/line-box-height-vlr-011.xht [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/line-box-height-vlr-013.xht [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1179,6 +1179,8 @@ css3/color-filters/color-filter-caret-color.html [ Skip ]
 # Not relevant for iOS.
 css3/color-filters/color-filter-ignore-semantic.html [ Skip ]
 
+fast/forms/vertical-writing-mode/progress.html [ ImageOnlyFailure ]
+
 # WebCryptoAPI features that enabled only for iOS 11/High Sierra+
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha1.html [ Pass ]
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha224.html [ Pass ]

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -550,6 +550,8 @@ fast/gradients/conic-from-angle.html [ Pass ]
 fast/gradients/conic-two-hints.html [ Pass ]
 fast/gradients/conic-gradient-alpha.html [ ImageOnlyFailure ]
 
+fast/forms/vertical-writing-mode/progress.html [ ImageOnlyFailure ]
+
 [ Debug ] animations/CSSKeyframesRule-name-null.html [ Pass Timeout ]
 
 [ Debug ] css3/filters/filter-property-computed-style.html [ Pass Timeout ]


### PR DESCRIPTION
#### e105446b239e5bea36bb218c7392271e850da146
<pre>
[macOS] Support rendering native &lt;progress&gt; in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261493">https://bugs.webkit.org/show_bug.cgi?id=261493</a>
rdar://115408537

Reviewed by Tim Nguyen and Richard Robinson.

Add support for rendering `&lt;progress&gt;` with `appearance: auto` with a vertical
writing mode, by rotating the CoreUI image by 90 degrees. This approach is viable
since the image does not have any shadows or orientation specific behaviors.

* LayoutTests/fast/forms/vertical-writing-mode/progress-expected.html: Added.
* LayoutTests/fast/forms/vertical-writing-mode/progress.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt:

These subtests were previously incorrectly passing, as the minimum block size
was not actually being enforced with a vertical writing mode. Now, the vertical
writing mode fails the same way as the horizontal writing mode.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
(WebCore::ProgressBarMac::rectForBounds const):

Adjust `rectForBounds` to ensure a minimum block-size is enforced. Support for
vertical writing modes is not added at a &quot;lower-level&quot; (`controlSizeForFont`,
`cellSize`, `cellOutsets`), since all controls can not necessarily be rotated.

(WebCore::ProgressBarMac::draw):

Draw vertical progress bars into a horizontal buffer and rotate the context to
achieve a vertical appearance.

Canonical link: <a href="https://commits.webkit.org/267988@main">https://commits.webkit.org/267988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b68710af511e74fc73e0a4f32ef0629cd1ddee12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19028 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20985 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23150 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17390 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14749 "7 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4359 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->