### PR TITLE
ShareableResource::Handle should always be valid

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -106,7 +106,7 @@ class SpeculativeLoadManager;
 struct MappedBody {
 #if ENABLE(SHAREABLE_RESOURCE)
     RefPtr<ShareableResource> shareableResource;
-    ShareableResource::Handle shareableResourceHandle;
+    std::optional<ShareableResource::Handle> shareableResourceHandle;
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -180,26 +180,11 @@ void Entry::capMaxAge(const Seconds seconds)
 }
 #endif
 
-#if ENABLE(SHAREABLE_RESOURCE)
-void Entry::initializeShareableResourceHandleFromStorageRecord() const
-{
-    auto sharedMemory = m_sourceStorageRecord.body.tryCreateSharedMemory();
-    if (!sharedMemory)
-        return;
-
-    auto shareableResource = ShareableResource::create(sharedMemory.releaseNonNull(), 0, m_sourceStorageRecord.body.size());
-    if (!shareableResource)
-        return;
-    if (auto handle = shareableResource->createHandle())
-        m_shareableResourceHandle = WTFMove(*handle);
-}
-#endif
-
 void Entry::initializeBufferFromStorageRecord() const
 {
 #if ENABLE(SHAREABLE_RESOURCE)
-    if (!shareableResourceHandle().isNull()) {
-        m_buffer = WTFMove(m_shareableResourceHandle).tryWrapInSharedBuffer();
+    if (auto handle = shareableResourceHandle()) {
+        m_buffer = WTFMove(*handle).tryWrapInSharedBuffer();
         if (m_buffer)
             return;
     }
@@ -216,12 +201,18 @@ WebCore::FragmentedSharedBuffer* Entry::buffer() const
 }
 
 #if ENABLE(SHAREABLE_RESOURCE)
-ShareableResource::Handle& Entry::shareableResourceHandle() const
+std::optional<ShareableResource::Handle> Entry::shareableResourceHandle() const
 {
-    if (m_shareableResourceHandle.isNull())
-        initializeShareableResourceHandleFromStorageRecord();
+    if (m_shareableResource)
+        return m_shareableResource->createHandle();
 
-    return m_shareableResourceHandle;
+    auto sharedMemory = m_sourceStorageRecord.body.tryCreateSharedMemory();
+    if (!sharedMemory)
+        return std::nullopt;
+
+    if ((m_shareableResource = ShareableResource::create(sharedMemory.releaseNonNull(), 0, m_sourceStorageRecord.body.size())))
+        return m_shareableResource->createHandle();
+    return std::nullopt;
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -61,7 +61,7 @@ public:
     const std::optional<WebCore::ResourceRequest>& redirectRequest() const { return m_redirectRequest; }
 
 #if ENABLE(SHAREABLE_RESOURCE)
-    ShareableResource::Handle& shareableResourceHandle() const;
+    std::optional<ShareableResource::Handle> shareableResourceHandle() const;
 #endif
 
     bool needsValidation() const;
@@ -78,9 +78,6 @@ public:
 
 private:
     void initializeBufferFromStorageRecord() const;
-#if ENABLE(SHAREABLE_RESOURCE)
-    void initializeShareableResourceHandleFromStorageRecord() const;
-#endif
 
     Key m_key;
     WallTime m_timeStamp;
@@ -90,7 +87,7 @@ private:
     std::optional<WebCore::ResourceRequest> m_redirectRequest;
     mutable RefPtr<WebCore::FragmentedSharedBuffer> m_buffer;
 #if ENABLE(SHAREABLE_RESOURCE)
-    mutable ShareableResource::Handle m_shareableResourceHandle;
+    mutable RefPtr<ShareableResource> m_shareableResource;
 #endif
 
     Storage::Record m_sourceStorageRecord { };

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -140,8 +140,6 @@ def types_that_must_be_moved():
         'IPC::Connection::Handle',
         'IPC::StreamServerConnection::Handle',
         'MachSendRight',
-        'std::optional<MachSendRight>',
-        'std::optional<WebKit::SharedVideoFrame::Buffer>',
         'Vector<WebKit::SharedMemory::Handle>',
         'WebCore::GraphicsContextGL::EGLImageSource',
         'WebKit::ConsumerSharedCARingBuffer::Handle',
@@ -155,6 +153,9 @@ def types_that_must_be_moved():
         'WebKit::UpdateInfo',
         'WebKit::WebProcessCreationParameters',
         'Win32Handle',
+        'std::optional<MachSendRight>',
+        'std::optional<WebKit::ShareableResource::Handle>',
+        'std::optional<WebKit::SharedVideoFrame::Buffer>',
         'std::optional<Win32Handle>'
     ]
 

--- a/Source/WebKit/Shared/ShareableResource.cpp
+++ b/Source/WebKit/Shared/ShareableResource.cpp
@@ -35,13 +35,12 @@
 namespace WebKit {
 using namespace WebCore;
 
-ShareableResourceHandle::ShareableResourceHandle() = default;
-
 ShareableResourceHandle::ShareableResourceHandle(SharedMemory::Handle&& handle, unsigned offset, unsigned size)
     : m_handle(WTFMove(handle))
     , m_offset(offset)
     , m_size(size)
 {
+    ASSERT(!m_handle.isNull());
 }
 
 RefPtr<SharedBuffer> ShareableResource::wrapInSharedBuffer()

--- a/Source/WebKit/Shared/ShareableResource.h
+++ b/Source/WebKit/Shared/ShareableResource.h
@@ -40,13 +40,11 @@ namespace WebKit {
 class ShareableResourceHandle {
     WTF_MAKE_NONCOPYABLE(ShareableResourceHandle);
 public:
-    ShareableResourceHandle();
     ShareableResourceHandle(ShareableResourceHandle&&) = default;
     ShareableResourceHandle(SharedMemory::Handle&&, unsigned, unsigned);
 
     ShareableResourceHandle& operator=(ShareableResourceHandle&&) = default;
 
-    bool isNull() const { return m_handle.isNull(); }
     unsigned size() const { return m_size; }
 
     RefPtr<WebCore::SharedBuffer> tryWrapInSharedBuffer() &&;

--- a/Source/WebKit/Shared/ShareableResource.serialization.in
+++ b/Source/WebKit/Shared/ShareableResource.serialization.in
@@ -24,7 +24,7 @@ header: "ShareableResource.h"
 
 #if ENABLE(SHAREABLE_RESOURCE)
 [CustomHeader, RValue] class WebKit::ShareableResourceHandle {
-    WebKit::SharedMemoryHandle m_handle;
+    [Validator='!m_handle->isNull()'] WebKit::SharedMemoryHandle m_handle;
     unsigned m_offset;
     [Validator='!(Checked<unsigned> { *m_offset } + *m_size).hasOverflowed() && (*m_offset + *m_size <= m_handle->size())'] unsigned m_size;
 }


### PR DESCRIPTION
#### bc3ff053ad9d4dc8da786f2d35c5d871796eca88
<pre>
ShareableResource::Handle should always be valid
<a href="https://bugs.webkit.org/show_bug.cgi?id=261610">https://bugs.webkit.org/show_bug.cgi?id=261610</a>

Reviewed by Kimmo Kinnunen.

The underyling `SharedMemory::Handle` in `ShareableResource::Handle`
should always be valid. Remove the `isNull` method and default
constructor. Use `std::optional&lt;ShareableResource::Handle&gt;` in place of
any `isNull` checks. Validate the handle within the generated
serialization.

This is a step towards `SharedMemory::Handle` also always being valid.

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::tryStoreAsCacheEntry):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::initializeBufferFromStorageRecord const):
(WebKit::NetworkCache::Entry::shareableResourceHandle const):
(WebKit::NetworkCache::Entry::initializeShareableResourceHandleFromStorageRecord const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/Shared/ShareableResource.cpp:
(WebKit::ShareableResourceHandle::ShareableResourceHandle):
* Source/WebKit/Shared/ShareableResource.h:
(WebKit::ShareableResourceHandle::isNull const): Deleted.
* Source/WebKit/Shared/ShareableResource.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::tryConvertToShareableResourceHandle):
(IPC::ArgumentCoder&lt;WebCore::ScriptBuffer&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::ScriptBuffer&gt;::decode):
(IPC::decodeScriptBufferAsShareableResourceHandle): Deleted.

Canonical link: <a href="https://commits.webkit.org/268077@main">https://commits.webkit.org/268077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/811e3b65f5208a0839fd0b50cfbbfbd0931c1e6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19271 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21354 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18784 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16219 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23414 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15042 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16792 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4420 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->