### PR TITLE
Use more smart pointers in the HTML parsing code

### DIFF
--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -129,16 +129,16 @@ static inline bool causesFosterParenting(const HTMLStackItem& item)
 
 static inline void insert(HTMLConstructionSiteTask& task)
 {
-    if (is<HTMLTemplateElement>(*task.parent)) {
-        task.parent = &downcast<HTMLTemplateElement>(*task.parent).fragmentForInsertion();
+    if (auto templateElement = dynamicDowncast<HTMLTemplateElement>(task.parent)) {
+        task.parent = &templateElement->fragmentForInsertion();
         task.nextChild = nullptr;
     }
 
     ASSERT(!task.child->parentNode());
     if (task.nextChild)
-        task.parent->parserInsertBefore(*task.child, *task.nextChild);
+        task.parent->parserInsertBefore(task.protectedNonNullChild(), task.protectedNonNullNextChild());
     else
-        task.parent->parserAppendChild(*task.child);
+        task.parent->parserAppendChild(task.protectedNonNullChild());
 }
 
 static inline void executeInsertTask(HTMLConstructionSiteTask& task)
@@ -164,7 +164,7 @@ static inline void executeReparentTask(HTMLConstructionSiteTask& task)
     if (task.child->parentNode() || task.child->contains(task.parent.get()))
         return;
 
-    task.parent->parserAppendChild(*task.child);
+    task.parent->parserAppendChild(task.protectedNonNullChild());
 }
 
 static inline void executeInsertAlreadyParsedChildTask(HTMLConstructionSiteTask& task)
@@ -192,7 +192,7 @@ static inline void executeTakeAllChildrenAndReparentTask(HTMLConstructionSiteTas
     task.parent->takeAllChildrenFrom(furthestBlock.get());
 
     RELEASE_ASSERT(!task.parent->parentNode());
-    furthestBlock->parserAppendChild(*task.parent);
+    furthestBlock->parserAppendChild(task.protectedNonNullParent());
 }
 
 static inline void executeTask(HTMLConstructionSiteTask& task)
@@ -215,7 +215,7 @@ static inline void executeTask(HTMLConstructionSiteTask& task)
     ASSERT_NOT_REACHED();
 }
 
-void HTMLConstructionSite::attachLater(ContainerNode& parent, Ref<Node>&& child, bool selfClosing)
+void HTMLConstructionSite::attachLater(Ref<ContainerNode>&& parent, Ref<Node>&& child, bool selfClosing)
 {
     ASSERT(scriptingContentIsAllowed(m_parserContentPolicy) || !is<Element>(child) || !isScriptElement(downcast<Element>(child.get())));
     ASSERT(pluginContentIsAllowed(m_parserContentPolicy) || !child->isPluginElement());
@@ -226,7 +226,7 @@ void HTMLConstructionSite::attachLater(ContainerNode& parent, Ref<Node>&& child,
     }
 
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::Insert);
-    task.parent = &parent;
+    task.parent = WTFMove(parent);
     task.child = WTFMove(child);
     task.selfClosing = selfClosing;
 
@@ -262,7 +262,7 @@ HTMLConstructionSite::HTMLConstructionSite(Document& document, OptionSet<ParserC
     , m_maximumDOMTreeDepth(maximumDOMTreeDepth)
     , m_inQuirksMode(document.inQuirksMode())
 {
-    ASSERT(m_document.isHTMLDocument() || m_document.isXHTMLDocument());
+    ASSERT(document.isHTMLDocument() || document.isXHTMLDocument());
 }
 
 HTMLConstructionSite::HTMLConstructionSite(DocumentFragment& fragment, OptionSet<ParserContentPolicy> parserContentPolicy, unsigned maximumDOMTreeDepth)
@@ -274,10 +274,20 @@ HTMLConstructionSite::HTMLConstructionSite(DocumentFragment& fragment, OptionSet
     , m_maximumDOMTreeDepth(maximumDOMTreeDepth)
     , m_inQuirksMode(fragment.document().inQuirksMode())
 {
-    ASSERT(m_document.isHTMLDocument() || m_document.isXHTMLDocument());
+    ASSERT(document().isHTMLDocument() || document().isXHTMLDocument());
 }
 
 HTMLConstructionSite::~HTMLConstructionSite() = default;
+
+Ref<Document> HTMLConstructionSite::protectedDocument() const
+{
+    return m_document.get();
+}
+
+Ref<ContainerNode> HTMLConstructionSite::protectedAttachmentRoot() const
+{
+    return m_attachmentRoot.get();
+}
 
 void HTMLConstructionSite::setForm(HTMLFormElement* form)
 {
@@ -296,15 +306,15 @@ void HTMLConstructionSite::dispatchDocumentElementAvailableIfNeeded()
     if (m_isParsingFragment)
         return;
 
-    if (RefPtr frame = m_document.frame())
+    if (RefPtr frame = document().frame())
         frame->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 }
 
 void HTMLConstructionSite::insertHTMLHtmlStartTagBeforeHTML(AtomHTMLToken&& token)
 {
-    auto element = HTMLHtmlElement::create(m_document);
+    auto element = HTMLHtmlElement::create(protectedDocument());
     setAttributes(element, token, m_parserContentPolicy);
-    attachLater(m_attachmentRoot, element.copyRef());
+    attachLater(protectedAttachmentRoot(), element.copyRef());
     m_openElements.pushHTMLHtmlElement(HTMLStackItem(element.copyRef(), WTFMove(token)));
 
     executeQueuedTasks();
@@ -340,7 +350,7 @@ void HTMLConstructionSite::setDefaultCompatibilityMode()
 {
     if (m_isParsingFragment)
         return;
-    if (m_document.isSrcdocDocument())
+    if (document().isSrcdocDocument())
         return;
     setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
 }
@@ -348,7 +358,7 @@ void HTMLConstructionSite::setDefaultCompatibilityMode()
 void HTMLConstructionSite::setCompatibilityMode(DocumentCompatibilityMode mode)
 {
     m_inQuirksMode = (mode == DocumentCompatibilityMode::QuirksMode);
-    m_document.setCompatibilityMode(mode);
+    protectedDocument()->setCompatibilityMode(mode);
 }
 
 void HTMLConstructionSite::setCompatibilityModeFromDoctype(const AtomString& name, const String& publicId, const String& systemId)
@@ -360,7 +370,7 @@ void HTMLConstructionSite::setCompatibilityModeFromDoctype(const AtomString& nam
     // No Quirks - no quirks apply. Web pages will obey the specifications to the letter.
 
     bool isNameHTML = name == HTMLNames::htmlTag->localName();
-    if (LIKELY((isNameHTML && publicId.isEmpty() && systemId.isEmpty()) || m_document.isSrcdocDocument())) {
+    if (LIKELY((isNameHTML && publicId.isEmpty() && systemId.isEmpty()) || document().isSrcdocDocument())) {
         setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
         return;
     }
@@ -447,7 +457,7 @@ void HTMLConstructionSite::setCompatibilityModeFromDoctype(const AtomString& nam
 
 void HTMLConstructionSite::finishedParsing()
 {
-    m_document.finishedParsing();
+    protectedDocument()->finishedParsing();
 }
 
 void HTMLConstructionSite::insertDoctype(AtomHTMLToken&& token)
@@ -457,7 +467,8 @@ void HTMLConstructionSite::insertDoctype(AtomHTMLToken&& token)
     String publicId = token.publicIdentifier();
     String systemId = token.systemIdentifier();
 
-    attachLater(m_attachmentRoot, DocumentType::create(m_document, token.name(), publicId, systemId));
+    auto document = protectedDocument();
+    attachLater(protectedAttachmentRoot(), DocumentType::create(document, token.name(), publicId, systemId));
 
     // DOCTYPE nodes are only processed when parsing fragments w/o contextElements, which
     // never occurs.  However, if we ever chose to support such, this code is subtly wrong,
@@ -468,7 +479,7 @@ void HTMLConstructionSite::insertDoctype(AtomHTMLToken&& token)
     if (m_isParsingFragment)
         return;
 
-    if (token.forceQuirks() && !m_document.isSrcdocDocument())
+    if (token.forceQuirks() && !document->isSrcdocDocument())
         setCompatibilityMode(DocumentCompatibilityMode::QuirksMode);
     else
         setCompatibilityModeFromDoctype(token.name(), publicId, systemId);
@@ -477,27 +488,28 @@ void HTMLConstructionSite::insertDoctype(AtomHTMLToken&& token)
 void HTMLConstructionSite::insertComment(AtomHTMLToken&& token)
 {
     ASSERT(token.type() == HTMLToken::Type::Comment);
-    attachLater(currentNode(), Comment::create(ownerDocumentForCurrentNode(), WTFMove(token.comment())));
+    attachLater(protectedCurrentNode(), Comment::create(protectedOwnerDocumentForCurrentNode(), WTFMove(token.comment())));
 }
 
 void HTMLConstructionSite::insertCommentOnDocument(AtomHTMLToken&& token)
 {
     ASSERT(token.type() == HTMLToken::Type::Comment);
-    attachLater(m_attachmentRoot, Comment::create(m_document, WTFMove(token.comment())));
+    attachLater(protectedAttachmentRoot(), Comment::create(protectedDocument(), WTFMove(token.comment())));
 }
 
 void HTMLConstructionSite::insertCommentOnHTMLHtmlElement(AtomHTMLToken&& token)
 {
     ASSERT(token.type() == HTMLToken::Type::Comment);
-    ContainerNode& parent = m_openElements.rootNode();
-    attachLater(parent, Comment::create(parent.document(), WTFMove(token.comment())));
+    Ref parent = m_openElements.rootNode();
+    Ref parentDocument = parent->document();
+    attachLater(WTFMove(parent), Comment::create(parentDocument, WTFMove(token.comment())));
 }
 
 void HTMLConstructionSite::insertHTMLHeadElement(AtomHTMLToken&& token)
 {
     ASSERT(!shouldFosterParent());
     m_head = HTMLStackItem(createHTMLElement(token), WTFMove(token));
-    attachLater(currentNode(), m_head.element());
+    attachLater(protectedCurrentNode(), m_head.element());
     m_openElements.pushHTMLHeadElement(HTMLStackItem(m_head));
 }
 
@@ -505,32 +517,31 @@ void HTMLConstructionSite::insertHTMLBodyElement(AtomHTMLToken&& token)
 {
     ASSERT(!shouldFosterParent());
     auto body = createHTMLElement(token);
-    attachLater(currentNode(), body.copyRef());
+    attachLater(protectedCurrentNode(), body.copyRef());
     m_openElements.pushHTMLBodyElement(HTMLStackItem(WTFMove(body), WTFMove(token)));
 }
 
 void HTMLConstructionSite::insertHTMLFormElement(AtomHTMLToken&& token)
 {
-    auto element = createHTMLElement(token);
-    auto& formElement = downcast<HTMLFormElement>(element.get());
+    auto formElement = downcast<HTMLFormElement>(createHTMLElement(token));
     // If there is no template element on the stack of open elements, set the
     // form element pointer to point to the element created.
     if (!openElements().hasTemplateInHTMLScope())
-        m_form = &formElement;
-    attachLater(currentNode(), formElement);
-    m_openElements.push(HTMLStackItem(formElement, WTFMove(token)));
+        m_form = formElement.ptr();
+    attachLater(protectedCurrentNode(), formElement.copyRef());
+    m_openElements.push(HTMLStackItem(WTFMove(formElement), WTFMove(token)));
 }
 
 void HTMLConstructionSite::insertHTMLElement(AtomHTMLToken&& token)
 {
     auto element = createHTMLElement(token);
-    attachLater(currentNode(), element.copyRef());
+    attachLater(protectedCurrentNode(), element.copyRef());
     m_openElements.push(HTMLStackItem(WTFMove(element), WTFMove(token)));
 }
 
 void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
 {
-    if (m_document.settings().declarativeShadowDOMEnabled() && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM)) {
+    if (document().settings().declarativeShadowDOMEnabled() && m_parserContentPolicy.contains(ParserContentPolicy::AllowDeclarativeShadowDOM)) {
         std::optional<ShadowRootMode> mode;
         bool delegatesFocus = false;
         for (auto& attribute : token.attributes()) {
@@ -563,7 +574,7 @@ std::unique_ptr<CustomElementConstructionData> HTMLConstructionSite::insertHTMLE
     auto element = createHTMLElementOrFindCustomElementInterface(token, &elementInterface);
     if (UNLIKELY(elementInterface))
         return makeUnique<CustomElementConstructionData>(*elementInterface, token.name(), WTFMove(token.attributes()));
-    attachLater(currentNode(), *element);
+    attachLater(protectedCurrentNode(), *element);
     m_openElements.push(HTMLStackItem(element.releaseNonNull(), WTFMove(token)));
     return nullptr;
 }
@@ -571,7 +582,7 @@ std::unique_ptr<CustomElementConstructionData> HTMLConstructionSite::insertHTMLE
 void HTMLConstructionSite::insertCustomElement(Ref<Element>&& element, Vector<Attribute>&& attributes)
 {
     setAttributes(element, attributes, HasDuplicateAttribute::No, m_parserContentPolicy);
-    attachLater(currentNode(), element.copyRef());
+    attachLater(protectedCurrentNode(), element.copyRef());
     m_openElements.push(HTMLStackItem(WTFMove(element), WTFMove(attributes)));
     executeQueuedTasks();
 }
@@ -582,7 +593,7 @@ void HTMLConstructionSite::insertSelfClosingHTMLElement(AtomHTMLToken&& token)
     // Normally HTMLElementStack is responsible for calling finishParsingChildren,
     // but self-closing elements are never in the element stack so the stack
     // doesn't get a chance to tell them that we're done parsing their children.
-    attachLater(currentNode(), createHTMLElement(token), true);
+    attachLater(protectedCurrentNode(), createHTMLElement(token), true);
     // FIXME: Do we want to acknowledge the token's self-closing flag?
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/tokenization.html#acknowledge-self-closing-flag
 }
@@ -609,7 +620,7 @@ void HTMLConstructionSite::insertScriptElement(AtomHTMLToken&& token)
     auto element = HTMLScriptElement::create(scriptTag, ownerDocumentForCurrentNode(), parserInserted, alreadyStarted);
     setAttributes(element, token, m_parserContentPolicy);
     if (scriptingContentIsAllowed(m_parserContentPolicy))
-        attachLater(currentNode(), element.copyRef());
+        attachLater(protectedCurrentNode(), element.copyRef());
     m_openElements.push(HTMLStackItem(WTFMove(element), WTFMove(token)));
 }
 
@@ -620,7 +631,7 @@ void HTMLConstructionSite::insertForeignElement(AtomHTMLToken&& token, const Ato
 
     auto element = createElement(token, namespaceURI);
     if (scriptingContentIsAllowed(m_parserContentPolicy) || !isScriptElement(element.get()))
-        attachLater(currentNode(), element.copyRef(), token.selfClosing());
+        attachLater(protectedCurrentNode(), element.copyRef(), token.selfClosing());
     if (!token.selfClosing())
         m_openElements.push(HTMLStackItem(WTFMove(element), WTFMove(token)));
 }
@@ -865,7 +876,7 @@ void HTMLConstructionSite::reconstructTheActiveFormattingElements()
         auto& unopenedEntry = m_activeFormattingElements.at(unopenEntryIndex);
         ASSERT(!unopenedEntry.stackItem().isNull());
         auto reconstructed = createElementFromSavedToken(unopenedEntry.stackItem());
-        attachLater(currentNode(), reconstructed.node());
+        attachLater(protectedCurrentNode(), reconstructed.node());
         m_openElements.push(HTMLStackItem(reconstructed));
         unopenedEntry.replaceElement(WTFMove(reconstructed));
     }

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -326,7 +326,7 @@ void HTMLDocumentParser::pumpTokenizer(SynchronousMode mode)
             m_preloadScanner = makeUnique<HTMLPreloadScanner>(m_options, document()->url(), document()->deviceScaleFactor());
             m_preloadScanner->appendToEnd(m_input.current());
         }
-        m_preloadScanner->scan(*m_preloader, *document());
+        m_preloadScanner->scan(*m_preloader, Ref { *document() });
     }
     // The viewport definition is known here, so we can load link preloads with media attributes.
     if (document()->loader())

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -57,6 +57,7 @@
 #include "QualifiedName.h"
 #include "Settings.h"
 #include <span>
+#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringParsingBuffer.h>
@@ -227,8 +228,8 @@ public:
     HTMLFastPathResult parseResult() const { return m_parseResult; }
 
 private:
-    Document& m_document;
-    ContainerNode& m_destinationParent;
+    CheckedRef<Document> m_document;
+    CheckedRef<ContainerNode> m_destinationParent;
 
     StringParsingBuffer<CharacterType> m_parsingBuffer;
 
@@ -462,7 +463,7 @@ private:
 
     template<typename ParentTag> void parseCompleteInput()
     {
-        parseChildren<ParentTag>(m_destinationParent);
+        parseChildren<ParentTag>(m_destinationParent.get());
         if (m_parsingBuffer.hasCharactersRemaining())
             didFail(HTMLFastPathResult::FailedDidntReachEndOfInput);
     }
@@ -685,7 +686,7 @@ private:
                 return;
 
             if (!text.isNull())
-                parent.parserAppendChild(Text::create(m_document, WTFMove(text)));
+                parent.parserAppendChild(Text::create(m_document.get(), WTFMove(text)));
 
             if (m_parsingBuffer.atEnd())
                 return;
@@ -827,9 +828,9 @@ private:
     template<typename Tag> Ref<typename Tag::HTMLElementClass> parseElementAfterTagName()
     {
         if constexpr (Tag::isVoid)
-            return parseVoidElement(Tag::create(m_document));
+            return parseVoidElement(Tag::create(m_document.get()));
         else
-            return parseContainerElement<Tag>(Tag::create(m_document));
+            return parseContainerElement<Tag>(Tag::create(m_document.get()));
     }
 
     template<typename Tag> Ref<typename Tag::HTMLElementClass> parseContainerElement(Ref<typename Tag::HTMLElementClass>&& element)

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -52,6 +52,7 @@ public:
         ~ElementRecord();
 
         Element& element() const { return m_item.element(); }
+        Ref<Element> protectedElement() const { return m_item.element(); }
         ContainerNode& node() const { return m_item.node(); }
         ElementName elementName() const { return m_item.elementName(); }
         HTMLStackItem& stackItem() { return m_item; }

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
@@ -75,12 +75,12 @@ auto HTMLFormattingElementList::bookmarkFor(Element& element) -> Bookmark
     return Bookmark(at(index));
 }
 
-void HTMLFormattingElementList::swapTo(Element& oldElement, HTMLStackItem&& newItem, const Bookmark& bookmark)
+void HTMLFormattingElementList::swapTo(Ref<Element> oldElement, HTMLStackItem&& newItem, const Bookmark& bookmark)
 {
     ASSERT(contains(oldElement));
     ASSERT(!contains(newItem.element()));
     if (!bookmark.hasBeenMoved()) {
-        ASSERT(&bookmark.mark().element() == &oldElement);
+        ASSERT(&bookmark.mark().element() == oldElement.ptr());
         bookmark.mark().replaceElement(WTFMove(newItem));
         return;
     }
@@ -208,7 +208,7 @@ void HTMLFormattingElementList::ensureNoahsArkCondition(HTMLStackItem& newItem)
     // however, that we will spin the loop more than once because of how the
     // formatting element list gets permuted.
     for (size_t i = kNoahsArkCapacity - 1; i < candidates.size(); ++i)
-        remove(candidates[i]->element());
+        remove(candidates[i]->protectedElement());
 }
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.h
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.h
@@ -108,7 +108,7 @@ public:
     void removeUpdatingBookmark(Element&, Bookmark&);
 
     Bookmark bookmarkFor(Element&);
-    void swapTo(Element& oldElement, HTMLStackItem&& newItem, const Bookmark&);
+    void swapTo(Ref<Element> oldElement, HTMLStackItem&& newItem, const Bookmark&);
 
     void appendMarker();
     // clearToLastMarker also clears the marker (per the HTML5 spec).

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -82,14 +82,15 @@ void HTMLResourcePreloader::preload(PreloadRequestStream requests)
 
 void HTMLResourcePreloader::preload(std::unique_ptr<PreloadRequest> preload)
 {
-    ASSERT(m_document.frame());
-    ASSERT(m_document.renderView());
+    Ref document = protectedDocument();
+    ASSERT(document->frame());
+    ASSERT(document->renderView());
 
-    auto queries = MQ::MediaQueryParser::parse(preload->media(), { m_document });
-    if (!MQ::MediaQueryEvaluator { screenAtom(), m_document, m_document.renderStyle() }.evaluate(queries))
+    auto queries = MQ::MediaQueryParser::parse(preload->media(), { document.get() });
+    if (!MQ::MediaQueryEvaluator { screenAtom(), document, document->renderStyle() }.evaluate(queries))
         return;
 
-    m_document.cachedResourceLoader().preload(preload->resourceType(), preload->resourceRequest(m_document));
+    document->cachedResourceLoader().preload(preload->resourceType(), preload->resourceRequest(document));
 }
 
 }

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -28,6 +28,7 @@
 #include "CachedResource.h"
 #include "CachedResourceRequest.h"
 #include "ScriptType.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -87,7 +88,9 @@ public:
     void preload(std::unique_ptr<PreloadRequest>);
 
 private:
-    Document& m_document;
+    Ref<Document> protectedDocument() const { return m_document.get(); }
+
+    CheckedRef<Document> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLStackItem.h
+++ b/Source/WebCore/html/parser/HTMLStackItem.h
@@ -53,6 +53,7 @@ public:
 
     ContainerNode& node() const { return *m_node; }
     Element& element() const { return downcast<Element>(node()); }
+    Ref<Element> protectedElement() const { return element(); }
     Element* elementOrNull() const { return downcast<Element>(m_node.get()); }
 
     const AtomString& localName() const { return isElement() ? element().localName() : nullAtom(); }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1643,7 +1643,7 @@ void HTMLTreeBuilder::callTheAdoptionAgency(AtomHTMLToken& token)
             // 4.13.5.
             auto* nodeEntry = m_tree.activeFormattingElements().find(node->element());
             if (!nodeEntry) {
-                m_tree.openElements().remove(node->element());
+                m_tree.openElements().remove(node->protectedElement());
                 node = nullptr;
                 continue;
             }


### PR DESCRIPTION
#### 49c1df2a930925b51ca1d41734345aa4dbc5bf78
<pre>
Use more smart pointers in the HTML parsing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=261589">https://bugs.webkit.org/show_bug.cgi?id=261589</a>

Reviewed by Brent Fulgham.

* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::insert):
(WebCore::executeReparentTask):
(WebCore::executeTakeAllChildrenAndReparentTask):
(WebCore::HTMLConstructionSite::attachLater):
(WebCore::HTMLConstructionSite::HTMLConstructionSite):
(WebCore::HTMLConstructionSite::protectedDocument const):
(WebCore::HTMLConstructionSite::protectedAttachmentRoot const):
(WebCore::HTMLConstructionSite::dispatchDocumentElementAvailableIfNeeded):
(WebCore::HTMLConstructionSite::insertHTMLHtmlStartTagBeforeHTML):
(WebCore::HTMLConstructionSite::setDefaultCompatibilityMode):
(WebCore::HTMLConstructionSite::setCompatibilityMode):
(WebCore::HTMLConstructionSite::setCompatibilityModeFromDoctype):
(WebCore::HTMLConstructionSite::finishedParsing):
(WebCore::HTMLConstructionSite::insertDoctype):
(WebCore::HTMLConstructionSite::insertComment):
(WebCore::HTMLConstructionSite::insertCommentOnDocument):
(WebCore::HTMLConstructionSite::insertCommentOnHTMLHtmlElement):
(WebCore::HTMLConstructionSite::insertHTMLHeadElement):
(WebCore::HTMLConstructionSite::insertHTMLBodyElement):
(WebCore::HTMLConstructionSite::insertHTMLFormElement):
(WebCore::HTMLConstructionSite::insertHTMLElement):
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement):
(WebCore::HTMLConstructionSite::insertHTMLElementOrFindCustomElementInterface):
(WebCore::HTMLConstructionSite::insertCustomElement):
(WebCore::HTMLConstructionSite::insertSelfClosingHTMLElement):
(WebCore::HTMLConstructionSite::insertScriptElement):
(WebCore::HTMLConstructionSite::insertForeignElement):
(WebCore::HTMLConstructionSite::reconstructTheActiveFormattingElements):
* Source/WebCore/html/parser/HTMLConstructionSite.h:
(WebCore::HTMLConstructionSite::protectedCurrentNode const):
(WebCore::HTMLConstructionSite::isTelephoneNumberParsingEnabled):
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::pumpTokenizer):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseCompleteInput):
(WebCore::HTMLFastPathParser::parseChildren):
(WebCore::HTMLFastPathParser::parseElementAfterTagName):
* Source/WebCore/html/parser/HTMLFormattingElementList.cpp:
(WebCore::HTMLFormattingElementList::swapTo):
(WebCore::HTMLFormattingElementList::ensureNoahsArkCondition):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
(WebCore::TokenPreloadScanner::StartTagScanner::createPreloadRequest):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::resourceType const):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::HTMLResourcePreloader::preload):
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::callTheAdoptionAgency):

Canonical link: <a href="https://commits.webkit.org/268278@main">https://commits.webkit.org/268278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7fd0f6334019aa0c698f7e5ea66590366b4c9ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19547 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21778 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23736 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15370 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17174 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4593 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->