### PR TITLE
[JSC] Megamorphic GetByVal / PutByVal DataIC code should be shared

### DIFF
--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -1643,6 +1643,39 @@ JSObject* AccessCase::alternateBase() const
     return result;
 }
 
+RefPtr<PolymorphicAccessJITStubRoutine> SharedJITStubSet::getMegamorphic(AccessType type)
+{
+    switch (type) {
+    case AccessType::GetByVal:
+        return m_getByValMegamorphic;
+    case AccessType::GetByValWithThis:
+        return m_getByValWithThisMegamorphic;
+    case AccessType::PutByValStrict:
+    case AccessType::PutByValSloppy:
+        return m_putByValMegamorphic;
+    default:
+        return nullptr;
+    }
+}
+
+void SharedJITStubSet::setMegamorphic(AccessType type, Ref<PolymorphicAccessJITStubRoutine> stub)
+{
+    switch (type) {
+    case AccessType::GetByVal:
+        m_getByValMegamorphic = WTFMove(stub);
+        break;
+    case AccessType::GetByValWithThis:
+        m_getByValWithThisMegamorphic = WTFMove(stub);
+        break;
+    case AccessType::PutByValStrict:
+    case AccessType::PutByValSloppy:
+        m_putByValMegamorphic = WTFMove(stub);
+        break;
+    default:
+        break;
+    }
+}
+
 } // namespace JSC
 
 #endif

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -562,8 +562,15 @@ public:
         return nullptr;
     }
 
+    RefPtr<PolymorphicAccessJITStubRoutine> getMegamorphic(AccessType);
+    void setMegamorphic(AccessType, Ref<PolymorphicAccessJITStubRoutine>);
+
 private:
     HashSet<Hash::Key, Hash, Hash::KeyTraits> m_stubs;
+
+    RefPtr<PolymorphicAccessJITStubRoutine> m_getByValMegamorphic;
+    RefPtr<PolymorphicAccessJITStubRoutine> m_getByValWithThisMegamorphic;
+    RefPtr<PolymorphicAccessJITStubRoutine> m_putByValMegamorphic;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 47fbfbce93f42fd200567a124d8ffe7922b3331b
<pre>
[JSC] Megamorphic GetByVal / PutByVal DataIC code should be shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=261570">https://bugs.webkit.org/show_bug.cgi?id=261570</a>
rdar://115516372

Reviewed by Alexey Shvayka.

This patch avoids repeated generation of code for Megamorphic GetByVal / PutByVal.
They can just use the shared code. So we first generate it, cache, and reuse it later.

* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::SharedJITStubSet::getMegamorphic):
(JSC::SharedJITStubSet::setMegamorphic):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):

Canonical link: <a href="https://commits.webkit.org/268012@main">https://commits.webkit.org/268012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b647ba68523f1a4dfa383db1aabc5856d25acec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17139 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21034 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23212 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15866 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21094 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17597 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14799 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21669 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16536 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5309 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20899 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/22905 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2260 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17283 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5157 "Passed tests") | 
<!--EWS-Status-Bubble-End-->