### PR TITLE
Use more smart pointers in CSS parsing code

### DIFF
--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -818,20 +818,16 @@ RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(C
             if (value.isFontFamily())
                 fontFamilies.append(AtomString { value.stringValue() });
         };
-        auto cssFontFamily = properties->getPropertyCSSValue(CSSPropertyFontFamily);
+        RefPtr cssFontFamily = properties->getPropertyCSSValue(CSSPropertyFontFamily);
         if (!cssFontFamily)
             return fontFamilies;
-        auto cssPrimitiveFontFamilies = dynamicDowncast<CSSValueList>(*cssFontFamily);
-        if (cssPrimitiveFontFamilies) {
-            for (auto& item : *cssPrimitiveFontFamilies)
+        if (RefPtr families = dynamicDowncast<CSSValueList>(*cssFontFamily)) {
+            for (auto& item : *families)
                 append(downcast<CSSPrimitiveValue>(item));
             return fontFamilies;
         }
-
-        auto cssPrimitiveFontFamily = dynamicDowncast<CSSPrimitiveValue>(*cssFontFamily);
-        if (!cssPrimitiveFontFamily)
-            return fontFamilies;
-        append(*cssPrimitiveFontFamily);
+        if (RefPtr family = dynamicDowncast<CSSPrimitiveValue>(cssFontFamily.releaseNonNull()))
+            append(*family);
         return fontFamilies;
     }();
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -494,9 +494,9 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
     };
 
     if (is<CSSValueList>(value.get()) || is<CSSTransformListValue>(value.get())) {
-        auto& valueList = downcast<CSSValueContainingVector>(*value);
-        auto syntaxValueList = CSSCustomPropertyValue::SyntaxValueList { { }, valueList.separator() };
-        for (auto& listValue : valueList) {
+        Ref valueList = downcast<CSSValueContainingVector>(value.releaseNonNull());
+        auto syntaxValueList = CSSCustomPropertyValue::SyntaxValueList { { }, valueList->separator() };
+        for (Ref listValue : valueList.get()) {
             auto syntaxValue = resolveSyntaxValue(listValue);
             if (!syntaxValue)
                 return nullptr;

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -32,6 +32,7 @@
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
 #include "MediaQuery.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -57,7 +58,9 @@ private:
     bool mediaConditionMatches(const MQ::MediaQuery&);
     unsigned effectiveSizeDefaultValue();
 
-    const Document& m_document;
+    Ref<const Document> protectedDocument() const;
+
+    CheckedRef<const Document> m_document;
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;
     float m_length { 0 };
     bool m_lengthWasSet { false };


### PR DESCRIPTION
#### f0a2432b920fc757138bcc928624389e773ba047
<pre>
Use more smart pointers in CSS parsing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=261578">https://bugs.webkit.org/show_bug.cgi?id=261578</a>

Reviewed by Darin Adler and Brent Fulgham.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
(WebCore::isValueIDPair):
(WebCore::isNumber):
(WebCore::isValueID):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::backgroundPositionFromThreeValues):
(WebCore::CSSPropertyParserHelpers::positionFromFourValues):
(WebCore::CSSPropertyParserHelpers::consumePositionCoordinates):
(WebCore::CSSPropertyParserHelpers::isGridTrackFixedSized):
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::calculateLengthInPixels):
(WebCore::SizesAttributeParser::mediaConditionMatches):
(WebCore::SizesAttributeParser::parse):
(WebCore::SizesAttributeParser::effectiveSizeDefaultValue):
(WebCore::SizesAttributeParser::protectedDocument const):
* Source/WebCore/css/parser/SizesAttributeParser.h:

Canonical link: <a href="https://commits.webkit.org/268048@main">https://commits.webkit.org/268048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7210686dd1daa95d74823664ca6262fb28302c99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19176 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21195 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21208 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14921 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16661 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4401 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->