### PR TITLE
WebCore::MouseButton should be an enum class

### DIFF
--- a/LayoutTests/fast/events/constructors/mouse-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/mouse-event-constructor.html
@@ -111,8 +111,8 @@ shouldBe("new MouseEvent('eventType', { button: 32767 }).button", "32767");
 shouldBe("new MouseEvent('eventType', { button: 32768 }).button", "-32768");
 shouldBe("new MouseEvent('eventType', { button: -32769 }).button", "32767");
 
-// Numbers out of the unsigned short range.
-// 2^{64}-1
+// Numbers out of the short range.
+// Greater than 2^{16}-1 or less than -2^{16}
 shouldBe("new MouseEvent('eventType', { button: 18446744073709551615 }).button", "0");
 shouldBe("new MouseEvent('eventType', { button: 12345678901234567890 }).button", "2048");
 shouldBe("new MouseEvent('eventType', { button: 123.45 }).button", "123");

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -406,7 +406,7 @@ void HTMLModelElement::defaultEventHandler(Event& event)
     ASSERT(is<MouseEvent>(event));
     auto& mouseEvent = downcast<MouseEvent>(event);
 
-    if (mouseEvent.button() != LeftButton)
+    if (mouseEvent.button() != MouseButton::Left)
         return;
 
     if (type == eventNames().mousedownEvent && !m_isDragging && !event.defaultPrevented() && isInteractive())

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -45,7 +45,7 @@ Ref<DragEvent> DragEvent::createForBindings()
 }
 
 Ref<DragEvent> DragEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, DataTransfer* dataTransfer, IsSimulated isSimulated, IsTrusted isTrusted)
 {
     return adoptRef(*new DragEvent(type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
@@ -60,7 +60,7 @@ DragEvent::DragEvent(const AtomString& eventType, DragEventInit&& init)
 
 DragEvent::DragEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, DataTransfer* dataTransfer, IsSimulated isSimulated, IsTrusted isTrusted)
     : MouseEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, isSimulated, isTrusted)
     , m_dataTransfer(dataTransfer)

--- a/Source/WebCore/dom/DragEvent.h
+++ b/Source/WebCore/dom/DragEvent.h
@@ -46,7 +46,7 @@ public:
     static Ref<DragEvent> create(const AtomString& eventType, DragEventInit&&);
     static Ref<DragEvent> createForBindings();
     static Ref<DragEvent> create(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         EventTarget* relatedTarget, double force, SyntheticClickType, DataTransfer* = nullptr, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
 
 
@@ -55,7 +55,7 @@ public:
 private:
     DragEvent(const AtomString& eventType, DragEventInit&&);
     DragEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         EventTarget* relatedTarget, double force, SyntheticClickType, DataTransfer*, IsSimulated, IsTrusted);
     DragEvent();
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3689,7 +3689,7 @@ bool Element::dispatchMouseForceWillBegin()
     if (!frame)
         return false;
 
-    PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), NoButton, PlatformEvent::Type::NoType, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap };
+    PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), MouseButton::None, PlatformEvent::Type::NoType, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap };
     auto mouseForceWillBeginEvent = MouseEvent::create(eventNames().webkitmouseforcewillbeginEvent, document().windowProxy(), platformMouseEvent, 0, nullptr);
     mouseForceWillBeginEvent->setTarget(Ref { *this });
     dispatchEvent(mouseForceWillBeginEvent);

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -62,7 +62,7 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowPro
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, IsSimulated isSimulated, IsTrusted isTrusted)
 {
     return adoptRef(*new MouseEvent(type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
@@ -70,7 +70,7 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& type, CanBubble canBubble, 
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, RefPtr<WindowProxy>&& view, int detail,
-    int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
 {
     return adoptRef(*new MouseEvent(eventType, canBubble, isCancelable, isComposed, WTFMove(view), detail, { screenX, screenY }, { clientX, clientY }, 0, 0, modifiers, button, buttons, syntheticClickType, relatedTarget));
@@ -80,13 +80,13 @@ MouseEvent::MouseEvent() = default;
 
 MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
-    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, short button, unsigned short buttons,
+    const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, IsSimulated isSimulated, IsTrusted isTrusted)
     : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, isSimulated, isTrusted)
-    , m_button(button == -2 ? 0 : button)
+    , m_button(enumToUnderlyingType(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
-    , m_syntheticClickType(button == -2 ? SyntheticClickType::NoTap : syntheticClickType)
-    , m_buttonDown(button != -2)
+    , m_syntheticClickType(button == MouseButton::None ? SyntheticClickType::NoTap : syntheticClickType)
+    , m_buttonDown(button != MouseButton::None)
     , m_relatedTarget(relatedTarget)
     , m_force(force)
 {
@@ -94,12 +94,12 @@ MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCance
 
 MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     RefPtr<WindowProxy>&& view, int detail, const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY,
-    OptionSet<Modifier> modifiers, short button, unsigned short buttons, SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
+    OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons, SyntheticClickType syntheticClickType, EventTarget* relatedTarget)
     : MouseRelatedEvent(eventType, canBubble, isCancelable, isComposed, MonotonicTime::now(), WTFMove(view), detail, screenLocation, { }, movementX, movementY, modifiers, IsSimulated::No)
-    , m_button(button == -2 ? 0 : button)
+    , m_button(enumToUnderlyingType(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
-    , m_syntheticClickType(button == -2 ? SyntheticClickType::NoTap : syntheticClickType)
-    , m_buttonDown(button != -2)
+    , m_syntheticClickType(button == MouseButton::None ? SyntheticClickType::NoTap : syntheticClickType)
+    , m_buttonDown(button != MouseButton::None)
     , m_relatedTarget(relatedTarget)
 {
     initCoordinates(clientLocation);
@@ -107,9 +107,9 @@ MouseEvent::MouseEvent(const AtomString& eventType, CanBubble canBubble, IsCance
 
 MouseEvent::MouseEvent(const AtomString& eventType, const MouseEventInit& initializer)
     : MouseRelatedEvent(eventType, initializer)
-    , m_button(initializer.button == -2 ? 0 : initializer.button)
+    , m_button(initializer.button == enumToUnderlyingType(MouseButton::None) ? enumToUnderlyingType(MouseButton::Left) : initializer.button)
     , m_buttons(initializer.buttons)
-    , m_buttonDown(initializer.button != -2)
+    , m_buttonDown(initializer.button != enumToUnderlyingType(MouseButton::None))
     , m_relatedTarget(initializer.relatedTarget)
 {
     initCoordinates({ initializer.clientX, initializer.clientY });
@@ -118,7 +118,7 @@ MouseEvent::MouseEvent(const AtomString& eventType, const MouseEventInit& initia
 MouseEvent::~MouseEvent() = default;
 
 void MouseEvent::initMouseEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&& view, int detail,
-    int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, short button, EventTarget* relatedTarget)
+    int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, int16_t button, EventTarget* relatedTarget)
 {
     if (isBeingDispatched())
         return;
@@ -127,9 +127,9 @@ void MouseEvent::initMouseEvent(const AtomString& type, bool canBubble, bool can
 
     m_screenLocation = IntPoint(screenX, screenY);
     setModifierKeys(ctrlKey, altKey, shiftKey, metaKey);
-    m_button = button == -2 ? 0 : button;
+    m_button = button == enumToUnderlyingType(MouseButton::None) ? enumToUnderlyingType(MouseButton::Left) : button;
     m_syntheticClickType = SyntheticClickType::NoTap;
-    m_buttonDown = button != -2;
+    m_buttonDown = button != enumToUnderlyingType(MouseButton::None);
     m_relatedTarget = relatedTarget;
 
     initCoordinates(IntPoint(clientX, clientY));
@@ -139,7 +139,7 @@ void MouseEvent::initMouseEvent(const AtomString& type, bool canBubble, bool can
 
 // FIXME: We need this quirk because iAd Producer is calling this function with a relatedTarget that is not an EventTarget (rdar://problem/30640101).
 // We should remove this quirk when possible.
-void MouseEvent::initMouseEventQuirk(JSGlobalObject& state, ScriptExecutionContext& scriptExecutionContext, const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&& view, int detail, int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, short button, JSValue relatedTargetValue)
+void MouseEvent::initMouseEventQuirk(JSGlobalObject& state, ScriptExecutionContext& scriptExecutionContext, const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&& view, int detail, int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, int16_t button, JSValue relatedTargetValue)
 {
     EventTarget* relatedTarget = nullptr;
 #if PLATFORM(MAC)
@@ -178,7 +178,16 @@ bool MouseEvent::isMouseEvent() const
 
 bool MouseEvent::canTriggerActivationBehavior(const Event& event)
 {
-    return event.type() == eventNames().clickEvent && (!is<MouseEvent>(event) || downcast<MouseEvent>(event).button() != RightButton);
+    return event.type() == eventNames().clickEvent && (!is<MouseEvent>(event) || downcast<MouseEvent>(event).button() != MouseButton::Right);
+}
+
+MouseButton MouseEvent::button() const
+{
+    static constexpr std::array mouseButtonCases { MouseButton::None, MouseButton::PointerMove, MouseButton::Left, MouseButton::Middle, MouseButton::Right };
+    const auto isKnownButton = WTF::anyOf(mouseButtonCases, [buttonValue = this->m_button](MouseButton button) {
+        return buttonValue == enumToUnderlyingType(button);
+    });
+    return isKnownButton ? static_cast<MouseButton>(m_button) : MouseButton::Other;
 }
 
 int MouseEvent::which() const

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -48,13 +48,13 @@ class MouseEvent : public MouseRelatedEvent {
     WTF_MAKE_ISO_ALLOCATED(MouseEvent);
 public:
     WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         EventTarget* relatedTarget, double force, SyntheticClickType, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
 
     WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& eventType, RefPtr<WindowProxy>&&, const PlatformMouseEvent&, int detail, Node* relatedTarget);
 
     static Ref<MouseEvent> create(const AtomString& eventType, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail,
-        int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier>, short button, unsigned short buttons,
+        int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         SyntheticClickType, EventTarget* relatedTarget);
 
     static Ref<MouseEvent> createForBindings() { return adoptRef(*new MouseEvent); }
@@ -69,13 +69,14 @@ public:
 
     WEBCORE_EXPORT void initMouseEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&&,
         int detail, int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey,
-        short button, EventTarget* relatedTarget);
+        int16_t button, EventTarget* relatedTarget);
 
     void initMouseEventQuirk(JSC::JSGlobalObject&, ScriptExecutionContext&, const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&&,
         int detail, int screenX, int screenY, int clientX, int clientY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey,
-        short button, JSC::JSValue relatedTarget);
+        int16_t button, JSC::JSValue relatedTarget);
 
-    short button() const { return m_button; }
+    MouseButton button() const;
+    int16_t buttonAsShort() const { return m_button; }
     unsigned short buttons() const { return m_buttons; }
     SyntheticClickType syntheticClickType() const { return m_syntheticClickType; }
     bool buttonDown() const { return m_buttonDown; }
@@ -92,11 +93,11 @@ public:
 
 protected:
     MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         EventTarget* relatedTarget, double force, SyntheticClickType, IsSimulated, IsTrusted);
 
     MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, RefPtr<WindowProxy>&&, int detail,
-        const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, short button, unsigned short buttons,
+        const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
         SyntheticClickType, EventTarget* relatedTarget);
 
     MouseEvent(const AtomString& type, const MouseEventInit&);
@@ -109,7 +110,7 @@ private:
 
     void setRelatedTarget(RefPtr<EventTarget>&& relatedTarget) final { m_relatedTarget = WTFMove(relatedTarget); }
 
-    short m_button { 0 };
+    int16_t m_button { enumToUnderlyingType(MouseButton::Left) };
     unsigned short m_buttons { 0 };
     SyntheticClickType m_syntheticClickType { SyntheticClickType::NoTap };
     bool m_buttonDown { false };

--- a/Source/WebCore/dom/MouseEvent.idl
+++ b/Source/WebCore/dom/MouseEvent.idl
@@ -34,7 +34,7 @@
     readonly attribute boolean shiftKey;
     readonly attribute boolean altKey;
     readonly attribute boolean metaKey;
-    readonly attribute short button;
+    [ImplementedAs=buttonAsShort] readonly attribute short button;
     readonly attribute unsigned short buttons;
     readonly attribute EventTarget? relatedTarget;
 

--- a/Source/WebCore/dom/MouseEventInit.h
+++ b/Source/WebCore/dom/MouseEventInit.h
@@ -32,7 +32,7 @@ namespace WebCore {
 struct MouseEventInit : MouseRelatedEventInit {
     int clientX { 0 };
     int clientY { 0 };
-    short button { 0 };
+    int16_t button { 0 };
     unsigned short buttons { 0 };
     RefPtr<EventTarget> relatedTarget;
 };

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2517,7 +2517,7 @@ void Node::defaultEventHandler(Event& event)
         }
 #if ENABLE(PAN_SCROLLING)
     } else if (eventType == eventNames.mousedownEvent && is<MouseEvent>(event)) {
-        if (downcast<MouseEvent>(event).button() == MiddleButton) {
+        if (downcast<MouseEvent>(event).button() == MouseButton::Middle) {
             if (enclosingLinkEventParentOrSelf())
                 return;
 

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -55,7 +55,7 @@ static AtomString pointerEventType(const AtomString& mouseEventType)
     return nullAtom();
 }
 
-RefPtr<PointerEvent> PointerEvent::create(short button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
+RefPtr<PointerEvent> PointerEvent::create(MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
 {
     auto type = pointerEventType(mouseEvent.type());
     if (type.isEmpty())
@@ -64,7 +64,7 @@ RefPtr<PointerEvent> PointerEvent::create(short button, const MouseEvent& mouseE
     return create(type, button, mouseEvent, pointerId, pointerType);
 }
 
-Ref<PointerEvent> PointerEvent::create(const AtomString& type, short button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
 {
     return adoptRef(*new PointerEvent(type, button, mouseEvent, pointerId, pointerType));
 }
@@ -91,7 +91,7 @@ PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
 {
 }
 
-PointerEvent::PointerEvent(const AtomString& type, short button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
+PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
     : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
         { mouseEvent.clientX(), mouseEvent.clientY() }, mouseEvent.movementX(), mouseEvent.movementY(), mouseEvent.modifierKeys(), button, mouseEvent.buttons(),
         mouseEvent.syntheticClickType(), mouseEvent.relatedTarget())
@@ -102,7 +102,7 @@ PointerEvent::PointerEvent(const AtomString& type, short button, const MouseEven
 }
 
 PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const String& pointerType, IsPrimary isPrimary)
-    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, 0, 0, SyntheticClickType::NoTap, nullptr)
+    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, MouseButton::Left, 0, SyntheticClickType::NoTap, nullptr)
     , m_pointerId(pointerId)
     , m_pointerType(pointerType)
     , m_isPrimary(isPrimary == IsPrimary::Yes)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -81,8 +81,8 @@ public:
         return adoptRef(*new PointerEvent);
     }
 
-    static RefPtr<PointerEvent> create(short button, const MouseEvent&, PointerID, const String& pointerType);
-    static Ref<PointerEvent> create(const AtomString& type, short button, const MouseEvent&, PointerID, const String& pointerType);
+    static RefPtr<PointerEvent> create(MouseButton, const MouseEvent&, PointerID, const String& pointerType);
+    static Ref<PointerEvent> create(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType);
     static Ref<PointerEvent> create(const AtomString& type, PointerID, const String& pointerType, IsPrimary = IsPrimary::No);
 
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
@@ -121,7 +121,7 @@ private:
     static IsCancelable typeIsCancelable(const AtomString& type) { return typeIsEnterOrLeave(type) ? IsCancelable::No : IsCancelable::Yes; }
     static IsComposed typeIsComposed(const AtomString& type) { return typeIsEnterOrLeave(type) ? IsComposed::No : IsComposed::Yes; }
 #if PLATFORM(WPE)
-    static short buttonForType(const AtomString& type) { return type == eventNames().pointermoveEvent ? -1 : 0; }
+    static MouseButton buttonForType(const AtomString& type) { return type == eventNames().pointermoveEvent ? MouseButton::PointerMove : MouseButton::Left; }
     static unsigned short buttonsForType(const AtomString& type)
     {
         // We have contact with the touch surface for most events except when we've released the touch or canceled it.
@@ -132,7 +132,7 @@ private:
 
     PointerEvent();
     PointerEvent(const AtomString&, Init&&);
-    PointerEvent(const AtomString& type, short button, const MouseEvent&, PointerID, const String& pointerType);
+    PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
     PointerEvent(const AtomString& type, const PlatformTouchEvent&, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -49,7 +49,7 @@ private:
     SimulatedMouseEvent(const AtomString& eventType, RefPtr<WindowProxy>&& view, RefPtr<Event>&& underlyingEvent, Element& target, SimulatedClickSource source)
         : MouseEvent(eventType, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
             underlyingEvent ? underlyingEvent->timeStamp() : MonotonicTime::now(), WTFMove(view), /* detail */ 0,
-            { }, { }, 0, 0, modifiersFromUnderlyingEvent(underlyingEvent), 0, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::Yes,
+            { }, { }, 0, 0, modifiersFromUnderlyingEvent(underlyingEvent), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::Yes,
             source == SimulatedClickSource::UserAgent ? IsTrusted::Yes : IsTrusted::No)
     {
         setUnderlyingEvent(underlyingEvent.get());

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -61,7 +61,7 @@ inline WheelEvent::WheelEvent(const AtomString& type, const Init& initializer)
 
 inline WheelEvent::WheelEvent(const PlatformWheelEvent& event, RefPtr<WindowProxy>&& view, IsCancelable isCancelable)
     : MouseEvent(eventNames().wheelEvent, CanBubble::Yes, isCancelable, IsComposed::Yes, event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
-        event.globalPosition(), event.position() , 0, 0, event.modifiers(), 0, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes)
+        event.globalPosition(), event.position() , 0, 0, event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes)
     , m_wheelDelta(event.wheelTicksX() * TickMultiplier, event.wheelTicksY() * TickMultiplier)
     , m_deltaX(-event.deltaX())
     , m_deltaY(-event.deltaY())
@@ -90,7 +90,7 @@ void WheelEvent::initWebKitWheelEvent(int rawDeltaX, int rawDeltaY, RefPtr<Windo
     if (isBeingDispatched())
         return;
     
-    initMouseEvent(eventNames().wheelEvent, true, true, WTFMove(view), 0, screenX, screenY, pageX, pageY, ctrlKey, altKey, shiftKey, metaKey, 0, nullptr);
+    initMouseEvent(eventNames().wheelEvent, true, true, WTFMove(view), 0, screenX, screenY, pageX, pageY, ctrlKey, altKey, shiftKey, metaKey, enumToUnderlyingType(MouseButton::Left), nullptr);
 
     // Normalize to 120 multiple for compatibility with IE.
     m_wheelDelta = { rawDeltaX * TickMultiplier, rawDeltaY * TickMultiplier };

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -53,7 +53,7 @@ Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned ind
 {
     return adoptRef(*new MouseEvent(mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
         event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0,
-        event.modifiers(), 0, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes));
+        event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, IsSimulated::No, IsTrusted::Yes));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -25,11 +25,11 @@
 
 #import "config.h"
 #import "PointerEvent.h"
-#import "PlatformMouseEvent.h"
 
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 
 #import "EventNames.h"
+#import "PlatformMouseEvent.h"
 
 namespace WebCore {
 
@@ -51,9 +51,9 @@ static const AtomString& pointerEventType(PlatformTouchPoint::TouchPhaseType pha
     return nullAtom();
 }
 
-static short buttonForType(const AtomString& type)
+static MouseButton buttonForType(const AtomString& type)
 {
-    return type == eventNames().pointermoveEvent ? -1 : 0;
+    return type == eventNames().pointermoveEvent ? MouseButton::PointerMove : MouseButton::Left;
 }
 
 static unsigned short buttonsForType(const AtomString& type)

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -197,7 +197,7 @@ void HTMLAnchorElement::defaultEventHandler(Event& event)
             // This keeps track of the editable block that the selection was in (if it was in one) just before the link was clicked
             // for the LiveWhenNotFocused editable link behavior
             auto& eventNames = WebCore::eventNames();
-            if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() != RightButton && document().frame()) {
+            if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() != MouseButton::Right && document().frame()) {
                 setRootEditableElementForSelectionOnMouseDown(document().frame()->selection().selection().rootEditableElement());
                 m_wasShiftKeyDownOnMouseDown = downcast<MouseEvent>(event).shiftKey();
             } else if (event.type() == eventNames.mouseoverEvent) {

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1209,7 +1209,7 @@ void HTMLInputElement::willDispatchEvent(Event& event, InputElementClickState& s
     auto& eventNames = WebCore::eventNames();
     if (event.type() == eventNames.textInputEvent && m_inputType->shouldSubmitImplicitly(event))
         event.stopPropagation();
-    if (event.type() == eventNames.clickEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == LeftButton) {
+    if (event.type() == eventNames.clickEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left) {
         m_inputType->willDispatchClick(state);
         state.stateful = true;
     }
@@ -1227,7 +1227,7 @@ void HTMLInputElement::didBlur()
 
 void HTMLInputElement::defaultEventHandler(Event& event)
 {
-    if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && mouseEvent->type() == eventNames().clickEvent && mouseEvent->button() == LeftButton) {
+    if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && mouseEvent->type() == eventNames().clickEvent && mouseEvent->button() == MouseButton::Left) {
         m_inputType->handleClickEvent(*mouseEvent);
         if (mouseEvent->defaultHandled())
             return;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1281,7 +1281,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
             keyboardEvent.setDefaultHandled();
     }
 
-    if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == LeftButton) {
+    if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left) {
         focus();
 #if !PLATFORM(IOS_FAMILY)
         document().updateStyleIfNeeded();
@@ -1372,7 +1372,7 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
     auto& listItems = this->listItems();
 
     auto& eventNames = WebCore::eventNames();
-    if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == LeftButton) {
+    if (event.type() == eventNames.mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left) {
         focus();
         document().updateStyleIfNeeded();
 
@@ -1401,7 +1401,7 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
         }
     } else if (event.type() == eventNames.mousemoveEvent && is<MouseEvent>(event) && !downcast<RenderListBox>(*renderer()).canBeScrolledAndHasScrollableArea()) {
         MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-        if (mouseEvent.button() != LeftButton || !mouseEvent.buttonDown())
+        if (mouseEvent.button() != MouseButton::Left || !mouseEvent.buttonDown())
             return;
 
         auto& renderListBox = downcast<RenderListBox>(*renderer());
@@ -1424,7 +1424,7 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
             }
             mouseEvent.setDefaultHandled();
         }
-    } else if (event.type() == eventNames.mouseupEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == LeftButton && document().frame()->eventHandler().autoscrollRenderer() != renderer()) {
+    } else if (event.type() == eventNames.mouseupEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left && document().frame()->eventHandler().autoscrollRenderer() != renderer()) {
         // This click or drag event was not over any of the options.
         if (m_lastOnChangeSelection.isEmpty())
             return;

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -136,7 +136,7 @@ void RangeInputType::handleMouseDownEvent(MouseEvent& event)
     if (element()->isDisabledFormControl())
         return;
 
-    if (event.button() != LeftButton || !is<Node>(event.target()))
+    if (event.button() != MouseButton::Left || !is<Node>(event.target()))
         return;
     ASSERT(element()->shadowRoot());
     auto& targetNode = downcast<Node>(*event.target());

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -326,7 +326,7 @@ void SliderThumbElement::defaultEventHandler(Event& event)
     }
 
     MouseEvent& mouseEvent = downcast<MouseEvent>(event);
-    bool isLeftButton = mouseEvent.button() == LeftButton;
+    bool isLeftButton = mouseEvent.button() == MouseButton::Left;
     const AtomString& eventType = mouseEvent.type();
 
     // We intentionally do not call event->setDefaultHandled() here because

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -95,7 +95,7 @@ void SpinButtonElement::defaultEventHandler(Event& event)
 
     MouseEvent& mouseEvent = downcast<MouseEvent>(event);
     IntPoint local = roundedIntPoint(box->absoluteToLocal(mouseEvent.absoluteLocation(), UseTransforms));
-    if (mouseEvent.type() == eventNames().mousedownEvent && mouseEvent.button() == LeftButton) {
+    if (mouseEvent.type() == eventNames().mousedownEvent && mouseEvent.button() == MouseButton::Left) {
         if (box->borderBoxRect().contains(local)) {
             // The following functions of HTMLInputElement may run JavaScript
             // code which detaches this shadow node. We need to take a reference
@@ -116,7 +116,7 @@ void SpinButtonElement::defaultEventHandler(Event& event)
             }
             mouseEvent.setDefaultHandled();
         }
-    } else if (mouseEvent.type() == eventNames().mouseupEvent && mouseEvent.button() == LeftButton)
+    } else if (mouseEvent.type() == eventNames().mouseupEvent && mouseEvent.button() == MouseButton::Left)
         stopRepeatingTimer();
     else if (mouseEvent.type() == eventNames().mousemoveEvent) {
         if (box->borderBoxRect().contains(local)) {

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -272,7 +272,7 @@ void SearchFieldResultsButtonElement::defaultEventHandler(Event& event)
 {
     // On mousedown, bring up a menu, if needed
     RefPtr input = downcast<HTMLInputElement>(shadowHost());
-    if (input && event.type() == eventNames().mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == LeftButton) {
+    if (input && event.type() == eventNames().mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left) {
         input->focus();
         input->select();
 #if !PLATFORM(IOS_FAMILY)
@@ -341,7 +341,7 @@ void SearchFieldCancelButtonElement::defaultEventHandler(Event& event)
         return;
     }
 
-    if (event.type() == eventNames().mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == LeftButton) {
+    if (event.type() == eventNames().mousedownEvent && is<MouseEvent>(event) && downcast<MouseEvent>(event).button() == MouseButton::Left) {
         input->focus();
         input->select();
         event.setDefaultHandled();

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -49,6 +49,7 @@ class MouseEvent;
 class UIEventWithKeyState;
 
 enum class SyntheticClickType : uint8_t;
+enum class MouseButton : int8_t;
 
 // NavigationAction should never hold a strong reference to the originating document either directly
 // or indirectly as doing so prevents its destruction even after navigating away from it because
@@ -83,7 +84,7 @@ public:
 
         LayoutPoint absoluteLocation;
         FloatPoint locationInRootViewCoordinates;
-        short button;
+        MouseButton button;
         SyntheticClickType syntheticClickType;
         bool buttonDown;
     };

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -206,7 +206,7 @@ void AutoscrollController::handleMouseReleaseEvent(const PlatformMouseEvent& mou
 {
     switch (m_autoscrollType) {
     case AutoscrollForPan:
-        if (mouseEvent.button() == MiddleButton)
+        if (mouseEvent.button() == MouseButton::Middle)
             m_autoscrollType = AutoscrollForPanCanStop;
         break;
     case AutoscrollForPanCanStop:

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1778,7 +1778,7 @@ void ContextMenuController::showContextMenuAt(LocalFrame& frame, const IntPoint&
     clearContextMenu();
     
     // Simulate a click in the middle of the accessibility object.
-    PlatformMouseEvent mouseEvent(clickPoint, clickPoint, RightButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap);
+    PlatformMouseEvent mouseEvent(clickPoint, clickPoint, MouseButton::Right, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap);
     frame.eventHandler().handleMousePressEvent(mouseEvent);
     bool handled = frame.eventHandler().sendContextMenuEvent(mouseEvent);
     if (handled)

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -595,7 +595,7 @@ bool InteractionRegionOverlay::mouseEvent(PageOverlay& overlay, const PlatformMo
         if (!rectForSettingAtIndex(i).contains(eventInContentsCoordinates))
             continue;
         cursorToSet = handCursor();
-        if (event.button() == LeftButton && event.type() == PlatformEvent::Type::MousePressed) {
+        if (event.button() == MouseButton::Left && event.type() == PlatformEvent::Type::MousePressed) {
             m_settings[i].value = !m_settings[i].value;
             m_page.forceRepaintAllFrames();
             return true;

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -131,7 +131,7 @@ bool isDraggableLink(const Element& element)
 static PlatformMouseEvent createMouseEvent(const DragData& dragData)
 {
     auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
-    return PlatformMouseEvent(dragData.clientPosition(), dragData.globalPosition(), LeftButton, PlatformEvent::Type::MouseMoved, 0, modifiers, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap);
+    return PlatformMouseEvent(dragData.clientPosition(), dragData.globalPosition(), MouseButton::Left, PlatformEvent::Type::MouseMoved, 0, modifiers, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap);
 }
 
 DragController::DragController(Page& page, std::unique_ptr<DragClient>&& client)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -629,7 +629,7 @@ void EventHandler::selectClosestContextualWordOrLinkFromHitTestResult(const HitT
 
 bool EventHandler::handleMousePressEventDoubleClick(const MouseEventWithHitTestResults& event)
 {
-    if (event.event().button() != LeftButton)
+    if (event.event().button() != MouseButton::Left)
         return false;
 
     if (m_frame.selection().isRange()) {
@@ -650,7 +650,7 @@ bool EventHandler::handleMousePressEventDoubleClick(const MouseEventWithHitTestR
 
 bool EventHandler::handleMousePressEventTripleClick(const MouseEventWithHitTestResults& event)
 {
-    if (event.event().button() != LeftButton)
+    if (event.event().button() != MouseButton::Left)
         return false;
     
     RefPtr targetNode = event.targetNode();
@@ -762,7 +762,7 @@ bool EventHandler::handleMousePressEventSingleClick(const MouseEventWithHitTestR
 
     bool handled = updateSelectionForMouseDownDispatchingSelectStart(targetNode.get(), newSelection, granularity);
 
-    if (event.event().button() == MiddleButton) {
+    if (event.event().button() == MouseButton::Middle) {
         // Ignore handled, since we want to paste to where the caret was placed anyway.
         handled = handlePasteGlobalSelection(event.event()) || handled;
     }
@@ -927,7 +927,7 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
         return true;
 
     RefPtr targetNode = event.targetNode();
-    if (event.event().button() != LeftButton || !targetNode)
+    if (event.event().button() != MouseButton::Left || !targetNode)
         return false;
 
     RenderObject* renderer = targetNode->renderer();
@@ -971,7 +971,7 @@ bool EventHandler::eventMayStartDrag(const PlatformMouseEvent& event) const
     if (!document)
         return false;
 
-    if (event.button() != LeftButton || event.clickCount() != 1)
+    if (event.button() != MouseButton::Left || event.clickCount() != 1)
         return false;
 
     auto* view = m_frame.view();
@@ -1153,7 +1153,7 @@ bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& e
             && m_dragStartPosition == event.event().position()
 #endif
             && m_frame.selection().isRange()
-            && event.event().button() != RightButton) {
+            && event.event().button() != MouseButton::Right) {
         VisibleSelection newSelection;
         RefPtr node = event.targetNode();
         bool caretBrowsing = m_frame.settings().caretBrowsingEnabled();
@@ -1176,7 +1176,7 @@ bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& e
         handled = true;
     }
 
-    if (event.event().button() == MiddleButton) {
+    if (event.event().button() == MouseButton::Middle) {
         // Ignore handled, since we want to paste to where the caret was placed anyway.
         handled = handlePasteGlobalSelection(event.event()) || handled;
     }
@@ -1946,7 +1946,7 @@ bool EventHandler::handleMouseDoubleClickEvent(const PlatformMouseEvent& platfor
 
     m_clickCount = platformMouseEvent.clickCount();
     bool swallowMouseUpEvent = !dispatchMouseEvent(eventNames().mouseupEvent, mouseEvent.targetNode(), m_clickCount, platformMouseEvent, FireMouseOverOut::No);
-    bool swallowClickEvent = platformMouseEvent.button() != RightButton && mouseEvent.targetNode() == m_clickNode && !dispatchMouseEvent(eventNames().clickEvent, mouseEvent.targetNode(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes);
+    bool swallowClickEvent = platformMouseEvent.button() != MouseButton::Right && mouseEvent.targetNode() == m_clickNode && !dispatchMouseEvent(eventNames().clickEvent, mouseEvent.targetNode(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes);
 
     if (m_lastScrollbarUnderMouse)
         swallowMouseUpEvent = m_lastScrollbarUnderMouse->mouseUp(platformMouseEvent);
@@ -2280,7 +2280,7 @@ HandleMouseEventResult EventHandler::handleMouseReleaseEvent(const PlatformMouse
         return true;
 
     bool swallowMouseUpEvent = !dispatchMouseEvent(eventNames().mouseupEvent, mouseEvent.targetNode(), m_clickCount, platformMouseEvent, FireMouseOverOut::No);
-    bool contextMenuEvent = platformMouseEvent.button() == RightButton;
+    bool contextMenuEvent = platformMouseEvent.button() == MouseButton::Right;
 
     auto nodeToClick = targetNodeForClickEvent(m_clickNode.get(), mouseEvent.targetNode());
     bool swallowClickEvent = m_clickCount > 0 && !contextMenuEvent && nodeToClick && !dispatchMouseEvent(eventNames().clickEvent, nodeToClick.get(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes);
@@ -2390,7 +2390,7 @@ bool EventHandler::dispatchDragEvent(const AtomString& eventType, Element& dragT
     auto dragEvent = DragEvent::create(eventType, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
         event.timestamp().approximateMonotonicTime(), &m_frame.windowProxy(), 0,
         event.globalPosition(), event.position(), event.movementDelta().x(), event.movementDelta().y(),
-        event.modifiers(), 0, 0, nullptr, event.force(), SyntheticClickType::NoTap, &dataTransfer);
+        event.modifiers(), MouseButton::Left, 0, nullptr, event.force(), SyntheticClickType::NoTap, &dataTransfer);
 
     dragTarget.dispatchEvent(dragEvent);
 
@@ -3471,7 +3471,7 @@ bool EventHandler::sendContextMenuEventForKey()
 #else
     PlatformEvent::Type eventType = PlatformEvent::Type::MousePressed;
 #endif
-    PlatformMouseEvent platformMouseEvent(position, globalPosition, RightButton, eventType, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap);
+    PlatformMouseEvent platformMouseEvent(position, globalPosition, MouseButton::Right, eventType, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap);
 
     return sendContextMenuEvent(platformMouseEvent);
 }
@@ -3557,7 +3557,7 @@ void EventHandler::fakeMouseMoveEventTimerFired()
         return;
 
     auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
-    PlatformMouseEvent fakeMouseMoveEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition, NoButton, PlatformEvent::Type::MouseMoved, 0, modifiers, WallTime::now(), 0, SyntheticClickType::NoTap);
+    PlatformMouseEvent fakeMouseMoveEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition, MouseButton::None, PlatformEvent::Type::MouseMoved, 0, modifiers, WallTime::now(), 0, SyntheticClickType::NoTap);
     mouseMoved(fakeMouseMoveEvent);
 }
 #endif // !ENABLE(IOS_TOUCH_EVENTS)
@@ -4176,7 +4176,7 @@ RefPtr<Element> EventHandler::draggedElement() const
 
 bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDragHysteresis checkDragHysteresis)
 {
-    if (event.event().button() != LeftButton || event.event().type() != PlatformEvent::Type::MouseMoved) {
+    if (event.event().button() != MouseButton::Left || event.event().type() != PlatformEvent::Type::MouseMoved) {
         // If we allowed the other side of the bridge to handle a drag
         // last time, then m_mousePressed might still be set. So we
         // clear it now to make sure the next move after a drag

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -327,9 +327,9 @@ RefPtr<PointerEvent> PointerCaptureController::pointerEventForMouseEvent(const M
     RefPtr capturingData = m_activePointerIdsToCapturingData.get(pointerId);
     bool pointerIsPressed = capturingData ? capturingData->pointerIsPressed : false;
 
-    short newButton = mouseEvent.button();
-    short previousMouseButton = capturingData ? capturingData->previousMouseButton : -1;
-    short button = (type == names.mousemoveEvent && newButton == previousMouseButton) ? -1 : newButton;
+    MouseButton newButton = mouseEvent.button();
+    MouseButton previousMouseButton = capturingData ? capturingData->previousMouseButton : MouseButton::PointerMove;
+    MouseButton button = (type == names.mousemoveEvent && newButton == previousMouseButton) ? MouseButton::PointerMove : newButton;
 
     // https://w3c.github.io/pointerevents/#chorded-button-interactions
     // Some pointer devices, such as mouse or pen, support multiple buttons. In the Mouse Event model, each button

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "ExceptionOr.h"
+#include "PlatformMouseEvent.h"
 #include "PointerID.h"
 #include <wtf/HashMap.h>
 
@@ -97,7 +98,7 @@ private:
         bool isPrimary { false };
         bool preventsCompatibilityMouseEvents { false };
         bool pointerIsPressed { false };
-        short previousMouseButton { -1 };
+        MouseButton previousMouseButton { MouseButton::PointerMove };
 
     private:
         CapturingData(const String& pointerType)

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -83,7 +83,7 @@ void ResourceUsageOverlay::initialize()
 
 bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& event)
 {
-    if (event.button() != LeftButton)
+    if (event.button() != MouseButton::Left)
         return false;
 
     switch (event.type()) {

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -724,8 +724,8 @@ bool EventHandler::tryToBeginDragAtPoint(const IntPoint& clientPosition, const I
     IntPoint adjustedClientPosition = roundedIntPoint(adjustedClientPositionAsFloatPoint);
     IntPoint adjustedGlobalPosition = protectedFrame->view()->windowToContents(adjustedClientPosition);
 
-    PlatformMouseEvent syntheticMousePressEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), 0, SyntheticClickType::NoTap);
-    PlatformMouseEvent syntheticMouseMoveEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, SyntheticClickType::NoTap);
+    PlatformMouseEvent syntheticMousePressEvent(adjustedClientPosition, adjustedGlobalPosition, MouseButton::Left, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), 0, SyntheticClickType::NoTap);
+    PlatformMouseEvent syntheticMouseMoveEvent(adjustedClientPosition, adjustedGlobalPosition, MouseButton::Left, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, SyntheticClickType::NoTap);
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent };
     auto documentPoint = protectedFrame->view() ? protectedFrame->view()->windowToContents(syntheticMouseMoveEvent.position()) : syntheticMouseMoveEvent.position();

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -575,7 +575,7 @@ bool ServicesOverlayController::mouseEvent(PageOverlay&, const PlatformMouseEven
     determineActiveHighlight(mouseIsOverActiveHighlightButton);
 
     // Cancel the potential click if any button other than the left button changes state, and ignore the event.
-    if (event.button() != MouseButton::LeftButton) {
+    if (event.button() != MouseButton::Left) {
         m_currentMouseDownOnButtonHighlight = nullptr;
         return false;
     }

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -36,10 +36,12 @@ namespace WebCore {
 const double ForceAtClick = 1;
 const double ForceAtForceClick = 2;
 
-    // These button numbers match the ones used in the DOM API, 0 through 2, except for NoButton which isn't specified.
-    // We use -2 for NoButton because -1 is a valid value in the DOM API for Pointer Events for pointermove events that
-    // indicate that the pressed mouse button hasn't changed since the last event.
-    enum MouseButton : int8_t { LeftButton = 0, MiddleButton, RightButton, NoButton = -2 };
+    // These button numbers match the ones used in the DOM API, 0 through 2, except for None and Other which aren't specified.
+    // We reserve -2 for the former and -1 to represent pointermove events that indicate that the pressed mouse button hasn't
+    // changed since the last event, as specified in the DOM API for Pointer Events.
+    // https://w3c.github.io/uievents/#dom-mouseevent-button
+    // https://w3c.github.io/pointerevents/#the-button-property
+    enum class MouseButton : int8_t { None = -2, PointerMove, Left, Middle, Right, Other };
     enum class SyntheticClickType : uint8_t { NoTap, OneFingerTap, TwoFingerTap };
 
     class PlatformMouseEvent : public PlatformEvent {
@@ -94,7 +96,7 @@ const double ForceAtForceClick = 2;
 #endif
 
     protected:
-        MouseButton m_button { MouseButton::NoButton };
+        MouseButton m_button { MouseButton::None };
         SyntheticClickType m_syntheticClickType { SyntheticClickType::NoTap };
 
         IntPoint m_position;

--- a/Source/WebCore/platform/ScrollbarTheme.cpp
+++ b/Source/WebCore/platform/ScrollbarTheme.cpp
@@ -44,7 +44,7 @@ ScrollbarTheme& ScrollbarTheme::theme()
 
 ScrollbarButtonPressAction ScrollbarTheme::handleMousePressEvent(Scrollbar&, const PlatformMouseEvent& event, ScrollbarPart pressedPart)
 {
-    if (event.button() == RightButton)
+    if (event.button() == MouseButton::Right)
         return ScrollbarButtonPressAction::None;
     if (pressedPart == ThumbPart)
         return ScrollbarButtonPressAction::StartDrag;

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
@@ -335,13 +335,13 @@ ScrollbarButtonPressAction ScrollbarThemeAdwaita::handleMousePressEvent(Scrollba
         }();
 #endif
         // The shift key or middle/right button reverses the sense.
-        if (event.shiftKey() || event.button() != LeftButton)
+        if (event.shiftKey() || event.button() != MouseButton::Left)
             warpSlider = !warpSlider;
         return warpSlider ?
             ScrollbarButtonPressAction::CenterOnThumb:
             ScrollbarButtonPressAction::Scroll;
     case ThumbPart:
-        if (event.button() != RightButton)
+        if (event.button() != MouseButton::Right)
             return ScrollbarButtonPressAction::StartDrag;
         break;
     case BackButtonStartPart:

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
@@ -502,13 +502,13 @@ ScrollbarButtonPressAction ScrollbarThemeGtk::handleMousePressEvent(Scrollbar&, 
             "gtk-primary-button-warps-slider",
             &warpSlider, nullptr);
         // The shift key or middle/right button reverses the sense.
-        if (event.shiftKey() || event.button() != LeftButton)
+        if (event.shiftKey() || event.button() != MouseButton::Left)
             warpSlider = !warpSlider;
         return warpSlider ?
             ScrollbarButtonPressAction::CenterOnThumb:
             ScrollbarButtonPressAction::Scroll;
     case ThumbPart:
-        if (event.button() != RightButton)
+        if (event.button() != MouseButton::Right)
             return ScrollbarButtonPressAction::StartDrag;
         break;
     case BackButtonStartPart:

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -92,7 +92,7 @@ public:
 
         m_position = pointForEvent(event);
         m_globalPosition = globalPointForEvent(event);
-        m_button = LeftButton; // This has always been the LeftButton on iOS.
+        m_button = MouseButton::Left; // This has always been the LeftButton on iOS.
         m_clickCount = 1; // This has always been 1 on iOS.
         m_modifiers = modifiersForEvent(event);
     }

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -109,17 +109,17 @@ static MouseButton mouseButtonForEvent(NSEvent *event)
     case NSEventTypeLeftMouseDown:
     case NSEventTypeLeftMouseUp:
     case NSEventTypeLeftMouseDragged:
-        return LeftButton;
+        return MouseButton::Left;
     case NSEventTypeRightMouseDown:
     case NSEventTypeRightMouseUp:
     case NSEventTypeRightMouseDragged:
-        return RightButton;
+        return MouseButton::Right;
     case NSEventTypeOtherMouseDown:
     case NSEventTypeOtherMouseUp:
     case NSEventTypeOtherMouseDragged:
-        return MiddleButton;
+        return MouseButton::Middle;
     default:
-        return NoButton;
+        return MouseButton::None;
     }
 }
 

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -444,7 +444,7 @@ int ScrollbarThemeMac::minimumThumbLength(Scrollbar& scrollbar)
 
 static bool shouldCenterOnThumb(const PlatformMouseEvent& evt)
 {
-    if (evt.button() != LeftButton)
+    if (evt.button() != MouseButton::Left)
         return false;
     if (gJumpOnTrackClick)
         return !evt.altKey();
@@ -453,7 +453,7 @@ static bool shouldCenterOnThumb(const PlatformMouseEvent& evt)
 
 ScrollbarButtonPressAction ScrollbarThemeMac::handleMousePressEvent(Scrollbar&, const PlatformMouseEvent& event, ScrollbarPart pressedPart)
 {
-    if (event.button() == RightButton)
+    if (event.button() == MouseButton::Right)
         return ScrollbarButtonPressAction::None;
 
     switch (pressedPart) {

--- a/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
+++ b/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
@@ -92,28 +92,28 @@ PlatformMouseEvent::PlatformMouseEvent(HWND hWnd, UINT message, WPARAM wParam, L
         case WM_LBUTTONDOWN:
         case WM_LBUTTONUP:
         case WM_LBUTTONDBLCLK:
-            m_button = LeftButton;
+            m_button = MouseButton::Left;
             break;
         case WM_RBUTTONDOWN:
         case WM_RBUTTONUP:
         case WM_RBUTTONDBLCLK:
-            m_button = RightButton;
+            m_button = MouseButton::Right;
             break;
         case WM_MBUTTONDOWN:
         case WM_MBUTTONUP:
         case WM_MBUTTONDBLCLK:
-            m_button = MiddleButton;
+            m_button = MouseButton::Middle;
             break;
         case WM_MOUSEMOVE:
         case WM_MOUSELEAVE:
             if (wParam & MK_LBUTTON)
-                m_button = LeftButton;
+                m_button = MouseButton::Left;
             else if (wParam & MK_MBUTTON)
-                m_button = MiddleButton;
+                m_button = MouseButton::Middle;
             else if (wParam & MK_RBUTTON)
-                m_button = RightButton;
+                m_button = MouseButton::Right;
             else
-                m_button = NoButton;
+                m_button = MouseButton::None;
             break;
         default:
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -418,7 +418,7 @@ void RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent(Event* event)
 
     Ref mouseEvent = downcast<MouseEvent>(*event);
     Ref element = downcast<HTMLPlugInElement>(frameOwnerElement());
-    if (mouseEvent->type() == eventNames().mousedownEvent && mouseEvent->button() == LeftButton) {
+    if (mouseEvent->type() == eventNames().mousedownEvent && mouseEvent->button() == MouseButton::Left) {
         m_mouseDownWasInUnavailablePluginIndicator = isInUnavailablePluginIndicator(mouseEvent);
         if (m_mouseDownWasInUnavailablePluginIndicator) {
             frame().eventHandler().setCapturingMouseEventsElement(element.copyRef());
@@ -427,7 +427,7 @@ void RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent(Event* event)
         }
         mouseEvent->setDefaultHandled();
     }
-    if (mouseEvent->type() == eventNames().mouseupEvent && mouseEvent->button() == LeftButton) {
+    if (mouseEvent->type() == eventNames().mouseupEvent && mouseEvent->button() == MouseButton::Left) {
         if (m_unavailablePluginIndicatorIsPressed) {
             frame().eventHandler().setCapturingMouseEventsElement(nullptr);
             element->setIsCapturingMouseEvents(false);

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -562,7 +562,7 @@ bool RenderFrameSet::userResize(MouseEvent& event)
     if (!m_isResizing) {
         if (needsLayout())
             return false;
-        if (event.type() == eventNames().mousedownEvent && event.button() == LeftButton) {
+        if (event.type() == eventNames().mousedownEvent && event.button() == MouseButton::Left) {
             FloatPoint localPos = absoluteToLocal(event.absoluteLocation(), UseTransforms);
             startResizing(m_cols, localPos.x());
             startResizing(m_rows, localPos.y());
@@ -572,11 +572,11 @@ bool RenderFrameSet::userResize(MouseEvent& event)
             }
         }
     } else {
-        if (event.type() == eventNames().mousemoveEvent || (event.type() == eventNames().mouseupEvent && event.button() == LeftButton)) {
+        if (event.type() == eventNames().mousemoveEvent || (event.type() == eventNames().mouseupEvent && event.button() == MouseButton::Left)) {
             FloatPoint localPos = absoluteToLocal(event.absoluteLocation(), UseTransforms);
             continueResizing(m_cols, localPos.x());
             continueResizing(m_rows, localPos.y());
-            if (event.type() == eventNames().mouseupEvent && event.button() == LeftButton) {
+            if (event.type() == eventNames().mouseupEvent && event.button() == MouseButton::Left) {
                 setIsResizing(false);
                 return true;
             }

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -327,16 +327,16 @@ inline WKEventMouseButton toAPI(WebMouseEventButton mouseButton)
     WKEventMouseButton wkMouseButton = kWKEventMouseButtonNoButton;
 
     switch (mouseButton) {
-    case WebMouseEventButton::NoButton:
+    case WebMouseEventButton::None:
         wkMouseButton = kWKEventMouseButtonNoButton;
         break;
-    case WebMouseEventButton::LeftButton:
+    case WebMouseEventButton::Left:
         wkMouseButton = kWKEventMouseButtonLeftButton;
         break;
-    case WebMouseEventButton::MiddleButton:
+    case WebMouseEventButton::Middle:
         wkMouseButton = kWKEventMouseButtonMiddleButton;
         break;
-    case WebMouseEventButton::RightButton:
+    case WebMouseEventButton::Right:
         wkMouseButton = kWKEventMouseButtonRightButton;
         break;
     }
@@ -349,17 +349,19 @@ inline WKEventMouseButton toAPI(WebCore::MouseButton mouseButton)
     WKEventMouseButton wkMouseButton = kWKEventMouseButtonNoButton;
 
     switch (mouseButton) {
-    case WebCore::MouseButton::NoButton:
+    case WebCore::MouseButton::None:
         wkMouseButton = kWKEventMouseButtonNoButton;
         break;
-    case WebCore::MouseButton::LeftButton:
+    case WebCore::MouseButton::Left:
         wkMouseButton = kWKEventMouseButtonLeftButton;
         break;
-    case WebCore::MouseButton::MiddleButton:
+    case WebCore::MouseButton::Middle:
         wkMouseButton = kWKEventMouseButtonMiddleButton;
         break;
-    case WebCore::MouseButton::RightButton:
+    case WebCore::MouseButton::Right:
         wkMouseButton = kWKEventMouseButtonRightButton;
+        break;
+    default:
         break;
     }
 

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -49,7 +49,7 @@ namespace WebKit {
 struct NavigationActionData {
     WebCore::NavigationType navigationType { WebCore::NavigationType::Other };
     OptionSet<WebEventModifier> modifiers;
-    WebMouseEventButton mouseButton { WebMouseEventButton::NoButton };
+    WebMouseEventButton mouseButton { WebMouseEventButton::None };
     WebMouseEventSyntheticClickType syntheticClickType { WebMouseEventSyntheticClickType::NoTap };
     uint64_t userGestureTokenIdentifier { 0 };
     std::optional<WTF::UUID> userGestureAuthorizationToken;

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -146,11 +146,11 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
 }
 #endif // ENABLE(TOUCH_EVENTS)
 
-[CustomHeader] enum class WebKit::WebMouseEventButton : int32_t {
-    LeftButton,
-    MiddleButton,
-    RightButton,
-    NoButton
+[CustomHeader] enum class WebKit::WebMouseEventButton : int8_t {
+    Left,
+    Middle,
+    Right,
+    None
 };
 
 [CustomHeader] enum class WebKit::WebMouseEventSyntheticClickType : uint8_t {

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -94,20 +94,20 @@ public:
 
         // PlatformMouseEvent
         switch (webEvent.button()) {
-        case WebMouseEventButton::NoButton:
-            m_button = WebCore::NoButton;
+        case WebMouseEventButton::None:
+            m_button = WebCore::MouseButton::None;
             break;
-        case WebMouseEventButton::LeftButton:
-            m_button = WebCore::LeftButton;
+        case WebMouseEventButton::Left:
+            m_button = WebCore::MouseButton::Left;
             break;
-        case WebMouseEventButton::MiddleButton:
-            m_button = WebCore::MiddleButton;
+        case WebMouseEventButton::Middle:
+            m_button = WebCore::MouseButton::Middle;
             break;
-        case WebMouseEventButton::RightButton:
-            m_button = WebCore::RightButton;
+        case WebMouseEventButton::Right:
+            m_button = WebCore::MouseButton::Right;
             break;
         default:
-            ASSERT_NOT_REACHED();
+            RELEASE_ASSERT_NOT_REACHED();
         }
 
         m_buttons = webEvent.buttons();

--- a/Source/WebKit/Shared/WebMouseEvent.cpp
+++ b/Source/WebKit/Shared/WebMouseEvent.cpp
@@ -77,7 +77,7 @@ WebMouseEventButton mouseButton(const WebCore::NavigationAction& navigationActio
     auto& mouseEventData = navigationAction.mouseEventData();
     if (mouseEventData && mouseEventData->buttonDown && mouseEventData->isTrusted)
         return static_cast<WebMouseEventButton>(mouseEventData->button);
-    return WebMouseEventButton::NoButton;
+    return WebMouseEventButton::None;
 }
 
 WebMouseEventSyntheticClickType syntheticClickType(const WebCore::NavigationAction& navigationAction)

--- a/Source/WebKit/Shared/WebMouseEvent.h
+++ b/Source/WebKit/Shared/WebMouseEvent.h
@@ -43,11 +43,11 @@ namespace WebKit {
 
 enum class GestureWasCancelled : bool { No, Yes };
 
-enum class WebMouseEventButton : int32_t {
-    LeftButton = 0,
-    MiddleButton,
-    RightButton,
-    NoButton = -2
+enum class WebMouseEventButton : int8_t {
+    Left,
+    Middle,
+    Right,
+    None = -2,
 };
 WebMouseEventButton mouseButton(const WebCore::NavigationAction&);
 
@@ -71,7 +71,7 @@ public:
     WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force = 0, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType(), GestureWasCancelled = GestureWasCancelled::No);
 #endif
 
-    WebMouseEventButton button() const { return static_cast<WebMouseEventButton>(m_button); }
+    WebMouseEventButton button() const { return m_button; }
     unsigned short buttons() const { return m_buttons; }
     const WebCore::IntPoint& position() const { return m_position; } // Relative to the view.
     void setPosition(const WebCore::IntPoint& position) { m_position = position; }
@@ -95,7 +95,7 @@ public:
 private:
     static bool isMouseEventType(WebEventType);
 
-    WebMouseEventButton m_button { WebMouseEventButton::NoButton };
+    WebMouseEventButton m_button { WebMouseEventButton::None };
     unsigned short m_buttons { 0 };
     WebCore::IntPoint m_position; // Relative to the view.
     WebCore::IntPoint m_globalPosition;

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -108,7 +108,7 @@ static inline OptionSet<WebEventModifier> modifiersForEvent(const GdkEvent* even
 
 static inline WebMouseEventButton buttonForEvent(const GdkEvent* event)
 {
-    WebMouseEventButton button = WebMouseEventButton::NoButton;
+    WebMouseEventButton button = WebMouseEventButton::None;
     GdkEventType type = gdk_event_get_event_type(const_cast<GdkEvent*>(event));
     switch (type) {
     case GDK_ENTER_NOTIFY:
@@ -117,11 +117,11 @@ static inline WebMouseEventButton buttonForEvent(const GdkEvent* event)
         GdkModifierType state;
         gdk_event_get_state(event, &state);
         if (state & GDK_BUTTON1_MASK)
-            button = WebMouseEventButton::LeftButton;
+            button = WebMouseEventButton::Left;
         else if (state & GDK_BUTTON2_MASK)
-            button = WebMouseEventButton::MiddleButton;
+            button = WebMouseEventButton::Middle;
         else if (state & GDK_BUTTON3_MASK)
-            button = WebMouseEventButton::RightButton;
+            button = WebMouseEventButton::Right;
         break;
     }
     case GDK_BUTTON_PRESS:
@@ -134,11 +134,11 @@ static inline WebMouseEventButton buttonForEvent(const GdkEvent* event)
         gdk_event_get_button(event, &eventButton);
 
         if (eventButton == 1)
-            button = WebMouseEventButton::LeftButton;
+            button = WebMouseEventButton::Left;
         else if (eventButton == 2)
-            button = WebMouseEventButton::MiddleButton;
+            button = WebMouseEventButton::Middle;
         else if (eventButton == 3)
-            button = WebMouseEventButton::RightButton;
+            button = WebMouseEventButton::Right;
         break;
     }
     default:
@@ -244,7 +244,7 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(const GdkEvent* event, const 
 WebMouseEvent WebEventFactory::createWebMouseEvent(const IntPoint& position)
 {
     // Mouse events without GdkEvent are crossing events, handled as a mouse move.
-    return WebMouseEvent({ WebEventType::MouseMove, { }, WallTime::now() }, WebMouseEventButton::NoButton, 0, position, position, 0, 0, 0, 0);
+    return WebMouseEvent({ WebEventType::MouseMove, { }, WallTime::now() }, WebMouseEventButton::None, 0, position, position, 0, 0, 0, 0);
 }
 
 WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(const GdkEvent* event, const String& text, bool isAutoRepeat, bool handledByInputMethod, std::optional<Vector<CompositionUnderline>>&& preeditUnderlines, std::optional<EditingRange>&& preeditSelectionRange, Vector<String>&& commands)

--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
@@ -136,7 +136,7 @@ WebKit::WebMouseEvent WebIOSEventFactory::createWebMouseEvent(::WebEvent *event)
     ASSERT_ARG(event, event.type == WebEventMouseMoved);
 
     auto type = WebKit::WebEventType::MouseMove;
-    auto button = WebKit::WebMouseEventButton::NoButton;
+    auto button = WebKit::WebMouseEventButton::None;
     unsigned short buttons = 0;
     auto position = WebCore::IntPoint(event.locationInWindow);
     float deltaX = 0;

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -198,16 +198,16 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(struct wpe_input_pointer_even
         ASSERT_NOT_REACHED();
     }
 
-    WebMouseEventButton button = WebMouseEventButton::NoButton;
+    WebMouseEventButton button = WebMouseEventButton::None;
     switch (event->type) {
     case wpe_input_pointer_event_type_motion:
     case wpe_input_pointer_event_type_button:
         if (event->button == 1)
-            button = WebMouseEventButton::LeftButton;
+            button = WebMouseEventButton::Left;
         else if (event->button == 2)
-            button = WebMouseEventButton::RightButton;
+            button = WebMouseEventButton::Right;
         else if (event->button == 3)
-            button = WebMouseEventButton::MiddleButton;
+            button = WebMouseEventButton::Middle;
         break;
     case wpe_input_pointer_event_type_null:
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -51,12 +51,12 @@ static WebMouseEventButton currentMouseButton()
 {
     NSUInteger pressedMouseButtons = [NSEvent pressedMouseButtons];
     if (!pressedMouseButtons)
-        return WebMouseEventButton::NoButton;
+        return WebMouseEventButton::None;
     if (pressedMouseButtons == 1 << 0)
-        return WebMouseEventButton::LeftButton;
+        return WebMouseEventButton::Left;
     if (pressedMouseButtons == 1 << 1)
-        return WebMouseEventButton::RightButton;
-    return WebMouseEventButton::MiddleButton;
+        return WebMouseEventButton::Right;
+    return WebMouseEventButton::Middle;
 }
 
 static WebMouseEventButton mouseButtonForEvent(NSEvent *event)
@@ -65,21 +65,21 @@ static WebMouseEventButton mouseButtonForEvent(NSEvent *event)
     case NSEventTypeLeftMouseDown:
     case NSEventTypeLeftMouseUp:
     case NSEventTypeLeftMouseDragged:
-        return WebMouseEventButton::LeftButton;
+        return WebMouseEventButton::Left;
     case NSEventTypeRightMouseDown:
     case NSEventTypeRightMouseUp:
     case NSEventTypeRightMouseDragged:
-        return WebMouseEventButton::RightButton;
+        return WebMouseEventButton::Right;
     case NSEventTypeOtherMouseDown:
     case NSEventTypeOtherMouseUp:
     case NSEventTypeOtherMouseDragged:
-        return WebMouseEventButton::MiddleButton;
+        return WebMouseEventButton::Middle;
     case NSEventTypePressure:
     case NSEventTypeMouseEntered:
     case NSEventTypeMouseExited:
         return currentMouseButton();
     default:
-        return WebMouseEventButton::NoButton;
+        return WebMouseEventButton::None;
     }
 }
 
@@ -508,13 +508,13 @@ NSEventModifierFlags WebEventFactory::toNSEventModifierFlags(OptionSet<WebKit::W
 NSInteger WebEventFactory::toNSButtonNumber(WebKit::WebMouseEventButton mouseButton)
 {
     switch (mouseButton) {
-    case WebKit::WebMouseEventButton::NoButton:
+    case WebKit::WebMouseEventButton::None:
         return 0;
-    case WebKit::WebMouseEventButton::LeftButton:
+    case WebKit::WebMouseEventButton::Left:
         return 1 << 0;
-    case WebKit::WebMouseEventButton::RightButton:
+    case WebKit::WebMouseEventButton::Right:
         return 1 << 1;
-    case WebKit::WebMouseEventButton::MiddleButton:
+    case WebKit::WebMouseEventButton::Middle:
         return 1 << 2;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -77,7 +77,7 @@ static inline int clickCount(WebEventType type, WebMouseEventButton button, cons
     static int gLastClickCount;
     static double gLastClickTime;
     static POINT lastClickPosition;
-    static WebMouseEventButton lastClickButton = WebMouseEventButton::LeftButton;
+    static WebMouseEventButton lastClickButton = WebMouseEventButton::Left;
 
     bool cancelPreviousClick = (std::abs(lastClickPosition.x - position.x) > (::GetSystemMetrics(SM_CXDOUBLECLK) / 2))
         || (std::abs(lastClickPosition.y - position.y) > (::GetSystemMetrics(SM_CYDOUBLECLK) / 2))
@@ -335,25 +335,25 @@ static String keyIdentifierFromEvent(WPARAM wparam, WebEventType type)
 WebMouseEvent WebEventFactory::createWebMouseEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam, bool didActivateWebView)
 {
     WebEventType type;
-    WebMouseEventButton button = WebMouseEventButton::NoButton;
+    WebMouseEventButton button = WebMouseEventButton::None;
     switch (message) {
     case WM_MOUSEMOVE:
         type = WebEventType::MouseMove;
         if (wParam & MK_LBUTTON)
-            button = WebMouseEventButton::LeftButton;
+            button = WebMouseEventButton::Left;
         else if (wParam & MK_MBUTTON)
-            button = WebMouseEventButton::MiddleButton;
+            button = WebMouseEventButton::Middle;
         else if (wParam & MK_RBUTTON)
-            button = WebMouseEventButton::RightButton;
+            button = WebMouseEventButton::Right;
         break;
     case WM_MOUSELEAVE:
         type = WebEventType::MouseMove;
         if (wParam & MK_LBUTTON)
-            button = WebMouseEventButton::LeftButton;
+            button = WebMouseEventButton::Left;
         else if (wParam & MK_MBUTTON)
-            button = WebMouseEventButton::MiddleButton;
+            button = WebMouseEventButton::Middle;
         else if (wParam & MK_RBUTTON)
-            button = WebMouseEventButton::RightButton;
+            button = WebMouseEventButton::Right;
 
         // Set the current mouse position (relative to the client area of the
         // current window) since none is specified for this event.
@@ -362,29 +362,29 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(HWND hWnd, UINT message, WPAR
     case WM_LBUTTONDOWN:
     case WM_LBUTTONDBLCLK:
         type = WebEventType::MouseDown;
-        button = WebMouseEventButton::LeftButton;
+        button = WebMouseEventButton::Left;
         break;
     case WM_MBUTTONDOWN:
     case WM_MBUTTONDBLCLK:
         type = WebEventType::MouseDown;
-        button = WebMouseEventButton::MiddleButton;
+        button = WebMouseEventButton::Middle;
         break;
     case WM_RBUTTONDOWN:
     case WM_RBUTTONDBLCLK:
         type = WebEventType::MouseDown;
-        button = WebMouseEventButton::RightButton;
+        button = WebMouseEventButton::Right;
         break;
     case WM_LBUTTONUP:
         type = WebEventType::MouseUp;
-        button = WebMouseEventButton::LeftButton;
+        button = WebMouseEventButton::Left;
         break;
     case WM_MBUTTONUP:
         type = WebEventType::MouseUp;
-        button = WebMouseEventButton::MiddleButton;
+        button = WebMouseEventButton::Middle;
         break;
     case WM_RBUTTONUP:
         type = WebEventType::MouseUp;
-        button = WebMouseEventButton::RightButton;
+        button = WebMouseEventButton::Right;
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
@@ -86,13 +86,13 @@ WebKitNavigationType toWebKitNavigationType(WebCore::NavigationType type)
 unsigned toWebKitMouseButton(WebKit::WebMouseEventButton button)
 {
     switch (button) {
-    case WebKit::WebMouseEventButton::NoButton:
+    case WebKit::WebMouseEventButton::None:
         return 0;
-    case WebKit::WebMouseEventButton::LeftButton:
+    case WebKit::WebMouseEventButton::Left:
         return 1;
-    case WebKit::WebMouseEventButton::MiddleButton:
+    case WebKit::WebMouseEventButton::Middle:
         return 2;
-    case WebKit::WebMouseEventButton::RightButton:
+    case WebKit::WebMouseEventButton::Right:
         return 3;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -202,15 +202,15 @@ struct MotionEvent {
             modifiers.add(WebEventModifier::MetaKey);
 
         if (state & GDK_BUTTON1_MASK) {
-            button = WebMouseEventButton::LeftButton;
+            button = WebMouseEventButton::Left;
             buttons |= 1;
         }
         if (state & GDK_BUTTON2_MASK) {
-            button = WebMouseEventButton::MiddleButton;
+            button = WebMouseEventButton::Middle;
             buttons |= 4;
         }
         if (state & GDK_BUTTON3_MASK) {
-            button = WebMouseEventButton::RightButton;
+            button = WebMouseEventButton::Right;
             buttons |= 2;
         }
     }
@@ -224,7 +224,7 @@ struct MotionEvent {
 
     FloatPoint position;
     FloatPoint globalPosition;
-    WebMouseEventButton button { WebMouseEventButton::NoButton };
+    WebMouseEventButton button { WebMouseEventButton::None };
     unsigned short buttons { 0 };
     OptionSet<WebEventModifier> modifiers;
 };
@@ -3216,19 +3216,19 @@ void webkitWebViewBaseSynthesizeMouseEvent(WebKitWebViewBase* webViewBase, Mouse
         return;
     }
 
-    WebMouseEventButton webEventButton = WebMouseEventButton::NoButton;
+    WebMouseEventButton webEventButton = WebMouseEventButton::None;
     switch (button) {
     case 0:
-        webEventButton = WebMouseEventButton::NoButton;
+        webEventButton = WebMouseEventButton::None;
         break;
     case 1:
-        webEventButton = WebMouseEventButton::LeftButton;
+        webEventButton = WebMouseEventButton::Left;
         break;
     case 2:
-        webEventButton = WebMouseEventButton::MiddleButton;
+        webEventButton = WebMouseEventButton::Middle;
         break;
     case 3:
-        webEventButton = WebMouseEventButton::RightButton;
+        webEventButton = WebMouseEventButton::Right;
         break;
     }
 
@@ -3247,7 +3247,7 @@ void webkitWebViewBaseSynthesizeMouseEvent(WebKitWebViewBase* webViewBase, Mouse
         webEventType = WebEventType::MouseDown;
         priv->inputMethodFilter.cancelComposition();
 #if !USE(GTK4)
-        if (webEventButton == WebMouseEventButton::RightButton) {
+        if (webEventButton == WebMouseEventButton::Right) {
             GUniquePtr<GdkEvent> event(gdk_event_new(GDK_BUTTON_PRESS));
             event->button.window = gtk_widget_get_window(GTK_WIDGET(webViewBase));
             g_object_ref(event->button.window);
@@ -3276,11 +3276,11 @@ void webkitWebViewBaseSynthesizeMouseEvent(WebKitWebViewBase* webViewBase, Mouse
     case MouseEventType::Motion:
         webEventType = WebEventType::MouseMove;
         if (buttons & GDK_BUTTON1_MASK)
-            webEventButton = WebMouseEventButton::LeftButton;
+            webEventButton = WebMouseEventButton::Left;
         else if (buttons & GDK_BUTTON2_MASK)
-            webEventButton = WebMouseEventButton::MiddleButton;
+            webEventButton = WebMouseEventButton::Middle;
         else if (buttons & GDK_BUTTON3_MASK)
-            webEventButton = WebMouseEventButton::RightButton;
+            webEventButton = WebMouseEventButton::Right;
 
         if (priv->lastMotionEvent)
             movementDelta = FloatPoint(x, y) - priv->lastMotionEvent->globalPosition;

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -153,11 +153,11 @@ static WebCore::IntPoint viewportLocationToWindowLocation(WebCore::IntPoint loca
 static WebMouseEventButton automationMouseButtonToPlatformMouseButton(MouseButton button)
 {
     switch (button) {
-    case MouseButton::Left:   return WebMouseEventButton::LeftButton;
-    case MouseButton::Middle: return WebMouseEventButton::MiddleButton;
-    case MouseButton::Right:  return WebMouseEventButton::RightButton;
-    case MouseButton::None:   return WebMouseEventButton::NoButton;
-    default: ASSERT_NOT_REACHED();
+    case MouseButton::Left:   return WebMouseEventButton::Left;
+    case MouseButton::Middle: return WebMouseEventButton::Middle;
+    case MouseButton::Right:  return WebMouseEventButton::Right;
+    case MouseButton::None:   return WebMouseEventButton::None;
+    default: RELEASE_ASSERT_NOT_REACHED();
     }
 }
 
@@ -187,20 +187,20 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
     NSEventType dragEventType = (NSEventType)0;
     NSEventType upEventType = (NSEventType)0;
     switch (automationMouseButtonToPlatformMouseButton(button)) {
-    case WebMouseEventButton::NoButton:
+    case WebMouseEventButton::None:
         downEventType = upEventType = dragEventType = NSEventTypeMouseMoved;
         break;
-    case WebMouseEventButton::LeftButton:
+    case WebMouseEventButton::Left:
         downEventType = NSEventTypeLeftMouseDown;
         dragEventType = NSEventTypeLeftMouseDragged;
         upEventType = NSEventTypeLeftMouseUp;
         break;
-    case WebMouseEventButton::MiddleButton:
+    case WebMouseEventButton::Middle:
         downEventType = NSEventTypeOtherMouseDown;
         dragEventType = NSEventTypeLeftMouseDragged;
         upEventType = NSEventTypeOtherMouseUp;
         break;
-    case WebMouseEventButton::RightButton:
+    case WebMouseEventButton::Right:
         downEventType = NSEventTypeRightMouseDown;
         upEventType = NSEventTypeRightMouseUp;
         break;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3248,7 +3248,7 @@ void WebPageProxy::handleMouseEvent(const NativeWebMouseEvent& event)
         return;
 
 #if ENABLE(CONTEXT_MENU_EVENT)
-    if (event.button() == WebMouseEventButton::RightButton && event.type() == WebEventType::MouseDown) {
+    if (event.button() == WebMouseEventButton::Right && event.type() == WebEventType::MouseDown) {
         ASSERT(m_contextMenuPreventionState != EventPreventionState::Waiting);
         m_contextMenuPreventionState = EventPreventionState::Waiting;
     }
@@ -3304,7 +3304,7 @@ void WebPageProxy::processNextQueuedMouseEvent()
     std::optional<Vector<SandboxExtension::Handle>> sandboxExtensions;
 
 #if PLATFORM(MAC)
-    bool eventMayStartDrag = !m_currentDragOperation && eventType == WebEventType::MouseMove && event.button() != WebMouseEventButton::NoButton;
+    bool eventMayStartDrag = !m_currentDragOperation && eventType == WebEventType::MouseMove && event.button() != WebMouseEventButton::None;
     if (eventMayStartDrag)
         sandboxExtensions = SandboxExtension::createHandlesForMachLookup({ "com.apple.iconservices"_s, "com.apple.iconservices.store"_s }, process().auditToken(), SandboxExtension::MachBootstrapOptions::EnableMachBootstrap);
 #endif
@@ -8573,7 +8573,7 @@ void WebPageProxy::didReceiveEvent(WebEventType eventType, bool handled)
         MESSAGE_CHECK(m_process, eventType == event.type());
 
 #if ENABLE(CONTEXT_MENU_EVENT)
-        if (event.button() == WebMouseEventButton::RightButton) {
+        if (event.button() == WebMouseEventButton::Right) {
             if (event.type() == WebEventType::MouseDown) {
                 ASSERT(m_contextMenuPreventionState == EventPreventionState::Waiting);
                 m_contextMenuPreventionState = handled ? EventPreventionState::Prevented : EventPreventionState::Allowed;

--- a/Source/WebKit/UIProcess/gtk/PointerLockManager.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManager.h
@@ -56,7 +56,7 @@ protected:
 
     WebPageProxy& m_webPage;
     WebCore::FloatPoint m_position;
-    WebMouseEventButton m_button { WebMouseEventButton::NoButton };
+    WebMouseEventButton m_button { WebMouseEventButton::None };
     unsigned short m_buttons { 0 };
     OptionSet<WebEventModifier> m_modifiers;
     WebCore::FloatPoint m_initialPoint;

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -194,10 +194,10 @@ inline static String pointerType(UITouchType type)
 
     auto button = [&] {
         if (!_touching)
-            return WebKit::WebMouseEventButton::NoButton;
+            return WebKit::WebMouseEventButton::None;
         if (isRightButton)
-            return WebKit::WebMouseEventButton::RightButton;
-        return WebKit::WebMouseEventButton::LeftButton;
+            return WebKit::WebMouseEventButton::Right;
+        return WebKit::WebMouseEventButton::Left;
     }();
 
     // FIXME: 'buttons' should report any buttons that are still down in the case when one button is released from a chord.

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -118,7 +118,7 @@ private:
             return m_client.mouseUp(toAPI(&pageOverlay), WebKit::toAPI(event.position()), WebKit::toAPI(event.button()), m_client.base.clientInfo);
         }
         case WebCore::PlatformMouseEvent::Type::MouseMoved: {
-            if (event.button() == WebCore::MouseButton::NoButton) {
+            if (event.button() == WebCore::MouseButton::None) {
                 if (!m_client.mouseMoved)
                     return false;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
@@ -72,7 +72,7 @@ private:
             return m_client.mouseUp(toAPI(pageBanner), toAPI(position), toAPI(button), m_client.base.clientInfo);
         }
         case WebEventType::MouseMove: {
-            if (button == WebMouseEventButton::NoButton) {
+            if (button == WebMouseEventButton::None) {
                 if (!m_client.mouseMoved)
                     return false;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMMouseEvent.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMMouseEvent.cpp
@@ -400,7 +400,7 @@ gushort webkit_dom_mouse_event_get_button(WebKitDOMMouseEvent* self)
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_MOUSE_EVENT(self), 0);
     WebCore::MouseEvent* item = WebKit::core(self);
-    gushort result = item->button();
+    gushort result = static_cast<gushort>(item->button());
     return result;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -2118,10 +2118,10 @@ static bool getEventTypeFromWebEvent(const WebEvent& event, NSEventType& eventTy
         return true;
     case WebEventType::MouseDown:
         switch (static_cast<const WebMouseEvent&>(event).button()) {
-        case WebMouseEventButton::LeftButton:
+        case WebMouseEventButton::Left:
             eventType = NSEventTypeLeftMouseDown;
             return true;
-        case WebMouseEventButton::RightButton:
+        case WebMouseEventButton::Right:
             eventType = NSEventTypeRightMouseDown;
             return true;
         default:
@@ -2129,10 +2129,10 @@ static bool getEventTypeFromWebEvent(const WebEvent& event, NSEventType& eventTy
         }
     case WebEventType::MouseUp:
         switch (static_cast<const WebMouseEvent&>(event).button()) {
-        case WebMouseEventButton::LeftButton:
+        case WebMouseEventButton::Left:
             eventType = NSEventTypeLeftMouseUp;
             return true;
-        case WebMouseEventButton::RightButton:
+        case WebMouseEventButton::Right:
             eventType = NSEventTypeRightMouseUp;
             return true;
         default:
@@ -2140,13 +2140,13 @@ static bool getEventTypeFromWebEvent(const WebEvent& event, NSEventType& eventTy
         }
     case WebEventType::MouseMove:
         switch (static_cast<const WebMouseEvent&>(event).button()) {
-        case WebMouseEventButton::LeftButton:
+        case WebMouseEventButton::Left:
             eventType = NSEventTypeLeftMouseDragged;
             return true;
-        case WebMouseEventButton::RightButton:
+        case WebMouseEventButton::Right:
             eventType = NSEventTypeRightMouseDragged;
             return true;
-        case WebMouseEventButton::NoButton:
+        case WebMouseEventButton::None:
             eventType = NSEventTypeMouseMoved;
             return true;
         default:
@@ -2206,7 +2206,7 @@ bool PDFPlugin::handleMouseEvent(const WebMouseEvent& event)
         return false;
 
     // Right-clicks and Control-clicks always call handleContextMenuEvent as well.
-    if (event.button() == WebMouseEventButton::RightButton || (event.button() == WebMouseEventButton::LeftButton && event.controlKey()))
+    if (event.button() == WebMouseEventButton::Right || (event.button() == WebMouseEventButton::Left && event.controlKey()))
         return true;
 
     NSEvent *nsEvent = nsEventForWebMouseEvent(event);
@@ -2227,44 +2227,50 @@ bool PDFPlugin::handleMouseEvent(const WebMouseEvent& event)
             targetScrollbarForLastMousePosition->mouseExited();
 
         switch (event.button()) {
-        case WebMouseEventButton::LeftButton:
+        case WebMouseEventButton::Left:
             [m_pdfLayerController mouseDragged:nsEvent];
             return true;
-        case WebMouseEventButton::RightButton:
-        case WebMouseEventButton::MiddleButton:
+        case WebMouseEventButton::Right:
+        case WebMouseEventButton::Middle:
             return false;
-        case WebMouseEventButton::NoButton:
+        case WebMouseEventButton::None:
             [m_pdfLayerController mouseMoved:nsEvent];
             return true;
+        default:
+            return false;
         }
         break;
     case WebEventType::MouseDown:
         switch (event.button()) {
-        case WebMouseEventButton::LeftButton:
+        case WebMouseEventButton::Left:
             if (targetScrollbar)
                 return targetScrollbar->mouseDown(platformEvent);
 
             [m_pdfLayerController mouseDown:nsEvent];
             return true;
-        case WebMouseEventButton::RightButton:
+        case WebMouseEventButton::Right:
             [m_pdfLayerController rightMouseDown:nsEvent];
             return true;
-        case WebMouseEventButton::MiddleButton:
-        case WebMouseEventButton::NoButton:
+        case WebMouseEventButton::Middle:
+        case WebMouseEventButton::None:
+            return false;
+        default:
             return false;
         }
         break;
     case WebEventType::MouseUp:
         switch (event.button()) {
-        case WebMouseEventButton::LeftButton:
+        case WebMouseEventButton::Left:
             if (targetScrollbar)
                 return targetScrollbar->mouseUp(platformEvent);
 
             [m_pdfLayerController mouseUp:nsEvent];
             return true;
-        case WebMouseEventButton::RightButton:
-        case WebMouseEventButton::MiddleButton:
-        case WebMouseEventButton::NoButton:
+        case WebMouseEventButton::Right:
+        case WebMouseEventButton::Middle:
+        case WebMouseEventButton::None:
+            return false;
+        default:
             return false;
         }
         break;
@@ -2293,7 +2299,7 @@ bool PDFPlugin::showContextMenuAtPoint(const IntPoint& point)
     if (!frameView)
         return false;
     IntPoint contentsPoint = frameView->contentsToRootView(point);
-    WebMouseEvent event({ WebEventType::MouseDown, OptionSet<WebEventModifier> { }, WallTime::now() }, WebMouseEventButton::RightButton, 0, contentsPoint, contentsPoint, 0, 0, 0, 1, WebCore::ForceAtClick);
+    WebMouseEvent event({ WebEventType::MouseDown, OptionSet<WebEventModifier> { }, WallTime::now() }, WebMouseEventButton::Right, 0, contentsPoint, contentsPoint, 0, 0, 0, 1, WebCore::ForceAtClick);
     return handleContextMenuEvent(event);
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -476,7 +476,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI
     NavigationActionData navigationActionData {
         WebCore::NavigationType::Other,
         { }, /* modifiers */
-        WebMouseEventButton::NoButton,
+        WebMouseEventButton::None,
         WebMouseEventSyntheticClickType::NoTap,
         WebProcess::singleton().userGestureTokenIdentifier(UserGestureIndicator::currentUserGesture()),
         UserGestureIndicator::currentUserGesture() ? UserGestureIndicator::currentUserGesture()->authorizationToken() : std::nullopt,

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1211,7 +1211,7 @@ static bool isContextClick(const PlatformMouseEvent& event)
 #if USE(APPKIT)
     return WebEventFactory::shouldBeHandledAsContextClick(event);
 #else
-    return event.button() == WebCore::RightButton;
+    return event.button() == WebCore::MouseButton::Right;
 #endif
 }
 
@@ -1274,7 +1274,7 @@ WebCore::HandleMouseEventResult WebFrame::handleMouseEvent(const WebMouseEvent& 
         // Lion when legacy scrollbars are enabled, WebKit receives mouse events all the time. If it is one
         // of those cases where the page is not active and the mouse is not pressed, then we can fire a more
         // efficient scrollbars-only version of the event.
-        if (!(page()->corePage()->focusController().isActive() || (mouseEvent.button() != WebMouseEventButton::NoButton)))
+        if (!(page()->corePage()->focusController().isActive() || (mouseEvent.button() != WebMouseEventButton::None)))
             return coreLocalFrame->eventHandler().passMouseMovedEventToScrollbars(platformMouseEvent);
 #endif
         return coreLocalFrame->eventHandler().mouseMoved(platformMouseEvent);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2053,7 +2053,7 @@ void WebPage::navigateToPDFLinkWithSimulatedClick(const String& url, IntPoint do
     // FIXME: Set modifier keys.
     // FIXME: This should probably set IsSimulated::Yes.
     auto mouseEvent = MouseEvent::create(eventNames().clickEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
-        MonotonicTime::now(), nullptr, singleClick, screenPoint, documentPoint, 0, 0, { }, 0, 0, nullptr, 0, WebCore::SyntheticClickType::NoTap);
+        MonotonicTime::now(), nullptr, singleClick, screenPoint, documentPoint, 0, 0, { }, MouseButton::Left, 0, nullptr, 0, WebCore::SyntheticClickType::NoTap);
 
     mainFrame->loader().changeLocation(mainFrameDocument->completeURL(url), emptyAtom(), mouseEvent.ptr(), ReferrerPolicy::NoReferrer, ShouldOpenExternalURLsPolicy::ShouldAllow);
 }
@@ -3121,11 +3121,11 @@ WebContextMenu* WebPage::contextMenuAtPointInWindow(FrameIdentifier frameID, con
     corePage()->contextMenuController().clearContextMenu();
 
     // Simulate a mouse click to generate the correct menu.
-    PlatformMouseEvent mousePressEvent(point, point, RightButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap);
+    PlatformMouseEvent mousePressEvent(point, point, MouseButton::Right, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap);
     coreFrame->eventHandler().handleMousePressEvent(mousePressEvent);
     bool handled = coreFrame->eventHandler().sendContextMenuEvent(mousePressEvent);
     auto* menu = handled ? &contextMenu() : nullptr;
-    PlatformMouseEvent mouseReleaseEvent(point, point, RightButton, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap);
+    PlatformMouseEvent mouseReleaseEvent(point, point, MouseButton::Right, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap);
     coreFrame->eventHandler().handleMouseReleaseEvent(mouseReleaseEvent);
 
     return menu;
@@ -3393,7 +3393,7 @@ void WebPage::mouseEvent(FrameIdentifier frameID, const WebMouseEvent& mouseEven
         if (mouseEvent.type() != WebEventType::MouseMove)
             return false;
 
-        if (mouseEvent.button() != WebMouseEventButton::NoButton)
+        if (mouseEvent.button() != WebMouseEventButton::None)
             return false;
 
         if (mouseEvent.force())
@@ -5072,7 +5072,7 @@ void WebPage::dragEnded(WebCore::IntPoint clientPosition, WebCore::IntPoint glob
     if (!view)
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
-    PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap);
+    PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, MouseButton::Left, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap);
     localMainFrame->eventHandler().dragSourceEndedAt(event, dragOperationMask);
 
     send(Messages::WebPageProxy::DidEndDragging());

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -714,7 +714,7 @@ void WebPage::updateSelectionAppearance()
 static void dispatchSyntheticMouseMove(LocalFrame& mainFrame, const WebCore::FloatPoint& location, OptionSet<WebEventModifier> modifiers, WebCore::PointerID pointerId = WebCore::mousePointerID)
 {
     IntPoint roundedAdjustedPoint = roundedIntPoint(location);
-    auto mouseEvent = PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, NoButton, PlatformEvent::Type::MouseMoved, 0, platform(modifiers), WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::OneFingerTap, pointerId);
+    auto mouseEvent = PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::None, PlatformEvent::Type::MouseMoved, 0, platform(modifiers), WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::OneFingerTap, pointerId);
     // FIXME: Pass caps lock state.
     mainFrame.eventHandler().dispatchSyntheticMouseMove(mouseEvent);
 }
@@ -887,7 +887,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     // FIXME: Pass caps lock state.
     auto platformModifiers = platform(modifiers);
 
-    bool handledPress = localMainFrame->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId)).wasHandled();
+    bool handledPress = localMainFrame->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MousePressed, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId)).wasHandled();
     if (m_isClosed)
         return;
 
@@ -896,7 +896,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
     else if (!handledPress)
         clearSelectionAfterTapIfNeeded();
 
-    bool handledRelease = localMainFrame->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId)).wasHandled();
+    bool handledRelease = localMainFrame->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MouseReleased, 1, platformModifiers, WallTime::now(), WebCore::ForceAtClick, syntheticClickType, pointerId)).wasHandled();
     if (m_isClosed)
         return;
 
@@ -908,7 +908,7 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
         // Dispatch mouseOut to dismiss tooltip content when tapping on the control bar buttons (cc, settings).
         if (document.quirks().needsYouTubeMouseOutQuirk()) {
             if (auto* frame = document.frame())
-                frame->eventHandler().dispatchSyntheticMouseOut(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::NoType, 0, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap, pointerId));
+                frame->eventHandler().dispatchSyntheticMouseOut(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::NoType, 0, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap, pointerId));
         }
     }
 
@@ -953,10 +953,10 @@ void WebPage::handleDoubleTapForDoubleClickAtPoint(const IntPoint& point, Option
 
     auto platformModifiers = platform(modifiers);
     auto roundedAdjustedPoint = roundedIntPoint(adjustedPoint);
-    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 2, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
+    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MousePressed, 2, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
     if (m_isClosed)
         return;
-    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 2, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
+    nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMouseReleaseEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::MouseReleased, 2, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::OneFingerTap));
 }
 
 void WebPage::requestFocusedElementInformation(CompletionHandler<void(const std::optional<FocusedElementInformation>&)>&& completionHandler)
@@ -985,7 +985,7 @@ void WebPage::requestAdditionalItemsForDragSession(const IntPoint& clientPositio
     // To augment the platform drag session with additional items, end the current drag session and begin a new drag session with the new drag item.
     // This process is opaque to the UI process, which still maintains the old drag item in its drag session. Similarly, this persistent drag session
     // is opaque to the web process, which only sees that the current drag has ended, and that a new one is beginning.
-    PlatformMouseEvent event(clientPosition, globalPosition, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap);
+    PlatformMouseEvent event(clientPosition, globalPosition, MouseButton::Left, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap);
     m_page->dragController().dragEnded();
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)
@@ -1281,7 +1281,7 @@ void WebPage::inspectorNodeSearchMovedToPosition(const FloatPoint& position)
         return;
     IntPoint adjustedPoint = roundedIntPoint(position);
 
-    localMainFrame->eventHandler().mouseMoved(PlatformMouseEvent(adjustedPoint, adjustedPoint, NoButton, PlatformEvent::Type::MouseMoved, 0, { }, { }, 0, WebCore::SyntheticClickType::NoTap));
+    localMainFrame->eventHandler().mouseMoved(PlatformMouseEvent(adjustedPoint, adjustedPoint, MouseButton::None, PlatformEvent::Type::MouseMoved, 0, { }, { }, 0, WebCore::SyntheticClickType::NoTap));
     localMainFrame->document()->updateStyleIfNeeded();
 }
 
@@ -1797,16 +1797,16 @@ void WebPage::dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch tou
     auto& eventHandler = localMainFrame->eventHandler();
     switch (touch) {
     case SelectionTouch::Started:
-        eventHandler.handleMousePressEvent({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap });
+        eventHandler.handleMousePressEvent({ adjustedPoint, adjustedPoint, MouseButton::Left, PlatformEvent::Type::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap });
         break;
     case SelectionTouch::Moved:
-        eventHandler.dispatchSyntheticMouseMove({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap });
+        eventHandler.dispatchSyntheticMouseMove({ adjustedPoint, adjustedPoint, MouseButton::Left, PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap });
         break;
     case SelectionTouch::Ended:
     case SelectionTouch::EndedMovingForward:
     case SelectionTouch::EndedMovingBackward:
     case SelectionTouch::EndedNotMoving:
-        eventHandler.handleMouseReleaseEvent({ adjustedPoint, adjustedPoint, LeftButton, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap });
+        eventHandler.handleMouseReleaseEvent({ adjustedPoint, adjustedPoint, MouseButton::Left, PlatformEvent::Type::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap });
         break;
     }
 }

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -464,7 +464,7 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
         return;
 
     auto event = MouseEvent::create(eventNames().clickEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
-        MonotonicTime::now(), nullptr, 1, { }, { }, 0, 0, { }, 0, 0, nullptr, 0, SyntheticClickType::NoTap, MouseEvent::IsSimulated::Yes);
+        MonotonicTime::now(), nullptr, 1, { }, { }, 0, 0, { }, MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, MouseEvent::IsSimulated::Yes);
 
     // Call to the frame loader because this is where our security checks are made.
     auto* frame = core([_dataSource webFrame]);

--- a/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm
@@ -95,7 +95,7 @@
 - (short)button
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->button();
+    return IMPL->buttonAsShort();
 }
 
 - (id <DOMEventTarget>)relatedTarget

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1553,10 +1553,8 @@ NSDictionary *WebFrameLoaderClient::actionDictionary(const WebCore::NavigationAc
         auto element = adoptNS([[WebElementDictionary alloc] initWithHitTestResult:core(m_webFrame.get())->eventHandler().hitTestResultAtPoint(mouseEventData->absoluteLocation, hitType)]);
         [result setObject:element.get() forKey:WebActionElementKey];
 
-        if (mouseEventData->isTrusted)
-            [result setObject:@(mouseEventData->button) forKey:WebActionButtonKey];
-        else
-            [result setObject:@(WebCore::NoButton) forKey:WebActionButtonKey];
+        auto button = enumToUnderlyingType(mouseEventData->isTrusted ? mouseEventData->button : MouseButton::None);
+        [result setObject:@(button) forKey:WebActionButtonKey];
     }
 
     if (formState)

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -951,7 +951,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
     WebCore::PlatformMouseEvent event(WebCore::IntPoint(windowLoc), WebCore::IntPoint(WebCore::globalPoint(windowLoc, [view->platformWidget() window])),
-        WebCore::LeftButton, WebCore::PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap);
+        WebCore::MouseButton::Left, WebCore::PlatformEvent::Type::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap);
     _private->coreFrame->eventHandler().dragSourceEndedAt(event, coreDragOperationMask(dragOperationMask));
 }
 #endif // ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -936,18 +936,17 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
 
     NSWindow *window = [sender window];
     NSEvent *nsEvent = [window currentEvent];
-    const int noButton = -2;
-    int button = noButton;
+    WebCore::MouseButton button = WebCore::MouseButton::None;
     RefPtr<WebCore::Event> event;
     switch ([nsEvent type]) {
     case NSEventTypeLeftMouseUp:
-        button = 0;
+        button = WebCore::MouseButton::Left;
         break;
     case NSEventTypeRightMouseUp:
-        button = 1;
+        button = WebCore::MouseButton::Right;
         break;
     case NSEventTypeOtherMouseUp:
-        button = [nsEvent buttonNumber];
+        button = static_cast<WebCore::MouseButton>([nsEvent buttonNumber]);
         break;
     case NSEventTypeKeyDown: {
         auto pe = WebCore::PlatformEventFactory::createPlatformKeyboardEvent(nsEvent);
@@ -958,7 +957,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
     default:
         break;
     }
-    if (button != noButton) {
+    if (button != WebCore::MouseButton::None) {
         // FIXME: Use createPlatformMouseEvent instead.
         event = WebCore::MouseEvent::create(WebCore::eventNames().clickEvent, WebCore::Event::CanBubble::Yes, WebCore::Event::IsCancelable::Yes, WebCore::Event::IsComposed::Yes,
             MonotonicTime::now(), nullptr, [nsEvent clickCount], { }, { }, 0, 0, WebCore::modifiersForEvent(nsEvent),

--- a/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
@@ -64,77 +64,77 @@ static void buildAndPerformTest(NSEventType buttonEvent, NSEventModifierFlags mo
 
 TEST(WebKitLegacy, MenuAndButtonForNormalLeftClick)
 {
-    buildAndPerformTest(NSEventTypeLeftMouseDown, 0, WebCore::LeftButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeLeftMouseDown, 0, WebCore::MouseButton::Left, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForNormalRightClick)
 {
-    buildAndPerformTest(NSEventTypeRightMouseDown, 0, WebCore::RightButton, NSMenuTypeContextMenu);
+    buildAndPerformTest(NSEventTypeRightMouseDown, 0, WebCore::MouseButton::Right, NSMenuTypeContextMenu);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForNormalMiddleClick)
 {
-    buildAndPerformTest(NSEventTypeOtherMouseDown, 0, WebCore::MiddleButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeOtherMouseDown, 0, WebCore::MouseButton::Middle, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForControlLeftClick)
 {
-    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagControl, WebCore::LeftButton, NSMenuTypeContextMenu);
+    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagControl, WebCore::MouseButton::Left, NSMenuTypeContextMenu);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForControlRightClick)
 {
-    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagControl, WebCore::RightButton, NSMenuTypeContextMenu);
+    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagControl, WebCore::MouseButton::Right, NSMenuTypeContextMenu);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForControlMiddleClick)
 {
-    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagControl, WebCore::MiddleButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagControl, WebCore::MouseButton::Middle, NSMenuTypeNone);
 }
     
 TEST(WebKitLegacy, MenuAndButtonForShiftLeftClick)
 {
-    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagShift, WebCore::LeftButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagShift, WebCore::MouseButton::Left, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForShiftRightClick)
 {
-    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagShift, WebCore::RightButton, NSMenuTypeContextMenu);
+    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagShift, WebCore::MouseButton::Right, NSMenuTypeContextMenu);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForShiftMiddleClick)
 {
-    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagShift, WebCore::MiddleButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagShift, WebCore::MouseButton::Middle, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForCommandLeftClick)
 {
-    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagCommand, WebCore::LeftButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagCommand, WebCore::MouseButton::Left, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForCommandRightClick)
 {
-    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagCommand, WebCore::RightButton, NSMenuTypeContextMenu);
+    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagCommand, WebCore::MouseButton::Right, NSMenuTypeContextMenu);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForCommandMiddleClick)
 {
-    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagCommand, WebCore::MiddleButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagCommand, WebCore::MouseButton::Middle, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForAltLeftClick)
 {
-    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagOption, WebCore::LeftButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeLeftMouseDown, NSEventModifierFlagOption, WebCore::MouseButton::Left, NSMenuTypeNone);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForAltRightClick)
 {
-    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagOption, WebCore::RightButton, NSMenuTypeContextMenu);
+    buildAndPerformTest(NSEventTypeRightMouseDown, NSEventModifierFlagOption, WebCore::MouseButton::Right, NSMenuTypeContextMenu);
 }
 
 TEST(WebKitLegacy, MenuAndButtonForAltMiddleClick)
 {
-    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagOption, WebCore::MiddleButton, NSMenuTypeNone);
+    buildAndPerformTest(NSEventTypeOtherMouseDown, NSEventModifierFlagOption, WebCore::MouseButton::Middle, NSMenuTypeNone);
 }
 
 


### PR DESCRIPTION
#### 865af240558dd997c13e159713ef3504d8f6e3c5
<pre>
WebCore::MouseButton should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=258909">https://bugs.webkit.org/show_bug.cgi?id=258909</a>
rdar://111820855

Reviewed by Wenson Hsieh.

Converting `WebCore::MouseButton` to an enum class prevents us from
assigning seemingly magic numbers (-1/-2) to the `button` property of a
`MouseEvent`. In other words, it improves readability because we don&apos;t
have to go back and forth between the DOM API for the meaning of various
integral values.

This commit also changes our internal representation of the `button`
property from a `short` to an `int16_t`. This represents a
small conformance win since the latter  is better aligned with the Web
IDL standard&apos;s definition of the `short` type.

To address undefined behavior concerns, we declare all expected
`MouseButton` cases together and only pass around `MouseButton` values
throughout the engine. This means that as long as we&apos;re safely
converting to/from integral button values received over IDL, we should
be behaving correctly.

I&apos;ve also taken the liberty to make the enumeration cases read less
redundantly: {LeftButton, RightButton, MiddleButton, NoButton} =&gt; {Left,
Right, Middle, None}.

* LayoutTests/fast/events/constructors/mouse-event-constructor.html:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::defaultEventHandler):
* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::create):
(WebCore::DragEvent::DragEvent):
* Source/WebCore/dom/DragEvent.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchMouseForceWillBegin):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::MouseEvent):
(WebCore::MouseEvent::initMouseEvent):
(WebCore::MouseEvent::initMouseEventQuirk):
(WebCore::MouseEvent::canTriggerActivationBehavior):
(WebCore::MouseEvent::button const):
* Source/WebCore/dom/MouseEvent.h:
(WebCore::MouseEvent::buttonAsShort const):
(WebCore::MouseEvent::button const): Deleted.
* Source/WebCore/dom/MouseEvent.idl:
* Source/WebCore/dom/MouseEventInit.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::defaultEventHandler):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::create):
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::WheelEvent):
(WebCore::WheelEvent::initWebKitWheelEvent):
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::MouseEvent::create):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::buttonForType):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::willDispatchEvent):
(WebCore::HTMLInputElement::defaultEventHandler):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::listBoxDefaultEventHandler):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleMouseDownEvent):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::defaultEventHandler):
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::defaultEventHandler):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldResultsButtonElement::defaultEventHandler):
(WebCore::SearchFieldCancelButtonElement::defaultEventHandler):
* Source/WebCore/loader/NavigationAction.h:
* Source/WebCore/page/AutoscrollController.cpp:
(WebCore::AutoscrollController::handleMouseReleaseEvent):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::showContextMenuAt):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::mouseEvent):
* Source/WebCore/page/DragController.cpp:
(WebCore::createMouseEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEventDoubleClick):
(WebCore::EventHandler::handleMousePressEventTripleClick):
(WebCore::EventHandler::handleMousePressEventSingleClick):
(WebCore::EventHandler::handleMouseDraggedEvent):
(WebCore::EventHandler::eventMayStartDrag const):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::dispatchDragEvent):
(WebCore::EventHandler::sendContextMenuEventForKey):
(WebCore::EventHandler::fakeMouseMoveEventTimerFired):
(WebCore::EventHandler::handleDrag):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerEventForMouseEvent):
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::tryToBeginDragAtPoint):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::mouseEvent):
* Source/WebCore/platform/PlatformMouseEvent.h:
* Source/WebCore/platform/ScrollbarTheme.cpp:
(WebCore::ScrollbarTheme::handleMousePressEvent):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp:
(WebCore::ScrollbarThemeAdwaita::handleMousePressEvent):
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp:
(WebCore::ScrollbarThemeGtk::handleMousePressEvent):
* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
(WebCore::PlatformMouseEventBuilder::PlatformMouseEventBuilder):
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::mouseButtonForEvent):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::shouldCenterOnThumb):
(WebCore::ScrollbarThemeMac::handleMousePressEvent):
* Source/WebCore/platform/win/PlatformMouseEventWin.cpp:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::userResize):
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
* Source/WebKit/Shared/WebMouseEvent.cpp:
(WebKit::mouseButton):
* Source/WebKit/Shared/WebMouseEvent.h:
(WebKit::WebMouseEvent::button const):
* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::buttonForEvent):
(WebKit::WebEventFactory::createWebMouseEvent):
* Source/WebKit/Shared/ios/WebIOSEventFactory.mm:
(WebIOSEventFactory::createWebMouseEvent):
* Source/WebKit/Shared/libwpe/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebMouseEvent):
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::currentMouseButton):
(WebKit::mouseButtonForEvent):
(WebKit::WebEventFactory::toNSButtonNumber):
* Source/WebKit/Shared/win/WebEventFactory.cpp:
(WebKit::clickCount):
(WebKit::WebEventFactory::createWebMouseEvent):
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp:
(toWebKitMouseButton):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(MotionEvent::MotionEvent):
(webkitWebViewBaseSynthesizeMouseEvent):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::automationMouseButtonToPlatformMouseButton):
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMouseEvent):
(WebKit::WebPageProxy::processNextQueuedMouseEvent):
(WebKit::WebPageProxy::didReceiveEvent):
* Source/WebKit/UIProcess/gtk/PointerLockManager.h:
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseInteraction createMouseEventWithType:wasCancelled:]):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMMouseEvent.cpp:
(webkit_dom_mouse_event_init_mouse_event):
(webkit_dom_mouse_event_get_button):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::getEventTypeFromWebEvent):
(WebKit::PDFPlugin::handleMouseEvent):
(WebKit::PDFPlugin::showContextMenuAtPoint):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::isContextClick):
(WebKit::WebFrame::handleMouseEvent):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::navigateToPDFLinkWithSimulatedClick):
(WebKit::WebPage::contextMenuAtPointInWindow):
(WebKit::WebPage::mouseEvent):
(WebKit::WebPage::dragEnded):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::dispatchSyntheticMouseMove):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::requestAdditionalItemsForDragSession):
(WebKit::WebPage::inspectorNodeSearchMovedToPosition):
(WebKit::WebPage::dispatchSyntheticMouseEventsForSelectionGesture):
* Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm:
(-[WebPDFViewPlaceholder simulateClickOnLinkToURL:]):
* Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm:
(-[DOMMouseEvent button]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::actionDictionary const):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _dragSourceEndedAt:operation:]):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView PDFViewWillClickOnLink:withURL:]):
* Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268053@main">https://commits.webkit.org/268053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b78e09b800bc3ca0976505b157d6ecc972f359c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18527 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17329 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19205 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21259 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23352 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14956 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16729 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4404 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->