### PR TITLE
storage/indexeddb/modern/handle-user-delete.html is flaky when running it locally

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -786,8 +786,6 @@ fast/scrolling/rtl-scrollbars-animation-property.html [ Pass ]
 
 webkit.org/b/167607 [ Debug ] http/tests/inspector/worker/blob-script-with-cross-domain-imported-scripts.html [ Pass Timeout ]
 
-webkit.org/b/159896 storage/indexeddb/modern/handle-user-delete.html [ Pass Timeout ]
-
 webkit.org/b/160042 accessibility/mac/value-change/value-change-user-info-contenteditable.html [ Pass Failure ]
 
 webkit.org/b/160309 fast/dom/Window/child-window-focus.html [ Pass Failure ]

--- a/LayoutTests/storage/indexeddb/modern/resources/handle-user-delete.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/handle-user-delete.js
@@ -47,11 +47,15 @@ function prepareDatabase(event)
 {
     log("Initial upgrade needed: Old version - " + event.oldVersion + " New version - " + event.newVersion);
 
+    // Overwrite the unexpected error handler of IDBOpenDBRequest set in indexedDBTest(),
+    // because this test expects version change transaction to fail.
+    event.target.onerror = () => { };
+
     var versionTransaction = event.target.transaction;
     var database = event.target.result;
     var objectStore = database.createObjectStore("TestObjectStore");
     objectStore.put("bar", "foo");
-    
+
     database.onerror = function(event) {
         databaseError = true;
         maybeFinish();


### PR DESCRIPTION
#### c9276d57243c3ad06f906c296239311cbc166e84
<pre>
storage/indexeddb/modern/handle-user-delete.html is flaky when running it locally
<a href="https://bugs.webkit.org/show_bug.cgi?id=261539">https://bugs.webkit.org/show_bug.cgi?id=261539</a>
rdar://115458802

Reviewed by Chris Dumez.

The test utility function indexedDBTest() sets error handler for IDBOpenDBRequest by default, which would print error
log and end the test early. However, this test expects error to occur (version change transaction will be aborted for
user delete). Therefore, this patch overwrites the error handler before issuing the error.

This patch also updates the test expectation since the test has been passing on all bots now.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/storage/indexeddb/modern/resources/handle-user-delete.js:

Canonical link: <a href="https://commits.webkit.org/267997@main">https://commits.webkit.org/267997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81c1f6d9d040efdd60a15c650a99e0e1c1c0476f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17066 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19008 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20956 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23125 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16460 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4365 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->