### PR TITLE
Add targets for vp8 and vp9 builds of vpx_dec_fuzzer.cc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/Base-libvpx.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/Base-libvpx.xcconfig
@@ -1,0 +1,15 @@
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_STRICT_PROTOTYPES = NO;
+CLANG_X86_VECTOR_INSTRUCTIONS = default;
+GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+COMBINE_HIDPI_IMAGES = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+
+HEADER_SEARCH_PATHS[arch=x86_64] = Source/third_party/libvpx/source/config/mac/x64 Source/third_party/libvpx/source/libvpx Source/third_party/libvpx/source/config;
+HEADER_SEARCH_PATHS[arch=arm64*] = Source/third_party/libvpx/source/config/ios/arm64 Source/third_party/libvpx/source/libvpx Source/third_party/libvpx/source/config;
+
+GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*] = $(inherited) WEBRTC_WEBKIT_DISABLE_HARDWARE_ACCELERATION;
+GCC_PREPROCESSOR_DEFINITIONS[sdk=macosx*] = $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_$(WK_IS_CATALYST))
+GCC_PREPROCESSOR_DEFINITIONS_YES = WEBRTC_WEBKIT_MAC_CATALIST

--- a/Source/ThirdParty/libwebrtc/Configurations/fuzz-libvpx-vp8.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/fuzz-libvpx-vp8.xcconfig
@@ -1,0 +1,5 @@
+#include "Base-libvpx.xcconfig"
+
+PRODUCT_NAME = fuzz-libvpx-vp8;
+
+OTHER_CFLAGS = $(inherited) -DDECODER=vp8;

--- a/Source/ThirdParty/libwebrtc/Configurations/fuzz-libvpx-vp9.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/fuzz-libvpx-vp9.xcconfig
@@ -1,0 +1,5 @@
+#include "Base-libvpx.xcconfig"
+
+PRODUCT_NAME = fuzz-libvpx-vp9;
+
+OTHER_CFLAGS = $(inherited) -DDECODER=vp9;

--- a/Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig
@@ -1,22 +1,10 @@
+#include "Base-libvpx.xcconfig"
+
 PRODUCT_NAME = vpx;
-
-CLANG_WARN_BOOL_CONVERSION = YES;
-CLANG_WARN_ENUM_CONVERSION = YES;
-CLANG_WARN_INT_CONVERSION = YES;
-GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
-COMBINE_HIDPI_IMAGES = NO;
-ENABLE_STRICT_OBJC_MSGSEND = YES;
-
-HEADER_SEARCH_PATHS[arch=x86_64] = Source/third_party/libvpx/source/config/mac/x64 Source/third_party/libvpx/source/libvpx Source/third_party/libvpx/source/config;
-HEADER_SEARCH_PATHS[arch=arm64*] = Source/third_party/libvpx/source/config/ios/arm64 Source/third_party/libvpx/source/libvpx Source/third_party/libvpx/source/config;
 
 INSTALL_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_INSTALL_PATH);
 PUBLIC_HEADERS_FOLDER_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH)/libwebrtc;
 USE_HEADERMAP = NO;
-
-GCC_PREPROCESSOR_DEFINITIONS[sdk=iphonesimulator*] = $(inherited) WEBRTC_WEBKIT_DISABLE_HARDWARE_ACCELERATION;
-GCC_PREPROCESSOR_DEFINITIONS[sdk=macosx*] = $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_$(WK_IS_CATALYST))
-GCC_PREPROCESSOR_DEFINITIONS_YES = WEBRTC_WEBKIT_MAC_CATALIST
 
 ARM_FILES = *_neon.c arm_cpudetect.c *_arm.c
 X86_FILES = *_sse2.c *_ssse3.c *_sse4.c *_avx2.c *_avx2.cc *_avx.c *.asm

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -3118,6 +3118,10 @@
 		41FE8679215C54AA00B62C07 /* cv-symline.c in Sources */ = {isa = PBXBuildFile; fileRef = 41FE8676215C54AA00B62C07 /* cv-symline.c */; };
 		41FE867A215C54AA00B62C07 /* cv-type.c in Sources */ = {isa = PBXBuildFile; fileRef = 41FE8677215C54AA00B62C07 /* cv-type.c */; };
 		41FE867B215C54AA00B62C07 /* cv-dbgfmt.c in Sources */ = {isa = PBXBuildFile; fileRef = 41FE8678215C54AA00B62C07 /* cv-dbgfmt.c */; };
+		448D48422AB0BEBA0065014C /* vpx_dec_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */; };
+		44A402A92AB0BFB000463B4B /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4105EB83212E01D2008C0C20 /* libvpx.a */; };
+		44C20E8D2AB39FA80046C6A8 /* vpx_dec_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */; };
+		44C20E8F2AB39FA80046C6A8 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4105EB83212E01D2008C0C20 /* libvpx.a */; };
 		5C0073031E5513E70042215A /* libboringssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C63FC601E418411002CA531 /* libboringssl.a */; };
 		5C0073041E5513E70042215A /* libopus.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C4B4A8E1E42C336002651C8 /* libopus.a */; };
 		5C0073051E5513E70042215A /* libsrtp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C0884D11E4A97E300403995 /* libsrtp.a */; };
@@ -5170,6 +5174,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 41F77D15215BE45E00E72967;
 			remoteInfo = yasm;
+		};
+		448D483C2AB0BDB80065014C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
+			remoteInfo = vpx;
+		};
+		44C20E8B2AB39FA80046C6A8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
+			remoteInfo = vpx;
 		};
 		5C0884DF1E4A982000403995 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -8911,6 +8929,13 @@
 		41FE8676215C54AA00B62C07 /* cv-symline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cv-symline.c"; sourceTree = "<group>"; };
 		41FE8677215C54AA00B62C07 /* cv-type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cv-type.c"; sourceTree = "<group>"; };
 		41FE8678215C54AA00B62C07 /* cv-dbgfmt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cv-dbgfmt.c"; sourceTree = "<group>"; };
+		448D48342AB0BDB00065014C /* fuzz-libvpx-vp8 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "fuzz-libvpx-vp8"; sourceTree = BUILT_PRODUCTS_DIR; };
+		448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vpx_dec_fuzzer.cc; sourceTree = "<group>"; };
+		449187232AB3800D007266F2 /* Base-libvpx.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libvpx.xcconfig"; sourceTree = "<group>"; };
+		449187242AB380BE007266F2 /* fuzz-libvpx-vp8.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "fuzz-libvpx-vp8.xcconfig"; sourceTree = "<group>"; };
+		449187252AB380BE007266F2 /* fuzz-libvpx-vp9.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "fuzz-libvpx-vp9.xcconfig"; sourceTree = "<group>"; };
+		449187262AB38132007266F2 /* mem_ops_aligned.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mem_ops_aligned.h; sourceTree = "<group>"; };
+		44C20E942AB39FA80046C6A8 /* fuzz-libvpx-vp9 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "fuzz-libvpx-vp9"; sourceTree = BUILT_PRODUCTS_DIR; };
 		44C229C12A0AF4130008308E /* libwebrtc.testing.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = libwebrtc.testing.exp; sourceTree = "<group>"; };
 		5C0073091E5513E70042215A /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		5C00730A1E5513E70042215A /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -10010,6 +10035,10 @@
 		5D7C59C51208C68B001C873E /* libwebrtc.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = libwebrtc.xcconfig; sourceTree = "<group>"; };
 		5D7C59C61208C68B001C873E /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = DebugRelease.xcconfig; sourceTree = "<group>"; };
+		72CDC3732AB0CDCF00640E85 /* vp8dx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8dx.h; sourceTree = "<group>"; };
+		72CDC3752AB0CDD800640E85 /* vpx_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vpx_decoder.h; sourceTree = "<group>"; };
+		72CDC3772AB0CE9300640E85 /* mem_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem_ops.h; sourceTree = "<group>"; };
+		72CDC3792AB0CEFE00640E85 /* vpx_integer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vpx_integer.h; sourceTree = "<group>"; };
 		9869CBB22A4D5B820031C401 /* video_rtp_depacketizer_h265.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_rtp_depacketizer_h265.h; sourceTree = "<group>"; };
 		9869CBB32A4D5B820031C401 /* video_rtp_depacketizer_h265.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_rtp_depacketizer_h265.cc; sourceTree = "<group>"; };
 		CD381F252581591F0077DEC8 /* WebKitVP8Decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitVP8Decoder.h; sourceTree = "<group>"; };
@@ -10584,6 +10613,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		448D48312AB0BDB00065014C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44A402A92AB0BFB000463B4B /* libvpx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44C20E8E2AB39FA80046C6A8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44C20E8F2AB39FA80046C6A8 /* libvpx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5C0884CA1E4A97E300403995 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -10708,6 +10753,7 @@
 		4105EB86212E0216008C0C20 /* libvpx */ = {
 			isa = PBXGroup;
 			children = (
+				448D48402AB0BE550065014C /* examples */,
 				4105EBA7212E02D8008C0C20 /* vp8 */,
 				4140362424AA303E00BCE9B2 /* vp9 */,
 				4105EBA8212E02E9008C0C20 /* vpx */,
@@ -10783,6 +10829,9 @@
 			children = (
 				41EAF1B8212E2A93009F73EC /* src */,
 				4140361524AA281700BCE9B2 /* vpx_scale */,
+				72CDC3732AB0CDCF00640E85 /* vp8dx.h */,
+				72CDC3752AB0CDD800640E85 /* vpx_decoder.h */,
+				72CDC3792AB0CEFE00640E85 /* vpx_integer.h */,
 			);
 			path = vpx;
 			sourceTree = "<group>";
@@ -10836,6 +10885,8 @@
 				41EED7BB2152EEC8000F2A16 /* arm.h */,
 				41EED7BC2152EEC8000F2A16 /* arm_cpudetect.c */,
 				4140361D24AA2E6700BCE9B2 /* emms_mmx.c */,
+				72CDC3772AB0CE9300640E85 /* mem_ops.h */,
+				449187262AB38132007266F2 /* mem_ops_aligned.h */,
 				41E59E9323ACB6520095A94B /* system_state.h */,
 				4140361624AA293F00BCE9B2 /* x86.h */,
 			);
@@ -15712,6 +15763,14 @@
 			path = codeview;
 			sourceTree = "<group>";
 		};
+		448D48402AB0BE550065014C /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
 		5C0885111E4A99C200403995 /* include */ = {
 			isa = PBXGroup;
 			children = (
@@ -18825,9 +18884,12 @@
 		5D7C59C41208C68B001C873E /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
+				449187232AB3800D007266F2 /* Base-libvpx.xcconfig */,
 				5D7C59C61208C68B001C873E /* Base.xcconfig */,
 				5C4B43B01E42877A002651C8 /* boringssl.xcconfig */,
 				5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */,
+				449187242AB380BE007266F2 /* fuzz-libvpx-vp8.xcconfig */,
+				449187252AB380BE007266F2 /* fuzz-libvpx-vp9.xcconfig */,
 				DDF30D0B27C5C01A006A526F /* libabsl.xcconfig */,
 				DDEBB11E24C0189600ADBD44 /* libaom.xcconfig */,
 				5C0884891E4A978C00403995 /* libsrtp.xcconfig */,
@@ -19333,6 +19395,8 @@
 				CDEBB11924C0187400ADBD44 /* libwebm.a */,
 				FB39D0D11200F0E300088E69 /* libwebrtc.dylib */,
 				5C0884DE1E4A980100403995 /* libyuv.a */,
+				448D48342AB0BDB00065014C /* fuzz-libvpx-vp8 */,
+				44C20E942AB39FA80046C6A8 /* fuzz-libvpx-vp9 */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -22034,6 +22098,40 @@
 			productReference = 41F77D16215BE45E00E72967 /* yasm */;
 			productType = "com.apple.product-type.tool";
 		};
+		448D48332AB0BDB00065014C /* fuzz-libvpx-vp8 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 448D483B2AB0BDB10065014C /* Build configuration list for PBXNativeTarget "fuzz-libvpx-vp8" */;
+			buildPhases = (
+				448D48302AB0BDB00065014C /* Sources */,
+				448D48312AB0BDB00065014C /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				448D483D2AB0BDB80065014C /* PBXTargetDependency */,
+			);
+			name = "fuzz-libvpx-vp8";
+			productName = "fuzz-libvpx";
+			productReference = 448D48342AB0BDB00065014C /* fuzz-libvpx-vp8 */;
+			productType = "com.apple.product-type.tool";
+		};
+		44C20E892AB39FA80046C6A8 /* fuzz-libvpx-vp9 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44C20E902AB39FA80046C6A8 /* Build configuration list for PBXNativeTarget "fuzz-libvpx-vp9" */;
+			buildPhases = (
+				44C20E8C2AB39FA80046C6A8 /* Sources */,
+				44C20E8E2AB39FA80046C6A8 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44C20E8A2AB39FA80046C6A8 /* PBXTargetDependency */,
+			);
+			name = "fuzz-libvpx-vp9";
+			productName = "fuzz-libvpx";
+			productReference = 44C20E942AB39FA80046C6A8 /* fuzz-libvpx-vp9 */;
+			productType = "com.apple.product-type.tool";
+		};
 		5C08848B1E4A97E300403995 /* srtp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5C0884CD1E4A97E300403995 /* Build configuration list for PBXNativeTarget "srtp" */;
@@ -22218,6 +22316,9 @@
 						CreatedOnToolsVersion = 10.0;
 						ProvisioningStyle = Manual;
 					};
+					448D48332AB0BDB00065014C = {
+						CreatedOnToolsVersion = 15.0;
+					};
 					CDEBB11824C0187400ADBD44 = {
 						CreatedOnToolsVersion = 12.0;
 						ProvisioningStyle = Automatic;
@@ -22251,6 +22352,8 @@
 				CDEBB11824C0187400ADBD44 /* webm */,
 				DDEBB11824C0187400ADBD44 /* aom */,
 				DDF30D0527C5C003006A526F /* absl */,
+				448D48332AB0BDB00065014C /* fuzz-libvpx-vp8 */,
+				44C20E892AB39FA80046C6A8 /* fuzz-libvpx-vp9 */,
 			);
 		};
 /* End PBXProject section */
@@ -22741,6 +22844,22 @@
 				41F77D35215BE72B00E72967 /* yasm-options.c in Sources */,
 				41F77D37215BE72B00E72967 /* yasm-plugin.c in Sources */,
 				41F77D36215BE72B00E72967 /* yasm.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		448D48302AB0BDB00065014C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				448D48422AB0BEBA0065014C /* vpx_dec_fuzzer.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44C20E8C2AB39FA80046C6A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44C20E8D2AB39FA80046C6A8 /* vpx_dec_fuzzer.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -24764,6 +24883,16 @@
 			target = 41F77D15215BE45E00E72967 /* yasm */;
 			targetProxy = 41BE7173215BF42300A7B196 /* PBXContainerItemProxy */;
 		};
+		448D483D2AB0BDB80065014C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4105EB69212E01D2008C0C20 /* vpx */;
+			targetProxy = 448D483C2AB0BDB80065014C /* PBXContainerItemProxy */;
+		};
+		44C20E8A2AB39FA80046C6A8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4105EB69212E01D2008C0C20 /* vpx */;
+			targetProxy = 44C20E8B2AB39FA80046C6A8 /* PBXContainerItemProxy */;
+		};
 		5C0884E01E4A982000403995 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5C08848B1E4A97E300403995 /* srtp */;
@@ -24801,10 +24930,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 411ED035212E05DE004320BA /* libvpx.xcconfig */;
 			buildSettings = {
-				CLANG_WARN_STRICT_PROTOTYPES = NO;
-				CLANG_X86_VECTOR_INSTRUCTIONS = default;
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
@@ -24812,10 +24937,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 411ED035212E05DE004320BA /* libvpx.xcconfig */;
 			buildSettings = {
-				CLANG_WARN_STRICT_PROTOTYPES = NO;
-				CLANG_X86_VECTOR_INSTRUCTIONS = default;
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
@@ -24823,10 +24944,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 411ED035212E05DE004320BA /* libvpx.xcconfig */;
 			buildSettings = {
-				CLANG_WARN_STRICT_PROTOTYPES = NO;
-				CLANG_X86_VECTOR_INSTRUCTIONS = default;
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				USE_HEADERMAP = NO;
 			};
 			name = Production;
 		};
@@ -24851,6 +24968,48 @@
 		41F77D1D215BE45E00E72967 /* Production */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 41F77D1E215BE4AD00E72967 /* yasm.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		448D48382AB0BDB10065014C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 449187242AB380BE007266F2 /* fuzz-libvpx-vp8.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		448D48392AB0BDB10065014C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 449187242AB380BE007266F2 /* fuzz-libvpx-vp8.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		448D483A2AB0BDB10065014C /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 449187242AB380BE007266F2 /* fuzz-libvpx-vp8.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
+		44C20E912AB39FA80046C6A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 449187252AB380BE007266F2 /* fuzz-libvpx-vp9.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		44C20E922AB39FA80046C6A8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 449187252AB380BE007266F2 /* fuzz-libvpx-vp9.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		44C20E932AB39FA80046C6A8 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 449187252AB380BE007266F2 /* fuzz-libvpx-vp9.xcconfig */;
 			buildSettings = {
 			};
 			name = Production;
@@ -25079,6 +25238,26 @@
 				41F77D1B215BE45E00E72967 /* Debug */,
 				41F77D1C215BE45E00E72967 /* Release */,
 				41F77D1D215BE45E00E72967 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		448D483B2AB0BDB10065014C /* Build configuration list for PBXNativeTarget "fuzz-libvpx-vp8" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				448D48382AB0BDB10065014C /* Debug */,
+				448D48392AB0BDB10065014C /* Release */,
+				448D483A2AB0BDB10065014C /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44C20E902AB39FA80046C6A8 /* Build configuration list for PBXNativeTarget "fuzz-libvpx-vp9" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44C20E912AB39FA80046C6A8 /* Debug */,
+				44C20E922AB39FA80046C6A8 /* Release */,
+				44C20E932AB39FA80046C6A8 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 6a846fbe08dd0edde4c1226cd5d20a5dc3424776
<pre>
Add targets for vp8 and vp9 builds of vpx_dec_fuzzer.cc
<a href="https://bugs.webkit.org/show_bug.cgi?id=261568">https://bugs.webkit.org/show_bug.cgi?id=261568</a>
&lt;rdar://115515990&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Configurations/Base-libvpx.xcconfig: Copied from libvpx.xcconfig.
- Extract common settings from libvpx.xcconfig.
* Source/ThirdParty/libwebrtc/Configurations/fuzz-libvpx-vp8.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/fuzz-libvpx-vp9.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/libvpx.xcconfig:
- Include Base-libvpx.xcconfig after extracting common settings.
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
- Add targets for fuzz-libvpx-vp8 and fuzz-libvpx-vp9.

Canonical link: <a href="https://commits.webkit.org/268023@main">https://commits.webkit.org/268023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de8efb8c84c774dbd20f455101725d73b25745e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20150 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17137 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19080 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21032 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23192 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21082 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14812 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20897 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2267 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->