### PR TITLE
[css-grid] Use ShorthandSerializer for grid-area in CSSComputedStyleDeclaration::getPropertyValue.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-layout-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-layout-properties-expected.txt
@@ -129,16 +129,16 @@ PASS grid-row.span <custom-ident>
 PASS grid-row.span <integer> <custom-ident>
 FAIL grid-row.reset assert_equals: reset expected "auto" but got "auto / auto"
 PASS grid-area
-FAIL grid-area.initial assert_equals: initial value of grid-area should be auto expected "auto" but got "auto / auto / auto / auto"
-FAIL grid-area.auto assert_equals: auto expected "auto" but got "auto / auto / auto / auto"
+PASS grid-area.initial
+PASS grid-area.auto
 PASS grid-area.<custom-ident>
-FAIL grid-area.<integer> start assert_equals: <integer> start expected "1 / 2" but got "1 / 2 / auto / auto"
+PASS grid-area.<integer> start
 PASS grid-area.<integer>
 PASS grid-area.<integer> <ident>
 PASS grid-area.span <integer>
 PASS grid-area.span <custom-ident>
 PASS grid-area.span <integer> <custom-ident>
-FAIL grid-area.reset assert_equals: reset expected "auto" but got "auto / auto / auto / auto"
+PASS grid-area.reset
 I T
 IT
 I

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -108,6 +108,7 @@ String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) c
 {
     auto canUseShorthandSerializerForPropertyValue = [&]() {
         switch (propertyID) {
+        case CSSPropertyGridArea:
         case CSSPropertyGridTemplate:
             return true;
         default:


### PR DESCRIPTION
#### c07a7a053c8c94486f771a89ae195a2fa427ea9e
<pre>
[css-grid] Use ShorthandSerializer for grid-area in CSSComputedStyleDeclaration::getPropertyValue.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261577">https://bugs.webkit.org/show_bug.cgi?id=261577</a>
rdar://115521493

Reviewed by Tim Nguyen.

We can reuse the logic that the ShorthandSerializer provides to
correctly serialize the computed style of this property. This will
help us avoid duplicating logic to get the computed value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-layout-properties-expected.txt:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::getPropertyValue const):

Canonical link: <a href="https://commits.webkit.org/268026@main">https://commits.webkit.org/268026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7ee3b853955ddb4a4b2e328afbac7b2e2ee67a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19098 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21069 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23223 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14831 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16561 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4385 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->