### PR TITLE
[NEW TEST] [ macOS ] API tests brings up a "There is no application set to open the URL callback:playing." dialogue box

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
@@ -78,8 +78,7 @@ TEST(WKWebViewSuspendAllMediaPlayback, AfterLoading)
     TestWebKitAPI::Util::run(&isPlaying);
 }
 
-// FIX ME: Un-disable test when https://bugs.webkit.org/show_bug.cgi?id=261529 is resolved
-TEST(WKWebViewSuspendAllMediaPlayback, DISABLED_PauseWhenResume)
+TEST(WKWebViewSuspendAllMediaPlayback, PauseWhenResume)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html
@@ -10,9 +10,7 @@
     function playing() {
         try {
             window.webkit.messageHandlers.testHandler.postMessage('playing');
-        } catch(e) {
-            window.location = 'callback:playing';
-        }
+        } catch(e) { }
     }
 
     function paused() {


### PR DESCRIPTION
#### 68ac9887adc95fe820ffa87d93ee4fef7c485bf8
<pre>
[NEW TEST] [ macOS ] API tests brings up a &quot;There is no application set to open the URL callback:playing.&quot; dialogue box
<a href="https://bugs.webkit.org/show_bug.cgi?id=261529">https://bugs.webkit.org/show_bug.cgi?id=261529</a>
rdar://115450715

Reviewed by Eric Carlson.

This patch fixes the issue that was causing a dialog box to appear when running
TestWebKitAPI.WKWebViewSuspendAllMediaPlayback.PauseWhenResume. When the test
Loads video-with-audio.html, the javascript posts the message &quot;playing&quot;, which
triggers an exception because the test does not provide a completion handler for
this message (because a completion handler is not needed). The code within the
catch block causes the dialog box to appear. To fix this, the catch block is now
empty, which unifies the behavior with the other javascript functions in the file.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm:
(TEST): un-disable test
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html: Make catch block
In playing() empty

Canonical link: <a href="https://commits.webkit.org/268036@main">https://commits.webkit.org/268036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20f1b6f5e4a998071879fcceb2404e0005594724

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19086 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21048 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23208 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14818 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16546 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->