### PR TITLE
Use more smart pointers in editing node

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -288,6 +288,14 @@ protected:
             initializeWeakPtrFactory();
     }
 
+    CanMakeWeakPtr(const CanMakeWeakPtr&)
+    {
+        if (initializationMode == WeakPtrFactoryInitialization::Eager)
+            initializeWeakPtrFactory();
+    }
+
+    CanMakeWeakPtr& operator=(const CanMakeWeakPtr&) { return *this; }
+
     void initializeWeakPtrFactory()
     {
         m_weakPtrFactory.initializeIfNeeded(static_cast<T&>(*this));

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -124,8 +124,8 @@ static std::optional<SimpleRange> findRangeByIdentifyingStartAndEndPositions(con
     if (!endContainer)
         return std::nullopt;
 
-    auto start = makeContainerOffsetPosition(startContainer.get(), range.startOffset());
-    auto end = makeContainerOffsetPosition(endContainer.get(), range.endOffset());
+    auto start = makeContainerOffsetPosition(WTFMove(startContainer), range.startOffset());
+    auto end = makeContainerOffsetPosition(WTFMove(endContainer), range.endOffset());
     if (start.isOrphan() || end.isOrphan())
         return std::nullopt;
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -850,7 +850,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
     }
 
     VisiblePosition offsetPosition = m_coreObject->visiblePositionForIndex(adjustInputOffset(*utf16Offset, m_hasListMarkerAtStart));
-    auto* childNode = offsetPosition.deepEquivalent().deprecatedNode();
+    auto childNode = offsetPosition.deepEquivalent().protectedDeprecatedNode();
     if (!childNode)
         return { WTFMove(defaultAttributes), -1, -1 };
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2873,7 +2873,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)showNodeForTextMarker:(AXTextMarkerRef)textMarker
 {
     auto visiblePosition = visiblePositionForTextMarker(self.axBackingObject->axObjectCache(), textMarker);
-    Node* node = visiblePosition.deepEquivalent().deprecatedNode();
+    auto node = visiblePosition.deepEquivalent().protectedDeprecatedNode();
     if (!node)
         return;
     node->showNode();
@@ -2883,7 +2883,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)showNodeTreeForTextMarker:(AXTextMarkerRef)textMarker
 {
     auto visiblePosition = visiblePositionForTextMarker(self.axBackingObject->axObjectCache(), textMarker);
-    Node* node = visiblePosition.deepEquivalent().deprecatedNode();
+    auto node = visiblePosition.deepEquivalent().protectedDeprecatedNode();
     if (!node)
         return;
     node->showTreeForThis();

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -81,6 +81,7 @@ StyleSheetContents::StyleSheetContents(StyleRuleImport* ownerRule, const String&
 
 StyleSheetContents::StyleSheetContents(const StyleSheetContents& o)
     : RefCounted<StyleSheetContents>()
+    , CanMakeWeakPtr<StyleSheetContents>()
     , m_ownerRule(nullptr)
     , m_originalURL(o.m_originalURL)
     , m_encodingFromCharsetRule(o.m_encodingFromCharsetRule)

--- a/Source/WebCore/dom/AbstractRange.cpp
+++ b/Source/WebCore/dom/AbstractRange.cpp
@@ -52,4 +52,14 @@ std::optional<SimpleRange> makeSimpleRange(const RefPtr<AbstractRange>& range)
     return makeSimpleRange(range.get());
 }
 
+Ref<Node> AbstractRange::protectedStartContainer() const
+{
+    return startContainer();
+}
+
+Ref<Node> AbstractRange::protectedEndContainer() const
+{
+    return endContainer();
+}
+
 }

--- a/Source/WebCore/dom/AbstractRange.h
+++ b/Source/WebCore/dom/AbstractRange.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -38,8 +39,10 @@ public:
     virtual ~AbstractRange() = default;
 
     virtual Node& startContainer() const = 0;
+    Ref<Node> protectedStartContainer() const;
     virtual unsigned startOffset() const = 0;
     virtual Node& endContainer() const = 0;
+    Ref<Node> protectedEndContainer() const;
     virtual unsigned endOffset() const = 0;
     virtual bool collapsed() const = 0;
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -279,6 +279,11 @@ private:
     ChildNodesLazySnapshot* m_nextSnapshot;
 };
 
+inline RefPtr<ContainerNode> Node::protectedParentNode() const
+{
+    return parentNode();
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ContainerNode)

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -25,6 +25,7 @@
 #include <variant>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -35,7 +36,7 @@ namespace WebCore {
 
 // A range of a node within a document that is "marked", such as the range of a misspelled word.
 // It optionally includes a description that could be displayed in the user interface.
-class DocumentMarker {
+class DocumentMarker : public CanMakeWeakPtr<DocumentMarker> {
 public:
     enum MarkerType {
         Spelling = 1 << 0,

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -448,19 +448,19 @@ DocumentMarker* DocumentMarkerController::markerContainingPoint(const LayoutPoin
     return nullptr;
 }
 
-Vector<RenderedDocumentMarker*> DocumentMarkerController::markersFor(Node& node, OptionSet<DocumentMarker::MarkerType> types)
+Vector<WeakPtr<RenderedDocumentMarker>> DocumentMarkerController::markersFor(Node& node, OptionSet<DocumentMarker::MarkerType> types)
 {
     if (!possiblyHasMarkers(types))
         return { };
 
-    Vector<RenderedDocumentMarker*> result;
+    Vector<WeakPtr<RenderedDocumentMarker>> result;
     auto list = m_markers.get(&node);
     if (!list)
         return result;
 
     for (auto& marker : *list) {
         if (types.contains(marker.type()))
-            result.append(&marker);
+            result.append(marker);
     }
 
     return result;
@@ -504,12 +504,12 @@ void DocumentMarkerController::forEachOfTypes(OptionSet<DocumentMarker::MarkerTy
     }
 }
 
-Vector<RenderedDocumentMarker*> DocumentMarkerController::markersInRange(const SimpleRange& range, OptionSet<DocumentMarker::MarkerType> types)
+Vector<WeakPtr<RenderedDocumentMarker>> DocumentMarkerController::markersInRange(const SimpleRange& range, OptionSet<DocumentMarker::MarkerType> types)
 {
     // FIXME: Consider making forEach public and changing callers to use that function instead of this one.
-    Vector<RenderedDocumentMarker*> markers;
+    Vector<WeakPtr<RenderedDocumentMarker>> markers;
     forEach(range, types, [&] (Node&, RenderedDocumentMarker& marker) {
-        markers.append(&marker);
+        markers.append(marker);
         return false;
     });
     return markers;

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -76,8 +76,8 @@ public:
 
     void dismissMarkers(OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
 
-    WEBCORE_EXPORT Vector<RenderedDocumentMarker*> markersFor(Node&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
-    WEBCORE_EXPORT Vector<RenderedDocumentMarker*> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
+    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersFor(Node&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
+    WEBCORE_EXPORT Vector<WeakPtr<RenderedDocumentMarker>> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
     WEBCORE_EXPORT Vector<SimpleRange> rangesForMarkersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
     void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -130,6 +130,7 @@ public:
     virtual NodeType nodeType() const = 0;
     virtual size_t approximateMemoryCost() const { return sizeof(*this); }
     ContainerNode* parentNode() const;
+    inline RefPtr<ContainerNode> protectedParentNode() const; // Defined in ContainerNode.h.
     static ptrdiff_t parentNodeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_parentNode); }
     inline Element* parentElement() const;
     Node* previousSibling() const { return m_previous; }

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -54,7 +54,7 @@ PositionIterator::operator Position() const
         return atStartOfNode() ? positionBeforeNode(m_anchorNode.get()) : positionAfterNode(m_anchorNode.get());
     if (m_anchorNode->hasChildNodes())
         return lastPositionInOrAfterNode(m_anchorNode.get());
-    return makeDeprecatedLegacyPosition(m_anchorNode.get(), m_offsetInAnchor);
+    return makeDeprecatedLegacyPosition(m_anchorNode.copyRef(), m_offsetInAnchor);
 }
 
 void PositionIterator::increment()

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -1041,8 +1041,8 @@ void Range::textNodeSplit(Text& oldNode)
 
 ExceptionOr<void> Range::expand(const String& unit)
 {
-    auto start = VisiblePosition { makeContainerOffsetPosition(&startContainer(), startOffset()) };
-    auto end = VisiblePosition { makeContainerOffsetPosition(&endContainer(), endOffset()) };
+    auto start = VisiblePosition { makeContainerOffsetPosition(protectedStartContainer(), startOffset()) };
+    auto end = VisiblePosition { makeContainerOffsetPosition(protectedEndContainer(), endOffset()) };
     if (unit == "word"_s) {
         start = startOfWord(start);
         end = endOfWord(end);

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -34,8 +34,10 @@ struct SimpleRange {
     BoundaryPoint end;
 
     Node& startContainer() const { return start.container.get(); }
+    Ref<Node> protectedStartContainer() const { return start.container.copyRef(); }
     unsigned startOffset() const { return start.offset; }
     Node& endContainer() const { return end.container.get(); }
+    Ref<Node> protectedEndContainer() const { return end.container.copyRef(); }
     unsigned endOffset() const { return end.offset; }
 
     bool collapsed() const { return start == end; }

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -72,7 +72,7 @@ static inline OptionSet<DocumentMarker::MarkerType> markerTypesForReplacement()
     return { DocumentMarker::Replacement, DocumentMarker::SpellCheckingExemption };
 }
 
-static bool markersHaveIdenticalDescription(const Vector<RenderedDocumentMarker*>& markers)
+static bool markersHaveIdenticalDescription(const Vector<WeakPtr<RenderedDocumentMarker>>& markers)
 {
     if (markers.isEmpty())
         return true;
@@ -417,7 +417,7 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
 
     Node* node = position.containerNode();
     ASSERT(node);
-    for (auto* marker : node->document().markers().markersFor(*node)) {
+    for (auto& marker : node->document().markers().markersFor(*node)) {
         ASSERT(marker);
         if (respondToMarkerAtEndOfWord(*marker, position))
             break;
@@ -472,7 +472,7 @@ void AlternativeTextController::markCorrection(const SimpleRange& replacedRange,
 void AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection(const SimpleRange& rangeOfCorrection, const String& corrected, const String& correction)
 {
     DocumentMarkerController& markers = rangeOfCorrection.startContainer().document().markers();
-    Vector<RenderedDocumentMarker*> correctedOnceMarkers = markers.markersInRange(rangeOfCorrection, DocumentMarker::Autocorrected);
+    auto correctedOnceMarkers = markers.markersInRange(rangeOfCorrection, DocumentMarker::Autocorrected);
     if (correctedOnceMarkers.isEmpty())
         return;
 
@@ -727,7 +727,7 @@ void AlternativeTextController::applyDictationAlternative(const String& alternat
     auto selection = editor.selectedRange();
     if (!selection || !editor.shouldInsertText(alternativeString, *selection, EditorInsertAction::Pasted))
         return;
-    for (auto* marker : selection->startContainer().document().markers().markersInRange(*selection, DocumentMarker::DictationAlternatives))
+    for (auto& marker : selection->startContainer().document().markers().markersInRange(*selection, DocumentMarker::DictationAlternatives))
         removeDictationAlternativesForMarker(*marker);
     applyAlternativeTextToRange(*selection, alternativeString, AlternativeTextType::DictationAlternatives, markerTypesForAppliedDictationAlternative());
 #else

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -65,6 +65,7 @@ protected:
     explicit EditCommand(Document&, EditAction = EditAction::Unspecified);
     EditCommand(Document&, const VisibleSelection&, const VisibleSelection&);
 
+    Ref<Document> protectedDocument() const { return m_document.copyRef(); }
     const Document& document() const { return m_document; }
     Document& document() { return m_document; }
     CompositeEditCommand* parent() const { return m_parent.get(); }

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -48,19 +48,19 @@ struct SimpleRange;
 // Node
 // -------------------------------------------------------------------------
 
-ContainerNode* highestEditableRoot(const Position&, EditableType = ContentIsEditable);
+RefPtr<ContainerNode> highestEditableRoot(const Position&, EditableType = ContentIsEditable);
 
 Node* highestEnclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node*), EditingBoundaryCrossingRule = CannotCrossEditingBoundary, Node* stayWithin = nullptr);
 Node* highestNodeToRemoveInPruning(Node*);
 Element* lowestEditableAncestor(Node*);
 
 Element* deprecatedEnclosingBlockFlowElement(Node*); // Use enclosingBlock instead.
-Element* enclosingBlock(Node*, EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
-Element* enclosingTableCell(const Position&);
+RefPtr<Element> enclosingBlock(RefPtr<Node>, EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
+RefPtr<Element> enclosingTableCell(const Position&);
 Node* enclosingEmptyListItem(const VisiblePosition&);
 Element* enclosingAnchorElement(const Position&);
 Element* enclosingElementWithTag(const Position&, const QualifiedName&);
-Node* enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node*), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
+RefPtr<Node> enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node*), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
 HTMLSpanElement* tabSpanNode(const Node*);
 Element* isLastPositionBeforeTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
 Element* isFirstPositionAfterTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -820,7 +820,7 @@ bool Editor::shouldInsertText(const String& text, const std::optional<SimpleRang
 void Editor::respondToChangedContents(const VisibleSelection& endingSelection)
 {
     if (AXObjectCache::accessibilityEnabled()) {
-        RefPtr node { endingSelection.start().deprecatedNode() };
+        auto node = endingSelection.start().protectedDeprecatedNode();
         if (AXObjectCache* cache = document().existingAXObjectCache())
             cache->postNotification(node.get(), AXObjectCache::AXValueChanged, PostTarget::ObservableParent);
     }
@@ -838,12 +838,12 @@ bool Editor::hasBidiSelection() const
 
     RefPtr<Node> startNode;
     if (m_document.selection().isRange()) {
-        startNode = m_document.selection().selection().start().downstream().deprecatedNode();
-        RefPtr endNode { m_document.selection().selection().end().upstream().deprecatedNode() };
+        startNode = m_document.selection().selection().start().downstream().protectedDeprecatedNode();
+        auto endNode = m_document.selection().selection().end().upstream().protectedDeprecatedNode();
         if (enclosingBlock(startNode.get()) != enclosingBlock(endNode.get()))
             return false;
     } else
-        startNode = m_document.selection().selection().visibleStart().deepEquivalent().deprecatedNode();
+        startNode = m_document.selection().selection().visibleStart().deepEquivalent().protectedDeprecatedNode();
 
     if (!startNode)
         return false;
@@ -1409,7 +1409,7 @@ bool Editor::insertTextWithoutSendingTextEvent(const String& text, bool selectIn
     // that is contained in the event target.
     selection = selectionForCommand(triggeringEvent);
     if (selection.isContentEditable()) {
-        if (RefPtr selectionStart = selection.start().deprecatedNode()) {
+        if (auto selectionStart = selection.start().protectedDeprecatedNode()) {
             Ref<Document> document(selectionStart->document());
 
             // Insert the text
@@ -2062,7 +2062,7 @@ WritingDirection Editor::baseWritingDirectionForSelectionStart() const
     auto result = WritingDirection::LeftToRight;
 
     Position pos = m_document.selection().selection().visibleStart().deepEquivalent();
-    RefPtr node { pos.deprecatedNode() };
+    auto node = pos.protectedDeprecatedNode();
     if (!node)
         return result;
 
@@ -2298,9 +2298,9 @@ void Editor::setComposition(const String& text, const Vector<CompositionUnderlin
         // Find out what node has the composition now.
         Position base = m_document.selection().selection().base().downstream();
         Position extent = m_document.selection().selection().extent();
-        RefPtr baseNode { base.deprecatedNode() };
+        auto baseNode = base.protectedDeprecatedNode();
         unsigned baseOffset = base.deprecatedEditingOffset();
-        RefPtr extentNode { extent.deprecatedNode() };
+        auto extentNode = extent.protectedDeprecatedNode();
         unsigned extentOffset = extent.deprecatedEditingOffset();
 
         if (is<Text>(baseNode) && baseNode == extentNode && baseOffset + text.length() == extentOffset) {
@@ -3266,7 +3266,7 @@ void Editor::updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionA
     // of marker that contains the word in question, and remove marker on that whole range.
     auto wordRange = *makeSimpleRange(startOfFirstWord, endOfLastWord);
 
-    for (auto* marker : document().markers().markersInRange(wordRange, DocumentMarker::DictationAlternatives))
+    for (auto& marker : document().markers().markersInRange(wordRange, DocumentMarker::DictationAlternatives))
         m_alternativeTextController->removeDictationAlternativesForMarker(*marker);
 
     OptionSet<DocumentMarker::MarkerType> markerTypesToRemove {
@@ -4056,14 +4056,13 @@ static RefPtr<Node> findFirstMarkable(Node* startingNode)
 
 bool Editor::selectionStartHasMarkerFor(DocumentMarker::MarkerType markerType, int from, int length) const
 {
-    auto node = findFirstMarkable(m_document.selection().selection().start().deprecatedNode());
+    auto node = findFirstMarkable(m_document.selection().selection().start().protectedDeprecatedNode().get());
     if (!node)
         return false;
 
     unsigned int startOffset = static_cast<unsigned int>(from);
     unsigned int endOffset = static_cast<unsigned int>(from + length);
-    Vector<RenderedDocumentMarker*> markers = document().markers().markersFor(*node);
-    for (auto* marker : markers) {
+    for (auto& marker : document().markers().markersFor(*node)) {
         if (marker->startOffset() <= startOffset && endOffset <= marker->endOffset() && marker->type() == markerType)
             return true;
     }
@@ -4181,13 +4180,13 @@ static Vector<TextList> editableTextListsAtPositionInDescendingOrder(const Posit
     if (!startContainer)
         return { };
 
-    auto* editableRoot = highestEditableRoot(firstPositionInOrBeforeNode(startContainer.get()));
+    auto editableRoot = highestEditableRoot(firstPositionInOrBeforeNode(startContainer.get()));
     if (!editableRoot)
         return { };
 
     Vector<Ref<HTMLElement>> enclosingLists;
     for (auto& ancestor : ancestorsOfType<HTMLElement>(*startContainer)) {
-        if (&ancestor == editableRoot)
+        if (&ancestor == editableRoot.get())
             break;
 
         auto* renderer = ancestor.renderer();
@@ -4533,7 +4532,7 @@ const RenderStyle* Editor::styleForSelectionStart(RefPtr<Node>& nodeToRemove)
 
     styleElement->appendChild(document().createEditingTextNode(String { emptyString() }));
 
-    auto positionNode = position.deprecatedNode();
+    auto positionNode = position.protectedDeprecatedNode();
     ASSERT(positionNode);
     RefPtr parent { positionNode->parentNode() };
     if (!parent || parent->appendChild(styleElement.get()).hasException())

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -270,13 +270,13 @@ void FrameSelection::moveWithoutValidationTo(const Position& base, const Positio
 
 void DragCaretController::setCaretPosition(const VisiblePosition& position)
 {
-    if (Node* node = m_position.deepEquivalent().deprecatedNode())
-        invalidateCaretRect(node);
+    if (auto node = m_position.deepEquivalent().protectedDeprecatedNode())
+        invalidateCaretRect(node.get());
     m_position = position;
     setCaretRectNeedsUpdate();
     Document* document = nullptr;
-    if (Node* node = m_position.deepEquivalent().deprecatedNode()) {
-        invalidateCaretRect(node);
+    if (auto node = m_position.deepEquivalent().protectedDeprecatedNode()) {
+        invalidateCaretRect(node.get());
         document = &node->document();
     }
     if (m_position.isNull() || m_position.isOrphan())
@@ -2949,8 +2949,8 @@ void FrameSelection::updateFromAssociatedLiveRange()
         disassociateLiveRange();
     else {
         // Don't use VisibleSelection's constructor that takes a SimpleRange, because it uses makeDeprecatedLegacyPosition instead of makeContainerOffsetPosition.
-        auto start = makeContainerOffsetPosition(&m_associatedLiveRange->startContainer(), m_associatedLiveRange->startOffset());
-        auto end = makeContainerOffsetPosition(&m_associatedLiveRange->endContainer(), m_associatedLiveRange->endOffset());
+        auto start = makeContainerOffsetPosition(m_associatedLiveRange->protectedStartContainer(), m_associatedLiveRange->startOffset());
+        auto end = makeContainerOffsetPosition(m_associatedLiveRange->protectedEndContainer(), m_associatedLiveRange->endOffset());
         setSelection({ start, end });
     }
 }

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -58,13 +58,13 @@ IndentOutdentCommand::IndentOutdentCommand(Document& document, EIndentType typeO
 bool IndentOutdentCommand::tryIndentingAsListItem(const Position& start, const Position& end)
 {
     // If our selection is not inside a list, bail out.
-    RefPtr lastNodeInSelectedParagraph = start.deprecatedNode();
+    auto lastNodeInSelectedParagraph = start.protectedDeprecatedNode();
     RefPtr<Element> listNode = enclosingList(lastNodeInSelectedParagraph.get());
     if (!listNode)
         return false;
 
     // Find the block that we want to indent.  If it's not a list item (e.g., a div inside a list item), we bail out.
-    RefPtr<Element> selectedListItem = enclosingBlock(lastNodeInSelectedParagraph.get());
+    RefPtr<Element> selectedListItem = enclosingBlock(WTFMove(lastNodeInSelectedParagraph));
 
     if (!selectedListItem || !selectedListItem->hasTagName(liTag))
         return false;
@@ -75,9 +75,9 @@ bool IndentOutdentCommand::tryIndentingAsListItem(const Position& start, const P
 
     RefPtr<Element> newList;
     if (is<HTMLUListElement>(*listNode))
-        newList = HTMLUListElement::create(document());
+        newList = HTMLUListElement::create(protectedDocument());
     else
-        newList = HTMLOListElement::create(document());
+        newList = HTMLOListElement::create(protectedDocument());
     insertNodeBefore(*newList, *selectedListItem);
 
     moveParagraphWithClones(start, end, newList.get(), selectedListItem.get());
@@ -97,7 +97,7 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
         if (enclosingCell)
             return enclosingCell;
         if (enclosingList(start.containerNode()))
-            return enclosingBlock(start.containerNode());
+            return enclosingBlock(start.protectedContainerNode());
         return editableRootForPosition(start);
     }();
 
@@ -141,12 +141,13 @@ void IndentOutdentCommand::outdentParagraph()
         return;
 
     // Use InsertListCommand to remove the selection from the list
+    auto document = protectedDocument();
     if (enclosingNode->hasTagName(olTag)) {
-        applyCommandToComposite(InsertListCommand::create(document(), InsertListCommand::Type::OrderedList));
+        applyCommandToComposite(InsertListCommand::create(document, InsertListCommand::Type::OrderedList));
         return;        
     }
     if (enclosingNode->hasTagName(ulTag)) {
-        applyCommandToComposite(InsertListCommand::create(document(), InsertListCommand::Type::UnorderedList));
+        applyCommandToComposite(InsertListCommand::create(document, InsertListCommand::Type::UnorderedList));
         return;
     }
     
@@ -174,18 +175,18 @@ void IndentOutdentCommand::outdentParagraph()
             }
         }
 
-        document().updateLayoutIgnorePendingStylesheets();
+        document->updateLayoutIgnorePendingStylesheets();
         visibleStartOfParagraph = VisiblePosition(visibleStartOfParagraph.deepEquivalent());
         visibleEndOfParagraph = VisiblePosition(visibleEndOfParagraph.deepEquivalent());
         if (visibleStartOfParagraph.isNotNull() && !isStartOfParagraph(visibleStartOfParagraph))
-            insertNodeAt(HTMLBRElement::create(document()), visibleStartOfParagraph.deepEquivalent());
+            insertNodeAt(HTMLBRElement::create(document), visibleStartOfParagraph.deepEquivalent());
         if (visibleEndOfParagraph.isNotNull() && !isEndOfParagraph(visibleEndOfParagraph))
-            insertNodeAt(HTMLBRElement::create(document()), visibleEndOfParagraph.deepEquivalent());
+            insertNodeAt(HTMLBRElement::create(document), visibleEndOfParagraph.deepEquivalent());
 
         return;
     }
 
-    RefPtr startOfParagraphNode = visibleStartOfParagraph.deepEquivalent().deprecatedNode();
+    auto startOfParagraphNode = visibleStartOfParagraph.deepEquivalent().protectedDeprecatedNode();
     RefPtr enclosingBlockFlow = enclosingBlock(startOfParagraphNode.get());
     RefPtr<Node> splitBlockquoteNode = enclosingNode;
     if (enclosingBlockFlow != enclosingNode)
@@ -195,7 +196,7 @@ void IndentOutdentCommand::outdentParagraph()
         RefPtr highestInlineNode = highestEnclosingNodeOfType(visibleStartOfParagraph.deepEquivalent(), isInline, CannotCrossEditingBoundary, enclosingBlockFlow.get());
         splitElement(*enclosingNode, highestInlineNode ? *highestInlineNode : *visibleStartOfParagraph.deepEquivalent().deprecatedNode());
     }
-    auto placeholder = HTMLBRElement::create(document());
+    auto placeholder = HTMLBRElement::create(document);
     insertNodeBefore(placeholder, *splitBlockquoteNode);
     if (!placeholder->isConnected())
         return;

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -219,12 +219,12 @@ void InsertListCommand::doApplyForSingleParagraph(bool forceCreateList, const HT
     // FIXME: This will produce unexpected results for a selection that starts just before a
     // table and ends inside the first cell, selectionForParagraphIteration should probably
     // be renamed and deployed inside setEndingSelection().
-    Node* selectionNode = endingSelection().start().deprecatedNode();
-    Node* listChildNode = enclosingListChild(selectionNode);
+    auto selectionNode = endingSelection().start().protectedDeprecatedNode();
+    RefPtr listChildNode = enclosingListChild(selectionNode.get());
     bool switchListType = false;
     if (listChildNode) {
         // Remove the list child.
-        RefPtr<HTMLElement> listNode = enclosingList(listChildNode);
+        RefPtr<HTMLElement> listNode = enclosingList(listChildNode.get());
         if (!listNode) {
             RefPtr<HTMLElement> listElement = fixOrphanedListChild(*listChildNode);
             if (!listElement || !listElement->isConnected())
@@ -280,7 +280,7 @@ void InsertListCommand::doApplyForSingleParagraph(bool forceCreateList, const HT
             return;
         }
         
-        unlistifyParagraph(endingSelection().visibleStart(), *listNode, listChildNode);
+        unlistifyParagraph(endingSelection().visibleStart(), *listNode, listChildNode.get());
     }
 
     if (!listChildNode || switchListType || forceCreateList)
@@ -353,7 +353,7 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
 
 static RefPtr<Element> adjacentEnclosingList(const VisiblePosition& pos, const VisiblePosition& adjacentPos, const QualifiedName& listTag)
 {
-    RefPtr<Element> listNode = outermostEnclosingList(adjacentPos.deepEquivalent().deprecatedNode());
+    RefPtr<Element> listNode = outermostEnclosingList(adjacentPos.deepEquivalent().protectedDeprecatedNode().get());
 
     if (!listNode)
         return nullptr;
@@ -364,7 +364,7 @@ static RefPtr<Element> adjacentEnclosingList(const VisiblePosition& pos, const V
     if (!listNode->hasTagName(listTag)
         || listNode->contains(pos.deepEquivalent().deprecatedNode())
         || previousCell != currentCell
-        || enclosingList(listNode.get()) != enclosingList(pos.deepEquivalent().deprecatedNode()))
+        || enclosingList(listNode.get()) != enclosingList(pos.deepEquivalent().protectedDeprecatedNode().get()))
         return nullptr;
 
     return listNode;

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -218,10 +218,10 @@ static bool isPhrasingContent(const Node* node)
 
 static bool isEditableRootPhrasingContent(Position position)
 {
-    auto* editableRoot = highestEditableRoot(position);
+    auto editableRoot = highestEditableRoot(position);
     if (!editableRoot)
         return false;
-    return enclosingNodeOfType(firstPositionInOrBeforeNode(editableRoot), isPhrasingContent);
+    return enclosingNodeOfType(firstPositionInOrBeforeNode(editableRoot.get()), isPhrasingContent);
 }
 
 void InsertParagraphSeparatorCommand::doApply()
@@ -241,7 +241,7 @@ void InsertParagraphSeparatorCommand::doApply()
     }
     
     // FIXME: The parentAnchoredEquivalent conversion needs to be moved into enclosingBlock.
-    RefPtr<Element> startBlock = enclosingBlock(insertionPosition.parentAnchoredEquivalent().containerNode());
+    RefPtr<Element> startBlock = enclosingBlock(insertionPosition.parentAnchoredEquivalent().protectedContainerNode());
     Position canonicalPos = VisiblePosition(insertionPosition).deepEquivalent();
     if (!startBlock
         || !startBlock->nonShadowBoundaryParentNode()
@@ -429,9 +429,9 @@ void InsertParagraphSeparatorCommand::doApply()
     // FIXME: leadingWhitespacePosition is returning the position before preserved newlines for positions
     // after the preserved newline, causing the newline to be turned into a nbsp.
     if (is<Text>(leadingWhitespace.deprecatedNode())) {
-        Text& textNode = downcast<Text>(*leadingWhitespace.deprecatedNode());
-        ASSERT(!textNode.renderer() || textNode.renderer()->style().collapseWhiteSpace());
-        replaceTextInNodePreservingMarkers(textNode, leadingWhitespace.deprecatedEditingOffset(), 1, nonBreakingSpaceString());
+        auto textNode = downcast<Text>(leadingWhitespace.protectedDeprecatedNode().releaseNonNull());
+        ASSERT(!textNode->renderer() || textNode->renderer()->style().collapseWhiteSpace());
+        replaceTextInNodePreservingMarkers(textNode.get(), leadingWhitespace.deprecatedEditingOffset(), 1, nonBreakingSpaceString());
     }
     
     // Split at pos if in the middle of a text node.

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -48,18 +48,18 @@ bool ModifySelectionListLevelCommand::preservesTypingStyle() const
 }
 
 // This needs to be static so it can be called by canIncreaseSelectionListLevel and canDecreaseSelectionListLevel
-static bool getStartEndListChildren(const VisibleSelection& selection, Node*& start, Node*& end)
+static bool getStartEndListChildren(const VisibleSelection& selection, RefPtr<Node>& start, RefPtr<Node>& end)
 {
     if (selection.isNone())
         return false;
 
     // start must be in a list child
-    Node* startListChild = enclosingListChild(selection.start().anchorNode());
+    RefPtr startListChild = enclosingListChild(selection.start().anchorNode());
     if (!startListChild || !startListChild->renderer())
         return false;
 
     // end must be in a list child
-    Node* endListChild = selection.isRange() ? enclosingListChild(selection.end().anchorNode()) : startListChild;
+    RefPtr endListChild = selection.isRange() ? enclosingListChild(selection.end().anchorNode()) : startListChild;
     if (!endListChild || !endListChild->renderer())
         return false;
     
@@ -85,8 +85,8 @@ static bool getStartEndListChildren(const VisibleSelection& selection, Node*& st
             endListChild = r->node();
     }
 
-    start = startListChild;
-    end = endListChild;
+    start = WTFMove(startListChild);
+    end = WTFMove(endListChild);
     return true;
 }
 
@@ -147,7 +147,7 @@ IncreaseSelectionListLevelCommand::IncreaseSelectionListLevelCommand(Document& d
 }
 
 // This needs to be static so it can be called by canIncreaseSelectionListLevel
-static bool canIncreaseListLevel(const VisibleSelection& selection, Node*& start, Node*& end)
+static bool canIncreaseListLevel(const VisibleSelection& selection, RefPtr<Node>& start, RefPtr<Node>& end)
 {
     if (!getStartEndListChildren(selection, start, end))
         return false;
@@ -176,16 +176,16 @@ static bool canIncreaseListLevel(const VisibleSelection& selection, Node*& start
 //  - (silly) client specifies whether to return pre-existing list nodes
 void IncreaseSelectionListLevelCommand::doApply()
 {
-    Node* startListChild;
-    Node* endListChild;
+    RefPtr<Node> startListChild;
+    RefPtr<Node> endListChild;
     if (!canIncreaseListLevel(endingSelection(), startListChild, endListChild))
         return;
 
-    Node* previousItem = startListChild->renderer()->previousSibling()->node();
-    if (isListHTMLElement(previousItem)) {
+    RefPtr previousItem = startListChild->renderer()->previousSibling()->node();
+    if (isListHTMLElement(previousItem.get())) {
         // move nodes up into preceding list
-        appendSiblingNodeRange(startListChild, endListChild, downcast<Element>(previousItem));
-        m_listElement = previousItem;
+        appendSiblingNodeRange(startListChild.get(), endListChild.get(), downcast<Element>(previousItem.get()));
+        m_listElement = WTFMove(previousItem);
     } else {
         // create a sublist for the preceding element and move nodes there
         RefPtr<Element> newParent;
@@ -203,15 +203,15 @@ void IncreaseSelectionListLevelCommand::doApply()
             break;
         }
         insertNodeBefore(*newParent, *startListChild);
-        appendSiblingNodeRange(startListChild, endListChild, newParent.get());
+        appendSiblingNodeRange(startListChild.get(), endListChild.get(), newParent.get());
         m_listElement = WTFMove(newParent);
     }
 }
 
 bool IncreaseSelectionListLevelCommand::canIncreaseSelectionListLevel(Document* document)
 {
-    Node* startListChild;
-    Node* endListChild;
+    RefPtr<Node> startListChild;
+    RefPtr<Node> endListChild;
     return canIncreaseListLevel(document->frame()->selection().selection(), startListChild, endListChild);
 }
 
@@ -245,7 +245,7 @@ DecreaseSelectionListLevelCommand::DecreaseSelectionListLevelCommand(Document& d
 }
 
 // This needs to be static so it can be called by canDecreaseSelectionListLevel
-static bool canDecreaseListLevel(const VisibleSelection& selection, Node*& start, Node*& end)
+static bool canDecreaseListLevel(const VisibleSelection& selection, RefPtr<Node>& start, RefPtr<Node>& end)
 {
     if (!getStartEndListChildren(selection, start, end))
         return false;
@@ -259,35 +259,35 @@ static bool canDecreaseListLevel(const VisibleSelection& selection, Node*& start
 
 void DecreaseSelectionListLevelCommand::doApply()
 {
-    Node* startListChild;
-    Node* endListChild;
+    RefPtr<Node> startListChild;
+    RefPtr<Node> endListChild;
     if (!canDecreaseListLevel(endingSelection(), startListChild, endListChild))
         return;
 
-    Node* previousItem = startListChild->renderer()->previousSibling() ? startListChild->renderer()->previousSibling()->node() : 0;
-    Node* nextItem = endListChild->renderer()->nextSibling() ? endListChild->renderer()->nextSibling()->node() : 0;
-    Element* listNode = startListChild->parentElement();
+    RefPtr previousItem = startListChild->renderer()->previousSibling() ? startListChild->renderer()->previousSibling()->node() : 0;
+    RefPtr nextItem = endListChild->renderer()->nextSibling() ? endListChild->renderer()->nextSibling()->node() : 0;
+    RefPtr listNode = startListChild->parentElement();
 
     if (!previousItem) {
         // at start of sublist, move the child(ren) to before the sublist
-        insertSiblingNodeRangeBefore(startListChild, endListChild, listNode);
+        insertSiblingNodeRangeBefore(startListChild.get(), endListChild.get(), listNode.get());
         // if that was the whole sublist we moved, remove the sublist node
         if (!nextItem && listNode)
             removeNode(*listNode);
     } else if (!nextItem) {
         // at end of list, move the child(ren) to after the sublist
-        insertSiblingNodeRangeAfter(startListChild, endListChild, listNode);    
+        insertSiblingNodeRangeAfter(startListChild.get(), endListChild.get(), listNode.get());
     } else if (listNode) {
         // in the middle of list, split the list and move the children to the divide
         splitElement(*listNode, *startListChild);
-        insertSiblingNodeRangeBefore(startListChild, endListChild, listNode);
+        insertSiblingNodeRangeBefore(startListChild.get(), endListChild.get(), listNode.get());
     }
 }
 
 bool DecreaseSelectionListLevelCommand::canDecreaseSelectionListLevel(Document* document)
 {
-    Node* startListChild;
-    Node* endListChild;
+    RefPtr<Node> startListChild;
+    RefPtr<Node> endListChild;
     return canDecreaseListLevel(document->frame()->selection().selection(), startListChild, endListChild);
 }
 

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -42,17 +42,17 @@ ReplaceNodeWithSpanCommand::ReplaceNodeWithSpanCommand(Ref<HTMLElement>&& elemen
 {
 }
 
-static void swapInNodePreservingAttributesAndChildren(HTMLElement& newNode, HTMLElement& nodeToReplace)
+static void swapInNodePreservingAttributesAndChildren(Ref<HTMLElement> newNode, HTMLElement& nodeToReplace)
 {
     ASSERT(nodeToReplace.isConnected());
     RefPtr<ContainerNode> parentNode = nodeToReplace.parentNode();
 
     // FIXME: Fix this to send the proper MutationRecords when MutationObservers are present.
-    newNode.cloneDataFromElement(nodeToReplace);
+    newNode->cloneDataFromElement(nodeToReplace);
     NodeVector children;
     collectChildNodes(nodeToReplace, children);
     for (auto& child : children)
-        newNode.appendChild(child);
+        newNode->appendChild(child);
 
     parentNode->insertBefore(newNode, &nodeToReplace);
     parentNode->removeChild(nodeToReplace);
@@ -69,9 +69,10 @@ void ReplaceNodeWithSpanCommand::doApply()
 
 void ReplaceNodeWithSpanCommand::doUnapply()
 {
-    if (!m_spanElement || !m_spanElement->isConnected())
+    RefPtr spanElement = m_spanElement;
+    if (!spanElement || !spanElement->isConnected())
         return;
-    swapInNodePreservingAttributesAndChildren(m_elementToReplace, *m_spanElement);
+    swapInNodePreservingAttributesAndChildren(m_elementToReplace, *spanElement);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -74,11 +74,13 @@ private:
 
         bool isEmpty() { return !m_firstNodeInserted; }
         Node* firstNodeInserted() const { return m_firstNodeInserted.get(); }
+        RefPtr<Node> protectedFirstNodeInserted() const { return m_firstNodeInserted; }
         Node* lastLeafInserted() const
         {
             ASSERT(m_lastNodeInserted);
             return m_lastNodeInserted->lastDescendant();
         }
+        RefPtr<Node> protectedLastLeafInserted() const { return lastLeafInserted(); }
         Node* pastLastLeaf() const
         {
             ASSERT(m_lastNodeInserted);

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -670,8 +670,8 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
 
         const VisiblePosition& visibleStart = endingSelection().visibleStart();
         const VisiblePosition& previousPosition = visibleStart.previous(CannotCrossEditingBoundary);
-        Node* enclosingTableCell = enclosingNodeOfType(visibleStart.deepEquivalent(), &isTableCell);
-        const Node* enclosingTableCellForPreviousPosition = enclosingNodeOfType(previousPosition.deepEquivalent(), &isTableCell);
+        auto enclosingTableCell = enclosingNodeOfType(visibleStart.deepEquivalent(), &isTableCell);
+        auto enclosingTableCellForPreviousPosition = enclosingNodeOfType(previousPosition.deepEquivalent(), &isTableCell);
         if (previousPosition.isNull() || enclosingTableCell != enclosingTableCellForPreviousPosition) {
             // When the caret is at the start of the editable area in an empty list item, break out of the list item.
             if (auto deleteListSelection = shouldBreakOutOfEmptyListItem(); !deleteListSelection.isNone()) {
@@ -692,7 +692,7 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
         }
 
         // If we have a caret selection at the beginning of a cell, we have nothing to do.
-        if (enclosingTableCell && visibleStart == firstPositionInNode(enclosingTableCell))
+        if (enclosingTableCell && visibleStart == firstPositionInNode(enclosingTableCell.get()))
             return;
 
         // If the caret is at the start of a paragraph after a table, move content into the last table cell.
@@ -791,8 +791,8 @@ void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool sh
 
         Position downstreamEnd = endingSelection().end().downstream();
         VisiblePosition visibleEnd = endingSelection().visibleEnd();
-        Node* enclosingTableCell = enclosingNodeOfType(visibleEnd.deepEquivalent(), &isTableCell);
-        if (enclosingTableCell && visibleEnd == lastPositionInNode(enclosingTableCell))
+        auto enclosingTableCell = enclosingNodeOfType(visibleEnd.deepEquivalent(), &isTableCell);
+        if (enclosingTableCell && visibleEnd == lastPositionInNode(enclosingTableCell.get()))
             return;
         if (visibleEnd == endOfParagraph(visibleEnd))
             downstreamEnd = visibleEnd.next(CannotCrossEditingBoundary).deepEquivalent().downstream();

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -456,7 +456,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrBefore(const VisiblePos
     if (position.isNull())
         return position;
     
-    auto* highestRoot = highestEditableRoot(deepEquivalent());
+    auto highestRoot = highestEditableRoot(deepEquivalent());
     
     // Return empty position if pos is not somewhere inside the editable region containing this position
     if (highestRoot && !position.deepEquivalent().deprecatedNode()->isDescendantOf(*highestRoot)) {
@@ -483,7 +483,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrBefore(const VisiblePos
     }
 
     // Return the last position before pos that is in the same editable region as this position
-    return lastEditablePositionBeforePositionInRoot(position.deepEquivalent(), highestRoot);
+    return lastEditablePositionBeforePositionInRoot(position.deepEquivalent(), highestRoot.get());
 }
 
 VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosition& otherPosition, bool* reachedBoundary) const
@@ -493,7 +493,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosi
     if (otherPosition.isNull())
         return otherPosition;
     
-    auto* highestRoot = highestEditableRoot(deepEquivalent());
+    auto highestRoot = highestEditableRoot(deepEquivalent());
     
     // Return empty position if otherPosition is not somewhere inside the editable region containing this position
     if (highestRoot && !otherPosition.deepEquivalent().deprecatedNode()->isDescendantOf(*highestRoot)) {
@@ -520,7 +520,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosi
     }
 
     // Return the next position after pos that is in the same editable region as this position
-    return firstEditablePositionAfterPositionInRoot(otherPosition.deepEquivalent(), highestRoot);
+    return firstEditablePositionAfterPositionInRoot(otherPosition.deepEquivalent(), highestRoot.get());
 }
 
 static Position canonicalizeCandidate(const Position& candidate)
@@ -565,8 +565,8 @@ Position VisiblePosition::canonicalPosition(const Position& passedPosition)
     // blocks or enter new ones), we search forward and backward until we find one.
     Position next = canonicalizeCandidate(nextCandidate(position));
     Position prev = canonicalizeCandidate(previousCandidate(position));
-    Node* nextNode = next.deprecatedNode();
-    Node* prevNode = prev.deprecatedNode();
+    auto nextNode = next.protectedDeprecatedNode();
+    auto prevNode = prev.protectedDeprecatedNode();
 
     // The new position must be in the same editable element. Enforce that first.
     // Unless the descent is from a non-editable html element to an editable body.

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -294,7 +294,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             VisiblePosition wordEnd(endOfWord(originalEnd, side));
             VisiblePosition end(wordEnd);
             
-            if (isEndOfParagraph(originalEnd) && !isEmptyTableCell(m_start.deprecatedNode())) {
+            if (isEndOfParagraph(originalEnd) && !isEmptyTableCell(m_start.protectedDeprecatedNode().get())) {
                 // Select the paragraph break (the space from the end of a paragraph to the start of 
                 // the next one) to match TextEdit.
                 end = wordEnd.next();
@@ -559,11 +559,11 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
     if (m_base == m_start && m_base == m_end)
         return;
 
-    auto* baseRoot = highestEditableRoot(m_base);
-    auto* startRoot = highestEditableRoot(m_start);
-    auto* endRoot = highestEditableRoot(m_end);
+    auto baseRoot = highestEditableRoot(m_base);
+    auto startRoot = highestEditableRoot(m_start);
+    auto endRoot = highestEditableRoot(m_end);
     
-    auto* baseEditableAncestor = lowestEditableAncestor(m_base.containerNode());
+    auto* baseEditableAncestor = lowestEditableAncestor(m_base.protectedContainerNode().get());
     
     // The base, start and end are all in the same region.  No adjustment necessary.
     if (baseRoot == startRoot && baseRoot == endRoot)
@@ -575,7 +575,7 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
         // If the start is in non-editable content that is inside the base's editable root, put it
         // at the first editable position after start inside the base's editable root.
         if (startRoot != baseRoot) {
-            VisiblePosition first = firstEditablePositionAfterPositionInRoot(m_start, baseRoot);
+            VisiblePosition first = firstEditablePositionAfterPositionInRoot(m_start, baseRoot.get());
             m_start = first.deepEquivalent();
             if (m_start.isNull()) {
                 ASSERT_NOT_REACHED();
@@ -586,7 +586,7 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
         // If the end is in non-editable content that is inside the base's root, put it
         // at the last editable position before the end inside the base's root.
         if (endRoot != baseRoot) {
-            VisiblePosition last = lastEditablePositionBeforePositionInRoot(m_end, baseRoot);
+            VisiblePosition last = lastEditablePositionBeforePositionInRoot(m_end, baseRoot.get());
             m_end = last.deepEquivalent();
             if (m_end.isNull())
                 m_end = m_start;

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -362,7 +362,8 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
         if (supportsClientSideAttachmentData(frame)) {
             if (is<HTMLImageElement>(originalElement) && contentTypeIsSuitableForInlineImageRepresentation(info.contentType)) {
                 auto& image = downcast<HTMLImageElement>(originalElement.get());
-                image.setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(*frame.document(), Blob::create(frame.document(), info.data->copyData(), info.contentType)) });
+                RefPtr document = frame.document();
+                image.setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(*document, Blob::create(document.get(), info.data->copyData(), info.contentType)) });
                 image.setAttachmentElement(attachment.copyRef());
             } else {
                 attachment->updateAttributes(info.data->size(), AtomString { info.contentType }, AtomString { info.fileName });
@@ -370,7 +371,8 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
             }
             frame.editor().registerAttachmentIdentifier(attachment->ensureUniqueIdentifier(), WTFMove(info.contentType), WTFMove(info.fileName), WTFMove(info.data));
         } else {
-            attachment->setFile(File::create(frame.document(), Blob::create(frame.document(), info.data->copyData(), WTFMove(info.contentType)), WTFMove(info.fileName)), HTMLAttachmentElement::UpdateDisplayAttributes::Yes);
+            RefPtr document = frame.document();
+            attachment->setFile(File::create(document.get(), Blob::create(document.get(), info.data->copyData(), WTFMove(info.contentType)), WTFMove(info.fileName)), HTMLAttachmentElement::UpdateDisplayAttributes::Yes);
             parent->replaceChild(WTFMove(attachment), WTFMove(originalElement));
         }
     }

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -589,18 +589,18 @@ bool FocusController::relinquishFocusToChrome(FocusDirection direction)
 bool FocusController::advanceFocusInDocumentOrder(FocusDirection direction, KeyboardEvent* event, bool initialFocus)
 {
     LocalFrame& frame = focusedOrMainFrame();
-    Document* document = frame.document();
+    RefPtr document = frame.document();
 
-    Node* currentNode = document->focusNavigationStartingNode(direction);
+    RefPtr<Node> currentNode = document->focusNavigationStartingNode(direction);
     // FIXME: Not quite correct when it comes to focus transitions leaving/entering the WebView itself
     bool caretBrowsing = frame.settings().caretBrowsingEnabled();
 
     if (caretBrowsing && !currentNode)
-        currentNode = frame.selection().selection().start().deprecatedNode();
+        currentNode = frame.selection().selection().start().protectedDeprecatedNode();
 
     document->updateLayoutIgnorePendingStylesheets();
 
-    RefPtr<Element> element = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(currentNode ? *currentNode : *document), currentNode, event);
+    RefPtr<Element> element = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(currentNode ? *currentNode : *document), currentNode.get(), event);
 
     if (!element) {
         // We didn't find a node to focus, so we should try to pass focus to Chrome.

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -735,7 +735,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     // The number of interpretations will be i1 * i2 * ... * iN, where iX is the number of interpretations for the Xth phrase with alternatives.
     size_t interpretationsCount = 1;
 
-    for (auto* marker : markersInRoot)
+    for (auto& marker : markersInRoot)
         interpretationsCount *= std::get<Vector<String>>(marker->data()).size() + 1;
 
     Vector<Vector<UChar>> interpretations;
@@ -746,7 +746,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     unsigned combinationsSoFar = 1;
 
     for (auto& node : intersectingNodes(rangeOfRootContents)) {
-        for (auto* marker : document()->markers().markersFor(node, DocumentMarker::DictationPhraseWithAlternatives)) {
+        for (auto& marker : document()->markers().markersFor(node, DocumentMarker::DictationPhraseWithAlternatives)) {
             auto& alternatives = std::get<Vector<String>>(marker->data());
 
             auto rangeForMarker = makeSimpleRange(node, *marker);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -70,7 +70,8 @@ FontCascade::FontCascade(FontCascadeDescription&& fd, float letterSpacing, float
 }
 
 FontCascade::FontCascade(const FontCascade& other)
-    : m_fontDescription(other.m_fontDescription)
+    : CanMakeWeakPtr<FontCascade>()
+    , m_fontDescription(other.m_fontDescription)
     , m_fonts(other.m_fonts)
     , m_letterSpacing(other.m_letterSpacing)
     , m_wordSpacing(other.m_wordSpacing)

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -42,74 +42,74 @@ namespace WebCore {
 LayoutUnit GridTrack::baseSize() const
 {
     ASSERT(isGrowthLimitBiggerThanBaseSize());
-    return std::max(m_data.baseSize, 0_lu);
+    return std::max(m_baseSize, 0_lu);
 }
 
 LayoutUnit GridTrack::unclampedBaseSize() const
 {
     ASSERT(isGrowthLimitBiggerThanBaseSize());
-    return m_data.baseSize;
+    return m_baseSize;
 }
 
 const LayoutUnit& GridTrack::growthLimit() const
 {
     ASSERT(isGrowthLimitBiggerThanBaseSize());
-    ASSERT(!m_data.growthLimitCap || m_data.growthLimitCap.value() >= m_data.growthLimit || baseSize() >= m_data.growthLimitCap.value());
-    return m_data.growthLimit;
+    ASSERT(!m_growthLimitCap || m_growthLimitCap.value() >= m_growthLimit || baseSize() >= m_growthLimitCap.value());
+    return m_growthLimit;
 }
 
 void GridTrack::setBaseSize(LayoutUnit baseSize)
 {
-    m_data.baseSize = baseSize;
+    m_baseSize = baseSize;
     ensureGrowthLimitIsBiggerThanBaseSize();
 }
 
 void GridTrack::setGrowthLimit(LayoutUnit growthLimit)
 {
-    m_data.growthLimit = growthLimit == infinity ? growthLimit : std::min(growthLimit, m_data.growthLimitCap.value_or(growthLimit));
+    m_growthLimit = growthLimit == infinity ? growthLimit : std::min(growthLimit, m_growthLimitCap.value_or(growthLimit));
     ensureGrowthLimitIsBiggerThanBaseSize();
 }
 
 LayoutUnit GridTrack::growthLimitIfNotInfinite() const
 {
     ASSERT(isGrowthLimitBiggerThanBaseSize());
-    return m_data.growthLimit == infinity ? baseSize() : m_data.growthLimit;
+    return m_growthLimit == infinity ? baseSize() : m_growthLimit;
 }
 
 void GridTrack::setTempSize(const LayoutUnit& tempSize)
 {
     ASSERT(tempSize >= 0);
     ASSERT(growthLimitIsInfinite() || growthLimit() >= tempSize);
-    m_data.tempSize = tempSize;
+    m_tempSize = tempSize;
 }
 
 void GridTrack::growTempSize(const LayoutUnit& tempSize)
 {
     ASSERT(tempSize >= 0);
-    m_data.tempSize += tempSize;
+    m_tempSize += tempSize;
 }
 
 void GridTrack::setGrowthLimitCap(std::optional<LayoutUnit> growthLimitCap)
 {
     ASSERT(!growthLimitCap || growthLimitCap.value() >= 0);
-    m_data.growthLimitCap = growthLimitCap;
+    m_growthLimitCap = growthLimitCap;
 }
 
 const GridTrackSize& GridTrack::cachedTrackSize() const
 {
-    RELEASE_ASSERT(m_data.cachedTrackSize);
-    return *m_data.cachedTrackSize;
+    RELEASE_ASSERT(m_cachedTrackSize);
+    return *m_cachedTrackSize;
 }
 
 void GridTrack::setCachedTrackSize(const GridTrackSize& cachedTrackSize)
 {
-    m_data.cachedTrackSize = cachedTrackSize;
+    m_cachedTrackSize = cachedTrackSize;
 }
 
 void GridTrack::ensureGrowthLimitIsBiggerThanBaseSize()
 {
-    if (m_data.growthLimit != infinity && m_data.growthLimit < std::max(m_data.baseSize, 0_lu))
-        m_data.growthLimit = std::max(m_data.baseSize, 0_lu);
+    if (m_growthLimit != infinity && m_growthLimit < std::max(m_baseSize, 0_lu))
+        m_growthLimit = std::max(m_baseSize, 0_lu);
 }
 
 // Static helper methods.

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -61,75 +61,47 @@ class GridItemWithSpan;
 class GridTrack : public CanMakeWeakPtr<GridTrack> {
 public:
     GridTrack() = default;
-    GridTrack(const GridTrack&);
-    GridTrack(GridTrack&&);
-    GridTrack& operator=(const GridTrack&);
-    GridTrack& operator=(GridTrack&&);
 
     LayoutUnit baseSize() const;
     LayoutUnit unclampedBaseSize() const;
     void setBaseSize(LayoutUnit);
 
     const LayoutUnit& growthLimit() const;
-    bool growthLimitIsInfinite() const { return m_data.growthLimit == infinity; }
+    bool growthLimitIsInfinite() const { return m_growthLimit == infinity; }
     void setGrowthLimit(LayoutUnit);
 
-    bool infiniteGrowthPotential() const { return growthLimitIsInfinite() || m_data.infinitelyGrowable; }
+    bool infiniteGrowthPotential() const { return growthLimitIsInfinite() || m_infinitelyGrowable; }
     LayoutUnit growthLimitIfNotInfinite() const;
 
-    const LayoutUnit& plannedSize() const { return m_data.plannedSize; }
-    void setPlannedSize(LayoutUnit plannedSize) { m_data.plannedSize = plannedSize; }
+    const LayoutUnit& plannedSize() const { return m_plannedSize; }
+    void setPlannedSize(LayoutUnit plannedSize) { m_plannedSize = plannedSize; }
 
-    const LayoutUnit& tempSize() const { return m_data.tempSize; }
+    const LayoutUnit& tempSize() const { return m_tempSize; }
     void setTempSize(const LayoutUnit&);
     void growTempSize(const LayoutUnit&);
 
-    bool infinitelyGrowable() const { return m_data.infinitelyGrowable; }
-    void setInfinitelyGrowable(bool infinitelyGrowable) { m_data.infinitelyGrowable = infinitelyGrowable; }
+    bool infinitelyGrowable() const { return m_infinitelyGrowable; }
+    void setInfinitelyGrowable(bool infinitelyGrowable) { m_infinitelyGrowable = infinitelyGrowable; }
 
     void setGrowthLimitCap(std::optional<LayoutUnit>);
-    std::optional<LayoutUnit> growthLimitCap() const { return m_data.growthLimitCap; }
+    std::optional<LayoutUnit> growthLimitCap() const { return m_growthLimitCap; }
 
     const GridTrackSize& cachedTrackSize() const;
     void setCachedTrackSize(const GridTrackSize&);
 
 private:
-    bool isGrowthLimitBiggerThanBaseSize() const { return growthLimitIsInfinite() || m_data.growthLimit >= std::max(m_data.baseSize, 0_lu); }
+    bool isGrowthLimitBiggerThanBaseSize() const { return growthLimitIsInfinite() || m_growthLimit >= std::max(m_baseSize, 0_lu); }
 
     void ensureGrowthLimitIsBiggerThanBaseSize();
 
-    struct Data {
-        LayoutUnit baseSize { 0 };
-        LayoutUnit growthLimit { 0 };
-        LayoutUnit plannedSize { 0 };
-        LayoutUnit tempSize { 0 };
-        std::optional<LayoutUnit> growthLimitCap;
-        bool infinitelyGrowable { false };
-        std::optional<GridTrackSize> cachedTrackSize;
-    } m_data;
+    LayoutUnit m_baseSize { 0 };
+    LayoutUnit m_growthLimit { 0 };
+    LayoutUnit m_plannedSize { 0 };
+    LayoutUnit m_tempSize { 0 };
+    std::optional<LayoutUnit> m_growthLimitCap;
+    bool m_infinitelyGrowable { false };
+    std::optional<GridTrackSize> m_cachedTrackSize;
 };
-
-inline GridTrack::GridTrack(const GridTrack& other)
-    : m_data(other.m_data)
-{
-}
-
-inline GridTrack::GridTrack(GridTrack&& other)
-    : m_data(WTFMove(other.m_data))
-{
-}
-
-inline GridTrack& GridTrack::operator=(const GridTrack& other)
-{
-    m_data = other.m_data;
-    return *this;
-}
-
-inline GridTrack& GridTrack::operator=(GridTrack&& other)
-{
-    m_data = WTFMove(other.m_data);
-    return *this;
-}
 
 class GridTrackSizingAlgorithm final {
     friend class GridTrackSizingAlgorithmStrategy;

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -199,7 +199,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
     if (!renderer.textNode())
         return { };
 
-    Vector<RenderedDocumentMarker*> markers = renderer.document().markers().markersFor(*renderer.textNode());
+    auto markers = renderer.document().markers().markersFor(*renderer.textNode());
 
     auto markedTextTypeForMarkerType = [] (DocumentMarker::MarkerType type) {
         switch (type) {
@@ -227,7 +227,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
 
     // Give any document markers that touch this run a chance to draw before the text has been drawn.
     // Note end() points at the last char, not one past it like endOffset and ranges do.
-    for (auto* marker : markers) {
+    for (auto& marker : markers) {
         // Collect either the background markers or the foreground markers, but not both
         switch (marker->type()) {
         case DocumentMarker::Grammar:
@@ -283,7 +283,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
 #endif
         case DocumentMarker::TextMatch: {
             auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
-            markedTexts.uncheckedAppend({ clampedStart, clampedEnd, markedTextTypeForMarkerType(marker->type()), marker });
+            markedTexts.uncheckedAppend({ clampedStart, clampedEnd, markedTextTypeForMarkerType(marker->type()), marker.get() });
             break;
         }
         case DocumentMarker::Replacement:

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -143,9 +143,9 @@ bool RenderReplaced::shouldDrawSelectionTint() const
     return selectionState() != HighlightState::None && !document().printing();
 }
 
-inline static bool draggedContentContainsReplacedElement(const Vector<RenderedDocumentMarker*>& markers, const Element& element)
+inline static bool draggedContentContainsReplacedElement(const Vector<WeakPtr<RenderedDocumentMarker>>& markers, const Element& element)
 {
-    for (auto* marker : markers) {
+    for (auto& marker : markers) {
         if (std::get<RefPtr<Node>>(marker->data()) == &element)
             return true;
     }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1399,7 +1399,7 @@ Vector<std::pair<unsigned, unsigned>> RenderText::draggedContentRangesBetweenOff
         return { };
 
     Vector<std::pair<unsigned, unsigned>> draggedContentRanges;
-    for (auto* marker : markers) {
+    for (auto& marker : markers) {
         unsigned markerStart = std::max(marker->startOffset(), startOffset);
         unsigned markerEnd = std::min(marker->endOffset(), endOffset);
         if (markerStart >= markerEnd || markerStart > endOffset || markerEnd < startOffset)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1915,10 +1915,10 @@ ExceptionOr<RenderedDocumentMarker*> Internals::markerAt(Node& node, const Strin
 
     node.document().editor().updateEditorUINowIfScheduled();
 
-    Vector<RenderedDocumentMarker*> markers = node.document().markers().markersFor(node, markerTypes);
+    auto markers = node.document().markers().markersFor(node, markerTypes);
     if (markers.size() <= index)
         return nullptr;
-    return markers[index];
+    return markers[index].get();
 }
 
 ExceptionOr<RefPtr<Range>> Internals::markerRangeForNode(Node& node, const String& markerType, unsigned index)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -186,7 +186,7 @@ WebCore::AttributedString TextCheckingControllerProxy::annotatedSubstringBetween
             continue;
         [string appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:it.text().createNSStringWithoutCopying().get()]).get()];
         auto range = it.range();
-        for (auto* marker : range.start.document().markers().markersInRange(range, DocumentMarker::PlatformTextChecking)) {
+        for (auto& marker : range.start.document().markers().markersInRange(range, DocumentMarker::PlatformTextChecking)) {
             auto& data = std::get<DocumentMarker::PlatformTextCheckingData>(marker->data());
             auto subrange = resolveCharacterRange(range, { marker->startOffset(), marker->endOffset() - marker->startOffset() }, behaviors);
             auto attributeRange = characterRange(*entireRange, subrange, behaviors);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -327,7 +327,7 @@ void WebPage::dictationAlternativesAtSelection(CompletionHandler<void(Vector<Dic
 
     auto markers = document->markers().markersInRange(*expandedSelectionRange, DocumentMarker::DictationAlternatives);
     contexts.reserveInitialCapacity(markers.size());
-    for (auto* marker : markers) {
+    for (auto& marker : markers) {
         if (std::holds_alternative<DocumentMarker::DictationData>(marker->data()))
             contexts.uncheckedAppend(std::get<DocumentMarker::DictationData>(marker->data()).context);
     }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -383,7 +383,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 #if USE(DICTATION_ALTERNATIVES)
     if (selectedRange) {
         auto markers = frame.document()->markers().markersInRange(*selectedRange, DocumentMarker::MarkerType::DictationAlternatives);
-        postLayoutData.dictationContextsForSelection = WTF::map(markers, [] (auto* marker) {
+        postLayoutData.dictationContextsForSelection = WTF::map(markers, [] (auto& marker) {
             return std::get<DocumentMarker::DictationData>(marker->data()).context;
         });
     }
@@ -1410,8 +1410,8 @@ static bool insideImageOverlay(const VisiblePosition& position)
 
 static std::optional<SimpleRange> expandForImageOverlay(const SimpleRange& range)
 {
-    VisiblePosition expandedStart(makeContainerOffsetPosition(&range.startContainer(), range.startOffset()));
-    VisiblePosition expandedEnd(makeContainerOffsetPosition(&range.endContainer(), range.endOffset()));
+    VisiblePosition expandedStart(makeContainerOffsetPosition(range.protectedStartContainer(), range.startOffset()));
+    VisiblePosition expandedEnd(makeContainerOffsetPosition(range.protectedEndContainer(), range.endOffset()));
 
     for (auto start = expandedStart; insideImageOverlay(start); start = start.previous()) {
         if (RefPtr container = start.deepEquivalent().containerNode(); is<Text>(container)) {
@@ -1891,7 +1891,7 @@ void WebPage::extendSelectionForReplacement(CompletionHandler<void()>&& completi
     if (!container)
         return;
 
-    auto markerRanges = document->markers().markersFor(*container, { DocumentMarker::DictationAlternatives, DocumentMarker::CorrectionIndicator }).map([&](auto* marker) {
+    auto markerRanges = document->markers().markersFor(*container, { DocumentMarker::DictationAlternatives, DocumentMarker::CorrectionIndicator }).map([&](auto& marker) {
         return makeSimpleRange(*container, *marker);
     });
 

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm
@@ -412,7 +412,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
 
     unsigned offset = position.deepEquivalent().deprecatedEditingOffset();
     auto& document = node->document();
-    for (auto marker : document.markers().markersFor(*node, DocumentMarker::DictationPhraseWithAlternatives)) {
+    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::DictationPhraseWithAlternatives)) {
         if (marker->startOffset() <= offset && marker->endOffset() >= offset) {
             *alternatives = createNSArray(std::get<Vector<String>>(marker->data())).autorelease();
             return kit(makeSimpleRange(*node, *marker));
@@ -430,7 +430,7 @@ static inline SelectionDirection toSelectionDirection(WebTextAdjustmentDirection
 
     unsigned offset = position.deepEquivalent().deprecatedEditingOffset();
     auto& document = node->document();
-    for (auto marker : document.markers().markersFor(*node, DocumentMarker::Spelling)) {
+    for (auto& marker : document.markers().markersFor(*node, DocumentMarker::Spelling)) {
         if (marker->startOffset() <= offset && marker->endOffset() >= offset)
             return kit(makeSimpleRange(*node, *marker));
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1701,7 +1701,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 
     for (WebCore::Node* node = root; node; node = WebCore::NodeTraversal::next(*node)) {
         auto markers = document->markers().markersFor(*node);
-        for (auto* marker : markers) {
+        for (auto& marker : markers) {
             if (marker->type() != WebCore::DocumentMarker::DictationResult)
                 continue;
 


### PR DESCRIPTION
#### 9318f2ff1342ea508beeba6bf16691be3c06d65d
<pre>
Use more smart pointers in editing node
<a href="https://bugs.webkit.org/show_bug.cgi?id=261572">https://bugs.webkit.org/show_bug.cgi?id=261572</a>

Reviewed by Darin Adler and Brent Fulgham.

* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::DocumentMarker):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::markersFor):
(WebCore::DocumentMarkerController::markersInRange):
(): Deleted.
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::markersHaveIdenticalDescription):
(WebCore::AlternativeTextController::respondToChangedSelection):
(WebCore::AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection):
(WebCore::AlternativeTextController::applyDictationAlternative):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyleChange):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::copyMarkers):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::initializePositionData):
(WebCore::DeleteSelectionCommand::handleGeneralDelete):
(WebCore::DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelection):
* Source/WebCore/editing/EditCommand.h:
(WebCore::EditCommand::protectedDocument const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::enclosingEmptyListItem):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::updateMarkersForWordsAffectedByEditing):
(WebCore::Editor::selectionStartHasMarkerFor const):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::updateFromAssociatedLiveRange):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::tryIndentingAsListItem):
(WebCore::IndentOutdentCommand::outdentParagraph):
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::adjacentEnclosingList):
* Source/WebCore/editing/ModifySelectionListLevel.cpp:
(WebCore::getStartEndListChildren):
(WebCore::canIncreaseListLevel):
(WebCore::IncreaseSelectionListLevelCommand::doApply):
(WebCore::IncreaseSelectionListLevelCommand::canIncreaseSelectionListLevel):
(WebCore::canDecreaseListLevel):
(WebCore::DecreaseSelectionListLevelCommand::doApply):
(WebCore::DecreaseSelectionListLevelCommand::canDecreaseSelectionListLevel):
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp:
(WebCore::ReplaceNodeWithSpanCommand::doUnapply):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::positionAvoidingPrecedingNodes):
(WebCore::ReplaceSelectionCommand::doApply):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::TextIterator):
(WebCore::TextIterator::init):
(WebCore::TextIterator::advance):
(WebCore::TextIterator::handleTextNode):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::handleReplacedElement):
(WebCore::TextIterator::shouldRepresentNodeOffsetZero):
(WebCore::TextIterator::representNodeOffsetZero):
(WebCore::TextIterator::handleNonTextNode):
(WebCore::TextIterator::exitNode):
(WebCore::TextIterator::protectedCurrentNode const):
(WebCore::SimplifiedBackwardsTextIterator::handleReplacedElement):
(WebCore::SimplifiedBackwardsTextIterator::handleNonTextNode):
(WebCore::SimplifiedBackwardsTextIterator::exitNode):
* Source/WebCore/editing/TextIterator.h:
(WebCore::SimplifiedBackwardsTextIterator::node const):
(WebCore::SimplifiedBackwardsTextIterator::protectedNode const):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::adjustSelectionRespectingGranularity):
(WebCore::VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::replaceRichContentWithAttachments):
* Source/WebCore/editing/markup.cpp:
(WebCore::restoreAttachmentElementsInFragment):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::interpretationsForCurrentRoot const):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::draggedContentContainsReplacedElement):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::draggedContentRangesBetweenOffsets const):
* Source/WebCore/testing/Internals.cpp:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictationAlternativesAtSelection):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKitLegacy/ios/WebCoreSupport/WebVisiblePosition.mm:
(-[WebVisiblePosition enclosingRangeWithDictationPhraseAlternatives:]):
(-[WebVisiblePosition enclosingRangeWithCorrectionIndicator]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame getDictationResultRanges:andMetadatas:]):

Canonical link: <a href="https://commits.webkit.org/268054@main">https://commits.webkit.org/268054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfe6840acad061cbd8ac656ce370c1b17439279d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19209 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21262 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23356 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16058 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21251 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14959 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21894 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16708 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4405 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21073 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23138 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17490 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5207 "Passed tests") | 
<!--EWS-Status-Bubble-End-->