### PR TITLE
'plan_file_optimizer' script should order entries in subtree->tree consistently.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/plan_file_optimizer.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/plan_file_optimizer.py
@@ -57,8 +57,18 @@ def optimize_plan_file(file_path):
             dictionary.pop(key, None)
 
     drop_keys(subtree, ['sha', 'size'])
+    tree_with_ordered_entries = []
     for entry in subtree['tree']:
         drop_keys(entry, ['sha', 'size', 'url'])
+        ordered_entry = OrderedDict()
+        for key in ['path', 'mode', 'type'] + sorted(entry.keys()):
+            if key in ordered_entry:
+                continue
+            if key not in entry:
+                continue
+            ordered_entry[key] = entry[key]
+        tree_with_ordered_entries.append(ordered_entry)
+    subtree['tree'] = tree_with_ordered_entries
 
     plan['github_subtree'] = subtree
     with open(file_path, 'w') as fp:


### PR DESCRIPTION
#### 5ecf78803c5bdd779eba30027e16abab9810402a
<pre>
&apos;plan_file_optimizer&apos; script should order entries in subtree-&gt;tree consistently.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261617">https://bugs.webkit.org/show_bug.cgi?id=261617</a>
rdar://115568555

Reviewed by Stephanie Lewis.

Add code in &apos;plan_file_optimizer&apos; script to ensure entries in &apos;subtree-&gt;tree&apos; are ordered
consistently to reduce unnecessary plan file diff on plan update.

* Tools/Scripts/webkitpy/benchmark_runner/plan_file_optimizer.py:
(optimize_plan_file):

Canonical link: <a href="https://commits.webkit.org/268043@main">https://commits.webkit.org/268043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f0bdfc4e0db2d6b53dfd69f7ca95a3988acd729

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20342 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18972 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21218 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18652 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16861 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23328 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21219 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17612 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16679 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4397 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->