### PR TITLE
REGRESSION (265576@main): Wrong paint order of positioned and in-flow content inside overflow:scroll

### DIFF
--- a/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 7
+      (children 8
         (GraphicsLayer
           (position 23.00 105.00)
           (bounds 402.00 352.00)
@@ -21,7 +21,6 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 385.00 832.00)
-                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (position 20.00 110.00)
@@ -58,6 +57,22 @@
                       )
                     )
                   )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 24.00 106.00)
+          (bounds 385.00 350.00)
+          (clips 1)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 80.00)
+                  (contentsOpaque 1)
                 )
               )
             )

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/absolute-in-nested-scroller-paint-order-expected.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/absolute-in-nested-scroller-paint-order-expected.html
@@ -1,0 +1,41 @@
+<html>
+  <head>
+    <style>
+      .page {
+        position: absolute;
+        margin: 20px;
+        height: 400px;
+        width: 400px;
+      }
+
+      .container {
+        height: 100%;
+        width: 100%;
+        overflow: auto;
+      }
+
+      .header {
+        position: absolute;
+        top: 0;
+        background: green;
+        height: 50px;
+        width: 100%;
+      }
+
+      .content {
+        height: 2000px;
+        padding-top: 50px;
+        background: silver;
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="container">
+        <div class="header"></div>
+        <div class="content">You should see a green header above</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/absolute-in-nested-scroller-paint-order.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/absolute-in-nested-scroller-paint-order.html
@@ -1,0 +1,42 @@
+<html>
+  <head>
+    <style>
+      .page {
+        position: absolute;
+        margin: 20px;
+        height: 400px;
+        width: 400px;
+        overflow: auto;
+      }
+
+      .container {
+        height: 100%;
+        width: 100%;
+        overflow: auto;
+      }
+
+      .header {
+        position: absolute;
+        top: 0;
+        background: green;
+        height: 50px;
+        width: 100%;
+      }
+
+      .content {
+        height: 2000px;
+        padding-top: 50px;
+        background: silver;
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="container">
+        <div class="header"></div>
+        <div class="content">You should see a green header above</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
@@ -1,0 +1,137 @@
+ 
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 784.00 422.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 767.00 405.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 767.00 842.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 10.00 130.00)
+                      (bounds 302.00 202.00)
+                      (drawsContent 1)
+                      (children 2
+                        (GraphicsLayer
+                          (offsetFromRenderer width=1 height=1)
+                          (position 1.00 1.00)
+                          (bounds 285.00 185.00)
+                          (children 1
+                            (GraphicsLayer
+                              (offsetFromRenderer width=1 height=1)
+                              (anchor 0.00 0.00)
+                              (bounds 285.00 620.00)
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (position 1.00 1.00)
+                          (bounds 300.00 200.00)
+                          (children 3
+                            (GraphicsLayer
+                              (position 0.00 185.00)
+                              (bounds 285.00 15.00)
+                              (drawsContent 1)
+                            )
+                            (GraphicsLayer
+                              (position 285.00 0.00)
+                              (bounds 15.00 185.00)
+                              (drawsContent 1)
+                            )
+                            (GraphicsLayer
+                              (position 285.00 185.00)
+                              (bounds 15.00 15.00)
+                              (drawsContent 1)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 767.00 405.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 20.00 20.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 767.00 405.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 11.00 131.00)
+                  (bounds 285.00 185.00)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 10.00)
+                          (bounds 100.00 100.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 782.00 420.00)
+          (children 3
+            (GraphicsLayer
+              (position 0.00 405.00)
+              (bounds 767.00 15.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 767.00 0.00)
+              (bounds 15.00 405.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 767.00 405.00)
+              (bounds 15.00 15.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .container {
+            border: 1px solid gray;
+            overflow: scroll;
+            padding: 10px;
+            height: 400px;
+        }
+        
+        .scroller {
+            width: 300px;
+            height: 200px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+        
+        .relative {
+            position: relative;
+        }
+        
+        .spacer {
+            height: 500px;
+        }
+        
+        .box {
+            margin: 10px;
+            width: 100px;
+            height: 100px;
+            background-color: silver;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        window.addEventListener('load', () => {
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="container">
+        <div class="outside relative box">&nbsp;</div>
+
+        <div class="scroller">
+            <div class="relative box"></div>
+            <div class="spacer"></div>
+        </div>
+        <div class="spacer"></div>
+    </div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
@@ -1,0 +1,123 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 6
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 302.00 202.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 285.00 185.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 285.00 620.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 200.00)
+          (bounds 302.00 202.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 285.00 185.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 285.00 620.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 285.00 185.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 300.00 200.00)
+          (children 3
+            (GraphicsLayer
+              (position 0.00 185.00)
+              (bounds 285.00 15.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 285.00 0.00)
+              (bounds 15.00 185.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 285.00 185.00)
+              (bounds 15.00 15.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 201.00)
+          (bounds 285.00 185.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 201.00)
+          (bounds 300.00 200.00)
+          (children 3
+            (GraphicsLayer
+              (position 0.00 185.00)
+              (bounds 285.00 15.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 285.00 0.00)
+              (bounds 15.00 185.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 285.00 185.00)
+              (bounds 15.00 15.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 300px;
+            height: 200px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+        
+        .second.scroller {
+            margin-top: -10px;
+        }
+        
+        .relative {
+            position: relative;
+        }
+        
+        .spacer {
+            height: 500px;
+        }
+        
+        .box {
+            margin: 10px;
+            width: 100px;
+            height: 100px;
+            background-color: silver;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        window.addEventListener('load', () => {
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="relative box"></div>
+        <div class="spacer"></div>
+    </div>
+    <div class="second scroller">
+        <div class="relative box"></div>
+        <div class="spacer"></div>
+    </div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 6
+      (children 7
         (GraphicsLayer
           (position 23.00 105.00)
           (bounds 402.00 352.00)
@@ -21,7 +21,6 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 400.00 832.00)
-                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (position 20.00 110.00)
@@ -46,6 +45,22 @@
                       )
                     )
                   )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 24.00 106.00)
+          (bounds 400.00 350.00)
+          (clips 1)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 80.00)
+                  (contentsOpaque 1)
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
@@ -1,0 +1,95 @@
+ 
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 784.00 422.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 782.00 420.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 782.00 842.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 10.00 130.00)
+                      (bounds 302.00 202.00)
+                      (drawsContent 1)
+                      (children 1
+                        (GraphicsLayer
+                          (offsetFromRenderer width=1 height=1)
+                          (position 1.00 1.00)
+                          (bounds 300.00 200.00)
+                          (children 1
+                            (GraphicsLayer
+                              (offsetFromRenderer width=1 height=1)
+                              (anchor 0.00 0.00)
+                              (bounds 300.00 620.00)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 782.00 420.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 20.00 20.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 782.00 420.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 11.00 131.00)
+                  (bounds 300.00 200.00)
+                  (children 1
+                    (GraphicsLayer
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 10.00)
+                          (bounds 100.00 100.00)
+                          (contentsOpaque 1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
@@ -1,0 +1,81 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 302.00 202.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 300.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 620.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 200.00)
+          (bounds 302.00 202.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 300.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 620.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 9.00)
+          (bounds 300.00 200.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 201.00)
+          (bounds 300.00 200.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (bounds 100.00 100.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
#### 416e2026cb6c5117a75c93627cc0634a2634a38f
<pre>
REGRESSION (265576@main): Wrong paint order of positioned and in-flow content inside overflow:scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=261302">https://bugs.webkit.org/show_bug.cgi?id=261302</a>
rdar://115144982

Reviewed by Antti Koivisto.

Backing sharing is used to reduce memory use by allowing multiple RenderLayers (normally siblings)
which share the same stacking context ancestor to render into the same compositing layer. This has
to be done in a way that preserves back-to-front paint order. The common case where this kicks in is
a non-stacking context overflow:scroll with position:relative descendants.

265576@main added support for multiple backing sharing providers, but in a way that broke certain
configurations, particularly with nested scrollers; the specific bug here was that we computed that
the abspos &quot;header&quot; element could share backing with the parent scroller, but that had it painting
behind the child scroller.

Getting backing sharing correct with overlapping and nested scrollers is hard, so this patch limits
multiple backing sharing providers to non-overlapping overflow scrollers only (which still fixes
walmart.com, the target of the original fix). A long comment was added to explain the complexities
of these configurations.

Additional cleanup fixes: &quot;continueBackingSharingSequence&quot; is renamed to
&quot;addBackingSharingCandidate&quot;, and &quot;canUseMultipleProviders&quot; to &quot;isAdditionalProviderCandidate&quot;. The
fix is to return false from &quot;isAdditionalProviderCandidate&quot; when things overlap.

* LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/absolute-in-nested-scroller-paint-order-expected.html: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/absolute-in-nested-scroller-paint-order.html: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt: Copied from LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt.
* LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing.html: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing.html: Added.
* LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt: Added.
* LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::firstProviderCandidateLayer const):
(WebCore::RenderLayerCompositor::BackingSharingState::startBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate):
(WebCore::RenderLayerCompositor::BackingSharingState::endBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):
(WebCore::RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate const):
(WebCore::RenderLayerCompositor::BackingSharingState::updateBeforeDescendantTraversal):
(WebCore::RenderLayerCompositor::BackingSharingState::updateAfterDescendantTraversal):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::BackingSharingState::continueBackingSharingSequence): Deleted.
(WebCore::RenderLayerCompositor::BackingSharingState::canUseMultipleProviders const): Deleted.

Canonical link: <a href="https://commits.webkit.org/268028@main">https://commits.webkit.org/268028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aab655e44e03868f62499fb9bed3171f86f4a6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19114 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21094 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16010 "6 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23240 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21127 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14848 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4383 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->