### PR TITLE
[MediaStream] Add support for whiteBalanceMode

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
@@ -27,6 +27,7 @@ video track capabilities:
   capabilities.frameRate = { max: 120, min: 1 }
   capabilities.groupId = <UUID>
   capabilities.height = { max: 2160, min: 1 }
+  capabilities.whiteBalanceMode = [ manual, single-shot, continuous ]
   capabilities.width = { max: 3840, min: 1 }
   capabilities.zoom = { max: 4, min: 1 }
 
@@ -36,6 +37,18 @@ audio track capabilities:
   capabilities.groupId = <UUID>
   capabilities.sampleRate = { max: 96000, min: 44100 }
   capabilities.volume = { max: 1, min: 0 }
+
+video track capabilities:
+  capabilities.aspectRatio = { max: 3840, min: 0.000 }
+  capabilities.deviceId = <UUID>
+  capabilities.facingMode = [ environment ]
+  capabilities.focusDistance = { min: 0.200 }
+  capabilities.frameRate = { max: 120, min: 1 }
+  capabilities.groupId = <UUID>
+  capabilities.height = { max: 2160, min: 1 }
+  capabilities.whiteBalanceMode = [ manual, single-shot, continuous ]
+  capabilities.width = { max: 3840, min: 1 }
+  capabilities.zoom = { max: 4, min: 1 }
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
@@ -98,6 +98,9 @@
                 listTrackProperties(mediaStream.getVideoTracks()[0]);
                 listTrackProperties(mediaStream.getAudioTracks()[0]);
 
+                mediaStream = await navigator.mediaDevices.getUserMedia({ video:{ whiteBalanceMode: 'manual' } });
+                listTrackProperties(mediaStream.getVideoTracks()[0]);
+
                 finishJSTest();
             }
 

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS getUserMedia whiteBalanceMode
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>Camera track whiteBalanceMode</title>
+    <script src='../../resources/testharness.js'></script>
+    <script src='../../resources/testharnessreport.js'></script>
+</head>
+<body>
+    <canvas id='canvas'></canvas>
+    <video controls autoplay width=640px height=480px playsInline id='video'></video>
+    <script>
+
+        let stream;
+        promise_test(async (test) => {
+            stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            assert_equals(stream.getVideoTracks()[0].getSettings().whiteBalanceMode, undefined, 'settings-1');
+            assert_equals(stream.getVideoTracks()[0].getCapabilities().whiteBalanceMode, undefined, 'capabilities-1');
+
+            stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, whiteBalanceMode : 'single-shot' } });
+            assert_equals(stream.getVideoTracks()[0].getSettings().whiteBalanceMode, 'single-shot', 'settings-2');
+
+            await stream.getVideoTracks()[0].applyConstraints({ whiteBalanceMode : 'manual' });
+            assert_equals(stream.getVideoTracks()[0].getSettings().whiteBalanceMode, 'manual', 'settings -3');
+
+        }, 'getUserMedia whiteBalanceMode');
+    </script>
+</body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -451,6 +451,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediastream/MediaTrackCapabilities.idl
     Modules/mediastream/MediaTrackConstraints.idl
     Modules/mediastream/MediaTrackSupportedConstraints.idl
+    Modules/mediastream/MeteringMode.idl
     Modules/mediastream/Navigator+MediaDevices.idl
     Modules/mediastream/OverconstrainedError.idl
     Modules/mediastream/OverconstrainedErrorEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -571,6 +571,7 @@ $(PROJECT_DIR)/Modules/mediastream/MediaStreamTrackEvent.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackCapabilities.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackConstraints.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackSupportedConstraints.idl
+$(PROJECT_DIR)/Modules/mediastream/MeteringMode.idl
 $(PROJECT_DIR)/Modules/mediastream/Navigator+MediaDevices.idl
 $(PROJECT_DIR)/Modules/mediastream/OverconstrainedError.idl
 $(PROJECT_DIR)/Modules/mediastream/OverconstrainedErrorEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1863,6 +1863,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMessageEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMessageEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMessagePort.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMessagePort.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMeteringMode.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMeteringMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCDMFactory.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockCDMFactory.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockContentFilterSettings.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -446,6 +446,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediastream/MediaTrackCapabilities.idl \
     $(WebCore)/Modules/mediastream/MediaTrackConstraints.idl \
     $(WebCore)/Modules/mediastream/MediaTrackSupportedConstraints.idl \
+    $(WebCore)/Modules/mediastream/MeteringMode.idl \
     $(WebCore)/Modules/mediastream/Navigator+MediaDevices.idl \
     $(WebCore)/Modules/mediastream/OverconstrainedError.idl \
     $(WebCore)/Modules/mediastream/OverconstrainedErrorEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -476,6 +476,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/mediastream/MediaStreamTrack.h
     Modules/mediastream/MediaTrackCapabilities.h
     Modules/mediastream/MediaTrackConstraints.h
+    Modules/mediastream/MeteringMode.h
     Modules/mediastream/RTCController.h
     Modules/mediastream/RTCDataChannel.h
     Modules/mediastream/RTCDataChannelRemoteHandler.h

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -229,6 +229,7 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
         case MediaConstraintType::EchoCancellation:
         case MediaConstraintType::FocusDistance:
         case MediaConstraintType::Zoom:
+        case MediaConstraintType::WhiteBalanceMode:
             // Ignored.
             break;
 
@@ -367,6 +368,7 @@ MediaTrackSupportedConstraints MediaDevices::getSupportedConstraints()
     result.aspectRatio = supported.supportsAspectRatio();
     result.frameRate = supported.supportsFrameRate();
     result.facingMode = supported.supportsFacingMode();
+    result.whiteBalanceMode = supported.supportsWhiteBalanceMode();
     result.volume = supported.supportsVolume();
     result.sampleRate = supported.supportsSampleRate();
     result.sampleSize = supported.supportsSampleSize();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
  * Copyright (C) 2011, 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,6 +36,7 @@
 #include "EventNames.h"
 #include "FrameLoader.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSMeteringMode.h"
 #include "JSOverconstrainedError.h"
 #include "LocalFrame.h"
 #include "Logging.h"
@@ -272,7 +273,9 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
     if (settings.supportsFrameRate())
         result.frameRate = settings.frameRate();
     if (settings.supportsFacingMode())
-        result.facingMode = RealtimeMediaSourceSettings::facingMode(settings.facingMode());
+        result.facingMode = convertEnumerationToString(settings.facingMode());
+    if (settings.supportsWhiteBalanceMode())
+        result.whiteBalanceMode = convertEnumerationToString(settings.whiteBalanceMode());
     if (settings.supportsVolume())
         result.volume = settings.volume();
     if (settings.supportsSampleRate())

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
  * Copyright (C) 2011, 2015 Ericsson AB. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  *
  * Redistribution and use in source and binary forms, with or without
@@ -110,6 +110,7 @@ public:
         std::optional<double> aspectRatio;
         std::optional<double> frameRate;
         String facingMode;
+        String whiteBalanceMode;
         std::optional<double> volume;
         std::optional<int> sampleRate;
         std::optional<int> sampleSize;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2013-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,4 +74,6 @@ enum MediaStreamTrackState { "live", "ended" };
     DOMString groupId;
     DOMString displaySurface;
     double zoom;
+    DOMString whiteBalanceMode;
+
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "JSMeteringMode.h"
 #include "RealtimeMediaSourceCapabilities.h"
 
 namespace WebCore {
@@ -84,7 +85,14 @@ static LongRange capabilityIntRange(const CapabilityValueOrRange& value)
 static Vector<String> capabilityStringVector(const Vector<VideoFacingMode>& modes)
 {
     return modes.map([](auto& mode) {
-        return RealtimeMediaSourceSettings::facingMode(mode);
+        return convertEnumerationToString(mode);
+    });
+}
+
+static Vector<String> capabilityStringVector(const Vector<MeteringMode>& modes)
+{
+    return modes.map([](auto& mode) {
+        return convertEnumerationToString(mode);
     });
 }
 
@@ -127,6 +135,9 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
         result.focusDistance = capabilityDoubleRange(capabilities.focusDistance());
     if (capabilities.supportsZoom())
         result.zoom = capabilityDoubleRange(capabilities.zoom());
+    if (capabilities.supportsWhiteBalanceMode())
+        result.whiteBalanceMode = capabilityStringVector(capabilities.whiteBalanceModes());
+
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
@@ -41,6 +41,7 @@ struct MediaTrackCapabilities {
     std::optional<DoubleRange> aspectRatio;
     std::optional<DoubleRange> frameRate;
     std::optional<Vector<String>> facingMode;
+    std::optional<Vector<String>> whiteBalanceMode;
     std::optional<DoubleRange> volume;
     std::optional<LongRange> sampleRate;
     std::optional<LongRange> sampleSize;

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2013-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,4 +44,5 @@
     DOMString displaySurface;
     DoubleRange focusDistance;
     DoubleRange zoom;
+    sequence<DOMString> whiteBalanceMode;
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -174,6 +174,7 @@ static MediaTrackConstraintSetMap convertToInternalForm(ConstraintSetType setTyp
     set(result, setType, "displaySurface"_s, MediaConstraintType::DisplaySurface, constraintSet.displaySurface);
     set(result, setType, "logicalSurface"_s, MediaConstraintType::LogicalSurface, constraintSet.logicalSurface);
     set(result, setType, "zoom"_s, MediaConstraintType::Zoom, constraintSet.zoom);
+    set(result, setType, "whiteBalanceMode"_s, MediaConstraintType::WhiteBalanceMode, constraintSet.whiteBalanceMode);
     return result;
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,6 +67,7 @@ struct MediaTrackConstraintSet {
     std::optional<ConstrainDouble> aspectRatio;
     std::optional<ConstrainDouble> frameRate;
     std::optional<ConstrainDOMString> facingMode;
+    std::optional<ConstrainDOMString> whiteBalanceMode;
     std::optional<ConstrainDouble> volume;
     std::optional<ConstrainLong> sampleRate;
     std::optional<ConstrainLong> sampleSize;

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,6 +50,7 @@
     ConstrainDOMString displaySurface;
     ConstrainBoolean logicalSurface;
     ConstrainDouble zoom;
+    ConstrainDOMString whiteBalanceMode;
 };
 
 typedef (double or ConstrainDoubleRange) ConstrainDouble;

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,7 @@ struct MediaTrackSupportedConstraints {
     bool groupId;
     bool displaySurface;
     bool zoom;
+    bool whiteBalanceMode;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2015 Apple Inc. All rights reserved.
+* Copyright (C) 2015-2023 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -47,4 +47,5 @@
     boolean groupId = true;
     boolean displaySurface = true;
     boolean zoom = true;
+    boolean whiteBalanceMode = true;
 };

--- a/Source/WebCore/Modules/mediastream/MeteringMode.h
+++ b/Source/WebCore/Modules/mediastream/MeteringMode.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM)
+
+namespace WebCore {
+
+enum class MeteringMode : uint8_t {
+    None,
+    Manual,
+    SingleShot,
+    Continuous,
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/MeteringMode.idl
+++ b/Source/WebCore/Modules/mediastream/MeteringMode.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/mediacapture-image/#meteringmode-section
+
+[
+    Conditional=MEDIA_STREAM
+]
+enum MeteringMode {
+  "none",
+  "manual",
+  "single-shot",
+  "continuous"
+};
+

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3847,6 +3847,7 @@ JSMerchantValidationEvent.cpp
 JSMessageChannel.cpp
 JSMessageEvent.cpp
 JSMessagePort.cpp
+JSMeteringMode.cpp
 JSMouseEvent.cpp
 JSMouseEventInit.cpp
 JSMultiCacheQueryOptions.cpp

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -213,6 +213,8 @@ void MediaTrackConstraintSetMap::filter(const Function<bool(const MediaConstrain
 
     if (m_facingMode && !m_facingMode->isEmpty() && callback(*m_facingMode))
         return;
+    if (m_whiteBalanceMode && !m_whiteBalanceMode->isEmpty() && callback(*m_whiteBalanceMode))
+        return;
     if (m_deviceId && !m_deviceId->isEmpty() && callback(*m_deviceId))
         return;
     if (m_groupId && !m_groupId->isEmpty() && callback(*m_groupId))
@@ -246,6 +248,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Zoom:
+    case MediaConstraintType::WhiteBalanceMode:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -279,6 +282,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::WhiteBalanceMode:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -310,6 +314,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::GroupId:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Zoom:
+    case MediaConstraintType::WhiteBalanceMode:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -321,6 +326,9 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     switch (constraintType) {
     case MediaConstraintType::FacingMode:
         m_facingMode = WTFMove(constraint);
+        break;
+    case MediaConstraintType::WhiteBalanceMode:
+        m_whiteBalanceMode = WTFMove(constraint);
         break;
     case MediaConstraintType::DeviceId:
         if (constraint)

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -628,6 +628,7 @@ public:
     std::optional<BooleanConstraint> logicalSurface() const { return m_logicalSurface; }
 
     std::optional<StringConstraint> facingMode() const { return m_facingMode; }
+    std::optional<StringConstraint> whiteBalanceMode() const { return m_whiteBalanceMode; }
     std::optional<StringConstraint> deviceId() const { return m_deviceId; }
     std::optional<StringConstraint> groupId() const { return m_groupId; }
 
@@ -648,6 +649,7 @@ private:
     std::optional<BooleanConstraint> m_logicalSurface;
 
     std::optional<StringConstraint> m_facingMode;
+    std::optional<StringConstraint> m_whiteBalanceMode;
     std::optional<StringConstraint> m_deviceId;
     std::optional<StringConstraint> m_groupId;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Ericsson AB. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  *
  * Redistribution and use in source and binary forms, with or without
@@ -180,6 +180,9 @@ public:
     VideoFacingMode facingMode() const { return m_facingMode; }
     void setFacingMode(VideoFacingMode);
 
+    MeteringMode whiteBalanceMode() const { return m_whiteBalanceMode; }
+    void setWhiteBalanceMode(MeteringMode);
+
     double volume() const { return m_volume; }
     void setVolume(double);
 
@@ -345,6 +348,7 @@ private:
     double m_sampleSize { 0 };
     double m_fitnessScore { 0 };
     VideoFacingMode m_facingMode { VideoFacingMode::User };
+    MeteringMode m_whiteBalanceMode { MeteringMode::None };
 
     bool m_muted { false };
     bool m_pendingSettingsDidChangeNotification { false };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "MeteringMode.h"
 #include "RealtimeMediaSourceSettings.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/NeverDestroyed.h>
@@ -153,12 +154,13 @@ public:
         ReadWrite = 1,
     };
     
-    RealtimeMediaSourceCapabilities(CapabilityValueOrRange&& width, CapabilityValueOrRange&& height, CapabilityValueOrRange&& aspectRatio, CapabilityValueOrRange&& frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityValueOrRange&& volume, CapabilityValueOrRange&& sampleRate, CapabilityValueOrRange&& sampleSize, EchoCancellation&& echoCancellation, AtomString&& deviceId, AtomString&& groupId, CapabilityValueOrRange&& focusDistance, CapabilityValueOrRange&& zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceCapabilities(CapabilityValueOrRange&& width, CapabilityValueOrRange&& height, CapabilityValueOrRange&& aspectRatio, CapabilityValueOrRange&& frameRate, Vector<VideoFacingMode>&& facingMode, Vector<MeteringMode>&& whiteBalanceModes, CapabilityValueOrRange&& volume, CapabilityValueOrRange&& sampleRate, CapabilityValueOrRange&& sampleSize, EchoCancellation&& echoCancellation, AtomString&& deviceId, AtomString&& groupId, CapabilityValueOrRange&& focusDistance, CapabilityValueOrRange&& zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(WTFMove(width))
         , m_height(WTFMove(height))
         , m_aspectRatio(WTFMove(aspectRatio))
         , m_frameRate(WTFMove(frameRate))
         , m_facingMode(WTFMove(facingMode))
+        , m_whiteBalanceModes(whiteBalanceModes)
         , m_volume(WTFMove(volume))
         , m_sampleRate(WTFMove(sampleRate))
         , m_sampleSize(WTFMove(sampleSize))
@@ -194,6 +196,10 @@ public:
     bool supportsFacingMode() const { return m_supportedConstraints.supportsFacingMode(); }
     const Vector<VideoFacingMode>& facingMode() const { return m_facingMode; }
     void addFacingMode(VideoFacingMode mode) { m_facingMode.append(mode); }
+
+    bool supportsWhiteBalanceMode() const { return m_supportedConstraints.supportsWhiteBalanceMode(); }
+    const Vector<MeteringMode>& whiteBalanceModes() const { return m_whiteBalanceModes; }
+    void setWhiteBalanceModes(Vector<MeteringMode>&& modes) { m_whiteBalanceModes = WTFMove(modes); }
 
     bool supportsAspectRatio() const { return m_supportedConstraints.supportsAspectRatio(); }
     const CapabilityValueOrRange& aspectRatio() const { return m_aspectRatio; }
@@ -240,6 +246,7 @@ private:
     CapabilityValueOrRange m_aspectRatio;
     CapabilityValueOrRange m_frameRate;
     Vector<VideoFacingMode> m_facingMode;
+    Vector<MeteringMode> m_whiteBalanceModes;
     CapabilityValueOrRange m_volume;
     CapabilityValueOrRange m_sampleRate;
     CapabilityValueOrRange m_sampleSize;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2011 Ericsson AB. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,6 +63,7 @@ RealtimeMediaSourceCenter::RealtimeMediaSourceCenter()
     m_supportedConstraints.setSupportsAspectRatio(true);
     m_supportedConstraints.setSupportsFrameRate(true);
     m_supportedConstraints.setSupportsFacingMode(true);
+    m_supportedConstraints.setSupportsWhiteBalanceMode(true);
     m_supportedConstraints.setSupportsVolume(true);
     m_supportedConstraints.setSupportsDeviceId(true);
     m_supportedConstraints.setSupportsDisplaySurface(true);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,24 +38,6 @@
 
 namespace WebCore {
 
-String RealtimeMediaSourceSettings::facingMode(VideoFacingMode mode)
-{
-    static const NeverDestroyed<String> values[] = {
-        MAKE_STATIC_STRING_IMPL("unknown"),
-        MAKE_STATIC_STRING_IMPL("user"),
-        MAKE_STATIC_STRING_IMPL("environment"),
-        MAKE_STATIC_STRING_IMPL("left"),
-        MAKE_STATIC_STRING_IMPL("right"),
-    };
-    static_assert(static_cast<size_t>(VideoFacingMode::Unknown) == 0, "VideoFacingMode::Unknown is not 0 as expected");
-    static_assert(static_cast<size_t>(VideoFacingMode::User) == 1, "VideoFacingMode::User is not 1 as expected");
-    static_assert(static_cast<size_t>(VideoFacingMode::Environment) == 2, "VideoFacingMode::Environment is not 2 as expected");
-    static_assert(static_cast<size_t>(VideoFacingMode::Left) == 3, "VideoFacingMode::Left is not 3 as expected");
-    static_assert(static_cast<size_t>(VideoFacingMode::Right) == 4, "VideoFacingMode::Right is not 4 as expected");
-    ASSERT(static_cast<size_t>(mode) < std::size(values));
-    return values[static_cast<size_t>(mode)];
-}
-
 VideoFacingMode RealtimeMediaSourceSettings::videoFacingModeEnum(const String& mode)
 {
     if (mode == "user"_s)
@@ -91,6 +73,9 @@ String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<Realtim
             break;
         case RealtimeMediaSourceSettings::FacingMode:
             builder.append("FacingMode");
+            break;
+        case RealtimeMediaSourceSettings::WhiteBalanceMode:
+            builder.append("WhiteBalanceMode");
             break;
         case RealtimeMediaSourceSettings::Volume:
             builder.append("Volume");
@@ -168,11 +153,11 @@ OptionSet<RealtimeMediaSourceSettings::Flag> RealtimeMediaSourceSettings::differ
 String convertEnumerationToString(VideoFacingMode enumerationValue)
 {
     static const NeverDestroyed<String> values[] = {
-        MAKE_STATIC_STRING_IMPL("Unknown"),
-        MAKE_STATIC_STRING_IMPL("User"),
-        MAKE_STATIC_STRING_IMPL("Environment"),
-        MAKE_STATIC_STRING_IMPL("Left"),
-        MAKE_STATIC_STRING_IMPL("Right"),
+        MAKE_STATIC_STRING_IMPL("unknown"),
+        MAKE_STATIC_STRING_IMPL("user"),
+        MAKE_STATIC_STRING_IMPL("environment"),
+        MAKE_STATIC_STRING_IMPL("left"),
+        MAKE_STATIC_STRING_IMPL("right"),
     };
     static_assert(static_cast<size_t>(VideoFacingMode::Unknown) == 0, "VideoFacingMode::Unknown is not 0 as expected");
     static_assert(static_cast<size_t>(VideoFacingMode::User) == 1, "VideoFacingMode::User is not 1 as expected");

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "MeteringMode.h"
 #include "RealtimeMediaSourceSupportedConstraints.h"
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
@@ -53,10 +54,9 @@ enum class DisplaySurfaceType : uint8_t {
 
 class RealtimeMediaSourceSettings {
 public:
-    static String facingMode(VideoFacingMode);
     static VideoFacingMode videoFacingModeEnum(const String&);
     static String displaySurface(DisplaySurfaceType);
-    
+
     enum Flag {
         Width = 1 << 0,
         Height = 1 << 1,
@@ -72,18 +72,20 @@ public:
         DisplaySurface = 1 << 11,
         LogicalSurface = 1 << 12,
         Zoom = 1 << 13,
+        WhiteBalanceMode = 1 << 14,
     };
 
-    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, Zoom }; }
+    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, Zoom, WhiteBalanceMode }; }
 
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     RealtimeMediaSourceSettings() = default;
-    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, String&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, double zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, MeteringMode whiteBalanceMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, String&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, double zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(width)
         , m_height(height)
         , m_frameRate(frameRate)
         , m_facingMode(facingMode)
+        , m_whiteBalanceMode(whiteBalanceMode)
         , m_volume(volume)
         , m_sampleRate(sampleRate)
         , m_sampleSize(sampleSize)
@@ -115,6 +117,10 @@ public:
     bool supportsFacingMode() const { return m_supportedConstraints.supportsFacingMode(); }
     VideoFacingMode facingMode() const { return m_facingMode; }
     void setFacingMode(VideoFacingMode facingMode) { m_facingMode = facingMode; }
+
+    bool supportsWhiteBalanceMode() const { return m_supportedConstraints.supportsWhiteBalanceMode(); }
+    MeteringMode whiteBalanceMode() const { return m_whiteBalanceMode; }
+    void setWhiteBalanceMode(MeteringMode mode) { m_whiteBalanceMode = mode; }
 
     bool supportsVolume() const { return m_supportedConstraints.supportsVolume(); }
     double volume() const { return m_volume; }
@@ -165,6 +171,7 @@ private:
     uint32_t m_height { 0 };
     float m_frameRate { 0 };
     VideoFacingMode m_facingMode { VideoFacingMode::Unknown };
+    MeteringMode m_whiteBalanceMode { MeteringMode::None };
     double m_volume { 0 };
     uint32_t m_sampleRate { 0 };
     uint32_t m_sampleSize { 0 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +65,8 @@ bool RealtimeMediaSourceSupportedConstraints::supportsConstraint(MediaConstraint
         return supportsFocusDistance();
     case MediaConstraintType::Zoom:
         return supportsZoom();
+    case MediaConstraintType::WhiteBalanceMode:
+        return supportsWhiteBalanceMode();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,6 +53,7 @@ enum class MediaConstraintType : uint8_t {
     LogicalSurface,
     FocusDistance,
     Zoom,
+    WhiteBalanceMode,
 };
 
 class RealtimeMediaSourceSupportedConstraints {
@@ -61,12 +62,13 @@ public:
     {
     }
     
-    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance, bool supportsZoom)
+    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsWhiteBalanceMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance, bool supportsZoom)
         : m_supportsWidth(supportsWidth)
         , m_supportsHeight(supportsHeight)
         , m_supportsAspectRatio(supportsAspectRatio)
         , m_supportsFrameRate(supportsFrameRate)
         , m_supportsFacingMode(supportsFacingMode)
+        , m_supportsWhiteBalanceMode(supportsWhiteBalanceMode)
         , m_supportsVolume(supportsVolume)
         , m_supportsSampleRate(supportsSampleRate)
         , m_supportsSampleSize(supportsSampleSize)
@@ -94,6 +96,9 @@ public:
 
     bool supportsFacingMode() const { return m_supportsFacingMode; }
     void setSupportsFacingMode(bool value) { m_supportsFacingMode = value; }
+
+    bool supportsWhiteBalanceMode() const { return m_supportsWhiteBalanceMode; }
+    void setSupportsWhiteBalanceMode(bool value) { m_supportsWhiteBalanceMode = value; }
 
     bool supportsVolume() const { return m_supportsVolume; }
     void setSupportsVolume(bool value) { m_supportsVolume = value; }
@@ -133,6 +138,7 @@ private:
     bool m_supportsAspectRatio { false };
     bool m_supportsFrameRate { false };
     bool m_supportsFacingMode { false };
+    bool m_supportsWhiteBalanceMode { false };
     bool m_supportsVolume { false };
     bool m_supportsSampleRate { false };
     bool m_supportsSampleSize { false };

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -127,6 +127,8 @@ private:
     std::optional<double> computeMinZoom() const;
     std::optional<double> computeMaxZoom(AVCaptureDeviceFormat*) const;
 
+    void updateWhiteBalanceMode();
+
     RefPtr<VideoFrame> m_buffer;
     RetainPtr<AVCaptureVideoDataOutput> m_videoOutput;
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;
@@ -149,6 +151,7 @@ private:
     double m_currentFrameRate;
     double m_currentZoom { 1 };
     double m_zoomScaleFactor { 1 };
+    uint64_t m_beginConfigurationCount { 0 };
     bool m_interrupted { false };
     bool m_isRunning { false };
 

--- a/Source/WebCore/platform/mock/MockMediaDevice.h
+++ b/Source/WebCore/platform/mock/MockMediaDevice.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,6 +91,7 @@ struct MockCameraProperties {
         encoder << facingMode;
         encoder << presets;
         encoder << fillColor;
+        encoder << whiteBalanceMode;
     }
 
     template <class Decoder>
@@ -116,13 +117,19 @@ struct MockCameraProperties {
         if (!fillColor)
             return std::nullopt;
 
-        return MockCameraProperties { *defaultFrameRate, *facingMode, WTFMove(*presets), *fillColor };
+        std::optional<Vector<MeteringMode>> whiteBalanceModes;
+        decoder >> whiteBalanceModes;
+        if (!whiteBalanceModes)
+            return std::nullopt;
+
+        return MockCameraProperties { *defaultFrameRate, *facingMode, WTFMove(*presets), *fillColor, WTFMove(*whiteBalanceModes) };
     }
 
     double defaultFrameRate { 30 };
     VideoFacingMode facingMode { VideoFacingMode::User };
     Vector<VideoPresetData> presets { { { 640, 480 }, { { 30, 30}, { 15, 15 } }, 1, 2 } };
     Color fillColor { Color::black };
+    Vector<MeteringMode> whiteBalanceMode { MeteringMode::None };
 };
 
 struct MockDisplayProperties {

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc.  All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,6 +76,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
                     { { 112, 112 },  { { 30, 30}, { 27.5, 27.5}, { 25, 25}, { 22.5, 22.5}, { 20, 20}, { 17.5, 17.5}, { 15, 15}, { 12.5, 12.5}, { 10, 10}, { 7.5, 7.5}, { 5, 5} }, 1, 1 },
                 },
                 Color::black,
+                { },
             } },
 
         MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, { },
@@ -92,6 +93,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
                     { { 160, 120 },   { { 2, 30 } }, 1, 4 },
                 },
                 Color::darkGray,
+                { MeteringMode::Manual, MeteringMode::SingleShot, MeteringMode::Continuous },
             } },
 
         MockMediaDevice { "SCREEN-1"_s, "Mock screen device 1"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::lightGray, { 1920, 1080 } } },

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1975,6 +1975,7 @@ struct WebCore::MediaStreamRequest {
     std::optional<WebCore::BooleanConstraint> m_displaySurface;
     std::optional<WebCore::BooleanConstraint> m_logicalSurface;
     std::optional<WebCore::StringConstraint> m_facingMode;
+    std::optional<WebCore::StringConstraint> m_whiteBalanceMode;
     std::optional<WebCore::StringConstraint> m_deviceId;
     std::optional<WebCore::StringConstraint> m_groupId;
 }
@@ -4632,6 +4633,7 @@ enum class WebCore::MediaConstraintType : uint8_t {
     DisplaySurface,
     LogicalSurface,
     Zoom,
+    WhiteBalanceMode,
 };
 
 header: <WebCore/MediaConstraints.h>
@@ -4684,6 +4686,7 @@ class WebCore::RealtimeMediaSourceSupportedConstraints {
     bool supportsAspectRatio();
     bool supportsFrameRate();
     bool supportsFacingMode();
+    bool supportsWhiteBalanceMode();
     bool supportsVolume();
     bool supportsSampleRate();
     bool supportsSampleSize();
@@ -4712,11 +4715,20 @@ enum class WebCore::DisplaySurfaceType : uint8_t {
     Invalid,
 };
 
+header: <WebCore/MeteringMode.h>
+[CustomHeader] enum class WebCore::MeteringMode : uint8_t {
+    None,
+    Manual,
+    SingleShot,
+    Continuous,
+};
+
 class WebCore::RealtimeMediaSourceSettings {
     uint32_t width();
     uint32_t height();
     float frameRate();
     WebCore::VideoFacingMode facingMode();
+    WebCore::MeteringMode whiteBalanceMode();
     double volume();
     uint32_t sampleRate();
     uint32_t sampleSize();
@@ -4764,6 +4776,7 @@ class WebCore::RealtimeMediaSourceCapabilities {
     WebCore::CapabilityValueOrRange aspectRatio();
     WebCore::CapabilityValueOrRange frameRate();
     Vector<WebCore::VideoFacingMode> facingMode();
+    Vector<WebCore::MeteringMode> whiteBalanceModes();
     WebCore::CapabilityValueOrRange volume();
     WebCore::CapabilityValueOrRange sampleRate();
     WebCore::CapabilityValueOrRange sampleSize();


### PR DESCRIPTION
#### 351ec2749d2563ff7aa631bcdcabcc58240a3889
<pre>
[MediaStream] Add support for whiteBalanceMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261602">https://bugs.webkit.org/show_bug.cgi?id=261602</a>
rdar://115552800

Reviewed by Youenn Fablet.

Add support for MediaTrackCapabilities `whiteBalanceMode` and expose &apos;whiteBalanceMode&apos; as
a supported constraint.

Update mock camera to support whiteBalanceMode and add new test.

* LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt:
* LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html:
* LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode.html: Added.
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::hasInvalidGetDisplayMediaConstraint):
(WebCore::MediaDevices::getSupportedConstraints):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getSettings const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::capabilityStringVector):
(WebCore::toMediaTrackCapabilities):
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp:
(WebCore::convertToInternalForm):
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl:
* Source/WebCore/Modules/mediastream/MeteringMode.h: New.
* Source/WebCore/Modules/mediastream/MeteringMode.idl: New.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaTrackConstraintSetMap::filter const):
(WebCore::MediaTrackConstraintSetMap::set):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaTrackConstraintSetMap::whiteBalanceMode const):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::supportsConstraint):
(WebCore::RealtimeMediaSource::supportsConstraints):
(WebCore::RealtimeMediaSource::setWhiteBalanceMode):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::supportsWhiteBalanceMode const):
(WebCore::RealtimeMediaSourceCapabilities::whiteBalanceModes const):
(WebCore::RealtimeMediaSourceCapabilities::setWhiteBalanceModes):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::RealtimeMediaSourceCenter):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::convertFlagsToString):
(WebCore::convertEnumerationToString):
(WebCore::RealtimeMediaSourceSettings::facingMode): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::allFlags):
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WebCore::RealtimeMediaSourceSettings::supportsWhiteBalanceMode const):
(WebCore::RealtimeMediaSourceSettings::whiteBalanceMode const):
(WebCore::RealtimeMediaSourceSettings::setWhiteBalanceMode):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp:
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsConstraint const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
(WebCore::RealtimeMediaSourceSupportedConstraints::RealtimeMediaSourceSupportedConstraints):
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsWhiteBalanceMode const):
(WebCore::RealtimeMediaSourceSupportedConstraints::setSupportsWhiteBalanceMode):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::whiteBalanceModeFromMeteringMode):
(WebCore::meteringModeFromAVCaptureWhiteBalanceMode):
(WebCore::AVVideoCaptureSource::settingsDidChange):
(WebCore::supportedWhiteBalanceModes):
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode):
* Source/WebCore/platform/mock/MockMediaDevice.h:
(WebCore::MockCameraProperties::encode const):
(WebCore::MockCameraProperties::decode):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::defaultDevices):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::settings):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268102@main">https://commits.webkit.org/268102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acdd31c4ef41e4adf4fdb84e7e04665de16edea9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18695 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19177 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21437 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17040 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17810 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22065 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16872 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5383 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4441 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21236 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23310 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17649 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5238 "Passed tests") | 
<!--EWS-Status-Bubble-End-->