### PR TITLE
Store less raw pointers in containers in Source/WebKit

### DIFF
--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -324,6 +324,24 @@ public:
         return *it;
     }
 
+    T& takeFirst()
+    {
+        auto it = begin();
+        auto& first = *it;
+        remove(it);
+        return first;
+    }
+
+    T* tryTakeFirst()
+    {
+        auto it = begin();
+        if (it == end())
+            return nullptr;
+        auto* first = it.get();
+        remove(it);
+        return first;
+    }
+
     T& last()
     {
         auto it = end();

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -114,7 +114,7 @@ public:
 #endif
 };
 
-class PlaybackSessionModelClient {
+class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient> {
 public:
     virtual ~PlaybackSessionModelClient() { };
     virtual void durationChanged(double) { }

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
@@ -97,7 +97,7 @@ public:
 #endif
 };
 
-class VideoFullscreenModelClient {
+class VideoFullscreenModelClient : public CanMakeWeakPtr<VideoFullscreenModelClient> {
 public:
     virtual ~VideoFullscreenModelClient() = default;
     virtual void hasVideoChanged(bool) { }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -49,8 +49,7 @@ class WebPlaybackSessionChangeObserver;
 
 class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit
     : public PlaybackSessionModelClient
-    , public RefCounted<PlaybackSessionInterfaceAVKit>
-    , public CanMakeWeakPtr<PlaybackSessionInterfaceAVKit> {
+    , public RefCounted<PlaybackSessionInterfaceAVKit> {
 
 public:
     static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel& model)

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -41,7 +41,7 @@ namespace WebKit {
 class NetworkLoadScheduler;
 class NetworkProcess;
 
-class NetworkLoad final : private NetworkDataTaskClient {
+class NetworkLoad final : public NetworkDataTaskClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     NetworkLoad(NetworkLoadClient&, NetworkLoadParameters&&, NetworkSession&);

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
@@ -31,7 +31,7 @@
 #include <tuple>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
-#include <wtf/ListHashSet.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -76,7 +76,7 @@ private:
 
     struct PendingMainResourcePreconnectInfo {
         unsigned pendingPreconnects {1};
-        ListHashSet<NetworkLoad *> pendingLoads;
+        WeakListHashSet<NetworkLoad> pendingLoads;
     };
     // Maps (protocolHostAndPort, userAgent) => PendingMainResourcePreconnectInfo.
     using PendingPreconnectMap = HashMap<std::tuple<String, String>, PendingMainResourcePreconnectInfo>;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
@@ -28,13 +28,14 @@
 #include "DatabaseUtilities.h"
 #include <WebCore/PrivateClickMeasurement.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit::PCM {
 
 struct DebugInfo;
 
 // This is created, used, and destroyed on the Store's queue.
-class Database : public DatabaseUtilities {
+class Database : public DatabaseUtilities, public CanMakeWeakPtr<Database> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     Database(const String& storageDirectory);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -32,6 +32,7 @@
 #include <WebCore/Region.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS CALayer;
 
@@ -81,7 +82,7 @@ struct BufferAndBackendInfo {
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, BufferAndBackendInfo&);
 };
 
-class RemoteLayerBackingStore {
+class RemoteLayerBackingStore : public CanMakeWeakPtr<RemoteLayerBackingStore> {
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStore);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -96,12 +96,12 @@ protected:
 
     RemoteLayerTreeContext& m_layerTreeContext;
 
-    HashSet<RemoteLayerBackingStore*> m_liveBackingStore;
-    HashSet<RemoteLayerBackingStore*> m_unparentedBackingStore;
+    WeakHashSet<RemoteLayerBackingStore> m_liveBackingStore;
+    WeakHashSet<RemoteLayerBackingStore> m_unparentedBackingStore;
 
     // Only used during a single flush.
-    HashSet<RemoteLayerBackingStore*> m_reachableBackingStoreInLatestFlush;
-    HashSet<RemoteLayerBackingStore*> m_backingStoresNeedingDisplay;
+    WeakHashSet<RemoteLayerBackingStore> m_reachableBackingStoreInLatestFlush;
+    WeakHashSet<RemoteLayerBackingStore> m_backingStoresNeedingDisplay;
 
     WebCore::Timer m_volatilityTimer;
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -38,6 +38,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebKit {
 
@@ -140,7 +141,7 @@ private:
 
     WeakPtr<PlaybackSessionManagerProxy> m_manager;
     PlaybackSessionContextIdentifier m_contextId;
-    HashSet<WebCore::PlaybackSessionModelClient*> m_clients;
+    WeakHashSet<WebCore::PlaybackSessionModelClient> m_clients;
     double m_playbackStartedTime { 0 };
     bool m_playbackStartedTimeNeedsUpdate { false };
     double m_duration { 0 };

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -51,14 +51,14 @@ PlaybackSessionModelContext::PlaybackSessionModelContext(PlaybackSessionManagerP
 
 void PlaybackSessionModelContext::addClient(PlaybackSessionModelClient& client)
 {
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 }
 
 void PlaybackSessionModelContext::removeClient(PlaybackSessionModelClient& client)
 {
-    ASSERT(m_clients.contains(&client));
-    m_clients.remove(&client);
+    ASSERT(m_clients.contains(client));
+    m_clients.remove(client);
 }
 
 void PlaybackSessionModelContext::sendRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
@@ -228,8 +228,8 @@ void PlaybackSessionModelContext::durationChanged(double duration)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, duration);
     m_duration = duration;
-    for (auto* client : m_clients)
-        client->durationChanged(duration);
+    for (auto& client : m_clients)
+        client.durationChanged(duration);
 }
 
 void PlaybackSessionModelContext::currentTimeChanged(double currentTime)
@@ -240,16 +240,16 @@ void PlaybackSessionModelContext::currentTimeChanged(double currentTime)
     if (m_playbackStartedTimeNeedsUpdate)
         playbackStartedTimeChanged(currentTime);
 
-    for (auto* client : m_clients)
-        client->currentTimeChanged(currentTime, anchorTime);
+    for (auto& client : m_clients)
+        client.currentTimeChanged(currentTime, anchorTime);
 }
 
 void PlaybackSessionModelContext::bufferedTimeChanged(double bufferedTime)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, bufferedTime);
     m_bufferedTime = bufferedTime;
-    for (auto* client : m_clients)
-        client->bufferedTimeChanged(bufferedTime);
+    for (auto& client : m_clients)
+        client.bufferedTimeChanged(bufferedTime);
 }
 
 void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
@@ -258,8 +258,8 @@ void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSession
     m_playbackState = playbackState;
     m_playbackRate = playbackRate;
     m_defaultPlaybackRate = defaultPlaybackRate;
-    for (auto* client : m_clients)
-        client->rateChanged(m_playbackState, m_playbackRate, m_defaultPlaybackRate);
+    for (auto& client : m_clients)
+        client.rateChanged(m_playbackState, m_playbackRate, m_defaultPlaybackRate);
 }
 
 void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
@@ -268,23 +268,23 @@ void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& see
     m_seekableRanges = seekableRanges;
     m_seekableTimeRangesLastModifiedTime = lastModifiedTime;
     m_liveUpdateInterval = liveUpdateInterval;
-    for (auto* client : m_clients)
-        client->seekableRangesChanged(seekableRanges, lastModifiedTime, liveUpdateInterval);
+    for (auto& client : m_clients)
+        client.seekableRangesChanged(seekableRanges, lastModifiedTime, liveUpdateInterval);
 }
 
 void PlaybackSessionModelContext::canPlayFastReverseChanged(bool canPlayFastReverse)
 {
     m_canPlayFastReverse = canPlayFastReverse;
-    for (auto* client : m_clients)
-        client->canPlayFastReverseChanged(canPlayFastReverse);
+    for (auto& client : m_clients)
+        client.canPlayFastReverseChanged(canPlayFastReverse);
 }
 
 void PlaybackSessionModelContext::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& audioMediaSelectionOptions, uint64_t audioMediaSelectedIndex)
 {
     m_audioMediaSelectionOptions = audioMediaSelectionOptions;
     m_audioMediaSelectedIndex = audioMediaSelectedIndex;
-    for (auto* client : m_clients)
-        client->audioMediaSelectionOptionsChanged(audioMediaSelectionOptions, audioMediaSelectedIndex);
+    for (auto& client : m_clients)
+        client.audioMediaSelectionOptionsChanged(audioMediaSelectionOptions, audioMediaSelectedIndex);
 }
 
 void PlaybackSessionModelContext::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& legibleMediaSelectionOptions, uint64_t legibleMediaSelectedIndex)
@@ -292,24 +292,24 @@ void PlaybackSessionModelContext::legibleMediaSelectionOptionsChanged(const Vect
     m_legibleMediaSelectionOptions = legibleMediaSelectionOptions;
     m_legibleMediaSelectedIndex = legibleMediaSelectedIndex;
 
-    for (auto* client : m_clients)
-        client->legibleMediaSelectionOptionsChanged(legibleMediaSelectionOptions, legibleMediaSelectedIndex);
+    for (auto& client : m_clients)
+        client.legibleMediaSelectionOptionsChanged(legibleMediaSelectionOptions, legibleMediaSelectedIndex);
 }
 
 void PlaybackSessionModelContext::audioMediaSelectionIndexChanged(uint64_t selectedIndex)
 {
     m_audioMediaSelectedIndex = selectedIndex;
 
-    for (auto* client : m_clients)
-        client->audioMediaSelectionIndexChanged(selectedIndex);
+    for (auto& client : m_clients)
+        client.audioMediaSelectionIndexChanged(selectedIndex);
 }
 
 void PlaybackSessionModelContext::legibleMediaSelectionIndexChanged(uint64_t selectedIndex)
 {
     m_legibleMediaSelectedIndex = selectedIndex;
 
-    for (auto* client : m_clients)
-        client->legibleMediaSelectionIndexChanged(selectedIndex);
+    for (auto& client : m_clients)
+        client.legibleMediaSelectionIndexChanged(selectedIndex);
 }
 
 void PlaybackSessionModelContext::externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType type, const String& localizedName)
@@ -318,43 +318,43 @@ void PlaybackSessionModelContext::externalPlaybackChanged(bool enabled, Playback
     m_externalPlaybackTargetType = type;
     m_externalPlaybackLocalizedDeviceName = localizedName;
 
-    for (auto* client : m_clients)
-        client->externalPlaybackChanged(enabled, type, localizedName);
+    for (auto& client : m_clients)
+        client.externalPlaybackChanged(enabled, type, localizedName);
 }
 
 void PlaybackSessionModelContext::wirelessVideoPlaybackDisabledChanged(bool wirelessVideoPlaybackDisabled)
 {
     m_wirelessVideoPlaybackDisabled = wirelessVideoPlaybackDisabled;
-    for (auto* client : m_clients)
-        client->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
+    for (auto& client : m_clients)
+        client.wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
 }
 
 void PlaybackSessionModelContext::mutedChanged(bool muted)
 {
     m_muted = muted;
-    for (auto* client : m_clients)
-        client->mutedChanged(muted);
+    for (auto& client : m_clients)
+        client.mutedChanged(muted);
 }
 
 void PlaybackSessionModelContext::volumeChanged(double volume)
 {
     m_volume = volume;
-    for (auto* client : m_clients)
-        client->volumeChanged(volume);
+    for (auto& client : m_clients)
+        client.volumeChanged(volume);
 }
 
 void PlaybackSessionModelContext::pictureInPictureSupportedChanged(bool supported)
 {
     m_pictureInPictureSupported = supported;
-    for (auto* client : m_clients)
-        client->isPictureInPictureSupportedChanged(supported);
+    for (auto& client : m_clients)
+        client.isPictureInPictureSupportedChanged(supported);
 }
 
 void PlaybackSessionModelContext::pictureInPictureActiveChanged(bool active)
 {
     m_pictureInPictureActive = active;
-    for (auto* client : m_clients)
-        client->pictureInPictureActiveChanged(active);
+    for (auto& client : m_clients)
+        client.pictureInPictureActiveChanged(active);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -137,7 +137,7 @@ private:
     RetainPtr<WebAVPlayerLayerView> m_playerView;
 #endif
 
-    HashSet<WebCore::VideoFullscreenModelClient*> m_clients;
+    WeakHashSet<WebCore::VideoFullscreenModelClient> m_clients;
     WebCore::FloatSize m_videoDimensions;
     bool m_hasVideo { false };
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -199,14 +199,14 @@ VideoFullscreenModelContext::~VideoFullscreenModelContext() = default;
 
 void VideoFullscreenModelContext::addClient(VideoFullscreenModelClient& client)
 {
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 }
 
 void VideoFullscreenModelContext::removeClient(VideoFullscreenModelClient& client)
 {
-    ASSERT(m_clients.contains(&client));
-    m_clients.remove(&client);
+    ASSERT(m_clients.contains(client));
+    m_clients.remove(client);
 }
 
 void VideoFullscreenModelContext::setPlayerLayer(RetainPtr<WebAVPlayerLayer>&& playerLayer)
@@ -222,8 +222,9 @@ void VideoFullscreenModelContext::setVideoDimensions(const WebCore::FloatSize& v
 
     m_videoDimensions = videoDimensions;
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoDimensions);
-    for (auto& client : copyToVector(m_clients))
-        client->videoDimensionsChanged(videoDimensions);
+    m_clients.forEach([&](auto& client) {
+        client.videoDimensionsChanged(videoDimensions);
+    });
 }
 
 void VideoFullscreenModelContext::requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&& completionHandler)
@@ -383,22 +384,25 @@ void VideoFullscreenModelContext::didExitPictureInPicture()
 void VideoFullscreenModelContext::willEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    for (auto& client : copyToVector(m_clients))
-        client->willEnterPictureInPicture();
+    m_clients.forEach([&](auto& client) {
+        client.willEnterPictureInPicture();
+    });
 }
 
 void VideoFullscreenModelContext::failedToEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    for (auto& client : copyToVector(m_clients))
-        client->failedToEnterPictureInPicture();
+    m_clients.forEach([&](auto& client) {
+        client.failedToEnterPictureInPicture();
+    });
 }
 
 void VideoFullscreenModelContext::willExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    for (auto& client : copyToVector(m_clients))
-        client->willExitPictureInPicture();
+    m_clients.forEach([&](auto& client) {
+        client.willExitPictureInPicture();
+    });
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -55,14 +55,14 @@ UIGamepadProvider::UIGamepadProvider()
 
 UIGamepadProvider::~UIGamepadProvider()
 {
-    if (!m_processPoolsUsingGamepads.isEmpty())
+    if (!m_processPoolsUsingGamepads.isEmptyIgnoringNullReferences())
         GamepadProvider::singleton().stopMonitoringGamepads(*this);
 }
 
 void UIGamepadProvider::gamepadSyncTimerFired()
 {
     RefPtr webPageProxy = platformWebPageProxyForGamepadInput();
-    if (!webPageProxy || !m_processPoolsUsingGamepads.contains(&webPageProxy->process().processPool()))
+    if (!webPageProxy || !m_processPoolsUsingGamepads.contains(webPageProxy->process().processPool()))
         return;
 
     webPageProxy->gamepadActivity(snapshotGamepads(), m_shouldMakeGamepadsVisibleOnSync ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
@@ -74,7 +74,7 @@ void UIGamepadProvider::scheduleGamepadStateSync()
     if (!m_isMonitoringGamepads || m_gamepadSyncTimer.isActive())
         return;
 
-    if (m_gamepads.isEmpty() || m_processPoolsUsingGamepads.isEmpty()) {
+    if (m_gamepads.isEmpty() || m_processPoolsUsingGamepads.isEmptyIgnoringNullReferences()) {
         m_gamepadSyncTimer.stop();
         return;
     }
@@ -95,7 +95,7 @@ void UIGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Event
     scheduleGamepadStateSync();
 
     for (auto& pool : m_processPoolsUsingGamepads)
-        pool->gamepadConnected(*m_gamepads[gamepad.index()], eventVisibility);
+        pool.gamepadConnected(*m_gamepads[gamepad.index()], eventVisibility);
 }
 
 void UIGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
@@ -108,7 +108,7 @@ void UIGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
     scheduleGamepadStateSync();
 
     for (auto& pool : m_processPoolsUsingGamepads)
-        pool->gamepadDisconnected(*disconnectedGamepad);
+        pool.gamepadDisconnected(*disconnectedGamepad);
 }
 
 void UIGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisible eventVisibility)
@@ -131,8 +131,8 @@ void UIGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisible e
 
 void UIGamepadProvider::processPoolStartedUsingGamepads(WebProcessPool& pool)
 {
-    ASSERT(!m_processPoolsUsingGamepads.contains(&pool));
-    m_processPoolsUsingGamepads.add(&pool);
+    ASSERT(!m_processPoolsUsingGamepads.contains(pool));
+    m_processPoolsUsingGamepads.add(pool);
 
     if (!m_isMonitoringGamepads && platformWebPageProxyForGamepadInput())
         startMonitoringGamepads();
@@ -140,8 +140,8 @@ void UIGamepadProvider::processPoolStartedUsingGamepads(WebProcessPool& pool)
 
 void UIGamepadProvider::processPoolStoppedUsingGamepads(WebProcessPool& pool)
 {
-    ASSERT(m_processPoolsUsingGamepads.contains(&pool));
-    m_processPoolsUsingGamepads.remove(&pool);
+    ASSERT(m_processPoolsUsingGamepads.contains(pool));
+    m_processPoolsUsingGamepads.remove(pool);
 
     if (m_isMonitoringGamepads && !platformWebPageProxyForGamepadInput())
         platformStopMonitoringInput();
@@ -149,7 +149,7 @@ void UIGamepadProvider::processPoolStoppedUsingGamepads(WebProcessPool& pool)
 
 void UIGamepadProvider::viewBecameActive(WebPageProxy& page)
 {
-    if (!m_processPoolsUsingGamepads.contains(&page.process().processPool()))
+    if (!m_processPoolsUsingGamepads.contains(page.process().processPool()))
         return;
 
     if (!m_isMonitoringGamepads)
@@ -172,7 +172,7 @@ void UIGamepadProvider::startMonitoringGamepads()
         return;
 
     m_isMonitoringGamepads = true;
-    ASSERT(!m_processPoolsUsingGamepads.isEmpty());
+    ASSERT(!m_processPoolsUsingGamepads.isEmptyIgnoringNullReferences());
     GamepadProvider::singleton().startMonitoringGamepads(*this);
 }
 
@@ -183,7 +183,7 @@ void UIGamepadProvider::stopMonitoringGamepads()
 
     m_isMonitoringGamepads = false;
 
-    ASSERT(m_processPoolsUsingGamepads.isEmpty());
+    ASSERT(m_processPoolsUsingGamepads.isEmptyIgnoringNullReferences());
     GamepadProvider::singleton().stopMonitoringGamepads(*this);
 
     m_gamepads.clear();

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -31,6 +31,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebKit {
 
@@ -79,7 +80,7 @@ private:
     void scheduleGamepadStateSync();
     void gamepadSyncTimerFired();
 
-    HashSet<WebProcessPool*> m_processPoolsUsingGamepads;
+    WeakHashSet<WebProcessPool> m_processPoolsUsingGamepads;
 
     Vector<std::unique_ptr<UIGamepad>> m_gamepads;
 


### PR DESCRIPTION
#### 73e7fff48f6eb8a81d05632c6eb407db09ee90c5
<pre>
Store less raw pointers in containers in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261533">https://bugs.webkit.org/show_bug.cgi?id=261533</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/VideoFullscreenModel.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::allStores):
(WebKit::ResourceLoadStatisticsStore::ResourceLoadStatisticsStore):
(WebKit::ResourceLoadStatisticsStore::~ResourceLoadStatisticsStore):
(WebKit::ResourceLoadStatisticsStore::interruptAllDatabases):
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp:
(WebKit::NetworkLoadScheduler::HostContext::shouldDelayLowPriority const):
(WebKit::NetworkLoadScheduler::HostContext::schedule):
(WebKit::NetworkLoadScheduler::HostContext::unschedule):
(WebKit::NetworkLoadScheduler::HostContext::prioritize):
(WebKit::NetworkLoadScheduler::HostContext::start):
(WebKit::NetworkLoadScheduler::HostContext::~HostContext):
(WebKit::NetworkLoadScheduler::scheduleMainResourceLoad):
(WebKit::NetworkLoadScheduler::unscheduleMainResourceLoad):
(WebKit::NetworkLoadScheduler::finishedPreconnectForMainResource):
(WebKit::NetworkLoadScheduler::maybePrunePreconnectInfo):
* Source/WebKit/NetworkProcess/NetworkLoadScheduler.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::allDatabases):
(WebKit::PCM::Database::Database):
(WebKit::PCM::Database::~Database):
(WebKit::PCM::Database::interruptAllDatabases):
(): Deleted.
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay):
(WebKit::RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents):
(WebKit::RemoteLayerBackingStoreCollection::willCommitLayerTree):
(WebKit::RemoteLayerBackingStoreCollection::updateUnreachableBackingStores):
(WebKit::RemoteLayerBackingStoreCollection::backingStoreWasCreated):
(WebKit::RemoteLayerBackingStoreCollection::backingStoreWillBeDestroyed):
(WebKit::RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayed):
(WebKit::RemoteLayerBackingStoreCollection::markBackingStoreVolatile):
(WebKit::RemoteLayerBackingStoreCollection::backingStoreBecameUnreachable):
(WebKit::RemoteLayerBackingStoreCollection::markAllBackingStoreVolatile):
(WebKit::RemoteLayerBackingStoreCollection::markAllBackingStoreVolatileFromTimer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::prepareBackingStoresForDisplay):
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::collectBackingStoreBufferIdentifiersToMarkVolatile):
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::collectAllBufferIdentifiersToMarkVolatile):
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::tryMarkAllBackingStoreVolatile):
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::markAllBackingStoreVolatileFromTimer):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::addClient):
(WebKit::PlaybackSessionModelContext::removeClient):
(WebKit::PlaybackSessionModelContext::durationChanged):
(WebKit::PlaybackSessionModelContext::currentTimeChanged):
(WebKit::PlaybackSessionModelContext::bufferedTimeChanged):
(WebKit::PlaybackSessionModelContext::rateChanged):
(WebKit::PlaybackSessionModelContext::seekableRangesChanged):
(WebKit::PlaybackSessionModelContext::canPlayFastReverseChanged):
(WebKit::PlaybackSessionModelContext::audioMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionModelContext::legibleMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionModelContext::audioMediaSelectionIndexChanged):
(WebKit::PlaybackSessionModelContext::legibleMediaSelectionIndexChanged):
(WebKit::PlaybackSessionModelContext::externalPlaybackChanged):
(WebKit::PlaybackSessionModelContext::wirelessVideoPlaybackDisabledChanged):
(WebKit::PlaybackSessionModelContext::mutedChanged):
(WebKit::PlaybackSessionModelContext::volumeChanged):
(WebKit::PlaybackSessionModelContext::pictureInPictureSupportedChanged):
(WebKit::PlaybackSessionModelContext::pictureInPictureActiveChanged):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::addClient):
(WebKit::VideoFullscreenModelContext::removeClient):
(WebKit::VideoFullscreenModelContext::setVideoDimensions):
(WebKit::VideoFullscreenModelContext::willEnterPictureInPicture):
(WebKit::VideoFullscreenModelContext::failedToEnterPictureInPicture):
(WebKit::VideoFullscreenModelContext::willExitPictureInPicture):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::~UIGamepadProvider):
(WebKit::UIGamepadProvider::gamepadSyncTimerFired):
(WebKit::UIGamepadProvider::scheduleGamepadStateSync):
(WebKit::UIGamepadProvider::platformGamepadConnected):
(WebKit::UIGamepadProvider::platformGamepadDisconnected):
(WebKit::UIGamepadProvider::processPoolStartedUsingGamepads):
(WebKit::UIGamepadProvider::processPoolStoppedUsingGamepads):
(WebKit::UIGamepadProvider::viewBecameActive):
(WebKit::UIGamepadProvider::startMonitoringGamepads):
(WebKit::UIGamepadProvider::stopMonitoringGamepads):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h:

Canonical link: <a href="https://commits.webkit.org/268002@main">https://commits.webkit.org/268002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeb3d1ad1b631ae9117aa9f419ca14f47f14f54b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19053 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21012 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23176 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15847 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21066 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17574 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14776 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21646 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16514 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5304 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4370 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20877 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22880 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17261 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5151 "Passed tests") | 
<!--EWS-Status-Bubble-End-->