### PR TITLE
Skip some tests on memory limited (aka slow) devices in lockdown test mode.

### DIFF
--- a/JSTests/microbenchmarks/mul-immediate-sub.js
+++ b/JSTests/microbenchmarks/mul-immediate-sub.js
@@ -1,5 +1,6 @@
 //@ skip if not $jitTests
-//@ $skipModes << :lockdown if $architecture == "mips"
+//@ $skipModes << :lockdown if $memoryLimited
+
 function doTest(max) {
     let sum = 0
     for (let i=0; i<max; ++i) {

--- a/JSTests/microbenchmarks/typed-array-from-array.js
+++ b/JSTests/microbenchmarks/typed-array-from-array.js
@@ -1,3 +1,6 @@
+//@ $skipModes << :lockdown if $memoryLimited
+// Here we're using $memoryLimited as a proxy for "slower device" and this test is very slow in lockdown.
+
 var a1 = new Array(1024 * 1024 * 1);
 a1.fill(99);
 for (var i = 0; i < 1e2; ++i)

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $memoryLimited
+
 function shouldEqual(actual, expected) {
     if (actual != expected) {
         throw "ERROR: expect " + expected + ", actual " + actual;

--- a/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
+++ b/JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $memoryLimited
+
 function shouldEqual(actual, expected) {
     if (actual != expected) {
         throw "ERROR: expect " + expected + ", actual " + actual;


### PR DESCRIPTION
#### 0621aef584f776393f96f130107a5f7dcd7ffc9c
<pre>
Skip some tests on memory limited (aka slow) devices in lockdown test mode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261558">https://bugs.webkit.org/show_bug.cgi?id=261558</a>
rdar://115496412

Reviewed by Alexey Shvayka.

These tests are timing out on slower devices.

* JSTests/microbenchmarks/mul-immediate-sub.js:
* JSTests/microbenchmarks/typed-array-from-array.js:
* JSTests/stress/array-prototype-concat-of-long-spliced-arrays.js:
* JSTests/stress/array-prototype-concat-of-long-spliced-arrays2.js:

Canonical link: <a href="https://commits.webkit.org/267998@main">https://commits.webkit.org/267998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83bb0fb59595130e065ad6bde5da1dd81998a2c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21007 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15937 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23171 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15843 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21062 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17569 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14771 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21641 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16509 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5302 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20872 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22875 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2246 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17256 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5148 "Passed tests") | 
<!--EWS-Status-Bubble-End-->