### PR TITLE
Add checks for the supported WebCrypto algorithms.

### DIFF
--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -122,6 +122,9 @@ static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerate
 
 std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
 {
+    if (!isPlatformSupportedCurve(namedCurve))
+        return std::nullopt;
+
     std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> keyPair;
     switch (namedCurve) {
     case NamedCurve::Ed25519:
@@ -131,6 +134,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
         keyPair = gcryptGenerateX25519Keys();
         break;
     default:
+        ASSERT_NOT_REACHED();
         return std::nullopt;
     }
 
@@ -152,6 +156,9 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
 
 bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve namedCurve, const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
 {
+    if (!isPlatformSupportedCurve(namedCurve))
+        return false;
+
     switch (namedCurve) {
     case NamedCurve::X25519: {
         // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
@@ -177,6 +184,9 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
+    if (!isPlatformSupportedCurve(curve))
+        return nullptr;
+
     // Decode the `SubjectPublicKeyInfo` structure using the provided key data.
     PAL::TASN1::Structure spki;
     if (!PAL::TASN1::decodeStructure(&spki, "WebCrypto.SubjectPublicKeyInfo", keyData))
@@ -205,7 +215,18 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifi
             return nullptr;
 
         // Construct the `public-key` expression to be used for generating the MPI structure.
-        gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, curve == CryptoKeyOKP::NamedCurve::Ed25519 ? "(public-key(ecc(curve Ed25519)(q %b)))" : "(public-key(ecc(curve Curve25519)(q %b)))", subjectPublicKey->size(), subjectPublicKey->data());
+        gcry_error_t error = GPG_ERR_NO_ERROR;
+        switch (curve) {
+        case CryptoKeyOKP::NamedCurve::Ed25519:
+            error = gcry_sexp_build(&platformKey, nullptr, "(public-key(ecc(curve Ed25519)(q %b)))", subjectPublicKey->size(), subjectPublicKey->data());
+            break;
+        case CryptoKeyOKP::NamedCurve::X25519:
+            error = gcry_sexp_build(&platformKey, nullptr, "(public-key(ecc(curve Curve25519)(q %b)))", subjectPublicKey->size(), subjectPublicKey->data());
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+            return nullptr;
+        }
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return nullptr;
@@ -227,6 +248,19 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifi
     return create(identifier, curve, CryptoKeyType::Public, Vector<uint8_t>(*rawKey), extractable, usages);
 }
 
+static const std::array<uint8_t, 12> algorithmId(WebCore::CryptoKeyOKP::NamedCurve curve)
+{
+    switch (curve) {
+    case CryptoKeyOKP::NamedCurve::Ed25519:
+        return CryptoConstants::s_ed25519Identifier;
+    case CryptoKeyOKP::NamedCurve::X25519:
+        return CryptoConstants::s_x25519Identifier;
+    default:
+        ASSERT_NOT_REACHED();
+        return { { "" } };
+    }
+}
+
 ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
 {
     if (type() != CryptoKeyType::Public)
@@ -239,7 +273,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
             return Exception { OperationError };
 
         // Write out the id-edPublicKey identifier under `algorithm.algorithm`.
-        if (!PAL::TASN1::writeElement(spki, "algorithm.algorithm", m_curve == CryptoKeyOKP::NamedCurve::Ed25519 ? CryptoConstants::s_ed25519Identifier.data() : CryptoConstants::s_x25519Identifier.data(), 1))
+        if (!PAL::TASN1::writeElement(spki, "algorithm.algorithm", algorithmId(m_curve).data(), 1))
             return Exception { OperationError };
 
         // The 'paramaters' element should not be present
@@ -271,6 +305,9 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
+    if (!isPlatformSupportedCurve(curve))
+        return nullptr;
+
     // Decode the `PrivateKeyInfo` structure using the provided key data.
     PAL::TASN1::Structure pkcs8;
     if (!PAL::TASN1::decodeStructure(&pkcs8, "WebCrypto.PrivateKeyInfo", keyData))
@@ -324,7 +361,18 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identif
             return nullptr;
 
         // Construct the `private-key` expression that will also be used for the EC context.
-        gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, curve == CryptoKeyOKP::NamedCurve::Ed25519 ? "(private-key(ecc(curve Ed25519)(flags eddsa)(d %b)))" : "(private-key(ecc(curve Curve25519)(d %b)))", privateKey->size(), privateKey->data());
+        gcry_error_t error = GPG_ERR_NO_ERROR;
+        switch (curve) {
+        case CryptoKeyOKP::NamedCurve::Ed25519:
+            error = gcry_sexp_build(&platformKey, nullptr, "(private-key(ecc(curve Ed25519)(flags eddsa)(d %b)))", privateKey->size(), privateKey->data());
+            break;
+        case CryptoKeyOKP::NamedCurve::X25519:
+            error = gcry_sexp_build(&platformKey, nullptr, "(private-key(ecc(curve Curve25519)(d %b)))", privateKey->size(), privateKey->data());
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+            return nullptr;
+        }
         if (error != GPG_ERR_NO_ERROR) {
             PAL::GCrypt::logError(error);
             return nullptr;
@@ -391,7 +439,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportPkcs8() const
             return Exception { OperationError };
 
         // Write out the id-Ed25519 identifier under `privateKeyAlgorithm.algorithm`.
-        if (!PAL::TASN1::writeElement(pkcs8, "privateKeyAlgorithm.algorithm", m_curve == CryptoKeyOKP::NamedCurve::Ed25519 ? CryptoConstants::s_ed25519Identifier.data() : CryptoConstants::s_x25519Identifier.data(), 1))
+        if (!PAL::TASN1::writeElement(pkcs8, "privateKeyAlgorithm.algorithm", algorithmId(m_curve).data(), 1))
             return Exception { OperationError };
 
         // The 'paramaters' element should not be present


### PR DESCRIPTION
#### 1fa83f2bc4ee72f8ebf13b4dae1348c2f4d1897a
<pre>
Add checks for the supported WebCrypto algorithms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261550">https://bugs.webkit.org/show_bug.cgi?id=261550</a>

Reviewed by Žan Doberšek.

We have several functions using if/then/else clauses and ternary
operators to  reuse the logic structure between several algorithms
that use the OKP keys (eg, Curve25519 and Curve488).

While it&apos;s not a big deal for Curve25519, since we are talking just
about 2 algorithms, it may become a problem if we want to add support
for Curve488 in the future.

This PR adds some checks in different functions to early return in
case of unsupported algorithms.

* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::algorithmId):
(WebCore::CryptoKeyOKP::exportSpki const):
(WebCore::CryptoKeyOKP::importPkcs8):
(WebCore::CryptoKeyOKP::exportPkcs8 const):
* Source/WebCore/crypto/mac/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::writeOID):
(WebCore::CryptoKeyOKP::importPkcs8):

Canonical link: <a href="https://commits.webkit.org/268079@main">https://commits.webkit.org/268079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f28e6b0e48678bb51f3147171bf404ab7e1baa35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17228 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21129 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23262 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14871 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16609 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4423 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->