### PR TITLE
Safari tab freeze and gpu process crash when calling canvas function drawimage/getimagedata/setimagedata from high resolution getUserMedia stream with several background tabs

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -510,6 +510,9 @@ void GPUConnectionToWebProcess::lowMemoryHandler(Critical critical, Synchronous 
 {
     for (auto& remoteRenderingBackend : m_remoteRenderingBackendMap.values())
         remoteRenderingBackend->lowMemoryHandler(critical, synchronous);
+#if ENABLE(VIDEO)
+    m_videoFrameObjectHeap->lowMemoryHandler();
+#endif
 }
 
 #if ENABLE(WEB_AUDIO)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -161,7 +161,10 @@ void RemoteVideoFrameObjectHeap::convertFrameBuffer(SharedVideoFrame&& sharedVid
     destinationColorSpace = DestinationColorSpace(createCGColorSpaceForCVPixelBuffer(buffer.get()));
 
     if (CVPixelBufferGetPixelFormatType(buffer.get()) != kCVPixelFormatType_32BGRA) {
-        createPixelConformerIfNeeded();
+        Locker locker { m_pixelBufferConformerLock };
+        if (!m_pixelBufferConformer)
+            m_pixelBufferConformer = createPixelConformer().moveToUniquePtr();
+
         auto convertedBuffer = m_pixelBufferConformer->convert(buffer.get());
         if (!convertedBuffer) {
             RELEASE_LOG_ERROR(WebRTC, "RemoteVideoFrameObjectHeap::convertFrameBuffer conformer failed");
@@ -190,6 +193,14 @@ void RemoteVideoFrameObjectHeap::setSharedVideoFrameMemory(SharedMemory::Handle&
 }
 
 #endif
+
+void RemoteVideoFrameObjectHeap::lowMemoryHandler()
+{
+#if PLATFORM(COCOA)
+    Locker locker { m_pixelBufferConformerLock };
+    m_pixelBufferConformer = nullptr;
+#endif
+}
 
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -54,6 +54,7 @@ public:
     RefPtr<WebCore::VideoFrame> get(RemoteVideoFrameReadReference&&);
 
     void stopListeningForIPC(Ref<RemoteVideoFrameObjectHeap>&&) { close(); }
+    void lowMemoryHandler();
 
 private:
     explicit RemoteVideoFrameObjectHeap(Ref<IPC::Connection>&&);
@@ -70,16 +71,17 @@ private:
     void convertFrameBuffer(SharedVideoFrame&&, CompletionHandler<void(WebCore::DestinationColorSpace)>&&);
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(SharedMemory::Handle&&);
-#endif
 
-    void createPixelConformerIfNeeded();
+    UniqueRef<WebCore::PixelBufferConformerCV> createPixelConformer();
+#endif
 
     const Ref<IPC::Connection> m_connection;
     IPC::ThreadSafeObjectHeap<RemoteVideoFrameIdentifier, RefPtr<WebCore::VideoFrame>> m_heap;
 #if PLATFORM(COCOA)
     SharedVideoFrameWriter m_sharedVideoFrameWriter;
     SharedVideoFrameReader m_sharedVideoFrameReader;
-    std::unique_ptr<WebCore::PixelBufferConformerCV> m_pixelBufferConformer;
+    Lock m_pixelBufferConformerLock;
+    std::unique_ptr<WebCore::PixelBufferConformerCV> m_pixelBufferConformer WTF_GUARDED_BY_LOCK(m_pixelBufferConformerLock);
 #endif
     bool m_isClosed { false };
 };

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.mm
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.mm
@@ -38,10 +38,9 @@ RefPtr<WebCore::VideoFrame> RemoteVideoFrameObjectHeap::get(RemoteVideoFrameRead
     return m_heap.read(WTFMove(read), 0_s);
 }
 
-void RemoteVideoFrameObjectHeap::createPixelConformerIfNeeded()
+UniqueRef<WebCore::PixelBufferConformerCV> RemoteVideoFrameObjectHeap::createPixelConformer()
 {
-    if (!m_pixelBufferConformer)
-        m_pixelBufferConformer = makeUnique<WebCore::PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });
+    return makeUniqueRef<WebCore::PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });
 }
 
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		0794742D25CB33FD00C597EB /* media-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EB /* media-remote.html */; };
 		0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EC /* webrtc-remote.html */; };
 		0794742D25CB33FD00C597ED /* webrtc-remote-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */; };
+		0794742D25CB33FD00C597EE /* camera-to-canvas.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EE /* camera-to-canvas.html */; };
 		0799C34B1EBA3301003B7532 /* disableGetUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */; };
 		079D45F22A2A6BBE003830C7 /* Viewport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D45F12A2A6BBE003830C7 /* Viewport.mm */; };
 		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
@@ -1530,6 +1531,7 @@
 				46C3AEB323D0E529001B0680 /* beforeunload.html in Copy Resources */,
 				2DE71B001D49C3ED00904094 /* blinking-div.html in Copy Resources */,
 				7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */,
+				0794742D25CB33FD00C597EE /* camera-to-canvas.html in Copy Resources */,
 				26DF5A6315A2A27E003689C2 /* CancelLoadFromResourceLoadDelegate.html in Copy Resources */,
 				F4D0A6382A2D520800D47257 /* canvas-fingerprinting.html in Copy Resources */,
 				F4E7A66327222CA900E74D36 /* canvas-image-data.html in Copy Resources */,
@@ -2002,6 +2004,7 @@
 		0794742C25CB33B000C597EB /* media-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-remote.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EC /* webrtc-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote-iframe.html"; sourceTree = "<group>"; };
+		0794742C25CB33B000C597EE /* camera-to-canvas.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "camera-to-canvas.html"; sourceTree = "<group>"; };
 		0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = disableGetUserMedia.html; sourceTree = "<group>"; };
 		079D45F12A2A6BBE003830C7 /* Viewport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Viewport.mm; sourceTree = "<group>"; };
 		07C046C91E42573E007201E7 /* CARingBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBufferTest.cpp; sourceTree = "<group>"; };
@@ -4678,6 +4681,7 @@
 				F41AB9971EF4692C0083FA08 /* background-image-link-and-input.html */,
 				464C764C230DF83200AFB020 /* BadServiceWorkerRegistrations-4.sqlite3 */,
 				2DE71AFF1D49C2F000904094 /* blinking-div.html */,
+				0794742C25CB33B000C597EE /* camera-to-canvas.html */,
 				F4D0A6362A2D51F900D47257 /* canvas-fingerprinting.html */,
 				F4E7A66227222BB100E74D36 /* canvas-image-data.html */,
 				2EFF06C41D8867700004BB30 /* change-video-source-on-click.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/camera-to-canvas.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/camera-to-canvas.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+async function startCamera()
+{
+    try {
+        local.srcObject = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+        window.webkit.messageHandlers.gum.postMessage("PASS");
+    } catch (e) {
+        window.webkit.messageHandlers.gum.postMessage("FAIL with " + e);
+    }
+}
+
+async function paintCameraInCanvas()
+{
+    try {
+        await local.play();
+    } catch (e) {
+        window.webkit.messageHandlers.gum.postMessage("FAIL with " + e);
+    }
+
+    canvas.getContext('2d').fillStyle = "#FFFFFF";
+    canvas.getContext('2d').fillRect(0, 0, 640, 480);
+    canvas.getContext('2d').drawImage(local, 0, 0, 640, 480);
+    const pixelData = canvas.getContext('2d').getImageData(0, 0, 1, 1,).data;
+
+    if (pixelData[0] != 0) {
+        window.webkit.messageHandlers.gum.postMessage("FAIL r");
+        return;
+    }
+
+    if (pixelData[1] != 0) {
+        window.webkit.messageHandlers.gum.postMessage("FAIL g");
+        return;
+    }
+
+    if (pixelData[2] != 0) {
+        window.webkit.messageHandlers.gum.postMessage("FAIL b");
+        return;
+    }
+
+    window.webkit.messageHandlers.gum.postMessage("PASS");
+}
+    </script>
+</head>
+<body onload="startCamera()">
+    <video controls autoplay playsinline muted id="local" width="100px" height="100px"></video>
+    <br>
+    <canvas width="640" height="480" id=canvas></video>
+</body>
+</html>


### PR DESCRIPTION
#### 9f4b18808c8363f95aea0e40a43ebb5793f0ac94
<pre>
Safari tab freeze and gpu process crash when calling canvas function drawimage/getimagedata/setimagedata from high resolution getUserMedia stream with several background tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=256366">https://bugs.webkit.org/show_bug.cgi?id=256366</a>
rdar://109074255

Reviewed by Jean-Yves Avenard.

In case of low memory warning, we now destroy the RemoteVideoFrameObjectHeap pixel conformer if any since it might have a non empty buffer pool.
We introduce a lock so that we can do that clean-up from any thread.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::lowMemoryHandler):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::convertFrameBuffer):
(WebKit::RemoteVideoFrameObjectHeap::lowMemoryHandler):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.mm:
(WebKit::RemoteVideoFrameObjectHeap::createPixelConformer):
(WebKit::RemoteVideoFrameObjectHeap::createPixelConformerIfNeeded): Deleted.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/camera-to-canvas.html: Added.

Canonical link: <a href="https://commits.webkit.org/268444@main">https://commits.webkit.org/268444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d416e799341318b1f6291eac39ccd5a381edc5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18967 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19509 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21724 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23692 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18035 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15293 "5 flakes 46 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17117 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->