### PR TITLE
[iOS] AudioContext is getting suspended when page goes in the background even if navigator.audioSession.type is set to playback

### DIFF
--- a/LayoutTests/media/now-playing-webaudio-expected.txt
+++ b/LayoutTests/media/now-playing-webaudio-expected.txt
@@ -1,0 +1,4 @@
+
+PASS AudioContext as the now playing info source
+PASS HTMLMediaElement will become the now playing info source over playing AudioContext
+

--- a/LayoutTests/media/now-playing-webaudio.html
+++ b/LayoutTests/media/now-playing-webaudio.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing basic video exchange from offerer to receiver</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+function waitFor(delay)
+{
+    return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+async function waitForCriteria(test, criteria)
+{
+    let counter = 0;
+    while (!criteria() && ++counter < 100)
+        await waitFor(50);
+}
+
+promise_test(async test => {
+    if (!window.internals)
+        return;
+
+    navigator.audioSession.type = "playback";
+
+    let context = new AudioContext();
+
+    await waitFor(100);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier);
+
+    let oscillator = null;
+    let gainNode = context.createGain();
+    oscillator = context.createOscillator();
+    oscillator.type = 'square';
+    oscillator.frequency.setValueAtTime(440, context.currentTime);
+
+    oscillator.connect(gainNode);
+    gainNode.gain.value = 0.1
+
+    internals.withUserGesture(() => {
+        context.resume();
+    });
+
+    await waitFor(100);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier);
+
+    gainNode.connect(context.destination);
+
+    await waitForCriteria(test, () => {
+        return !!internals.nowPlayingState.uniqueIdentifier;
+    });
+    assert_true(!!internals.nowPlayingState.uniqueIdentifier, "active now playing");
+
+    context.suspend();
+
+    await waitForCriteria(test, () => {
+        return !internals.nowPlayingState.uniqueIdentifier;
+    });
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "inactive now playing");
+
+    context.resume();
+
+    await waitForCriteria(test, () => {
+        return !!internals.nowPlayingState.uniqueIdentifier;
+    });
+    assert_true(!!internals.nowPlayingState.uniqueIdentifier, "active now playing again");
+}, "AudioContext as the now playing info source");
+
+promise_test(async test => {
+    if (!window.internals)
+        return;
+
+    const identifier = internals.nowPlayingState.uniqueIdentifier;
+    let mediaElement = document.createElement("audio");
+    document.body.appendChild(mediaElement);
+
+    await waitFor(100);
+    assert_equals(internals.nowPlayingState.uniqueIdentifier, identifier, "AudioContext identifier");
+
+    await waitFor(100);
+    assert_equals(internals.nowPlayingState.uniqueIdentifier, identifier, "AudioContext identifier 2");
+
+    mediaElement.src = "content/test.wav";
+
+    await waitForCriteria(test, () => {
+        return internals.nowPlayingState.uniqueIdentifier !== identifier;
+    });
+    assert_not_equals(internals.nowPlayingState.uniqueIdentifier, identifier, "HTMLMediaElement identifier");
+    const mediaElementIdentifier = internals.nowPlayingState.uniqueIdentifier
+
+    document.body.removeChild(mediaElement);
+
+    await waitForCriteria(test, () => {
+        return internals.nowPlayingState.uniqueIdentifier !== mediaElementIdentifier;
+    });
+    assert_equals(internals.nowPlayingState.uniqueIdentifier, identifier, "AudioContext identifier 3");
+}, "HTMLMediaElement will become the now playing info source over playing AudioContext");
+
+        </script>
+    </body>
+</html>

--- a/LayoutTests/media/webaudio-background-playback-expected.txt
+++ b/LayoutTests/media/webaudio-background-playback-expected.txt
@@ -1,3 +1,6 @@
 
 PASS Ensure WebAudio stops playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set
+PASS Ensure WebAudio does not stop playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set and audioSession type is playback
+PASS Ensure WebAudio does not stop playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set and audioSession type is play-and-record
+PASS Ensure WebAudio stops playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set and audioSession type is back to default
 

--- a/LayoutTests/media/webaudio-background-playback.html
+++ b/LayoutTests/media/webaudio-background-playback.html
@@ -10,7 +10,8 @@
     <body>
         <script>
 
-promise_test(async (test) => {
+async function doTest(test, expectToStopInBackground)
+{
     if (!window.internals)
         return Promise.reject("Test requires internals API");
 
@@ -80,7 +81,7 @@ promise_test(async (test) => {
             break;
     }
 
-    assert_true(onProcessCount == oldOnProcessCount, "audio playback suspended in background");
+    assert_equals(onProcessCount == oldOnProcessCount, expectToStopInBackground, "audio playback suspended in background");
 
     // Context state changes are asynchronous, so delay the test to until the context has restarted + 100 additional milli-seconds.
     context.onstatechange = () => {
@@ -91,8 +92,30 @@ promise_test(async (test) => {
 
     if (window.internals)
         internals.applicationWillEnterForeground();
+}
 
+promise_test(async (test) => {
+    const expectToStopInBackground = true;
+    return doTest(test, expectToStopInBackground);
 }, "Ensure WebAudio stops playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set");
+
+promise_test(async (test) => {
+    navigator.audioSession.type = "playback";
+    const expectToStopInBackground = false;
+    return doTest(test, expectToStopInBackground);
+}, "Ensure WebAudio does not stop playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set and audioSession type is playback");
+
+promise_test(async (test) => {
+    navigator.audioSession.type = "play-and-record";
+    const expectToStopInBackground = false;
+    return doTest(test, expectToStopInBackground);
+}, "Ensure WebAudio does not stop playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set and audioSession type is play-and-record");
+
+promise_test(async (test) => {
+    navigator.audioSession.type = "";
+    const expectToStopInBackground = false;
+    return doTest(test, expectToStopInBackground);
+}, "Ensure WebAudio stops playing in the background when the 'BackgroundProcessPlaybackRestricted' restriction is set and audioSession type is back to default");
 
         </script>
     </body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -270,6 +270,8 @@ media/mediacapabilities/mediacapabilities-types.html [ Pass ]
 media/video-controller-currentTime-rate.html [ Pass ]
 webaudio/codec-tests/aac/vbr-128kbps-44khz.html [ Pass ]
 webaudio/codec-tests/mp3/128kbps-44khz.html [ Pass ]
+media/now-playing-webaudio.html [ Failure ]
+media/webaudio-background-playback.html [ Failure ]
 
 # uiController.simulateRotationLikeSafari() is not implemented on glib ports.
 fast/screen-orientation/orientation-in-resize-event.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1936,8 +1936,6 @@ webkit.org/b/221491 animations/keyframe-pseudo-shadow.html [ Pass ImageOnlyFailu
 
 webkit.org/b/221973 [ Monterey+ ] media/media-webm-no-duration.html [ Failure ]
 
-webkit.org/b/221935 media/webaudio-background-playback.html [ Pass Failure ]
-
 webkit.org/b/221218 [ Monterey+ ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-v-framesize.html [ Pass Failure ]
 
 webkit.org/b/221100 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-channel-count.https.html [ Pass Failure ]

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
@@ -46,11 +46,21 @@ MediaSession& NavigatorMediaSession::mediaSession(Navigator& navigator)
     return NavigatorMediaSession::from(navigator)->mediaSession();
 }
 
+RefPtr<MediaSession> NavigatorMediaSession::mediaSessionIfExists(Navigator& navigator)
+{
+    return NavigatorMediaSession::from(navigator)->mediaSessionIfExists();
+}
+
 MediaSession& NavigatorMediaSession::mediaSession()
 {
     if (!m_mediaSession)
         m_mediaSession = MediaSession::create(m_navigator);
     return *m_mediaSession;
+}
+
+RefPtr<MediaSession> NavigatorMediaSession::mediaSessionIfExists()
+{
+    return m_mediaSession;
 }
 
 NavigatorMediaSession* NavigatorMediaSession::from(Navigator& navigator)

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
@@ -42,7 +42,9 @@ public:
     ~NavigatorMediaSession();
 
     WEBCORE_EXPORT static MediaSession& mediaSession(Navigator&);
+    static RefPtr<MediaSession> mediaSessionIfExists(Navigator&);
     MediaSession& mediaSession();
+    RefPtr<MediaSession> mediaSessionIfExists();
 
 private:
     static NavigatorMediaSession* from(Navigator&);

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -30,10 +30,15 @@
 #include "AudioContext.h"
 #include "AudioContextOptions.h"
 #include "AudioTimestamp.h"
+#include "DOMAudioSession.h"
 #include "DocumentInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindow.h"
 #include "Logging.h"
+#include "MediaSession.h"
+#include "Navigator.h"
+#include "NavigatorAudioSession.h"
+#include "NavigatorMediaSession.h"
 #include "PageInlines.h"
 #include "Performance.h"
 #include "PlatformMediaSessionManager.h"
@@ -122,6 +127,7 @@ AudioContext::AudioContext(Document& document, const AudioContextOptions& contex
     : BaseAudioContext(document)
     , m_destinationNode(makeUniqueRef<DefaultAudioDestinationNode>(*this, contextOptions.sampleRate))
     , m_mediaSession(PlatformMediaSession::create(PlatformMediaSessionManager::sharedManager(), *this))
+    , m_currentIdentifier(MediaUniqueIdentifier::generate())
 {
     constructCommon();
 
@@ -370,6 +376,9 @@ void AudioContext::mayResumePlayback(bool shouldResume)
         return;
     }
 
+    if (m_wasSuspendedByScript)
+        return;
+
     if (!willBeginPlayback())
         return;
 
@@ -451,10 +460,134 @@ void AudioContext::suspendPlayback()
     });
 }
 
+bool AudioContext::canReceiveRemoteControlCommands() const
+{
+#if ENABLE(DOM_AUDIO_SESSION)
+    return isNowPlayingEligible();
+#else
+    return false;
+#endif
+}
+
+void AudioContext::didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType command, const PlatformMediaSession::RemoteCommandArgument&)
+{
+    switch (command) {
+    case PlatformMediaSession::RemoteControlCommandType::PlayCommand:
+        mayResumePlayback(true);
+        break;
+    case PlatformMediaSession::RemoteControlCommandType::StopCommand:
+    case PlatformMediaSession::RemoteControlCommandType::PauseCommand:
+        suspendPlayback();
+        break;
+    case PlatformMediaSession::RemoteControlCommandType::TogglePlayPauseCommand:
+        if (state() == State::Interrupted || state() == State::Suspended)
+            mayResumePlayback(true);
+        else
+            suspendPlayback();
+        break;
+    case PlatformMediaSession::RemoteControlCommandType::BeginSeekingBackwardCommand:
+    case PlatformMediaSession::RemoteControlCommandType::BeginSeekingForwardCommand:
+    case PlatformMediaSession::RemoteControlCommandType::EndSeekingBackwardCommand:
+    case PlatformMediaSession::RemoteControlCommandType::EndSeekingForwardCommand:
+    case PlatformMediaSession::RemoteControlCommandType::BeginScrubbingCommand:
+    case PlatformMediaSession::RemoteControlCommandType::EndScrubbingCommand:
+    case PlatformMediaSession::RemoteControlCommandType::SkipForwardCommand:
+    case PlatformMediaSession::RemoteControlCommandType::SkipBackwardCommand:
+    case PlatformMediaSession::RemoteControlCommandType::SeekToPlaybackPositionCommand:
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
 MediaSessionGroupIdentifier AudioContext::mediaSessionGroupIdentifier() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
     return document && document->page() ? document->page()->mediaSessionGroupIdentifier() : MediaSessionGroupIdentifier { };
+}
+
+static bool hasPlayBackAudioSession(Document* document)
+{
+#if ENABLE(DOM_AUDIO_SESSION)
+    RefPtr window = document ? document->domWindow() : nullptr;
+
+    RefPtr navigator = window ? window->optionalNavigator() : nullptr;
+    RefPtr audioSession = navigator ? NavigatorAudioSession::audioSession(*navigator) : nullptr;
+
+    auto audioSessionType = audioSession ? audioSession->type() : DOMAudioSessionType::Auto;
+    return audioSessionType == DOMAudioSessionType::Playback || audioSessionType == DOMAudioSessionType::PlayAndRecord;
+#else
+    UNUSED_PARAM(document);
+    return false;
+#endif
+}
+
+bool AudioContext::isNowPlayingEligible() const
+{
+    if (!destination().isConnected() || m_wasSuspendedByScript)
+        return false;
+
+    RefPtr document = this->document();
+    return hasPlayBackAudioSession(document.get());
+}
+
+std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
+{
+    if (!isNowPlayingEligible())
+        return { };
+
+    RefPtr document = this->document();
+    RefPtr page = document ? document->page() : nullptr;
+    RefPtr window = document ? document->domWindow() : nullptr;
+    if (!page || !window)
+        return { };
+
+    NowPlayingInfo nowPlayingInfo {
+        { },
+        { },
+        { },
+        { },
+        MediaPlayer::invalidTime(),
+        MediaPlayer::invalidTime(),
+        1.0,
+        false,
+        m_currentIdentifier,
+        isPlaying(),
+        !page->isVisibleAndActive(),
+        { }
+    };
+
+#if ENABLE(MEDIA_SESSION)
+    if (RefPtr mediaSession = NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator()))
+        mediaSession->updateNowPlayingInfo(nowPlayingInfo);
+#endif
+
+    if (nowPlayingInfo.title.isEmpty()) {
+        RegistrableDomain domain { document->securityOrigin().data() };
+        if (!domain.isEmpty())
+            nowPlayingInfo.title = domain.string();
+    }
+
+    return nowPlayingInfo;
+}
+
+WeakPtr<PlatformMediaSession> AudioContext::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>& sessions, PlatformMediaSession::PlaybackControlsPurpose purpose)
+{
+    if (purpose != PlatformMediaSession::PlaybackControlsPurpose::NowPlaying)
+        return nullptr;
+
+    WeakPtr<PlatformMediaSession> audibleSession;
+    for (auto& session : sessions) {
+        if (!isNowPlayingEligible())
+            continue;
+
+        if (!audibleSession)
+            audibleSession = session;
+
+        if (session->isPlaying())
+            return session;
+    }
+
+    return audibleSession;
 }
 
 bool AudioContext::isSuspended() const
@@ -496,25 +629,32 @@ void AudioContext::isPlayingAudioDidChange()
 
 bool AudioContext::shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType interruption) const
 {
-    if (!m_canOverrideBackgroundPlaybackRestriction || interruption != PlatformMediaSession::InterruptionType::EnteringBackground)
+    if (interruption != PlatformMediaSession::InterruptionType::EnteringBackground)
+        return false;
+
+    if (m_canOverrideBackgroundPlaybackRestriction && !destination().isConnected())
+        return true;
+
+    RefPtr document = this->document();
+    if (!document)
         return false;
 
 #if PLATFORM(VISION) && ENABLE(WEBXR)
-    if (RefPtr document = this->document()) {
-        RefPtr page = document->page();
-        if (page && page->hasActiveImmersiveSession())
-            return true;
-    }
+    RefPtr page = document->page();
+    if (page && page->hasActiveImmersiveSession())
+        return true;
 #endif
 
-    return !destination().isConnected();
+    return hasPlayBackAudioSession(document.get());
 }
 
 void AudioContext::defaultDestinationWillBecomeConnected()
 {
     // We might need to interrupt if we previously overrode a background interruption.
-    if (!PlatformMediaSessionManager::sharedManager().isApplicationInBackground() || m_mediaSession->state() == PlatformMediaSession::State::Interrupted)
+    if (!PlatformMediaSessionManager::sharedManager().isApplicationInBackground() || m_mediaSession->state() == PlatformMediaSession::State::Interrupted) {
+        PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();
         return;
+    }
 
     // We end the overriden interruption (if any) to get the right count of interruptions and start a new interruption.
     m_mediaSession->endInterruption(PlatformMediaSession::EndInterruptionFlags::NoFlags);

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -29,6 +29,7 @@
 #include "DefaultAudioDestinationNode.h"
 #include "MediaCanStartListener.h"
 #include "MediaProducer.h"
+#include "MediaUniqueIdentifier.h"
 #include "PlatformMediaSession.h"
 #include <wtf/UniqueRef.h>
 
@@ -124,8 +125,8 @@ private:
     PlatformMediaSession::MediaType presentationType() const final { return PlatformMediaSession::MediaType::WebAudio; }
     void mayResumePlayback(bool shouldResume) final;
     void suspendPlayback() final;
-    bool canReceiveRemoteControlCommands() const final { return false; }
-    void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) final { }
+    bool canReceiveRemoteControlCommands() const final;
+    void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) final;
     bool supportsSeeking() const final { return false; }
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const final;
     bool canProduceAudio() const final { return true; }
@@ -133,6 +134,9 @@ private:
     bool isPlaying() const final;
     bool isAudible() const final;
     MediaSessionGroupIdentifier mediaSessionGroupIdentifier() const final;
+    bool isNowPlayingEligible() const final;
+    std::optional<NowPlayingInfo> nowPlayingInfo() const final;
+    WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 
     // MediaCanStartListener.
     void mediaCanStart(Document&) final;
@@ -145,6 +149,7 @@ private:
 
     UniqueRef<DefaultAudioDestinationNode> m_destinationNode;
     std::unique_ptr<PlatformMediaSession> m_mediaSession;
+    MediaUniqueIdentifier m_currentIdentifier;
 
     BehaviorRestrictions m_restrictions { NoRestrictions };
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -73,6 +73,7 @@
 #include "PannerNode.h"
 #include "PeriodicWave.h"
 #include "PeriodicWaveOptions.h"
+#include "PlatformMediaSessionManager.h"
 #include "ScriptController.h"
 #include "ScriptProcessorNode.h"
 #include "StereoPannerNode.h"
@@ -230,6 +231,7 @@ void BaseAudioContext::setState(State state)
     if (m_state != state) {
         m_state = state;
         queueTaskToDispatchEvent(*this, TaskSource::MediaElement, Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+        PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();
     }
 
     size_t stateIndex = static_cast<size_t>(state);

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -839,9 +839,10 @@ WeakPtr<PlatformMediaSession> PlatformMediaSessionManager::bestEligibleSessionFo
     Vector<WeakPtr<PlatformMediaSession>> eligibleAudioVideoSessions;
     Vector<WeakPtr<PlatformMediaSession>> eligibleWebAudioSessions;
     forEachMatchingSession(filterFunction, [&](auto& session) {
-        if (eligibleAudioVideoSessions.isEmpty() && session.presentationType() == PlatformMediaSession::MediaType::WebAudio)
-            eligibleWebAudioSessions.append(session);
-        else
+        if (session.presentationType() == PlatformMediaSession::MediaType::WebAudio) {
+            if (eligibleAudioVideoSessions.isEmpty())
+                eligibleWebAudioSessions.append(session);
+        } else
             eligibleAudioVideoSessions.append(session);
     });
 


### PR DESCRIPTION
#### b848143a2ad57c80405dc5b30e61c750f5896d72
<pre>
[iOS] AudioContext is getting suspended when page goes in the background even if navigator.audioSession.type is set to playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=261554">https://bugs.webkit.org/show_bug.cgi?id=261554</a>
<a href="https://rdar.apple.com/115485355">rdar://115485355</a>

Reviewed by Eric Carlson.

Implement isNowPlayingEligible, nowPlayingInfo and selectBestMediaSession to enable NowPlayingInfo handling.
Only activated by JS AudioContext(s) are NowPlayingInfo-able if DOM AudioSession type is playback or plabyack and record.

Implement canReceiveRemoteControlCommands and didReceiveRemoteControlCommand to be able to play/pause according commands.
Update AudioContext::mayResumePlayback to only resume for activated by JS AudioContext(s).
Update AudioContext::shouldOverrideBackgroundPlaybackRestriction to be able to continue in the background in case of
playback or plabyack and record DOM AudioSession(s).

Update bug in PlatformMediaSessionManager::bestEligibleSessionForRemoteControls late time optimization to only add web audio sessions to its list
when there is no media element eligible session. If there is an eligible media element session, we do not want to add web audio session to the media session list.

* LayoutTests/media/now-playing-webaudio-expected.txt: Added.
* LayoutTests/media/now-playing-webaudio.html: Added.
* LayoutTests/media/webaudio-background-playback-expected.txt:
* LayoutTests/media/webaudio-background-playback.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp:
(WebCore::NavigatorMediaSession::mediaSessionIfExists):
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.h:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::AudioContext):
(WebCore::AudioContext::mayResumePlayback):
(WebCore::AudioContext::canReceiveRemoteControlCommands const):
(WebCore::AudioContext::didReceiveRemoteControlCommand):
(WebCore::hasPlayBackAudioSession):
(WebCore::AudioContext::isNowPlayingEligible const):
(WebCore::AudioContext::nowPlayingInfo const):
(WebCore::AudioContext::selectBestMediaSession):
(WebCore::AudioContext::shouldOverrideBackgroundPlaybackRestriction const):
(WebCore::AudioContext::defaultDestinationWillBecomeConnected):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::setState):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::bestEligibleSessionForRemoteControls):

Canonical link: <a href="https://commits.webkit.org/275558@main">https://commits.webkit.org/275558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e25fca4ac0bb1c74c6ec605bddfafd97d583da5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9443 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->