### PR TITLE
Add fast path of getting arguments.length for LLInt and Baseline

### DIFF
--- a/JSTests/microbenchmarks/get-arguments-length-fast.js
+++ b/JSTests/microbenchmarks/get-arguments-length-fast.js
@@ -1,0 +1,49 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)} should be ${String(expected)}`);
+}
+noInline(shouldBe);
+
+function argumentLength() {
+    shouldBe(arguments.length, 2);
+}
+noInline(argumentLength);
+
+function argumentsWithNestedNormalFunction() {
+    function nested() {
+        var arguments = 0;
+    }
+    nested();
+    shouldBe(arguments.length, 2);
+}
+noInline(argumentsWithNestedNormalFunction);
+
+function declareLexicalArgumentsWithBlock() {
+    {
+        let arguments = 1;
+    }
+    shouldBe(arguments.length, 3);
+}
+noInline(declareLexicalArgumentsWithBlock);
+
+function forInLetArguments() {
+    for (let arguments in [1, 2]) {
+    }
+    shouldBe(arguments.length, 2);
+}
+noInline(forInLetArguments);
+
+function forOfLetArguments() {
+    for (let arguments of [1, 2]) {
+    }
+    shouldBe(arguments.length, 0);
+}
+noInline(forOfLetArguments);
+
+for (let i = 0; i < 1e4; i++) {
+    argumentLength(1, 2);
+    argumentsWithNestedNormalFunction(1, 2);
+    declareLexicalArgumentsWithBlock(1,2,3);
+    forInLetArguments(1, 2);
+    forOfLetArguments();
+}

--- a/JSTests/stress/get-arguments-length-fast.js
+++ b/JSTests/stress/get-arguments-length-fast.js
@@ -1,0 +1,302 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)} should be ${String(expected)}`);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)} expected ${errorMessage}`);
+}
+
+// ----- Use the fast path ----- 
+function argumentLength() {
+    shouldBe(arguments.length, 2);
+}
+argumentLength(1, 2);
+
+function argumentsWithNestedNormalFunction() {
+    function nested() {
+        var arguments = 0;
+    }
+    nested();
+    shouldBe(arguments.length, 2);
+}
+argumentsWithNestedNormalFunction(1, 2);
+
+function declareLexicalArgumentsWithBlock() {
+    {
+        let arguments = 1;
+    }
+    shouldBe(arguments.length, 3);
+}
+declareLexicalArgumentsWithBlock(1, 2, 3);
+
+function forInLetArguments() {
+    for (let arguments in [1, 2]) {
+    }
+    shouldBe(arguments.length, 2);
+}
+forInLetArguments(1, 2);
+
+function forOfLetArguments() {
+    for (let arguments of [1, 2]) {
+    }
+    shouldBe(arguments.length, 0);
+}
+forOfLetArguments();
+
+function argumentsDotLengthDot() {
+    arguments.length.p1 = 1;
+    shouldBe(arguments.length.p1, undefined);
+}
+argumentsDotLengthDot();
+
+function argumentsDotLengthOpenBracket() {
+    arguments.length["p1"] = 1;
+    shouldBe(arguments.length["p1"], undefined);
+}
+argumentsDotLengthOpenBracket();
+
+function assignArgumentsDotLengthDot() {
+    let a = arguments.length.p1;
+    shouldBe(a, undefined);
+}
+assignArgumentsDotLengthDot();
+
+function assignArgumentsDotLengthOpenBracket() {
+    let a = arguments.length["p1"];
+    shouldBe(a, undefined);
+}
+assignArgumentsDotLengthOpenBracket();
+
+function callArgumentsLength() {
+    arguments.length();
+}
+shouldThrow(callArgumentsLength, `TypeError: arguments.length is not a function. (In 'arguments.length()', 'arguments.length' is 0)`);
+
+function callArgumentsLengthWithArgs() {
+    arguments.length(1, 2, 3, 4, 5);
+}
+shouldThrow(callArgumentsLengthWithArgs, `TypeError: arguments.length is not a function. (In 'arguments.length(1, 2, 3, 4, 5)', 'arguments.length' is 0)`);
+
+// ----- Should use the fast path but currently not supported ----- 
+function declareArrowFunctionArgumentsWithBlock() {
+    {
+        let arguments = () => { };
+        arguments();
+    }
+    shouldBe(arguments.length, 3);
+}
+declareArrowFunctionArgumentsWithBlock(1, 2, 3);
+
+// ----- Shouldn't use the fast path ----- 
+function argumentsNonLengthAccess() {
+    arguments.callee;
+    shouldBe(arguments.length, 1);
+}
+argumentsNonLengthAccess(1);
+
+function argumentsLengthAssignment() {
+    arguments.length = 3;
+    shouldBe(arguments.length, 3);
+}
+argumentsLengthAssignment(1);
+
+function argumentsAssignmentLHS() {
+    arguments = 0;
+    shouldBe(arguments.length, undefined);
+}
+argumentsAssignmentLHS();
+
+function argumentsAssignmentRHS() {
+    var a = arguments;
+    shouldBe(arguments.length, 0);
+}
+argumentsAssignmentRHS();
+
+function argumentsLengthIncAndDec() {
+    arguments.length++;
+    arguments.length--;
+    ++arguments.length;
+    --arguments.length;
+    shouldBe(arguments.length, 0);
+}
+argumentsLengthIncAndDec();
+
+function argumentsDestructuringAssignment() {
+    [arguments.length, arguments.length] = [1, 1];
+    shouldBe(arguments.length, 1);
+}
+argumentsDestructuringAssignment();
+
+function declareVarArguments() {
+    var arguments = 0;
+    shouldBe(arguments.length, undefined);
+}
+declareVarArguments();
+
+function declareVarArgumentsWithBlock() {
+    {
+        var arguments = 0;
+    }
+    shouldBe(arguments.length, undefined);
+}
+declareVarArgumentsWithBlock();
+
+function declareLexicalArguments() {
+    var arguments = 0;
+    shouldBe(arguments.length, undefined);
+}
+declareLexicalArguments();
+
+function declareArrowFunctionArguments() {
+    var arguments = () => { };
+    arguments();
+    shouldBe(arguments.length, 0);
+}
+declareArrowFunctionArguments(1, 2, 3);
+
+function declareFunctionArguments() {
+    function arguments() { }
+    arguments();
+    shouldBe(arguments.length, 0);
+}
+declareFunctionArguments();
+
+function declareFunctionArgumentsWithBlock() {
+    {
+        function arguments() { }
+        arguments();
+    }
+    shouldBe(arguments.length, 0);
+}
+declareFunctionArgumentsWithBlock();
+
+function declareParameterArguments(arguments) {
+    shouldBe(arguments.length, undefined);
+}
+declareParameterArguments(1);
+
+function returnArguments() {
+    shouldBe(arguments.length, 1);
+    return arguments;
+}
+returnArguments(1);
+
+function helper() { }
+function passArgumentsToFunctionCall() {
+    helper(arguments);
+    shouldBe(arguments.length, 1);
+}
+passArgumentsToFunctionCall(1);
+
+function ifArguments() {
+    if (arguments) { }
+    shouldBe(arguments.length, 1);
+}
+ifArguments(1);
+
+function forInArguments() {
+    for (arguments in [1, 2]) {
+    }
+    shouldBe(arguments, "1");
+    shouldBe(arguments.length, 1);
+}
+forInArguments(1, 2);
+
+function forInVarArguments() {
+    for (var arguments in [1, 2]) {
+    }
+    shouldBe(arguments.length, 1);
+}
+forInVarArguments(1, 2);
+
+function forOfArguments() {
+    for (arguments of [1, 2]) {
+    }
+    shouldBe(arguments.length, undefined);
+}
+forOfArguments();
+
+function forOfVarArguments() {
+    for (var arguments of [1, 2]) {
+    }
+    shouldBe(arguments.length, undefined);
+}
+forOfVarArguments();
+
+function withArguments() {
+    with (arguments) { }
+    shouldBe(arguments.length, 1);
+}
+withArguments(1);
+
+function argumentsWithNestedFunctions() {
+    var nestedArrowFunction = () => {
+        shouldBe(arguments.length, 1);
+    };
+    nestedArrowFunction(1, 2);
+
+    var nestedAsyncArrowFunction = () => {
+        shouldBe(arguments.length, 1);
+        arguments = 1;
+    };
+    nestedAsyncArrowFunction(1, 2);
+
+    shouldBe(arguments.length, undefined);
+}
+argumentsWithNestedFunctions(1);
+
+function argumentsLengthTryCatch() {
+    try {
+        throw ["foo"];
+    } catch (arguments) {
+        var arguments = ["foo", "bar"];
+    }
+    shouldBe(arguments.length, 3);
+}
+argumentsLengthTryCatch(1, 2, 3);
+
+function argumentsLengthWith() {
+    var object = { 'arguments': ["foo"] };
+
+    with (object) {
+        var arguments = ["foo", "bar"];
+    }
+
+    shouldBe(arguments.length, 0);
+}
+argumentsLengthWith();
+
+function shouldBeAsync(expected, run, msg) {
+    let actual;
+    var hadError = false;
+    run().then(function (value) { actual = value; },
+        function (error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (hadError)
+        throw actual;
+    shouldBe(expected, actual, msg);
+}
+
+async function argumentsWithAsyncFunction() {
+    if (arguments.length === 3 &&
+        arguments.callee.name === "argumentsWithAsyncFunction")
+        return 14;
+}
+shouldBeAsync(14, () => argumentsWithAsyncFunction(1, 2, 3));
+
+{
+    var arguments = [3, 2];
+    shouldBe(arguments.length, 2);
+}

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -367,6 +367,8 @@ namespace JSC {
         bool needsToUpdateArrowFunctionContext() const { return m_needsToUpdateArrowFunctionContext; }
         bool usesEval() const { return m_scopeNode->usesEval(); }
         bool usesThis() const { return m_scopeNode->usesThis(); }
+        bool isFunctionNode() const { return m_scopeNode->isFunctionNode(); }
+        bool hasShadowsArgumentsCodeFeature() const { return m_scopeNode->hasShadowsArgumentsFeature(); }
         LexicalScopeFeatures lexicalScopeFeatures() const { return m_scopeNode->lexicalScopeFeatures(); }
         PrivateBrandRequirement privateBrandRequirement() const { return m_codeBlock->privateBrandRequirement(); }
         ConstructorKind constructorKind() const { return m_codeBlock->constructorKind(); }
@@ -1234,6 +1236,16 @@ namespace JSC {
         void pushPrivateAccessNames(const PrivateNameEnvironment*);
         void popPrivateAccessNames();
 
+        bool needsArguments() const { return m_needsArguments; };
+        bool shouldGetArgumentsDotLengthFast(ExpressionNode* node) const
+        {
+            return isFunctionNode()
+                && !needsArguments()
+                && !hasShadowsArgumentsCodeFeature()
+                && node->isArgumentsLengthAccess(vm())
+                && !isArrowFunctionParseMode(parseMode())
+                && !isGeneratorOrAsyncFunctionBodyParseMode(parseMode());
+        }
     private:
         OptionSet<CodeGenerationMode> m_codeGenerationMode;
 
@@ -1337,6 +1349,7 @@ namespace JSC {
         bool m_allowTailCallOptimization { false };
         bool m_allowCallIgnoreResultOptimization { false };
         bool m_needsToUpdateArrowFunctionContext : 1;
+        bool m_needsArguments : 1 { false };
         ECMAMode m_ecmaMode;
         DerivedContextType m_derivedContextType { DerivedContextType::None };
 

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -216,6 +216,8 @@ namespace JSC {
         virtual bool isOptionalChain() const { return false; }
         virtual bool isOptionalCall() const { return false; }
         virtual bool isPrivateIdentifier() const { return false; }
+        virtual bool isArgumentsLengthAccess(VM&) const { return false; }
+        virtual bool isArguments(VM&) const { return false; }
 
         virtual void emitBytecodeInConditionContext(BytecodeGenerator&, Label&, Label&, FallThroughMode);
 
@@ -672,6 +674,7 @@ namespace JSC {
         ResolveNode(const JSTokenLocation&, const Identifier&, const JSTextPosition& start);
 
         const Identifier& identifier() const { return m_ident; }
+        bool isArguments(VM& vm) const final { return m_ident == vm.propertyNames->arguments; }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
@@ -887,6 +890,7 @@ namespace JSC {
         const Identifier& identifier() const { return m_ident; }
         DotType type() const { return m_type; }
         bool isPrivateMember() const { return m_type == DotType::PrivateMember; }
+        bool isArgumentsLengthAccess(VM& vm) const final { return m_base->isArguments(vm) && identifier() == vm.propertyNames->length; }
 
         RegisterID* emitGetPropertyValue(BytecodeGenerator&, RegisterID* dst, RegisterID* base, RefPtr<RegisterID>& thisValue);
         RegisterID* emitGetPropertyValue(BytecodeGenerator&, RegisterID* dst, RegisterID* base);
@@ -1950,6 +1954,7 @@ namespace JSC {
         bool doAnyInnerArrowFunctionsUseNewTarget() { return m_innerArrowFunctionCodeFeatures & NewTargetInnerArrowFunctionFeature; }
 
         bool usesEval() const { return m_features & EvalFeature; }
+        bool hasShadowsArgumentsFeature() const { return m_features & ShadowsArgumentsFeature; }
         bool usesArguments() const { return (m_features & ArgumentsFeature) && !(m_features & ShadowsArgumentsFeature); }
         bool usesArrowFunction() const { return m_features & ArrowFunctionFeature; }
         bool isStrictMode() const { return m_lexicalScopeFeatures & StrictModeLexicalFeature; }

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -451,6 +451,12 @@ public:
         return result;
     }
 
+    ALWAYS_INLINE bool hasDeclaredGlobalArguments()
+    {
+        const Identifier& ident = m_vm.propertyNames->arguments;
+        return hasLexicallyDeclaredVariable(ident) || hasDeclaredVariable(ident) || shadowsArguments();
+    }
+
     ALWAYS_INLINE bool hasDeclaredVariable(const Identifier& ident)
     {
         return hasDeclaredVariable(ident.impl());
@@ -1802,6 +1808,7 @@ private:
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseUnaryExpression(TreeBuilder&);
     template <class TreeBuilder> NEVER_INLINE TreeExpression parseAwaitExpression(TreeBuilder&);
     template <class TreeBuilder> TreeExpression parseMemberExpression(TreeBuilder&);
+    template <class TreeBuilder> ALWAYS_INLINE TreeExpression tryParseArgumentsDotLengthForFastPath(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parsePrimaryExpression(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseArrayLiteral(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseObjectLiteral(TreeBuilder&);
@@ -2150,6 +2157,7 @@ private:
     bool m_isInsideOrdinaryFunction;
     bool m_seenTaggedTemplateInNonReparsingFunctionMode { false };
     bool m_seenPrivateNameUseInNonReparsingFunctionMode { false };
+    bool m_seenArgumentsDotLength { false };
 };
 
 

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -172,7 +172,7 @@ public:
     ALWAYS_INLINE bool isMetaProperty(ExpressionType type) { return type & MetaPropertyBit; }
     ALWAYS_INLINE bool isNewTarget(ExpressionType type) { return type == NewTargetExpr; }
     ALWAYS_INLINE bool isImportMeta(ExpressionType type) { return type == ImportMetaExpr; }
-    ExpressionType createResolve(const JSTokenLocation&, const Identifier&, int, int) { return ResolveExpr; }
+    ExpressionType createResolve(const JSTokenLocation&, const Identifier&, int, int, const bool = true) { return ResolveExpr; }
     ExpressionType createPrivateIdentifierNode(const JSTokenLocation&, const Identifier&) { return PrivateIdentifier; }
     ExpressionType createObjectLiteral(const JSTokenLocation&) { return ObjectLiteralExpr; }
     ExpressionType createObjectLiteral(const JSTokenLocation&, int) { return ObjectLiteralExpr; }
@@ -447,6 +447,8 @@ public:
     JSTextPosition breakpointLocation(int) { return { }; }
 
     void propagateArgumentsUse() { }
+
+    bool hasArgumentsFeature() const { return true; }
 
 private:
     VM& m_vm;


### PR DESCRIPTION
#### cacf00c5fdeedd4db49495feaa674396691def67
<pre>
Add fast path of getting arguments.length for LLInt and Baseline
<a href="https://bugs.webkit.org/show_bug.cgi?id=261543">https://bugs.webkit.org/show_bug.cgi?id=261543</a>
rdar://115462355

Reviewed by Yusuke Suzuki.

We observed that `arguments.length` is frequently used for reading only
without accessing/modifying arguments self or its other properties. If that&apos;s
the case we should directly get `argumentCountIncludingThis` from CallFrame
without materializing `arguments` object first. So far, DFG and FTL can
handle this well in varargs forwarding phase. This patch adds the fast
path of getting arguments.length for LLInt and Baseline with simple
heuristic in parser layer.

JavaScriptCode:

    function test() {
        return arguments.length === 3;
    }

Bytecode Before:

    Predecessors: [ ]
    [   0] enter
    [   1] create_direct_arguments dst:loc5
    [   3] mov                dst:loc6, src:loc5
    [   6] get_by_id          dst:loc7, base:loc6, property:0, valueProfile:1
    [  12] stricteq           dst:loc7, lhs:loc7, rhs:Int32: 3(const0)
    [  16] ret                value:loc7
    Successors: [ ]

Bytecode After:

    Predecessors: [ ]
    [   0] enter
    [   1] argument_count     dst:loc5
    [   3] stricteq           dst:loc5, lhs:loc5, rhs:Int32: 3(const0)
    [   7] ret                value:loc5
    Successors: [ ]

Micro Benchmark Result:

                                without                     with

get-arguments-length-fast    2.6024+-0.0750     ^      2.4034+-0.0359        ^ definitely 1.0828x faster

* JSTests/microbenchmarks/get-arguments-length-fast.js: Added.
(test):
* JSTests/stress/get-arguments-length-fast.js: Added.
(shouldBe):
(argumentsWithNestedNormalFunction.nested):
(argumentsWithNestedNormalFunction):
(argumentsNonLengthAccess):
(argumentsLengthAssignment):
(argumentsAssignmentLHS):
(argumentsAssignmentRHS):
(argumentsDestructuringAssignment):
(declareVarArguments):
(declareVarArgumentsWithBlock):
(declareLexicalArguments):
(declareLexicalArgumentsWithBlock):
(declareArrowFunctionArguments):
(declareArrowFunctionArgumentsWithBlock):
(declareFunctionArguments.arguments):
(declareFunctionArguments):
(declareFunctionArgumentsWithBlock.arguments):
(declareFunctionArgumentsWithBlock):
(declareParameterArguments):
(returnArguments):
(helper):
(passArgumentsToFunctionCall):
(ifArguments):
(forInArguments):
(forInVarArguments):
(forInLetArguments):
(forOfArguments):
(forOfVarArguments):
(forOfLetArguments):
(withArguments):
(argumentsWithNestedFunctions.nestedNormalFunction):
(argumentsWithNestedFunctions):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::useGetArgumentsLengthFast):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::DotAccessorNode::emitBytecode):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createDotAccess):
(JSC::ASTBuilder::createAssignment):
(JSC::ASTBuilder::createAssignmentElement):
(JSC::ASTBuilder::checkAssignmentForArguments):
(JSC::ASTBuilder::useArgumentsOnlyForReadingLength):
(JSC::ASTBuilder::usesArguments):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::ExpressionNode::isArgumentsAccess const):
(JSC::ExpressionNode::isArgumentsLengthAccess const):
(JSC::ExpressionNode::isArguments const):
(JSC::ScopeNode::useGetArgumentsLengthFast const):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::hasDeclaredArguments const):
(JSC::Scope::setHasDeclaredArguments):
(JSC::Scope::declareCallee):
(JSC::Scope::declareVariable):
(JSC::Scope::declareFunction):
(JSC::Scope::declareLexicalVariable):
(JSC::Scope::addDeclaredVariable):
(JSC::Scope::addDeclareLexicalVariable):
(JSC::Scope::addDeclaredParameters):
(JSC::Scope::declareParameter):
(JSC::Scope::getSloppyModeHoistedFunctions):
(JSC::Scope::setReadArgumentsLengthOnly):
(JSC::Scope::useGetArgumentsLengthFast const):
(JSC::Parser::popScopeInternal):
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/parser/VariableEnvironment.h:

Canonical link: <a href="https://commits.webkit.org/268480@main">https://commits.webkit.org/268480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ce8bb6054e4566b2f6502d08004d4990708bf2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17990 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19660 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21986 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23856 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16687 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21815 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18554 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15470 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22617 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17397 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/5602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21754 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23867 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18103 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5338 "Found 1 jsc stress test failure: microbenchmarks/array-from-object-func.js.lockdown") | 
<!--EWS-Status-Bubble-End-->