### PR TITLE
[Filters] Referenced SVG filters with outsets get clipped

### DIFF
--- a/LayoutTests/css3/filters/effect-reference-outsets-expected.html
+++ b/LayoutTests/css3/filters/effect-reference-outsets-expected.html
@@ -1,0 +1,28 @@
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        display: inline-block;
+        margin: 20px;
+    }
+    .red-drop-shadow {
+        filter: drop-shadow(30px 30px 0px black);
+        background-color: red;
+    }
+    .green-drop-shadow {
+        filter: drop-shadow(30px 30px 0px black);
+        background-color: green;
+    }
+    .blue-drop-shadow {
+        filter: drop-shadow(30px 30px 0px black);
+        background-color: blue;
+    }
+</style>
+<body>
+    <div class="box red-drop-shadow">
+    </div>
+    <div class="box green-drop-shadow">
+    </div>
+    <div class="box blue-drop-shadow">
+    </div>
+</body>

--- a/LayoutTests/css3/filters/effect-reference-outsets.html
+++ b/LayoutTests/css3/filters/effect-reference-outsets.html
@@ -1,0 +1,42 @@
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        display: inline-block;
+        margin: 20px;
+    }
+    .css-drop-shadow {
+        filter: drop-shadow(30px 30px 0px black);
+        background-color: red;
+    }
+    .svg-drop-shadow-1 {
+        filter: url(#svgDropShadow-1);
+        background-color: green;
+    }
+    .svg-drop-shadow-2 {
+        filter: url(#svgDropShadow-2);
+        background-color: blue;
+    }
+</style>
+<body>
+    <div class="box css-drop-shadow">
+    </div>
+    <div class="box svg-drop-shadow-1">
+    </div>
+    <div class="box svg-drop-shadow-2">
+    </div>
+    <svg style="position: absolute; top: -999999px" xmlns="http://www.w3.org/2000/svg">
+        <filter id="svgDropShadow-1">
+            <feOffset dx="30" dy="30" result="offset"/>
+            <feFlood flood-color="black"/>
+            <feComposite in2="offset" operator="in"/>
+            <feMerge>
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic"/>
+            </feMerge>
+        </filter>
+        <filter id="svgDropShadow-2">
+            <feDropShadow dx="30" dy="30" stdDeviation="0" flood-color="black"/>
+        </filter>
+    </svg>
+</body>

--- a/LayoutTests/css3/filters/reference-filter-outsets-expected.html
+++ b/LayoutTests/css3/filters/reference-filter-outsets-expected.html
@@ -1,7 +1,7 @@
 <style>
     .container {
-        width: 90px;
-        height: 90px;
+        width: 100px;
+        height: 100px;
         display: inline-block;
         background-color: black;
         margin: 10px;
@@ -9,26 +9,25 @@
     .box {
         width: 100px;
         height: 100px;
-        display: inline-block;
         background-color: green;
     }
 </style>
 <body>
     <div>
-        <div class="container" style="transform: translate(-10px, -10px);">
-            <div class="box" style="transform: translate(10px, 10px);"></div>
+        <div class="container" style="transform: translate(-20px, -20px);">
+            <div class="box" style="transform: translate(20px, 20px);"></div>
         </div>
 
-        <div class="container" style="transform: translate(30px, -10px);">
-            <div class="box" style="transform: translate(-20px, 10px);"></div>
+        <div class="container" style="transform: translate(20px, -20px);">
+            <div class="box" style="transform: translate(-20px, 20px);"></div>
         </div>
     </div>
     <div>
-        <div class="container" style="transform: translate(-10px, 30px);">
-            <div class="box" style="transform: translate(10px, -20px);"></div>
+        <div class="container" style="transform: translate(-20px, 20px);">
+            <div class="box" style="transform: translate(20px, -20px);"></div>
         </div>
 
-        <div class="container" style="transform: translate(30px, 30px);">
+        <div class="container" style="transform: translate(20px, 20px);">
             <div class="box" style="transform: translate(-20px, -20px);"></div>
         </div>
     </div>

--- a/LayoutTests/css3/filters/svg-morphology-clipped-expected.html
+++ b/LayoutTests/css3/filters/svg-morphology-clipped-expected.html
@@ -1,9 +1,8 @@
 <style>
     .filtered {
         position: absolute;
-        width: 120px;
-        height: 120px;
-        margin: 40px;
+        width: 200px;
+        height: 200px;
         border: none;
         background-color: lime;
     }

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -118,6 +118,16 @@ inline RectEdges<T>& operator+=(RectEdges<T>& a, const RectEdges<T>& b)
 }
 
 template<typename T>
+inline RectEdges<T> unionEdges(const RectEdges<T>& a, const RectEdges<T>& b)
+{
+    auto top    = std::max(a.top(),    b.top());
+    auto right  = std::max(a.right(),  b.right());
+    auto bottom = std::max(a.bottom(), b.bottom());
+    auto left   = std::max(a.left(),   b.left());
+    return { top, right, bottom, left };
+}
+
+template<typename T>
 TextStream& operator<<(TextStream& ts, const RectEdges<T>& edges)
 {
     ts << "[top " << edges.top() << " right " << edges.right() << " bottom " << edges.bottom() << " left " << edges.left() << "]";


### PR DESCRIPTION
#### 5d1ec678ed0af1250e07f258aae69963a5dfd016
<pre>
[Filters] Referenced SVG filters with outsets get clipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=261615">https://bugs.webkit.org/show_bug.cgi?id=261615</a>
rdar://115567857

Reviewed by NOBODY (OOPS!).

When updating the CSSFilter filterRegion, we should update the filterRegion of
all referenced SVGFilters.

Because the CSSFilter should not clip its effects, the outsets of the referenced
SVG filter should take into account the outsets of the SVGFilterElement itself.
These outsets are used to calculate the Filter maxEffectRect. The maxEffectRect
is the default primitive subregion.

* LayoutTests/css3/filters/effect-reference-outsets-expected.html: Added.
* LayoutTests/css3/filters/effect-reference-outsets.html: Added.
Add new tests.

* LayoutTests/css3/filters/reference-filter-outsets-expected.html:
* LayoutTests/css3/filters/svg-morphology-clipped-expected.html:
The expected files for these tests are incorrect.

* Source/WebCore/platform/RectEdges.h:
(WebCore::unionEdges):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::calculateReferenceFilterOutsets):
(WebCore::CSSFilter::setFilterRegion):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d1ec678ed0af1250e07f258aae69963a5dfd016

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20750 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19356 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21634 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17210 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21560 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17043 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21402 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->