### PR TITLE
Move off of UIKit SPI: `_UISheetDetent`

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -898,17 +898,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (UIPanGestureRecognizer *)gestureRecognizerForInteractiveTransition:(_UINavigationInteractiveTransitionBase *)interactiveTransition WithTarget:(id)target action:(SEL)action;
 @end
 
-@interface _UISheetDetent : NSObject
-@property (class, nonatomic, readonly) _UISheetDetent *_mediumDetent;
-@property (class, nonatomic, readonly) _UISheetDetent *_largeDetent;
-@end
-
-@interface _UISheetPresentationController : UIPresentationController
-@property (nonatomic, copy, setter=_setDetents:) NSArray<_UISheetDetent *> *_detents;
-@property (nonatomic, setter=_setWantsBottomAttachedInCompactHeight:) BOOL _wantsBottomAttachedInCompactHeight;
-@property (nonatomic, setter=_setWidthFollowsPreferredContentSizeWhenBottomAttached:) BOOL _widthFollowsPreferredContentSizeWhenBottomAttached;
-@end
-
 @class BKSAnimationFenceHandle;
 
 @interface UIGestureRecognizer (SPI)

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -28,13 +28,13 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import "UIKitSPI.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKFormPopover.h"
 #import "WKFormSelectControl.h"
 #import "WKWebViewPrivateForTesting.h"
 #import "WebPageProxy.h"
+#import <UIKit/UIKit.h>
 #import <WebCore/LocalizedStrings.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 
@@ -1196,13 +1196,11 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
 
         UIPresentationController *presentationController = [_navigationController presentationController];
         presentationController.delegate = self;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        if ([presentationController isKindOfClass:[_UISheetPresentationController class]]) {
-            _UISheetPresentationController *sheetPresentationController = (_UISheetPresentationController *)presentationController;
-            sheetPresentationController._detents = @[_UISheetDetent._mediumDetent, _UISheetDetent._largeDetent];
-ALLOW_DEPRECATED_DECLARATIONS_END
-            sheetPresentationController._widthFollowsPreferredContentSizeWhenBottomAttached = YES;
-            sheetPresentationController._wantsBottomAttachedInCompactHeight = YES;
+
+        if (auto sheetPresentationController = dynamic_objc_cast<UISheetPresentationController>(presentationController)) {
+            sheetPresentationController.detents = @[UISheetPresentationControllerDetent.mediumDetent, UISheetPresentationControllerDetent.largeDetent];
+            sheetPresentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = YES;
+            sheetPresentationController.prefersEdgeAttachedInCompactHeight = YES;
         }
     } else {
         [_navigationController setModalPresentationStyle:UIModalPresentationPopover];


### PR DESCRIPTION
#### 6f6557cd266c66f828329c38ff521fc8e2005752
<pre>
Move off of UIKit SPI: `_UISheetDetent`
<a href="https://bugs.webkit.org/show_bug.cgi?id=261540">https://bugs.webkit.org/show_bug.cgi?id=261540</a>
rdar://115331913

Reviewed by Wenson Hsieh.

These deprecated SPIs have existing public API replacements:

• `_UISheetDetent` -&gt; `UISheetPresentationControllerDetent`
• `_UISheetPresentationController` -&gt; `UISheetPresentationController`
• `+_mediumDetent` -&gt; `+mediumDetent`
• `+_largeDetent` -&gt; `+largeDetent`
• `_widthFollowsPreferredContentSizeWhenBottomAttached` -&gt; `widthFollowsPreferredContentSizeWhenEdgeAttached`
• `_wantsBottomAttachedInCompactHeight` -&gt; `prefersEdgeAttachedInCompactHeight`

Therefore, we can simply adopt these 1-1 replacements and remove their declarations in SPI headers.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectMultiplePicker configurePresentation]):

Canonical link: <a href="https://commits.webkit.org/267978@main">https://commits.webkit.org/267978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e41511986682aeb339a69cea6e6d33dedce187c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20960 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15892 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23128 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17367 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16464 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4344 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->