### PR TITLE
[ macOS ] storage/indexeddb/database-transaction-cycle.html is a consistent failure

### DIFF
--- a/LayoutTests/storage/indexeddb/database-transaction-cycle.html
+++ b/LayoutTests/storage/indexeddb/database-transaction-cycle.html
@@ -6,7 +6,6 @@ description('This test verifies that IDBTransaction objects are collected when c
 
 const gcInterval = 50;
 var gcCountdown = 50;
-var frame = null;
 
 function databaseName()
 {
@@ -28,7 +27,6 @@ function frameTransactionAborted(event)
 {
     preamble(event);
 
-    frame.src = "about::blank";
     gcCheck();
 }
 
@@ -66,7 +64,7 @@ function test()
         return;
     }
 
-    frame = document.createElement('iframe');
+    let frame = document.createElement('iframe');
     frame.src = "resources/database-transaction-cycle-iframe.html";
     document.body.appendChild(frame);
 }

--- a/LayoutTests/storage/indexeddb/resources/database-transaction-cycle-iframe.html
+++ b/LayoutTests/storage/indexeddb/resources/database-transaction-cycle-iframe.html
@@ -1,28 +1,20 @@
 <!DOCTYPE html>
 <script>
 
-var objectStore = null;
-var putRequest = null;
-
-function keepTransactionAlive() {
-    try {
-        putRequest = objectStore.put("value", "key");
-        putRequest.onsuccess = keepTransactionAlive;
-    } catch (e) {
-        putRequest = null;
-    }
+function keepTransactionAlive(event) {
+    let objectStore = event.target.transaction.objectStore("objectStore");
+    objectStore.put("value", "key").onsuccess = keepTransactionAlive;
 }
 
 function openDatabase() {
-    var databaseName = "database-transaction-cycle-iframe";
+    let databaseName = "database-transaction-cycle-iframe";
     window.indexedDB.deleteDatabase(databaseName);
-    var openRequest = window.indexedDB.open(databaseName);
+    let openRequest = window.indexedDB.open(databaseName);
     openRequest.onupgradeneeded = (event) => {
-        var database = event.target.result;
-        objectStore = database.createObjectStore("objectStore");
+        let database = event.target.result;
+        let objectStore = database.createObjectStore("objectStore");
+        objectStore.put("value", "key").onsuccess = keepTransactionAlive;
         event.target.transaction.onabort = () => parent.frameTransactionAborted();
-
-        keepTransactionAlive();
 
         parent.frameDatabaseOpened();
     };

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1466,10 +1466,8 @@ void IDBTransaction::connectionClosedFromServer(const IDBError& error)
     m_abortQueue.clear();
     m_transactionOperationMap.clear();
 
-    m_idbError = error;
     m_domError = error.toDOMException();
-    m_database->didAbortTransaction(*this);
-    fireOnAbort();
+    didAbort(error);
 }
 
 template<typename Visitor>


### PR DESCRIPTION
#### e012709bf3974ae056e29b36220178b5e867d9e5
<pre>
[ macOS ] storage/indexeddb/database-transaction-cycle.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=261535">https://bugs.webkit.org/show_bug.cgi?id=261535</a>
rdar://115457418

Reviewed by Brady Eidson.

IDBTransaction&apos;s wrapper is kept alive when its state is not Finished (see IDBTransaction::virtualHasPendingActivity()).
However, its state is never changed from Aborting to Finished when the failure is caused by closed connection. To fix
that, we now invoke didAbort() in IDBTransaction::connectionClosedFromServer which performs necessary cleanup tasks.

The test also has an issue that it uses global variable for IDBObjectStore, which will keep IDBTranaction alive (see
IDBObjectStore::ref()). To avoid such issue, this patch removes the use of global variables. In addition, IDBTransaction
can be destroyed when it&apos;s no longer active (and there is no reference from JS), so we don&apos;t need to set url of the
iframe.

* LayoutTests/storage/indexeddb/database-transaction-cycle.html:
* LayoutTests/storage/indexeddb/resources/database-transaction-cycle-iframe.html:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::connectionClosedFromServer):

Canonical link: <a href="https://commits.webkit.org/268031@main">https://commits.webkit.org/268031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c90810c29eee88732964244c106bd3b59f9ecba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19082 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21038 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23205 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21084 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14813 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4388 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->