### PR TITLE
First parseable meta@name=color-scheme should win

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-first-valid-applies-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-first-valid-applies-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Tree order decides which meta color-scheme applies. assert_equals: expected "dark" but got "light"
+PASS Tree order decides which meta color-scheme applies.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-remove-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-remove-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL First meta applies. assert_equals: expected "dark" but got "light"
+PASS First meta applies.
 PASS Second meta applies after first one is removed.
 PASS Initial color-scheme with both meta elements removed.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-remove-head-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-remove-head-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Meta color-scheme applies.
-FAIL Initial value after removing head including meta color-scheme. assert_equals: expected "light" but got "dark"
+PASS Initial value after removing head including meta color-scheme.
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -36,6 +36,7 @@
 #include "CSSAnimation.h"
 #include "CSSFontSelector.h"
 #include "CSSParser.h"
+#include "CSSPropertyNames.h"
 #include "CSSStyleDeclaration.h"
 #include "CSSStyleSheet.h"
 #include "CachedCSSStyleSheet.h"
@@ -4264,6 +4265,21 @@ void Document::processColorScheme(const String& colorSchemeString)
 
     if (auto* page = this->page())
         page->updateStyleAfterChangeInEnvironment();
+}
+
+void Document::metaElementColorSchemeChanged()
+{
+    RefPtr<CSSValue> colorScheme;
+    auto colorSchemeString = emptyString();
+    auto cssParserContext = CSSParserContext(document());
+    for (auto& metaElement : descendantsOfType<HTMLMetaElement>(rootNode())) {
+        const AtomString& nameValue = metaElement.attributeWithoutSynchronization(nameAttr);
+        if ((equalLettersIgnoringASCIICase(nameValue, "color-scheme"_s) || equalLettersIgnoringASCIICase(nameValue, "supported-color-schemes"_s)) && (colorScheme = CSSParser::parseSingleValue(CSSPropertyColorScheme, metaElement.attributeWithoutSynchronization(contentAttr), cssParserContext))) {
+            colorSchemeString = colorScheme->cssText();
+            break;
+        }
+    }
+    processColorScheme(colorSchemeString);
 }
 #endif
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1002,6 +1002,7 @@ public:
 
 #if ENABLE(DARK_MODE_CSS)
     void processColorScheme(const String& colorScheme);
+    void metaElementColorSchemeChanged();
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -143,6 +143,10 @@ void HTMLMetaElement::removedFromAncestor(RemovalType removalType, ContainerNode
 
     if (removalType.disconnectedFromDocument && equalLettersIgnoringASCIICase(name(), "theme-color"_s))
         oldParentOfRemovedTree.document().metaElementThemeColorChanged(*this);
+#if ENABLE(DARK_MODE_CSS)
+    else if (removalType.disconnectedFromDocument && (equalLettersIgnoringASCIICase(name(), "color-scheme"_s) || equalLettersIgnoringASCIICase(name(), "supported-color-schemes"_s)))
+        oldParentOfRemovedTree.document().metaElementColorSchemeChanged();
+#endif
 }
 
 void HTMLMetaElement::process()
@@ -174,7 +178,7 @@ void HTMLMetaElement::process()
         document().processDisabledAdaptations(contentValue);
 #if ENABLE(DARK_MODE_CSS)
     else if (equalLettersIgnoringASCIICase(nameValue, "color-scheme"_s) || equalLettersIgnoringASCIICase(nameValue, "supported-color-schemes"_s))
-        document().processColorScheme(contentValue);
+        document().metaElementColorSchemeChanged();
 #endif
     else if (equalLettersIgnoringASCIICase(nameValue, "theme-color"_s))
         document().metaElementThemeColorChanged(*this);


### PR DESCRIPTION
#### 7d7215513fb5d3a7ac39d3809200c0a7aba58bd7
<pre>
First parseable meta@name=color-scheme should win
<a href="https://bugs.webkit.org/show_bug.cgi?id=213563">https://bugs.webkit.org/show_bug.cgi?id=213563</a>

Reviewed by Aditya Keerthi.

This change gets WebKit conforming to the requirement in the HTML spec
at <a href="https://html.spec.whatwg.org/#standard-metadata-names">https://html.spec.whatwg.org/#standard-metadata-names</a>:page&apos;s-supported-color-schemes-2
that UAs must respect the first parseable &lt;meta name=color-scheme&gt; value
encountered in tree order. And the change gets WebKit passing the WPT
tests related to that spec requirement.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-first-valid-applies-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-remove-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-remove-head-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::metaElementColorSchemeChanged):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::removedFromAncestor):
(WebCore::HTMLMetaElement::process):

Canonical link: <a href="https://commits.webkit.org/268064@main">https://commits.webkit.org/268064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de54749378ce906ef24c53d42719066b9b313386

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18590 "Failed to checkout and rebase branch from PR 17817") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17395 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18786 "Failed to checkout and rebase branch from PR 17817") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19070 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18815 "Failed to checkout and rebase branch from PR 17817") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/18975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/16944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/21326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->