### PR TITLE
[WGSL] Add support for function call statements

### DIFF
--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -38,6 +38,7 @@
 #include "ASTBreakStatement.h"
 #include "ASTBuiltinAttribute.h"
 #include "ASTCallExpression.h"
+#include "ASTCallStatement.h"
 #include "ASTCompoundAssignmentStatement.h"
 #include "ASTCompoundStatement.h"
 #include "ASTConstAttribute.h"

--- a/Source/WebGPU/WGSL/AST/ASTCallStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallStatement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,38 +25,26 @@
 
 #pragma once
 
-#include "ASTExpression.h"
+#include "ASTCallExpression.h"
+#include "ASTStatement.h"
 
 namespace WGSL::AST {
 
-// A CallExpression expresses a "function" call, which consists of a target to be called,
-// and a list of arguments. The target does not necesserily have to be a function identifier,
-// but can also be a type, in which the whole call is a type conversion expression. The exact
-// kind of expression can only be resolved during semantic analysis.
-class CallExpression final : public Expression {
-    WGSL_AST_BUILDER_NODE(CallExpression);
+class CallStatement final : public Statement {
+    WGSL_AST_BUILDER_NODE(CallStatement);
 public:
-    using Ref = std::reference_wrapper<CallExpression>;
-
     NodeKind kind() const override;
-    Expression& target() { return m_target.get(); }
-    Expression::List& arguments() { return m_arguments; }
+    CallExpression& call() { return m_call.get(); }
 
 private:
-    CallExpression(SourceSpan span, Expression::Ref&& target, Expression::List&& arguments)
-        : Expression(span)
-        , m_target(WTFMove(target))
-        , m_arguments(WTFMove(arguments))
+    CallStatement(SourceSpan span, CallExpression::Ref&& call)
+        : Statement(span)
+        , m_call(WTFMove(call))
     { }
 
-    // If m_target is a NamedType, it could either be a:
-    //   * Type that does not accept parameters (bool, i32, u32, ...)
-    //   * Identifier that refers to a type alias.
-    //   * Identifier that refers to a function.
-    Expression::Ref m_target;
-    Expression::List m_arguments;
+    CallExpression::Ref m_call;
 };
 
 } // namespace WGSL::AST
 
-SPECIALIZE_TYPE_TRAITS_WGSL_AST(CallExpression)
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(CallStatement)

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -68,6 +68,7 @@ class Identifier;
 class Statement;
 class AssignmentStatement;
 class BreakStatement;
+class CallStatement;
 class CompoundAssignmentStatement;
 class CompoundStatement;
 class ContinueStatement;

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -309,6 +309,12 @@ void StringDumper::visit(AssignmentStatement& statement)
     m_out.print(";");
 }
 
+void StringDumper::visit(CallStatement& statement)
+{
+    visit(statement.call());
+    m_out.print(";");
+}
+
 void StringDumper::visit(CompoundAssignmentStatement& statement)
 {
     m_out.print(m_indent);

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -77,6 +77,7 @@ public:
 
     // Statement
     void visit(AssignmentStatement&) override;
+    void visit(CallStatement&) override;
     void visit(CompoundAssignmentStatement&) override;
     void visit(CompoundStatement&) override;
     void visit(AST::DecrementIncrementStatement&) override;

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -333,6 +333,9 @@ void Visitor::visit(Statement& statement)
     case AST::NodeKind::BreakStatement:
         checkErrorAndVisit(downcast<AST::BreakStatement>(statement));
         break;
+    case AST::NodeKind::CallStatement:
+        checkErrorAndVisit(downcast<AST::CallStatement>(statement));
+        break;
     case AST::NodeKind::CompoundAssignmentStatement:
         checkErrorAndVisit(downcast<AST::CompoundAssignmentStatement>(statement));
         break;
@@ -388,6 +391,11 @@ void Visitor::visit(AST::AssignmentStatement& assignmentStatement)
 
 void Visitor::visit(AST::BreakStatement&)
 {
+}
+
+void Visitor::visit(AST::CallStatement& callStatement)
+{
+    checkErrorAndVisit(callStatement.call());
 }
 
 void Visitor::visit(AST::CompoundAssignmentStatement& compoundAssignmentStatement)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -86,6 +86,7 @@ public:
     virtual void visit(AST::Statement&);
     virtual void visit(AST::AssignmentStatement&);
     virtual void visit(AST::BreakStatement&);
+    virtual void visit(AST::CallStatement&);
     virtual void visit(AST::CompoundAssignmentStatement&);
     virtual void visit(AST::CompoundStatement&);
     virtual void visit(AST::ContinueStatement&);

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -83,6 +83,7 @@ public:
     Result<AST::Statement::Ref> parseForStatement();
     Result<AST::Statement::Ref> parseReturnStatement();
     Result<AST::Statement::Ref> parseVariableUpdatingStatement();
+    Result<AST::Statement::Ref> parseVariableUpdatingStatement(AST::Expression::Ref&&);
     Result<AST::Expression::Ref> parseShortCircuitExpression(AST::Expression::Ref&&, TokenType, AST::BinaryOperation);
     Result<AST::Expression::Ref> parseRelationalExpression();
     Result<AST::Expression::Ref> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -74,6 +74,7 @@ public:
 
     // Statements
     void visit(AST::AssignmentStatement&) override;
+    void visit(AST::CallStatement&) override;
     void visit(AST::CompoundAssignmentStatement&) override;
     void visit(AST::DecrementIncrementStatement&) override;
     void visit(AST::IfStatement&) override;
@@ -426,6 +427,13 @@ void TypeChecker::visit(AST::AssignmentStatement& statement)
     }
     if (!unify(reference->element, rhs))
         typeError(InferBottom::No, statement.span(), "cannot assign value of type '", *rhs, "' to '", *reference->element, "'");
+}
+
+void TypeChecker::visit(AST::CallStatement& statement)
+{
+    auto* result = infer(statement.call());
+    // FIXME: this should check if the function has a must_use attribute
+    UNUSED_PARAM(result);
 }
 
 void TypeChecker::visit(AST::CompoundAssignmentStatement& statement)

--- a/Source/WebGPU/WGSL/tests/valid/reordering.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/reordering.wgsl
@@ -14,11 +14,10 @@ struct S {
 @compute @workgroup_size(1)
 fn main()
 {
-    _ = helper();
+    helper();
 }
 
-fn helper() -> i32
+fn helper()
 {
     _ = T(S(y));
-    return 0;
 }


### PR DESCRIPTION
#### dd53a2fe4da2dea96b6b3e3bafd327f816e2e52c
<pre>
[WGSL] Add support for function call statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=261599">https://bugs.webkit.org/show_bug.cgi?id=261599</a>
rdar://115547291

Reviewed by Dan Glastonbury.

Extend the parser to allow calls as statements as well as expressions.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTCallExpression.h:
* Source/WebGPU/WGSL/AST/ASTCallStatement.h: Copied from Source/WebGPU/WGSL/AST/ASTCallExpression.h.
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseVariableUpdatingStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/tests/valid/reordering.wgsl:

Canonical link: <a href="https://commits.webkit.org/268076@main">https://commits.webkit.org/268076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/675fd810d8977e054425acd117df12e56bb92f61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17231 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19134 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21132 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16042 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23266 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14873 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16612 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4422 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->