### PR TITLE
Add more browser.test functions for common assertions.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -60,7 +60,12 @@ public:
     void assertEq(JSContextRef, JSValue *expectedValue, JSValue *actualValue, NSString *message);
 
     JSValue *assertRejects(JSContextRef, JSValue *promise, JSValue *expectedError, NSString *message);
+    JSValue *assertResolves(JSContextRef, JSValue *promise, NSString *message);
+
     void assertThrows(JSContextRef, JSValue *function, JSValue *expectedError, NSString *message);
+    JSValue *assertSafe(JSContextRef, JSValue *function, NSString *message);
+
+    JSValue *assertSafeResolve(JSContextRef, JSValue *function, NSString *message);
 
     WebExtensionAPIWebNavigationEvent& testWebNavigationEvent();
     void fireTestWebNavigationEvent(NSString *urlString);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -61,8 +61,17 @@
     // Asserts the promise is rejected.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] any assertRejects(any promise, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
 
+    // Asserts the promise is resolved.
+    [NeedsScriptContext] any assertResolves(any promise, [Optional] DOMString message);
+
     // Asserts the function throws an exception.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
+
+    // Asserts the function does not thow an exception.
+    [NeedsScriptContext] any assertSafe(any function, [Optional] DOMString message);
+
+    // Asserts the function does not thow an exception and the result promise is resolved.
+    [NeedsScriptContext] any assertSafeResolve(any function, [Optional] DOMString message);
 
     // Temporary webNavigation event for bring-up.
     // FIXME: Remove this.

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -106,8 +106,8 @@
 
     ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, "") = ::testing::Message()
         << message.UTF8String << ":\n"
-        << "  " << actualValue.UTF8String << "\n"
-        << "  " << expectedValue.UTF8String;
+        << "  Actual: " << actualValue.UTF8String << "\n"
+        << "Expected: " << expectedValue.UTF8String;
 }
 
 - (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context


### PR DESCRIPTION
#### 79b593943c9bf5ee81a42580cea576b670f342c1
<pre>
Add more browser.test functions for common assertions.
<a href="https://webkit.org/b/261580">https://webkit.org/b/261580</a>
rdar://problem/115523406

Reviewed by Brian Weinstein.

Implement `assertResolves`, `assertSafe`, and `assertSafeResolve` testing utility methods.
Adoption in tests to follow in subsequent changes.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::debugString): Make clearer by using _isRegularExpression getter instead.
(WebKit::combineMessages): Added. Helper to concat two messages since the message was not being used for throw and reject assertions before now.
(WebKit::assertEquals): Added. Helper to use in throw and reject asserts that better logs the values.
(WebKit::WebExtensionAPITest::assertEq):
(WebKit::WebExtensionAPITest::assertRejects):
(WebKit::WebExtensionAPITest::assertResolves):
(WebKit::WebExtensionAPITest::assertThrows):
(WebKit::WebExtensionAPITest::assertSafe):
(WebKit::WebExtensionAPITest::assertSafeResolve):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager _webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:forExtensionContext:]):
Improve output so it is clear what is the expected and actual values.

Canonical link: <a href="https://commits.webkit.org/268009@main">https://commits.webkit.org/268009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2b8a4802133ec9db4687612ee6d1c162305651

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18826 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21059 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16727 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21106 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17466 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16555 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/20918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2257 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->