### PR TITLE
[Fast text codepath] Slight cleanups after 267095@main

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -187,7 +187,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     bool shouldNotBeUsedForArabic() const { return m_shouldNotBeUsedForArabic; };
 #endif
-#if PLATFORM(COCOA)
+#if USE(CORE_TEXT)
     CTFontRef getCTFont() const { return m_platformData.font(); }
     RetainPtr<CFDictionaryRef> getCFStringAttributes(bool enableKerning, FontOrientation, const AtomString& locale) const;
     bool supportsSmallCaps() const;

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -281,7 +281,6 @@ void Font::platformCharWidthInit()
 
 bool Font::variantCapsSupportedForSynthesis(FontVariantCaps fontVariantCaps) const
 {
-#if (PLATFORM(IOS_FAMILY) && TARGET_OS_IOS) || PLATFORM(MAC)
     switch (fontVariantCaps) {
     case FontVariantCaps::Small:
         return supportsSmallCaps();
@@ -295,21 +294,8 @@ bool Font::variantCapsSupportedForSynthesis(FontVariantCaps fontVariantCaps) con
         // Synthesis only supports the variant-caps values listed above.
         return true;
     }
-#else
-    switch (fontVariantCaps) {
-    case FontVariantCaps::Small:
-    case FontVariantCaps::Petite:
-    case FontVariantCaps::AllSmall:
-    case FontVariantCaps::AllPetite:
-        return false;
-    default:
-        // Synthesis only supports the variant-caps values listed above.
-        return true;
-    }
-#endif
 }
 
-#if (PLATFORM(IOS_FAMILY) && TARGET_OS_IOS) || PLATFORM(MAC)
 static RetainPtr<CFDictionaryRef> smallCapsOpenTypeDictionary(CFStringRef key, int rawValue)
 {
     RetainPtr<CFNumberRef> value = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &rawValue));
@@ -400,7 +386,6 @@ bool Font::supportsAllPetiteCaps() const
     }
     return m_supportsAllPetiteCaps == SupportsFeature::Yes;
 }
-#endif
 
 static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrientation orientation, CTFontSymbolicTraits fontTraits, bool syntheticBold, bool syntheticItalic, FontWidthVariant fontWidthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
 {


### PR DESCRIPTION
#### 95990ec923ef7e850b34f8c30fd046dd8c2da54c
<pre>
[Fast text codepath] Slight cleanups after 267095@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=261548">https://bugs.webkit.org/show_bug.cgi?id=261548</a>
rdar://115471679

Reviewed by Cameron McCormack.

Most of this is stylistic. The only non-stylistic change is to
take the Mac/iOS codepath on all Apple platforms.

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::resetGlyphBuffer):
(WebCore::SmallCapsState::SmallCapsState):
(WebCore::SmallCapsState::setSmallCapsData):
(WebCore::WidthIterator::startNewFontRangeIfNeeded):
(WebCore::resetFontRangeIfNeeded):
(WebCore::WidthIterator::advanceInternal):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::variantCapsSupportedForSynthesis const):

Canonical link: <a href="https://commits.webkit.org/267982@main">https://commits.webkit.org/267982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e126ee9096e401c81183c177d888f44939c3bc89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17089 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20982 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23146 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21035 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16485 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4350 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->