### PR TITLE
Implement tabs.create(), tabs.duplicate(), and tabs.update() for Web Extensions.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -79,8 +79,21 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param context The context in which the web extension is running.
  @return The parent tab of the tab, if the tab was opened from another tab.
  @discussion Defaults to `nil` if not implemented.
+ @seealso setParentTab:forWebExtensionContext:completionHandler:
  */
 - (nullable id <_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to set or clear the parent tab for the tab.
+ @param parentTab The tab that should be set as the parent of the tab. If \c nil is provided, the current
+ parent tab should be cleared.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion No action is performed if not implemented.
+ @seealso parentTabForWebExtensionContext:
+ */
+- (void)setParentTab:(nullable id <_WKWebExtensionTab>)parentTab forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called when the main web view for the tab is needed.
@@ -95,6 +108,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param context The context in which the web extension is running.
  @return An array of web views for the tab.
  @discussion Defaults to an array containing the main web view if not implemented.
+ @seealso mainWebViewForWebExtensionContext:
  */
 - (NSArray<WKWebView *> *)webViewsForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -107,14 +121,6 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (nullable NSString *)tabTitleForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the selected state of the tab is needed.
- @param context The context in which the web extension is running.
- @return `YES` if the tab is selected, `NO` otherwise.
- @discussion Defaults to `YES` for the active tab and `NO` for other tabs if not implemented.
- */
-- (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context;
-
-/*!
  @abstract Called when the pinned state of the tab is needed.
  @param context The context in which the web extension is running.
  @return `YES` if the tab is pinned, `NO` otherwise.
@@ -123,10 +129,35 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (BOOL)isPinnedForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
+ @abstract Called to pin the tab.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion This is equivalent to the user selecting to pin the tab through a menu item. When a tab is pinned,
+ it should be moved to the front of the tab bar and usually reduced in size. No action is performed if not implemented.
+ @seealso isPinnedForWebExtensionContext:
+ @seealso pinForWebExtensionContext:completionHandler:
+ */
+- (void)pinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called to unpin the tab.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion This is equivalent to the user selecting to unpin the tab through a menu item. When a tab is unpinned,
+ it should be restored to a normal size and position in the tab bar. No action is performed if not implemented.
+ @seealso isPinnedForWebExtensionContext:
+ @seealso pinForWebExtensionContext:completionHandler:
+ */
+- (void)unpinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
  @abstract Called to check if reader mode is available for the tab.
  @param context The context in which the web extension is running.
  @return `YES` if reader mode is available for the tab, `NO` otherwise.
  @discussion Defaults to `NO` if not implemented.
+ @seealso isShowingReaderModeForWebExtensionContext:
  */
 - (BOOL)isReaderModeAvailableForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -135,6 +166,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param context The context in which the web extension is running.
  @return `YES` if the tab is showing reader mode, `NO` otherwise.
  @discussion Defaults to `NO` if not implemented.
+ @seealso isReaderModeAvailableForWebExtensionContext:
  */
 - (BOOL)isShowingReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -144,6 +176,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
+ @seealso isReaderModeAvailableForWebExtensionContext:
+ @seealso isShowingReaderModeForWebExtensionContext:
  */
 - (void)toggleReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -169,6 +203,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
+ @seealso isMutedForWebExtensionContext:
+ @seealso unmuteForWebExtensionContext:completionHandler:
  */
 - (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -178,6 +214,8 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
+ @seealso isMutedForWebExtensionContext:
+ @seealso muteForWebExtensionContext:completionHandler:
  */
 - (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -194,6 +232,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param context The context in which the web extension is running.
  @return The zoom factor of the tab.
  @discussion Defaults to `pageZoom` for the main web view if not implemented.
+ @seealso setZoomFactor:forWebExtensionContext:completionHandler:
  */
 - (double)zoomFactorForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -202,8 +241,9 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param zoomFactor The desired zoom factor for the tab.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
- which should be provided if any errors occured.
- @discussion Sets `pageZoom` for the main web view if not implemented..
+ which should be provided if any errors occurred.
+ @discussion Sets `pageZoom` for the main web view if not implemented.
+ @seealso zoomFactorForWebExtensionContext:
  */
 - (void)setZoomFactor:(double)zoomFactor forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -236,7 +276,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to detect the locale of the webpage currently loaded in the tab.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. The block takes two arguments:
- the detected locale (or \c nil if the locale is unknown) and an error, which should be provided if any errors occured.
+ the detected locale (or \c nil if the locale is unknown) and an error, which should be provided if any errors occurred.
  @discussion No action is performed if not implemented.
  */
 - (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale * _Nullable locale, NSError * _Nullable error))completionHandler;
@@ -246,7 +286,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param url The URL to be loaded in the tab.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
- which should be provided if any errors occured.
+ which should be provided if any errors occurred.
  @discussion If the tab is already loading a page, calling this method should stop the current page from loading and start
  loading the new URL. Loads the URL in the main web view via `loadRequest:` if not implemented.
  */
@@ -256,7 +296,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to reload the current page in the tab.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
- which should be provided if any errors occured.
+ which should be provided if any errors occurred.
  @discussion Reloads the main web view via `reload` if not implemented.
  */
 - (void)reloadForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
@@ -265,7 +305,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to reload the current page in the tab, bypassing the cache.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
- which should be provided if any errors occured.
+ which should be provided if any errors occurred.
  @discussion Reloads the main web view via `reloadFromOrigin` if not implemented.
  */
 - (void)reloadFromOriginForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
@@ -274,7 +314,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to navigate the tab to the previous page in its history.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
- which should be provided if any errors occured.
+ which should be provided if any errors occurred.
  @discussion Navigates to the previous page in the main web view via `goBack` if not implemented.
  */
 - (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
@@ -283,7 +323,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called to navigate the tab to the next page in its history.
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
- which should be provided if any errors occured.
+ which should be provided if any errors occurred.
  @discussion Navigates to the next page in the main web view via `goForward` if not implemented.
  */
 - (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
@@ -300,24 +340,44 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (void)activateForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
- @abstract Called to select the tab, potentially extending the current selection to include multiple tabs.
+ @abstract Called when the selected state of the tab is needed.
  @param context The context in which the web extension is running.
- @param extendSelection A boolean value that determines whether the selection should be extended. If set to \c YES,
- the selection should contain the tab along with any previously selected tabs without changing the active tab.
- If set to \c NO, the selection should be cleared, and the tab should be the active tab and only one selected.
+ @return `YES` if the tab is selected, `NO` otherwise.
+ @discussion Defaults to `YES` for the active tab and `NO` for other tabs if not implemented.
+ */
+- (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Called to select the tab, adding it to the current tab selection.
+ @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion This is equivalent to the user clicking on the tab in a tab bar. No action is performed if not implemented.
- @seealso activateForWebExtensionContext:completionHandler:
+ @discussion This is equivalent to the user command-clicking on the tab to add it to a selection.
+ The method should add the tab to the current selection without changing the active tab. No action is performed if not implemented.
+ @seealso isSelectedForWebExtensionContext:
+ @seealso deselectForWebExtensionContext:completionHandler:
  */
-- (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context extendSelection:(BOOL)extendSelection completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+- (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Called to deselect the tab, removing it from the current tab selection.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion This is equivalent to the user command-clicking on an already selected tab to remove it from the selection.
+ The method should remove the tab from the current selection without changing the active tab. If the tab is the active tab, it should
+ remain selected and active or another tab should become selected and active in its place. No action is performed if not implemented.
+ @seealso isSelectedForWebExtensionContext:
+ @seealso selectForWebExtensionContext:completionHandler:
+ */
+- (void)deselectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called to duplicate the tab.
  @param context The context in which the web extension is running.
  @param options The tab creation options influencing the duplicated tab's properties.
  @param completionHandler A block that must be called upon completion. It takes two arguments:
- the duplicated tab (or \c nil if no tab was created) and an error, which should be provided if any errors occured.
+ the duplicated tab (or \c nil if no tab was created) and an error, which should be provided if any errors occurred.
  @discussion This is equivalent to the user selecting to duplicate the tab through a menu item, with the specified options.
  No action is performed if not implemented.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h
@@ -65,23 +65,20 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, nullable, readonly, copy) NSURL *desiredURL;
 
 /*!
- @abstract Indicates whether the new tab should be selected.
- @discussion If this property is set to `YES`, and if `shouldExtendSelection` is also `YES`, the new tab
- should be added to the current selection without altering the frontmost tab. If `shouldExtendSelection` is `NO`,
- the previous selection should be cleared and the new tab should be the only one selected. If `shouldSelect` is `NO`,
- this tab should not be part of the selection regardless of the `shouldExtendSelection` value.
- @seealso shouldExtendSelection
+ @abstract Indicates whether the new tab should become the active tab.
+ @discussion If this property is set to `YES`, the new tab should be made active in the window, ensuring it is
+ the frontmost tab. Being active implies the tab is also selected. If this property is set to `NO`,  the new tab shouldn't
+ affect the currently active tab.
  */
-@property (nonatomic, readonly) BOOL shouldSelect;
+@property (nonatomic, readonly) BOOL shouldActivate;
 
 /*!
- @abstract Indicates whether the new tab's selection should extend the current selection.
- @discussion If this property is set to `YES`, and if `shouldSelect` is also `YES`, the new tab should be added
- to the current selection without altering the frontmost tab. If this property is set to `NO`, or if `shouldSelect` is `NO`,
- the current selection state of other tabs should not be affected by the creation of the new tab.
- @seealso shouldSelect
+ @abstract Indicates whether the new tab should be added to the current tab selection.
+ @discussion If this property is set to `YES`, the new tab should be part of the current selection, but not necessarily
+ become the active tab unless `shouldActivate` is also `YES`. If this property is set to `NO`, the new tab shouldn't
+ be part of the current selection.
  */
-@property (nonatomic, readonly) BOOL shouldExtendSelection;
+@property (nonatomic, readonly) BOOL shouldSelect;
 
 /*! @abstract Indicates whether the new tab should be pinned. */
 @property (nonatomic, readonly) BOOL shouldPin;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h
@@ -37,8 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, setter=_setDesiredIndex:) NSUInteger desiredIndex;
 @property (readwrite, setter=_setDesiredParentTab:) id <_WKWebExtensionTab> desiredParentTab;
 @property (readwrite, setter=_setDesiredURL:) NSURL *desiredURL;
+@property (readwrite, setter=_setShouldActivate:) BOOL shouldActivate;
 @property (readwrite, setter=_setShouldSelect:) BOOL shouldSelect;
-@property (readwrite, setter=_setShouldExtendSelection:) BOOL shouldExtendSelection;
 @property (readwrite, setter=_setShouldPin:) BOOL shouldPin;
 @property (readwrite, setter=_setShouldMute:) BOOL shouldMute;
 @property (readwrite, setter=_setShouldShowReaderMode:) BOOL shouldShowReaderMode;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -72,7 +72,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 /*!
  @abstract Called when the active tab is needed for the window.
  @param context The context in which the web extension is running.
- @return The active tab in the window.
+ @return The active tab in the window, which represents the frontmost tab currently in view.
  @discussion Defaults to `nil` if not implemented.
  */
 - (nullable id <_WKWebExtensionTab>)activeTabForWebExtensionContext:(_WKWebExtensionContext *)context;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -356,6 +356,9 @@ private:
     void firePermissionsEventListenerIfNecessary(WebExtensionEventListenerType, const PermissionsSet&, const MatchPatternSet&);
 
     // Tabs APIs
+    void tabsCreate(WebPageProxyIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
+    void tabsUpdate(WebExtensionTabIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
+    void tabsDuplicate(WebExtensionTabIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
     void tabsGet(WebExtensionTabIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
     void tabsGetCurrent(WebPageProxyIdentifier, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
     void tabsQuery(WebPageProxyIdentifier, const WebExtensionTabQueryParameters&, CompletionHandler<void(Vector<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -51,6 +51,9 @@ messages -> WebExtensionContext {
     PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
 
     // Tabs APIs
+    TabsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
+    TabsUpdate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters updateParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
+    TabsDuplicate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
     TabsGet(WebKit::WebExtensionTabIdentifier tabIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
     TabsGetCurrent(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
     TabsQuery(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabQueryParameters queryParameters) -> (Vector<WebKit::WebExtensionTabParameters> tabs, WebKit::WebExtensionWindow::Error error);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -71,7 +71,6 @@ public:
         All        = Audible | Loading | Muted | Pinned | ReaderMode | Size | Title | URL | ZoomFactor,
     };
 
-    enum class ExtendSelection : bool { No, Yes };
     enum class AssumeWindowMatches : bool { No, Yes };
 
     using Error = std::optional<String>;
@@ -92,6 +91,7 @@ public:
     size_t index() const;
 
     RefPtr<WebExtensionTab> parentTab() const;
+    void setParentTab(RefPtr<WebExtensionTab>, CompletionHandler<void(Error)>&&);
 
     WKWebView *mainWebView() const;
     NSArray *webViews() const;
@@ -100,8 +100,12 @@ public:
 
     bool isActive() const;
     bool isSelected() const;
-    bool isPinned() const;
     bool isPrivate() const;
+
+    void pin(CompletionHandler<void(Error)>&&);
+    void unpin(CompletionHandler<void(Error)>&&);
+
+    bool isPinned() const;
 
     void toggleReaderMode(CompletionHandler<void(Error)>&&);
 
@@ -135,9 +139,10 @@ public:
     void goForward(CompletionHandler<void(Error)>&&);
 
     void activate(CompletionHandler<void(Error)>&&);
-    void select(ExtendSelection, CompletionHandler<void(Error)>&&);
+    void select(CompletionHandler<void(Error)>&&);
+    void deselect(CompletionHandler<void(Error)>&&);
 
-    void duplicate(CompletionHandler<void(RefPtr<WebExtensionTab>, Error)>&&);
+    void duplicate(const WebExtensionTabParameters&, CompletionHandler<void(RefPtr<WebExtensionTab>, Error)>&&);
 
     void close(CompletionHandler<void(Error)>&&);
 
@@ -153,11 +158,14 @@ private:
     WeakObjCPtr<_WKWebExtensionTab> m_delegate;
     bool m_respondsToWindow : 1 { false };
     bool m_respondsToParentTab : 1 { false };
+    bool m_respondsToSetParentTab : 1 { false };
     bool m_respondsToMainWebView : 1 { false };
     bool m_respondsToWebViews : 1 { false };
     bool m_respondsToTabTitle : 1 { false };
     bool m_respondsToIsSelected : 1 { false };
     bool m_respondsToIsPinned : 1 { false };
+    bool m_respondsToPin : 1 { false };
+    bool m_respondsToUnpin : 1 { false };
     bool m_respondsToIsReaderModeAvailable : 1 { false };
     bool m_respondsToIsShowingReaderMode : 1 { false };
     bool m_respondsToToggleReaderMode : 1 { false };
@@ -179,6 +187,7 @@ private:
     bool m_respondsToGoForward : 1 { false };
     bool m_respondsToActivate : 1 { false };
     bool m_respondsToSelect : 1 { false };
+    bool m_respondsToDeselect : 1 { false };
     bool m_respondsToDuplicate : 1 { false };
     bool m_respondsToClose : 1 { false };
 };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -47,19 +47,19 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
-    void createTab(NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void createTab(WebPage*, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void query(WebPage*, NSDictionary *queryInfo, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void query(WebPage*, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void get(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getCurrent(WebPage*, Ref<WebExtensionCallbackHandler>&&);
     void getSelected(WebPage*, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void duplicate(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void update(WebPage*, double tabID, NSDictionary *updateProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void duplicate(double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void update(WebPage*, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void reload(WebPage*, double tabID, NSDictionary *reloadProperties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void reload(WebPage*, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void goBack(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void goForward(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
@@ -85,6 +85,7 @@ public:
 private:
     static bool parseTabCreateOptions(NSDictionary *, WebExtensionTabParameters&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseTabUpdateOptions(NSDictionary *, WebExtensionTabParameters&, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseTabDuplicateOptions(NSDictionary *, WebExtensionTabParameters&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseTabQueryOptions(NSDictionary *, WebExtensionTabQueryParameters&, NSString *sourceKey, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onActivated;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -29,7 +29,7 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPITabs {
 
-    [RaisesException, ImplementedAs=createTab] void create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage, ImplementedAs=createTab] void create([NSDictionary] any properties, [Optional, CallbackHandler] function callback);
 
     [RaisesException, NeedsPage] void query([NSDictionary] any info, [Optional, CallbackHandler] function callback);
 
@@ -37,7 +37,7 @@
     [NeedsPage] void getCurrent([Optional, CallbackHandler] function callback);
     [RaisesException, Dynamic, NeedsPage] void getSelected([Optional] double windowID, [Optional, CallbackHandler] function callback);
 
-    [RaisesException] void duplicate(double tabID, [Optional, CallbackHandler] function callback);
+    [RaisesException] void duplicate(double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
     [RaisesException, NeedsPage] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any tabIDs, [Optional, CallbackHandler] function callback);
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -62,6 +62,11 @@
 @property (nonatomic, weak) id<_WKWebExtensionWindow> window;
 @property (nonatomic, strong) WKWebView *mainWebView;
 
+@property (nonatomic, weak) id<_WKWebExtensionTab> parentTab;
+
+@property (nonatomic, getter=isPinned) bool pinned;
+@property (nonatomic, getter=isMuted) bool muted;
+@property (nonatomic, getter=isSelected) bool selected;
 @property (nonatomic, getter=isShowingReaderMode) bool showingReaderMode;
 
 @property (nonatomic, copy) void (^toggleReaderMode)(void);
@@ -71,6 +76,7 @@
 @property (nonatomic, copy) void (^reloadFromOrigin)(void);
 @property (nonatomic, copy) void (^goBack)(void);
 @property (nonatomic, copy) void (^goForward)(void);
+@property (nonatomic, copy) void (^duplicate)(_WKWebExtensionTabCreationOptions *, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *));
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -221,6 +221,93 @@
     completionHandler(nil);
 }
 
+- (id<_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _parentTab;
+}
+
+- (void)setParentTab:(id<_WKWebExtensionTab>)parentTab forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _parentTab = parentTab;
+
+    completionHandler(nil);
+}
+
+- (BOOL)isPinnedForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _pinned;
+}
+
+- (void)pinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _pinned = YES;
+
+    completionHandler(nil);
+}
+
+- (void)unpinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _pinned = NO;
+
+    completionHandler(nil);
+}
+
+- (BOOL)isMutedForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _muted;
+}
+
+- (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _muted = YES;
+
+    completionHandler(nil);
+}
+
+- (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _muted = NO;
+
+    completionHandler(nil);
+}
+
+- (void)duplicateForWebExtensionContext:(_WKWebExtensionContext *)context withOptions:(_WKWebExtensionTabCreationOptions *)options completionHandler:(void (^)(id<_WKWebExtensionTab>, NSError *))completionHandler
+{
+    if (_duplicate)
+        _duplicate(options, completionHandler);
+    else
+        completionHandler(nil, nil);
+}
+
+- (void)activateForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    if (auto *window = dynamic_objc_cast<TestWebExtensionWindow>(_window))
+        window.activeTab = self;
+
+    _selected = YES;
+
+    completionHandler(nil);
+}
+
+- (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _selected || dynamic_objc_cast<TestWebExtensionWindow>(_window).activeTab == self;
+}
+
+- (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _selected = YES;
+
+    completionHandler(nil);
+}
+
+- (void)deselectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    _selected = NO;
+
+    completionHandler(nil);
+}
+
 - (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
     if (auto *window = dynamic_objc_cast<TestWebExtensionWindow>(_window))


### PR DESCRIPTION
#### 90a0f95cb2f41c15e49785bde7d3fefc9de9d6f5
<pre>
Implement tabs.create(), tabs.duplicate(), and tabs.update() for Web Extensions.
<a href="https://webkit.org/b/261579">https://webkit.org/b/261579</a>
rdar://problem/115523124

Reviewed by Brian Weinstein.

Added support for the last three base tabs APIs for Web Extensions.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
(WebKit::WebExtensionContext::tabsUpdate):
(WebKit::WebExtensionContext::tabsDuplicate):
(WebKit::WebExtensionContext::tabsGetCurrent):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getWindow):
(WebKit::WebExtensionContext::getTab):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::setParentTab):
(WebKit::WebExtensionTab::pin):
(WebKit::WebExtensionTab::unpin):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::select):
(WebKit::WebExtensionTab::deselect):
(WebKit::WebExtensionTab::duplicate):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseTabDuplicateOptions):
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::duplicate):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::reload):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab goForwardForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab parentTabForWebExtensionContext:]):
(-[TestWebExtensionTab setParentTab:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab isPinnedForWebExtensionContext:]):
(-[TestWebExtensionTab pinForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab unpinForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab isMutedForWebExtensionContext:]):
(-[TestWebExtensionTab muteForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab unmuteForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab duplicateForWebExtensionContext:withOptions:completionHandler:]):
(-[TestWebExtensionTab activateForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab isSelectedForWebExtensionContext:]):
(-[TestWebExtensionTab selectForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab deselectForWebExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/268010@main">https://commits.webkit.org/268010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0be5349fab9170b521b7c834b3357e2f31aca2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18334 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18824 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18559 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18763 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21056 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23215 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20916 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2258 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->