### PR TITLE
jquery/attributes.html is flaky fail with StreamClientConnection  ASSERTION FAILED: !m_connection->isValid()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5285,6 +5285,9 @@ imported/w3c/web-platform-tests/css/motion/offset-path-shape-xywh-003.html [ Ima
 # mac-only IPC test
 ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]
 
+# WebGPU settings need to be exposed through the test runner.
+ipc/restrictedendpoints/allow-access-webGPU.html [ Pass Failure ]
+
 # Restarted GPUP seems to crash.
 webkit.org/b/239959 ipc/stream-sync-crash-no-timeout.html [ Skip ]
 

--- a/LayoutTests/ipc/restrictedendpoints/allow-access-webGPU-expected.txt
+++ b/LayoutTests/ipc/restrictedendpoints/allow-access-webGPU-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: PASS: Test runner did not detect GPUP crash.
 

--- a/LayoutTests/ipc/restrictedendpoints/allow-access-webGPU.html
+++ b/LayoutTests/ipc/restrictedendpoints/allow-access-webGPU.html
@@ -1,63 +1,67 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true WebGPUEnabled=true ] -->
-<title>Test that instantiating a remoteGPU is allowed if WebGPUEnabled</title>
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false WebGPUEnabled=true runSingly=true ] -->
+<title>Test that instantiating a remoteGPU is allowed if WebGPUEnabled=true</title>
 <script src="../../resources/ipc.js"></script>
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
 <body>
 <script>
-    if (window.IPC) {
-        function randomID() {
-            return Math.floor(Math.random() * 10000) + 1;
-        }
+testRunner.dumpAsText();
+if (window.IPC)
+    runTest();
 
-        function sleep(ms) {
-            return new Promise(resolve => setTimeout(resolve, ms));
-        }
-
-        let renderingBackendID = randomID();
-        let webgpuID = randomID();
-        let semaphore = IPC.createSemaphore();
-
-        let connectionIdentifier = IPC.createSharedMemory(0x1000);
-
-        let connectionPair = IPC.createConnectionPair();
-        let streamConnection = IPC.createStreamClientConnection(16);
-        let webgpuStreamConnection = IPC.createStreamClientConnection(16);
-
+function runTest() {
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+    let rrbStreamConnection;
+    let rrbStreamConnectionHandle;
+    let webGPUStreamConnection;
+    let webGPUStreamConnectionHandle;
+    try {
+        [rrbStreamConnection, rrbStreamConnectionHandle] = IPC.createStreamClientConnection(16);
+        let renderingBackendID = randomIPCID();
         IPC.sendMessage(
-        'GPU',
-        IPC.webPageProxyID,
-        IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name,
-        [
-            { // creationParameters
-            type: 'RemoteRenderingBackendCreationParameters',
-            identifier: renderingBackendID,
-            pageProxyID: IPC.webPageProxyID,
-            pageID: IPC.pageID,
-            },
-            { // connectionIdentifier
-            type: 'StreamServerConnectionHandle',
-            value: streamConnection[1],
-            }
-        ]
-        );
+            'GPU',
+            IPC.webPageProxyID,
+            IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name,
+            [
+                { // creationParameters
+                    type: 'RemoteRenderingBackendCreationParameters',
+                    identifier: renderingBackendID,
+                    pageProxyID: IPC.webPageProxyID,
+                    pageID: IPC.pageID,
+                },
+                {
+                    type: 'StreamServerConnectionHandle',
+                    value: rrbStreamConnectionHandle,
+                }
+            ]);
 
+        let webGPUID = randomIPCID();
+        [webGPUStreamConnection, webGPUStreamConnectionHandle] = IPC.createStreamClientConnection(16);
         var result = IPC.sendMessage(
-        'GPU',
-        IPC.webPageProxyID,
-        IPC.messages.GPUConnectionToWebProcess_CreateRemoteGPU.name,
-        [
-            { type: 'uint64_t', value: webgpuID }, // identifier
-            { type: 'uint64_t', value: renderingBackendID }, // renderingBackendIdentifier
-            { type: 'StreamServerConnectionHandle', value: streamConnection[1] }, // stream
-        ]
-        );
+            'GPU',
+            IPC.webPageProxyID,
+            IPC.messages.GPUConnectionToWebProcess_CreateRemoteGPU.name,
+            [
+                { type: 'uint64_t', value: webGPUID }, // identifier
+                { type: 'uint64_t', value: renderingBackendID }, // renderingBackendIdentifier
+                { type: 'StreamServerConnectionHandle', value: webGPUStreamConnectionHandle }, // stream
+            ]);
 
-        asyncFlush('GPU').then(() => {
-            testRunner.notifyDone();
-        });
-    } else {
-        testRunner.notifyDone();
+        const success = syncFlush('GPU');
+        if (!success)
+            console.log("FAIL: Failed to flush GPU process commands");
+        // FIXME: currently we cannot detect that GPUP crashes and test runner doesn't
+        // let the test continue if the subprocesses crash.
+        setTimeout(() => {
+            console.log("PASS: Test runner did not detect GPUP crash.");
+            if (window.testRunner)
+                testRunner.notifyDone()
+        }, 300);
+    } finally {
+        if (rrbStreamConnection)
+            rrbStreamConnection.invalidate();
+        if (webGPUStreamConnection)
+            webGPUStreamConnection.invalidate();
     }
+}
 </script>
 </body>

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-webGPU.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-webGPU.html
@@ -1,66 +1,67 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false WebGPUEnabled=false ] -->
-<title>Test that instantiating a remoteGPU is allowed if WebGPUEnabled</title>
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false WebGPUEnabled=false runSingly=true ] -->
+<title>Test that instantiating a remoteGPU is not allowed if WebGPUEnabled=false</title>
 <script src="../../resources/ipc.js"></script>
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
 <body>
 <script>
-    testRunner.dumpAsText();
+testRunner.dumpAsText();
+if (window.IPC)
+    runTest();
 
-    if (window.IPC) {
-        function randomID() {
-            return Math.floor(Math.random() * 10000) + 1;
-        }
-
-        function sleep(ms) {
-            return new Promise(resolve => setTimeout(resolve, ms));
-        }
-
-        let renderingBackendID = randomID();
-        let webgpuID = randomID();
-        let semaphore = IPC.createSemaphore();
-
-        let connectionIdentifier = IPC.createSharedMemory(0x1000);
-
-        let connectionPair = IPC.createConnectionPair();
-        let streamConnection = IPC.createStreamClientConnection(16);
-        let webgpuStreamConnection = IPC.createStreamClientConnection(16);
-        console.log("HERE")
-
+function runTest() {
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+    let rrbStreamConnection;
+    let rrbStreamConnectionHandle;
+    let webGPUStreamConnection;
+    let webGPUStreamConnectionHandle;
+    try {
+        [rrbStreamConnection, rrbStreamConnectionHandle] = IPC.createStreamClientConnection(16);
+        let renderingBackendID = randomIPCID();
         IPC.sendMessage(
-        'GPU',
-        IPC.webPageProxyID,
-        IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name,
-        [
-            { // creationParameters
-            type: 'RemoteRenderingBackendCreationParameters',
-            identifier: renderingBackendID,
-            pageProxyID: IPC.webPageProxyID,
-            pageID: IPC.pageID,
-            },
-            { // connectionIdentifier
-            type: 'StreamServerConnectionHandle',
-            value: streamConnection[1],
-            }
-        ]
-        );
+            'GPU',
+            IPC.webPageProxyID,
+            IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name,
+            [
+                { // creationParameters
+                    type: 'RemoteRenderingBackendCreationParameters',
+                    identifier: renderingBackendID,
+                    pageProxyID: IPC.webPageProxyID,
+                    pageID: IPC.pageID,
+                },
+                {
+                    type: 'StreamServerConnectionHandle',
+                    value: rrbStreamConnectionHandle,
+                }
+            ]);
 
+        let webGPUID = randomIPCID();
+        [webGPUStreamConnection, webGPUStreamConnectionHandle] = IPC.createStreamClientConnection(16);
         var result = IPC.sendMessage(
-        'GPU',
-        IPC.webPageProxyID,
-        IPC.messages.GPUConnectionToWebProcess_CreateRemoteGPU.name,
-        [
-            { type: 'uint64_t', value: webgpuID }, // identifier
-            { type: 'uint64_t', value: renderingBackendID }, // renderingBackendIdentifier
-            { type: 'StreamServerConnectionHandle', value: streamConnection[1] }, // stream
-        ]
-        );
+            'GPU',
+            IPC.webPageProxyID,
+            IPC.messages.GPUConnectionToWebProcess_CreateRemoteGPU.name,
+            [
+                { type: 'uint64_t', value: webGPUID }, // identifier
+                { type: 'uint64_t', value: renderingBackendID }, // renderingBackendIdentifier
+                { type: 'StreamServerConnectionHandle', value: webGPUStreamConnectionHandle }, // stream
+            ]);
 
-        asyncFlush('GPU').then(() => {
-            console.log("Should have crashed!");
-        });
-    } else {
-        testRunner.notifyDone();
+        syncFlush('GPU');
+        console.log("PASS: Will pass if test runner ends the test prematurely.");
+
+        // FIXME: currently we cannot detect that GPUP crashes and test runner doesn't
+        // let the test continue if the subprocesses crash.
+        setTimeout(() => {
+            console.log("FAIL: test runner should have detected GPUP crash.");
+            if (window.testRunner)
+                testRunner.notifyDone()
+        }, 1000);
+    } finally {
+        if (rrbStreamConnection)
+            rrbStreamConnection.invalidate();
+        if (webGPUStreamConnection)
+            webGPUStreamConnection.invalidate();
     }
+}
 </script>
 </body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1740,6 +1740,7 @@ webkit.org/b/258142 fast/canvas/webgl/match-page-color-space-p3.html [ ImageOnly
 webgl/webgl-via-metal-flag-on.html [ Skip ]
 webgl/webgl-via-metal-flag-off.html [ Skip ]
 webgl/webgl-backend-type.html [ Skip ]
+ipc/restrictedendpoints/allow-access-webGPU.html  [ Skip ]
 
 # Failing with ANGLE backend
 fast/canvas/webgl/draw-elements-out-of-bounds-uint-index.html [ Failure ]
@@ -3328,7 +3329,6 @@ webkit.org/b/236298 fast/text/simple-lines-text-transform.html [ ImageOnlyFailur
 webkit.org/b/236298 fast/text/strikethrough-int.html [ ImageOnlyFailure ]
 
 http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/multiple_buffers.html [ Skip ]
-
 
 # NetworkStorageSession::deleteCookies() doesn't obey partitioning for glib ports.
 http/wpt/clear-site-data/partitioning.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2530,7 +2530,7 @@ imported/w3c/web-platform-tests/geolocation-API/permission.https.html [ WontFix 
 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
 
 # IPC is for WK2
-ipc/shared-video-frame-size.html [ Skip ]
+ipc [ WontFix ]
 
 # Displays blank on WK1
 fullscreen/fullscreen-iframe-navigation.html [ Skip ]

--- a/LayoutTests/resources/ipc.js
+++ b/LayoutTests/resources/ipc.js
@@ -1,14 +1,18 @@
+function randomIPCID() {
+    return Math.floor(Math.random() * 10000) + 1;
+}
+
 function asyncFlush(processTarget) {
     if (!IPC.processTargets.includes(processTarget))
         throw Error("Invalid processTarget passed to asyncFlush")
-    return IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_AsyncPing.name, [])
+    return IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_AsyncPing.name, [{type: "uint32_t", value: 88}]);
 }
 
 function syncFlush(processTarget) {
     if (!IPC.processTargets.includes(processTarget))
         throw Error("Invalid processTarget passed to syncFlush")
-    return new Promise((resolve) => {
-        IPC.sendSyncMessage(processTarget, 0, IPC.messages.IPCTester_SyncPing.name, 1000, []);
-        resolve();
-    })
+
+    let reply = IPC.sendSyncMessage(processTarget, 0, IPC.messages.IPCTester_SyncPing.name, 1000, [{type: "uint32_t", value: 77}]);
+    const firstResult = reply.arguments[0];
+    return firstResult.type == "uint32_t" && firstResult.value == 78;
 }

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -203,14 +203,14 @@ void IPCTester::releaseConnectionTester(IPCConnectionTesterIdentifier identifier
     completionHandler();
 }
 
-void IPCTester::asyncPing(IPC::Connection&, CompletionHandler<void()>&& completionHandler)
+void IPCTester::asyncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
-    completionHandler();
+    completionHandler(value + 1);
 }
 
-void IPCTester::syncPing(IPC::Connection&, CompletionHandler<void()>&& completionHandler)
+void IPCTester::syncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
-    completionHandler();
+    completionHandler(value + 1);
 }
 
 void IPCTester::stopIfNeeded()

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -71,8 +71,8 @@ private:
     void sendSameSemaphoreBack(IPC::Connection&, IPC::Semaphore&&);
     void sendSemaphoreBackAndSignalProtocol(IPC::Connection&, IPC::Semaphore&&);
     void sendAsyncMessageToReceiver(IPC::Connection&, uint32_t);
-    void asyncPing(IPC::Connection&, CompletionHandler<void()>&&);
-    void syncPing(IPC::Connection&, CompletionHandler<void()>&&);
+    void asyncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
+    void syncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
 
     void stopIfNeeded();
 

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -34,8 +34,8 @@ messages -> IPCTester NotRefCounted {
     SendSameSemaphoreBack(IPC::Semaphore semaphore)
     SendSemaphoreBackAndSignalProtocol(IPC::Semaphore semaphore)
 
-    AsyncPing() -> ()
-    SyncPing() -> () Synchronous
+    AsyncPing(uint32_t value) -> (uint32_t nextValue)
+    SyncPing(uint32_t value) -> (uint32_t nextValue) Synchronous
 
     SendAsyncMessageToReceiver(uint32_t arg0)
 }


### PR DESCRIPTION
#### c0a9a955b480bb69772ceccfa2eca68906532e7f
<pre>
jquery/attributes.html is flaky fail with StreamClientConnection  ASSERTION FAILED: !m_connection-&gt;isValid()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261555">https://bugs.webkit.org/show_bug.cgi?id=261555</a>
rdar://115494068

Reviewed by Antti Koivisto.

Fix two tests that create StreamClientConnection instances through
the JS IPC Testing API. The connections must be invalidated
if they are created.

Both allow and deny tests are run as normal JS business as usual, even
though the test runner automatically ends the deny test when GPUP
crashes. This means that the JS GC will clean up the stream connections
during the next tests, causing unrelated tests to fail with the
assertion.

Fix the allow test to actually test what it tests, e.g. to fail if
WebGPU is disabled.

* LayoutTests/ipc/restrictedendpoints/allow-access-webGPU-expected.txt:
* LayoutTests/ipc/restrictedendpoints/allow-access-webGPU.html:
* LayoutTests/ipc/restrictedendpoints/deny-access-webGPU.html:
* LayoutTests/resources/ipc.js:
(randomID):
(asyncFlush):
(syncFlush): Deleted.
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::asyncPing):
(WebKit::IPCTester::syncPing):
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/IPCTester.messages.in:

Canonical link: <a href="https://commits.webkit.org/268086@main">https://commits.webkit.org/268086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2020a809d7a72ace1922df6eacf1976c14f323c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21378 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23433 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21331 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->