### PR TITLE
[WGSL] Add scope for for-statement

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -54,6 +54,7 @@ public:
 
     // Statements
     void visit(AST::CompoundStatement&) override;
+    void visit(AST::ForStatement&) override;
 
     // Expressions
     void visit(AST::IdentifierExpression&) override;
@@ -145,6 +146,12 @@ void ConstantRewriter::visit(AST::Function& function)
 void ConstantRewriter::visit(AST::CompoundStatement& statement)
 {
     ContextScope blockScope(this);
+    AST::Visitor::visit(statement);
+}
+
+void ConstantRewriter::visit(AST::ForStatement& statement)
+{
+    ContextScope forScope(this);
     AST::Visitor::visit(statement);
 }
 

--- a/Source/WebGPU/WGSL/GlobalSorting.cpp
+++ b/Source/WebGPU/WGSL/GlobalSorting.cpp
@@ -176,6 +176,7 @@ public:
     void visit(AST::Function&) override;
     void visit(AST::VariableStatement&) override;
     void visit(AST::CompoundStatement&) override;
+    void visit(AST::ForStatement&) override;
     void visit(AST::IdentifierExpression&) override;
 
 private:
@@ -228,6 +229,13 @@ template<typename ASTNode>
 void GraphBuilder<ASTNode>::visit(AST::CompoundStatement& statement)
 {
     ContextScope blockScope(this);
+    AST::Visitor::visit(statement);
+}
+
+template<typename ASTNode>
+void GraphBuilder<ASTNode>::visit(AST::ForStatement& statement)
+{
+    ContextScope forScope(this);
     AST::Visitor::visit(statement);
 }
 

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -80,6 +80,7 @@ public:
     void visit(AST::Structure&) override;
     void visit(AST::Variable&) override;
     void visit(AST::CompoundStatement&) override;
+    void visit(AST::ForStatement&) override;
     void visit(AST::IdentifierExpression&) override;
     void visit(AST::FieldAccessExpression&) override;
 
@@ -196,6 +197,12 @@ void NameManglerVisitor::visitVariableDeclaration(AST::Variable& variable, Mangl
 void NameManglerVisitor::visit(AST::CompoundStatement& statement)
 {
     ContextScope blockScope(this);
+    AST::Visitor::visit(statement);
+}
+
+void NameManglerVisitor::visit(AST::ForStatement& statement)
+{
+    ContextScope forScope(this);
     AST::Visitor::visit(statement);
 }
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -509,6 +509,7 @@ void TypeChecker::visit(AST::CompoundStatement& statement)
 
 void TypeChecker::visit(AST::ForStatement& statement)
 {
+    ContextScope forScope(this);
     if (auto* initializer = statement.maybeInitializer())
         AST::Visitor::visit(*initializer);
 


### PR DESCRIPTION
#### 9aa4f5708d1b88917b8660ce5fc8081663ff3699
<pre>
[WGSL] Add scope for for-statement
<a href="https://bugs.webkit.org/show_bug.cgi?id=261612">https://bugs.webkit.org/show_bug.cgi?id=261612</a>
rdar://115561511

Reviewed by Dan Glastonbury.

For statements can introduce variables which are only in scope within its body,
so it needs to introduce a new scope.

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::visit):
* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::GraphBuilder&lt;ASTNode&gt;::visit):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/268078@main">https://commits.webkit.org/268078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f339b1a7782e283e251712ad97368ad42013bd41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17260 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19156 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21161 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16068 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23288 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21175 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14900 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16640 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->