### PR TITLE
Store less raw pointers in containers in Source/rendering/

### DIFF
--- a/Source/WTF/wtf/WeakHashMap.h
+++ b/Source/WTF/wtf/WeakHashMap.h
@@ -253,7 +253,7 @@ public:
         return m_map.take(*keyImpl);
     }
 
-    typename ValueTraits::PeekType get(const KeyType& key)
+    typename ValueTraits::PeekType get(const KeyType& key) const
     {
         increaseOperationCountSinceLastCleanup();
         auto* keyImpl = keyImplIfExists(key);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1687,10 +1687,10 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
 
     // If there are any position:fixed inside of us, game over.
     if (auto* viewPositionedObjects = renderBox.view().positionedObjects()) {
-        for (auto* positionedBox : *viewPositionedObjects) {
-            if (positionedBox == &renderBox)
+        for (auto& positionedBox : *viewPositionedObjects) {
+            if (&positionedBox == &renderBox)
                 continue;
-            if (positionedBox->isFixedPositioned() && renderBox.element()->contains(positionedBox->element()))
+            if (positionedBox.isFixedPositioned() && renderBox.element()->contains(positionedBox.element()))
                 return false;
         }
     }
@@ -1703,10 +1703,10 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
     // This renderer may have positioned descendants whose containing block is some ancestor.
     if (auto* containingBlock = RenderObject::containingBlockForPositionType(PositionType::Absolute, renderBox)) {
         if (auto* positionedObjects = containingBlock->positionedObjects()) {
-            for (auto* positionedBox : *positionedObjects) {
-                if (positionedBox == &renderBox)
+            for (auto& positionedBox : *positionedObjects) {
+                if (&positionedBox == &renderBox)
                     continue;
-                if (renderBox.element()->contains(positionedBox->element()))
+                if (renderBox.element()->contains(positionedBox.element()))
                     return false;
             }
         }
@@ -1738,7 +1738,7 @@ LayoutRect Element::absoluteEventBounds(bool& boundsIncludeAllDescendantElements
             if (RenderFragmentedFlow* fragmentedFlow = box.enclosingFragmentedFlow()) {
                 bool wasFixed = false;
                 Vector<FloatQuad> quads;
-                if (fragmentedFlow->absoluteQuadsForBox(quads, &wasFixed, &box)) {
+                if (fragmentedFlow->absoluteQuadsForBox(quads, &wasFixed, box)) {
                     result = LayoutRect(unitedBoundingBoxes(quads));
                     computedBounds = true;
                 } else {

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4296,11 +4296,11 @@ float LocalFrameView::adjustVerticalPageScrollStepForFixedContent(float step)
     float topObscuredArea = 0;
     float bottomObscuredArea = 0;
     for (const auto& positionedObject : *positionedObjects) {
-        const RenderStyle& style = positionedObject->style();
+        const RenderStyle& style = positionedObject.style();
         if (style.position() != PositionType::Fixed || style.visibility() == Visibility::Hidden || !style.opacity())
             continue;
 
-        FloatQuad contentQuad = positionedObject->absoluteContentQuad();
+        FloatQuad contentQuad = positionedObject.absoluteContentQuad();
         if (!contentQuad.isRectilinear())
             continue;
 

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -93,7 +93,7 @@ void InlineBoxPainter::paint()
         if (containingBlockPaintsContinuationOutline) {
             // Add ourselves to the containing block of the entire continuation so that it can
             // paint us atomically.
-            containingBlock->addContinuationWithOutline(downcast<RenderInline>(renderer().element()->renderer()));
+            containingBlock->addContinuationWithOutline(*downcast<RenderInline>(renderer().element()->renderer()));
         } else if (!inlineFlow.isContinuation())
             m_paintInfo.outlineObjects->add(inlineFlow);
 

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -2158,12 +2158,12 @@ void LegacyLineLayout::addOverflowFromInlineChildren()
         m_flow.addLayoutOverflow(curr->paddedLayoutOverflowRect(endPadding));
         RenderFragmentContainer* fragment = m_flow.enclosingFragmentedFlow() ? curr->containingFragment() : nullptr;
         if (fragment)
-            fragment->addLayoutOverflowForBox(&m_flow, curr->paddedLayoutOverflowRect(endPadding));
+            fragment->addLayoutOverflowForBox(m_flow, curr->paddedLayoutOverflowRect(endPadding));
         if (!m_flow.hasNonVisibleOverflow()) {
             LayoutRect childVisualOverflowRect = curr->visualOverflowRect(curr->lineTop(), curr->lineBottom());
             m_flow.addVisualOverflow(childVisualOverflowRect);
             if (fragment)
-                fragment->addVisualOverflowForBox(&m_flow, childVisualOverflowRect);
+                fragment->addVisualOverflowForBox(m_flow, childVisualOverflowRect);
         }
     }
 }

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -27,7 +27,7 @@
 #include "RenderBox.h"
 #include "TextRun.h"
 #include <memory>
-#include <wtf/ListHashSet.h>
+#include <wtf/WeakListHashSet.h>
 
 namespace WebCore {
 
@@ -39,7 +39,7 @@ class RenderText;
 struct BidiRun;
 struct PaintInfo;
 
-typedef ListHashSet<RenderBox*> TrackedRendererListHashSet;
+using TrackedRendererListHashSet = WeakListHashSet<RenderBox>;
 
 enum CaretType { CursorCaret, DragCaret };
 enum ContainingBlockState { NewContainingBlock, SameContainingBlock };
@@ -83,8 +83,8 @@ public:
     TrackedRendererListHashSet* positionedObjects() const;
     bool hasPositionedObjects() const
     {
-        TrackedRendererListHashSet* objects = positionedObjects();
-        return objects && !objects->isEmpty();
+        auto* objects = positionedObjects();
+        return objects && !objects->isEmptyIgnoringNullReferences();
     }
 
     void addPercentHeightDescendant(RenderBox&);
@@ -92,8 +92,8 @@ public:
     TrackedRendererListHashSet* percentHeightDescendants() const;
     bool hasPercentHeightDescendants() const
     {
-        TrackedRendererListHashSet* objects = percentHeightDescendants();
-        return objects && !objects->isEmpty();
+        auto* objects = percentHeightDescendants();
+        return objects && !objects->isEmptyIgnoringNullReferences();
     }
     static bool hasPercentHeightContainerMap();
     static bool hasPercentHeightDescendant(RenderBox&);
@@ -166,8 +166,8 @@ public:
 
     LayoutRect logicalRectToPhysicalRect(const LayoutPoint& physicalPosition, const LayoutRect& logicalRect);
 
-    void addContinuationWithOutline(RenderInline*);
-    bool paintsContinuationOutline(RenderInline*);
+    void addContinuationWithOutline(RenderInline&);
+    bool paintsContinuationOutline(RenderInline&);
 
     static RenderPtr<RenderBlock> createAnonymousWithParentRendererAndDisplay(const RenderBox& parent, DisplayType = DisplayType::Block);
     RenderPtr<RenderBlock> createAnonymousBlock(DisplayType = DisplayType::Block) const;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -170,8 +170,8 @@ public:
     
     void addVisualEffectOverflow();
     LayoutRect applyVisualEffectOverflow(const LayoutRect&) const;
-    void addOverflowFromChild(const RenderBox* child) { addOverflowFromChild(child, child->locationOffset()); }
-    void addOverflowFromChild(const RenderBox* child, const LayoutSize& delta);
+    void addOverflowFromChild(const RenderBox& child) { addOverflowFromChild(child, child.locationOffset()); }
+    void addOverflowFromChild(const RenderBox& child, const LayoutSize& delta);
 
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
 
@@ -355,7 +355,7 @@ public:
 
     enum RenderBoxFragmentInfoFlags { CacheRenderBoxFragmentInfo, DoNotCacheRenderBoxFragmentInfo };
     LayoutRect borderBoxRectInFragment(const RenderFragmentContainer*, RenderBoxFragmentInfoFlags = CacheRenderBoxFragmentInfo) const;
-    LayoutRect clientBoxRectInFragment(const RenderFragmentContainer*) const;
+    LayoutRect clientBoxRectInFragment(const RenderFragmentContainer&) const;
     RenderFragmentContainer* clampToStartAndEndFragments(RenderFragmentContainer*) const;
     bool hasFragmentRangeInFragmentedFlow() const;
     virtual LayoutUnit offsetFromLogicalTopOfFirstPage() const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2138,8 +2138,8 @@ bool RenderFlexibleBox::childHasPercentHeightDescendants(const RenderBox& render
     // return false for a child of a <button> with a percentage height.
     if (hasPercentHeightDescendants() && skipContainingBlockForPercentHeightCalculation(renderer, isHorizontalWritingMode() != renderer.isHorizontalWritingMode())) {
         auto& descendants = *percentHeightDescendants();
-        for (auto* descendant : descendants) {
-            if (renderBlock.isContainingBlockAncestorFor(*descendant))
+        for (auto& descendant : descendants) {
+            if (renderBlock.isContainingBlockAncestorFor(descendant))
                 return true;
         }
     }
@@ -2153,7 +2153,7 @@ bool RenderFlexibleBox::childHasPercentHeightDescendants(const RenderBox& render
 
     for (auto it = percentHeightDescendants->begin(), end = percentHeightDescendants->end(); it != end; ++it) {
         bool hasOutOfFlowAncestor = false;
-        for (auto* ancestor = (*it)->containingBlock(); ancestor && ancestor != &renderBlock; ancestor = ancestor->containingBlock()) {
+        for (auto* ancestor = (*it).containingBlock(); ancestor && ancestor != &renderBlock; ancestor = ancestor->containingBlock()) {
             if (ancestor->isOutOfFlowPositioned()) {
                 hasOutOfFlowAncestor = true;
                 break;

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -406,12 +406,12 @@ void RenderFragmentContainer::computePreferredLogicalWidths()
     setPreferredLogicalWidthsDirty(false);
 }
 
-void RenderFragmentContainer::ensureOverflowForBox(const RenderBox* box, RefPtr<RenderOverflow>& overflow, bool forceCreation) const
+void RenderFragmentContainer::ensureOverflowForBox(const RenderBox& box, RefPtr<RenderOverflow>& overflow, bool forceCreation) const
 {
     ASSERT(m_fragmentedFlow->renderFragmentContainerList().contains(*this));
     ASSERT(isValid());
 
-    RenderBoxFragmentInfo* boxInfo = renderBoxFragmentInfo(box);
+    auto* boxInfo = renderBoxFragmentInfo(&box);
     if (!boxInfo && !forceCreation)
         return;
 
@@ -420,14 +420,14 @@ void RenderFragmentContainer::ensureOverflowForBox(const RenderBox* box, RefPtr<
         return;
     }
     
-    LayoutRect borderBox = box->borderBoxRectInFragment(this);
+    LayoutRect borderBox = box.borderBoxRectInFragment(this);
     LayoutRect clientBox;
     ASSERT(m_fragmentedFlow->objectShouldFragmentInFlowFragment(box, this));
 
     if (!borderBox.isEmpty()) {
         borderBox = rectFlowPortionForBox(box, borderBox);
         
-        clientBox = box->clientBoxRectInFragment(this);
+        clientBox = box.clientBoxRectInFragment(*this);
         clientBox = rectFlowPortionForBox(box, clientBox);
         
         m_fragmentedFlow->flipForWritingModeLocalCoordinates(borderBox);
@@ -441,7 +441,7 @@ void RenderFragmentContainer::ensureOverflowForBox(const RenderBox* box, RefPtr<
         overflow = adoptRef(new RenderOverflow(clientBox, borderBox));
 }
 
-LayoutRect RenderFragmentContainer::rectFlowPortionForBox(const RenderBox* box, const LayoutRect& rect) const
+LayoutRect RenderFragmentContainer::rectFlowPortionForBox(const RenderBox& box, const LayoutRect& rect) const
 {
     LayoutRect mappedRect = m_fragmentedFlow->mapFromLocalToFragmentedFlow(box, rect);
 
@@ -464,7 +464,7 @@ LayoutRect RenderFragmentContainer::rectFlowPortionForBox(const RenderBox* box, 
     return m_fragmentedFlow->mapFromFragmentedFlowToLocal(box, mappedRect);
 }
 
-void RenderFragmentContainer::addLayoutOverflowForBox(const RenderBox* box, const LayoutRect& rect)
+void RenderFragmentContainer::addLayoutOverflowForBox(const RenderBox& box, const LayoutRect& rect)
 {
     if (rect.isEmpty())
         return;
@@ -478,7 +478,7 @@ void RenderFragmentContainer::addLayoutOverflowForBox(const RenderBox* box, cons
     fragmentOverflow->addLayoutOverflow(rect);
 }
 
-void RenderFragmentContainer::addVisualOverflowForBox(const RenderBox* box, const LayoutRect& rect)
+void RenderFragmentContainer::addVisualOverflowForBox(const RenderBox& box, const LayoutRect& rect)
 {
     if (rect.isEmpty())
         return;
@@ -503,7 +503,7 @@ LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBoxMode
 
     if (is<RenderBox>(box)) {
         RefPtr<RenderOverflow> overflow;
-        ensureOverflowForBox(&downcast<RenderBox>(box), overflow, true);
+        ensureOverflowForBox(downcast<RenderBox>(box), overflow, true);
 
         ASSERT(overflow);
         return overflow->visualOverflowRect();
@@ -514,25 +514,25 @@ LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBoxMode
 }
 
 // FIXME: This doesn't work for writing modes.
-LayoutRect RenderFragmentContainer::layoutOverflowRectForBoxForPropagation(const RenderBox* box)
+LayoutRect RenderFragmentContainer::layoutOverflowRectForBoxForPropagation(const RenderBox& box)
 {
     // Only propagate interior layout overflow if we don't clip it.
-    LayoutRect rect = box->borderBoxRectInFragment(this);
+    LayoutRect rect = box.borderBoxRectInFragment(this);
     rect = rectFlowPortionForBox(box, rect);
-    if (!box->hasNonVisibleOverflow()) {
+    if (!box.hasNonVisibleOverflow()) {
         RefPtr<RenderOverflow> overflow;
         ensureOverflowForBox(box, overflow, true);
         ASSERT(overflow);
         rect.unite(overflow->layoutOverflowRect());
     }
 
-    bool hasTransform = box->isTransformed();
-    if (box->isInFlowPositioned() || hasTransform) {
+    bool hasTransform = box.isTransformed();
+    if (box.isInFlowPositioned() || hasTransform) {
         if (hasTransform)
-            rect = box->layer()->currentTransform().mapRect(rect);
+            rect = box.layer()->currentTransform().mapRect(rect);
 
-        if (box->isInFlowPositioned())
-            rect.move(box->offsetForInFlowPosition());
+        if (box.isInFlowPositioned())
+            rect.move(box.offsetForInFlowPosition());
     }
 
     return rect;

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -101,13 +101,13 @@ public:
 
     virtual void collectLayerFragments(LayerFragments&, const LayoutRect&, const LayoutRect&) { }
 
-    void addLayoutOverflowForBox(const RenderBox*, const LayoutRect&);
-    void addVisualOverflowForBox(const RenderBox*, const LayoutRect&);
+    void addLayoutOverflowForBox(const RenderBox&, const LayoutRect&);
+    void addVisualOverflowForBox(const RenderBox&, const LayoutRect&);
     LayoutRect visualOverflowRectForBox(const RenderBoxModelObject&) const;
-    LayoutRect layoutOverflowRectForBoxForPropagation(const RenderBox*);
+    LayoutRect layoutOverflowRectForBoxForPropagation(const RenderBox&);
     LayoutRect visualOverflowRectForBoxForPropagation(const RenderBoxModelObject&);
 
-    LayoutRect rectFlowPortionForBox(const RenderBox*, const LayoutRect&) const;
+    LayoutRect rectFlowPortionForBox(const RenderBox&, const LayoutRect&) const;
     
     void setFragmentObjectsFragmentStyle();
     void restoreFragmentObjectsOriginalStyle();
@@ -122,7 +122,7 @@ protected:
     RenderFragmentContainer(Element&, RenderStyle&&, RenderFragmentedFlow*);
     RenderFragmentContainer(Document&, RenderStyle&&, RenderFragmentedFlow*);
 
-    void ensureOverflowForBox(const RenderBox*, RefPtr<RenderOverflow>&, bool) const;
+    void ensureOverflowForBox(const RenderBox&, RefPtr<RenderOverflow>&, bool) const;
 
     void computePreferredLogicalWidths() override;
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -111,7 +111,7 @@ public:
 
     virtual RenderFragmentContainer* mapFromFlowToFragment(TransformState&) const;
 
-    void logicalWidthChangedInFragmentsForBlock(const RenderBlock*, bool&);
+    void logicalWidthChangedInFragmentsForBlock(const RenderBlock&, bool&);
 
     LayoutUnit contentLogicalWidthOfFirstFragment() const;
     LayoutUnit contentLogicalHeightOfFirstFragment() const;
@@ -121,15 +121,15 @@ public:
     RenderFragmentContainer* lastFragment() const;
 
     virtual void setFragmentRangeForBox(const RenderBox&, RenderFragmentContainer*, RenderFragmentContainer*);
-    bool getFragmentRangeForBox(const RenderBox*, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
-    bool computedFragmentRangeForBox(const RenderBox*, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
+    bool getFragmentRangeForBox(const RenderBox&, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
+    bool computedFragmentRangeForBox(const RenderBox&, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
     bool hasCachedFragmentRangeForBox(const RenderBox&) const;
 
     // Check if the object is in fragment and the fragment is part of this flow thread.
     bool objectInFlowFragment(const RenderObject*, const RenderFragmentContainer*) const;
     
     // Check if the object should be painted in this fragment and if the fragment is part of this flow thread.
-    bool objectShouldFragmentInFlowFragment(const RenderObject*, const RenderFragmentContainer*) const;
+    bool objectShouldFragmentInFlowFragment(const RenderObject&, const RenderFragmentContainer*) const;
 
     void markFragmentsForOverflowLayoutIfNeeded();
 
@@ -145,15 +145,15 @@ public:
     LayoutUnit offsetFromLogicalTopOfFirstFragment(const RenderBlock*) const;
     void clearRenderBoxFragmentInfoAndCustomStyle(const RenderBox&, const RenderFragmentContainer*, const RenderFragmentContainer*, const RenderFragmentContainer*, const RenderFragmentContainer*);
 
-    void addFragmentsVisualEffectOverflow(const RenderBox*);
-    void addFragmentsVisualOverflowFromTheme(const RenderBlock*);
-    void addFragmentsOverflowFromChild(const RenderBox*, const RenderBox*, const LayoutSize&);
-    void addFragmentsLayoutOverflow(const RenderBox*, const LayoutRect&);
-    void addFragmentsVisualOverflow(const RenderBox*, const LayoutRect&);
-    void clearFragmentsOverflow(const RenderBox*);
+    void addFragmentsVisualEffectOverflow(const RenderBox&);
+    void addFragmentsVisualOverflowFromTheme(const RenderBlock&);
+    void addFragmentsOverflowFromChild(const RenderBox&, const RenderBox&, const LayoutSize&);
+    void addFragmentsLayoutOverflow(const RenderBox&, const LayoutRect&);
+    void addFragmentsVisualOverflow(const RenderBox&, const LayoutRect&);
+    void clearFragmentsOverflow(const RenderBox&);
 
-    LayoutRect mapFromFragmentedFlowToLocal(const RenderBox*, const LayoutRect&) const;
-    LayoutRect mapFromLocalToFragmentedFlow(const RenderBox*, const LayoutRect&) const;
+    LayoutRect mapFromFragmentedFlowToLocal(const RenderBox&, const LayoutRect&) const;
+    LayoutRect mapFromLocalToFragmentedFlow(const RenderBox&, const LayoutRect&) const;
 
     void flipForWritingModeLocalCoordinates(LayoutRect&) const;
 
@@ -162,7 +162,7 @@ public:
 
     bool fragmentInRange(const RenderFragmentContainer* targetFragment, const RenderFragmentContainer* startFragment, const RenderFragmentContainer* endFragment) const;
 
-    bool absoluteQuadsForBox(Vector<FloatQuad>&, bool*, const RenderBox*) const;
+    bool absoluteQuadsForBox(Vector<FloatQuad>&, bool*, const RenderBox&) const;
 
     void layout() override;
 
@@ -200,7 +200,7 @@ protected:
     void updateFragmentsFragmentedFlowPortionRect();
     bool shouldRepaint(const LayoutRect&) const;
 
-    bool getFragmentRangeForBoxFromCachedInfo(const RenderBox*, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
+    bool getFragmentRangeForBoxFromCachedInfo(const RenderBox&, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
 
     void removeRenderBoxFragmentInfo(RenderBox&);
     void removeLineFragmentInfo(const RenderBlockFlow&);

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -85,7 +85,7 @@ void RenderInline::willBeDestroyed()
         if (containingBlockPaintsContinuationOutline) {
             if (RenderBlock* cb = containingBlock()) {
                 if (RenderBlock* cbCb = cb->containingBlock())
-                    ASSERT(!cbCb->paintsContinuationOutline(this));
+                    ASSERT(!cbCb->paintsContinuationOutline(*this));
             }
         }
     }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1205,7 +1205,7 @@ void RenderObject::outputRegionsInformation(TextStream& stream) const
 
     RenderFragmentContainer* startContainer = nullptr;
     RenderFragmentContainer* endContainer = nullptr;
-    fragmentedFlow->getFragmentRangeForBox(downcast<RenderBox>(this), startContainer, endContainer);
+    fragmentedFlow->getFragmentRangeForBox(downcast<RenderBox>(*this), startContainer, endContainer);
     stream << " [spans fragment containers in flow " << fragmentedFlow << " from " << startContainer << " to " << endContainer << "]";
 }
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -699,12 +699,12 @@ void RenderTable::addOverflowFromChildren()
     }
 
     // Add overflow from our caption.
-    for (unsigned i = 0; i < m_captions.size(); i++) 
-        addOverflowFromChild(m_captions[i].get());
+    for (unsigned i = 0; i < m_captions.size(); i++)
+        addOverflowFromChild(*m_captions[i]);
 
     // Add overflow from our sections.
-    for (RenderTableSection* section = topSection(); section; section = sectionBelow(section))
-        addOverflowFromChild(section);
+    for (auto* section = topSection(); section; section = sectionBelow(section))
+        addOverflowFromChild(*section);
 }
 
 void RenderTable::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -514,8 +514,8 @@ void RenderTableSection::relayoutCellIfFlexed(RenderTableCell& cell, int rowInde
 
     if (!cellChildrenFlex) {
         if (TrackedRendererListHashSet* percentHeightDescendants = cell.percentHeightDescendants()) {
-            for (auto* descendant : *percentHeightDescendants) {
-                if (flexAllChildren || shouldFlexCellChild(cell, *descendant)) {
+            for (auto& descendant : *percentHeightDescendants) {
+                if (flexAllChildren || shouldFlexCellChild(cell, descendant)) {
                     cellChildrenFlex = true;
                     break;
                 }
@@ -660,13 +660,13 @@ void RenderTableSection::computeOverflowFromCells(unsigned totalRows, unsigned n
     // Now that our height has been determined, add in overflow from cells.
     for (unsigned r = 0; r < totalRows; r++) {
         for (unsigned c = 0; c < nEffCols; c++) {
-            CellStruct& cs = cellAt(r, c);
-            RenderTableCell* cell = cs.primaryCell();
+            auto& cs = cellAt(r, c);
+            auto* cell = cs.primaryCell();
             if (!cell || cs.inColSpan)
                 continue;
             if (r < totalRows - 1 && cell == primaryCellAt(r + 1, c))
                 continue;
-            addOverflowFromChild(cell);
+            addOverflowFromChild(*cell);
 #if ASSERT_ENABLED
             hasOverflowingCell |= cell->hasVisualOverflow();
 #endif
@@ -1287,7 +1287,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             // To make sure we properly repaint the section, we repaint all the overflowing cells that we collected.
             auto cells = copyToVector(m_overflowingCells);
 
-            HashSet<RenderTableCell*> spanningCells;
+            WeakHashSet<RenderTableCell> spanningCells;
 
             for (unsigned r = dirtiedRows.start; r < dirtiedRows.end; r++) {
                 RenderTableRow* row = m_grid[r].rowRenderer;
@@ -1302,7 +1302,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
                             continue;
 
                         if (current.cells[i]->rowSpan() > 1 || current.cells[i]->colSpan() > 1) {
-                            if (!spanningCells.add(current.cells[i]).isNewEntry)
+                            if (!spanningCells.add(*current.cells[i]).isNewEntry)
                                 continue;
                         }
 

--- a/Source/WebCore/rendering/SelectionRangeData.cpp
+++ b/Source/WebCore/rendering/SelectionRangeData.cpp
@@ -141,7 +141,7 @@ void SelectionRangeData::clear()
 
 void SelectionRangeData::repaint() const
 {
-    HashSet<RenderBlock*> processedBlocks;
+    WeakHashSet<RenderBlock> processedBlocks;
     RenderObject* end = nullptr;
     if (m_renderRange.end())
         end = rendererAfterOffset(*m_renderRange.end(), m_renderRange.endOffset());
@@ -154,7 +154,7 @@ void SelectionRangeData::repaint() const
         RenderSelectionInfo(*renderer, true).repaint();
         // Blocks are responsible for painting line gaps and margin gaps. They must be examined as well.
         for (auto* block = containingBlockBelowView(*renderer); block; block = containingBlockBelowView(*block)) {
-            if (!processedBlocks.add(block).isNewEntry)
+            if (!processedBlocks.add(*block).isNewEntry)
                 break;
             RenderSelectionInfo(*block, true).repaint();
         }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -642,7 +642,7 @@ void RenderSVGRoot::boundingRects(Vector<LayoutRect>& rects, const LayoutPoint& 
 void RenderSVGRoot::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
 {
     auto* fragmentedFlow = enclosingFragmentedFlow();
-    if (fragmentedFlow && fragmentedFlow->absoluteQuadsForBox(quads, wasFixed, this))
+    if (fragmentedFlow && fragmentedFlow->absoluteQuadsForBox(quads, wasFixed, *this))
         return;
 
     quads.append(localToAbsoluteQuad(FloatRect { borderBoxRect() }, UseTransforms, wasFixed));


### PR DESCRIPTION
#### 8650e88882f120e9a711764b2bb85ba75356b0bc
<pre>
Store less raw pointers in containers in Source/rendering/
<a href="https://bugs.webkit.org/show_bug.cgi?id=261545">https://bugs.webkit.org/show_bug.cgi?id=261545</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/WeakHashMap.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::layoutOverflowRectContainsAllDescendants):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::adjustVerticalPageScrollStepForFixedContent):
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paint):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::insertIntoTrackedRendererMaps):
(WebCore::removeFromTrackedRendererMaps):
(WebCore::PositionedDescendantsMap::addDescendant):
(WebCore::PositionedDescendantsMap::removeDescendant):
(WebCore::PositionedDescendantsMap::removeContainingBlock):
(WebCore::PositionedDescendantsMap::positionedRenderers const):
(WebCore::removeBlockFromPercentageDescendantAndContainerMaps):
(WebCore::RenderBlock::~RenderBlock):
(WebCore::RenderBlock::blockWillBeDestroyed):
(WebCore::RenderBlock::hasRareData const):
(WebCore::getBlockRareData):
(WebCore::ensureBlockRareData):
(WebCore::RenderBlock::addOverflowFromPositionedObjects):
(WebCore::RenderBlock::dirtyForLayoutFromPercentageHeightDescendants):
(WebCore::RenderBlock::layoutPositionedObjects):
(WebCore::RenderBlock::markPositionedObjectsForLayout):
(WebCore::RenderBlock::paintObject):
(WebCore::RenderBlock::addContinuationWithOutline):
(WebCore::RenderBlock::paintsContinuationOutline):
(WebCore::RenderBlock::paintContinuationOutlines):
(WebCore::clipOutPositionedObjects):
(WebCore::RenderBlock::removePositionedObjects):
(WebCore::RenderBlock::percentHeightDescendants const):
(WebCore::RenderBlock::hasPercentHeightDescendant):
(WebCore::RenderBlock::checkPositionedObjectsNeedLayout):
* Source/WebCore/rendering/RenderBlock.h:
(WebCore::RenderBlock::hasPositionedObjects const):
(WebCore::RenderBlock::hasPercentHeightDescendants const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats):
(WebCore::RenderBlockFlow::simplifiedNormalFlowLayout):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::childHasPercentHeightDescendants const):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::willBeDestroyed):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::relayoutCellIfFlexed):
(WebCore::RenderTableSection::paintObject):
* Source/WebCore/rendering/SelectionRangeData.cpp:
(WebCore::SelectionRangeData::repaint const):

Canonical link: <a href="https://commits.webkit.org/268000@main">https://commits.webkit.org/268000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/109001e86f5289e7e816f9b9e099ba7122edd08b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23174 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15845 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21064 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17572 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14774 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21644 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16511 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5303 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4368 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20875 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22878 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17259 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5150 "Passed tests") | 
<!--EWS-Status-Bubble-End-->