### PR TITLE
Prepare RemoteScrollingCoordinatorTransaction pieces for generated serialization

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
@@ -40,8 +40,18 @@ Ref<ScrollingStateFixedNode> ScrollingStateFixedNode::create(ScrollingStateTree&
     return adoptRef(*new ScrollingStateFixedNode(stateTree, nodeID));
 }
 
+Ref<ScrollingStateFixedNode> ScrollingStateFixedNode::create(ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStateFixedNode(nodeID));
+}
+
+ScrollingStateFixedNode::ScrollingStateFixedNode(ScrollingNodeID nodeID)
+    : ScrollingStateNode(ScrollingNodeType::Fixed, nullptr, nodeID)
+{
+}
+
 ScrollingStateFixedNode::ScrollingStateFixedNode(ScrollingStateTree& tree, ScrollingNodeID nodeID)
-    : ScrollingStateNode(ScrollingNodeType::Fixed, tree, nodeID)
+    : ScrollingStateNode(ScrollingNodeType::Fixed, &tree, nodeID)
 {
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.h
@@ -39,6 +39,7 @@ class FixedPositionViewportConstraints;
 class ScrollingStateFixedNode final : public ScrollingStateNode {
 public:
     static Ref<ScrollingStateFixedNode> create(ScrollingStateTree&, ScrollingNodeID);
+    static WEBCORE_EXPORT Ref<ScrollingStateFixedNode> create(ScrollingNodeID);
 
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) final;
 
@@ -48,6 +49,7 @@ public:
     const FixedPositionViewportConstraints& viewportConstraints() const { return m_constraints; }
 
 private:
+    ScrollingStateFixedNode(ScrollingNodeID);
     ScrollingStateFixedNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateFixedNode(const ScrollingStateFixedNode&, ScrollingStateTree&);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp
@@ -38,8 +38,19 @@ Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(Scrol
     return adoptRef(*new ScrollingStateFrameHostingNode(stateTree, nodeID));
 }
 
+Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStateFrameHostingNode(nodeID));
+}
+
+ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingNodeID nodeID)
+    : ScrollingStateNode(ScrollingNodeType::FrameHosting, nullptr, nodeID)
+{
+    ASSERT(isFrameHostingNode());
+}
+
 ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingStateTree& stateTree, ScrollingNodeID nodeID)
-    : ScrollingStateNode(ScrollingNodeType::FrameHosting, stateTree, nodeID)
+    : ScrollingStateNode(ScrollingNodeType::FrameHosting, &stateTree, nodeID)
 {
     ASSERT(isFrameHostingNode());
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h
@@ -36,6 +36,7 @@ class Scrollbar;
 class ScrollingStateFrameHostingNode final : public ScrollingStateNode {
 public:
     WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingStateTree&, ScrollingNodeID);
+    WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingNodeID);
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
 
     virtual ~ScrollingStateFrameHostingNode();
@@ -43,6 +44,7 @@ public:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
 private:
+    ScrollingStateFrameHostingNode(ScrollingNodeID);
     ScrollingStateFrameHostingNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateFrameHostingNode(const ScrollingStateFrameHostingNode&, ScrollingStateTree&);
 };

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -33,9 +33,20 @@
 
 namespace WebCore {
 
+Ref<ScrollingStateFrameScrollingNode> ScrollingStateFrameScrollingNode::create(bool mainFrame, ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStateFrameScrollingNode(mainFrame, nodeID));
+}
+
 Ref<ScrollingStateFrameScrollingNode> ScrollingStateFrameScrollingNode::create(ScrollingStateTree& stateTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingStateFrameScrollingNode(stateTree, nodeType, nodeID));
+}
+
+ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(bool mainFrame, ScrollingNodeID nodeID)
+    : ScrollingStateScrollingNode(mainFrame ? ScrollingNodeType::MainFrame : ScrollingNodeType::Subframe, nodeID)
+{
+    ASSERT(isFrameScrollingNode());
 }
 
 ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(ScrollingStateTree& stateTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
@@ -317,6 +328,11 @@ void ScrollingStateFrameScrollingNode::setOverlayScrollbarsEnabled(bool enabled)
         return;
     m_overlayScrollbarsEnabled = enabled;
     setPropertyChanged(Property::OverlayScrollbarsEnabled);
+}
+
+bool ScrollingStateFrameScrollingNode::isMainFrame() const
+{
+    return nodeType() == ScrollingNodeType::MainFrame;
 }
 
 void ScrollingStateFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -39,7 +39,9 @@ class Scrollbar;
 
 class ScrollingStateFrameScrollingNode final : public ScrollingStateScrollingNode {
 public:
+    static WEBCORE_EXPORT Ref<ScrollingStateFrameScrollingNode> create(bool mainFrame, ScrollingNodeID);
     static Ref<ScrollingStateFrameScrollingNode> create(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
+    static WEBCORE_EXPORT Ref<ScrollingStateFrameScrollingNode> create(ScrollingNodeType, ScrollingNodeID);
 
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
 
@@ -119,10 +121,13 @@ public:
     
     bool overlayScrollbarsEnabled() const { return m_overlayScrollbarsEnabled; }
     WEBCORE_EXPORT void setOverlayScrollbarsEnabled(bool);
+
+    WEBCORE_EXPORT bool isMainFrame() const;
     
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
 private:
+    ScrollingStateFrameScrollingNode(bool mainFrame, ScrollingNodeID);
     ScrollingStateFrameScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
     ScrollingStateFrameScrollingNode(const ScrollingStateFrameScrollingNode&, ScrollingStateTree&);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -315,6 +315,8 @@ public:
     Vector<Ref<ScrollingStateNode>>& children() { return m_children; }
     const Vector<Ref<ScrollingStateNode>>& children() const { return m_children; }
     Vector<Ref<ScrollingStateNode>> takeChildren() { return std::exchange(m_children, { }); }
+    WEBCORE_EXPORT void setChildren(Vector<Ref<ScrollingStateNode>>&&);
+    void traverse(const Function<void(ScrollingStateNode&)>&);
 
     void appendChild(Ref<ScrollingStateNode>&&);
     void insertChild(Ref<ScrollingStateNode>&&, size_t index);
@@ -326,10 +328,13 @@ public:
     RefPtr<ScrollingStateNode> childAtIndex(size_t) const;
 
     String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const;
+#if ASSERT_ENABLED
+    bool parentPointersAreCorrect() const;
+#endif
 
 protected:
     ScrollingStateNode(const ScrollingStateNode&, ScrollingStateTree&);
-    ScrollingStateNode(ScrollingNodeType, ScrollingStateTree&, ScrollingNodeID);
+    ScrollingStateNode(ScrollingNodeType, ScrollingStateTree*, ScrollingNodeID);
 
     void setPropertyChangedInternal(Property property) { m_changedProperties.add(property); }
     void setPropertiesChangedInternal(OptionSet<Property> properties) { m_changedProperties.add(properties); }

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp
@@ -39,8 +39,18 @@ Ref<ScrollingStateOverflowScrollProxyNode> ScrollingStateOverflowScrollProxyNode
     return adoptRef(*new ScrollingStateOverflowScrollProxyNode(stateTree, nodeID));
 }
 
+Ref<ScrollingStateOverflowScrollProxyNode> ScrollingStateOverflowScrollProxyNode::create(ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStateOverflowScrollProxyNode(nodeID));
+}
+
+ScrollingStateOverflowScrollProxyNode::ScrollingStateOverflowScrollProxyNode(ScrollingNodeID nodeID)
+    : ScrollingStateNode(ScrollingNodeType::OverflowProxy, nullptr, nodeID)
+{
+}
+
 ScrollingStateOverflowScrollProxyNode::ScrollingStateOverflowScrollProxyNode(ScrollingStateTree& stateTree, ScrollingNodeID nodeID)
-    : ScrollingStateNode(ScrollingNodeType::OverflowProxy, stateTree, nodeID)
+    : ScrollingStateNode(ScrollingNodeType::OverflowProxy, &stateTree, nodeID)
 {
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class ScrollingStateOverflowScrollProxyNode : public ScrollingStateNode {
 public:
     static Ref<ScrollingStateOverflowScrollProxyNode> create(ScrollingStateTree&, ScrollingNodeID);
+    static WEBCORE_EXPORT Ref<ScrollingStateOverflowScrollProxyNode> create(ScrollingNodeID);
 
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
 
@@ -44,6 +45,7 @@ public:
     WEBCORE_EXPORT void setOverflowScrollingNode(ScrollingNodeID);
 
 private:
+    ScrollingStateOverflowScrollProxyNode(ScrollingNodeID);
     ScrollingStateOverflowScrollProxyNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateOverflowScrollProxyNode(const ScrollingStateOverflowScrollProxyNode&, ScrollingStateTree&);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
@@ -38,6 +38,16 @@ Ref<ScrollingStateOverflowScrollingNode> ScrollingStateOverflowScrollingNode::cr
     return adoptRef(*new ScrollingStateOverflowScrollingNode(stateTree, nodeID));
 }
 
+Ref<ScrollingStateOverflowScrollingNode> ScrollingStateOverflowScrollingNode::create(ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStateOverflowScrollingNode(nodeID));
+}
+
+ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(ScrollingNodeID nodeID)
+    : ScrollingStateScrollingNode(ScrollingNodeType::Overflow, nodeID)
+{
+}
+
 ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(ScrollingStateTree& stateTree, ScrollingNodeID nodeID)
     : ScrollingStateScrollingNode(stateTree, ScrollingNodeType::Overflow, nodeID)
 {

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class ScrollingStateOverflowScrollingNode : public ScrollingStateScrollingNode {
 public:
+    static WEBCORE_EXPORT Ref<ScrollingStateOverflowScrollingNode> create(ScrollingNodeID);
     static Ref<ScrollingStateOverflowScrollingNode> create(ScrollingStateTree&, ScrollingNodeID);
 
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
@@ -42,6 +43,7 @@ public:
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
 private:
+    ScrollingStateOverflowScrollingNode(ScrollingNodeID);
     ScrollingStateOverflowScrollingNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateOverflowScrollingNode(const ScrollingStateOverflowScrollingNode&, ScrollingStateTree&);
 };

--- a/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp
@@ -40,8 +40,18 @@ Ref<ScrollingStatePositionedNode> ScrollingStatePositionedNode::create(Scrolling
     return adoptRef(*new ScrollingStatePositionedNode(stateTree, nodeID));
 }
 
+Ref<ScrollingStatePositionedNode> ScrollingStatePositionedNode::create(ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStatePositionedNode(nodeID));
+}
+
+ScrollingStatePositionedNode::ScrollingStatePositionedNode(ScrollingNodeID nodeID)
+    : ScrollingStateNode(ScrollingNodeType::Positioned, nullptr, nodeID)
+{
+}
+
 ScrollingStatePositionedNode::ScrollingStatePositionedNode(ScrollingStateTree& tree, ScrollingNodeID nodeID)
-    : ScrollingStateNode(ScrollingNodeType::Positioned, tree, nodeID)
+    : ScrollingStateNode(ScrollingNodeType::Positioned, &tree, nodeID)
 {
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h
@@ -40,6 +40,7 @@ namespace WebCore {
 class ScrollingStatePositionedNode final : public ScrollingStateNode {
 public:
     static Ref<ScrollingStatePositionedNode> create(ScrollingStateTree&, ScrollingNodeID);
+    static WEBCORE_EXPORT Ref<ScrollingStatePositionedNode> create(ScrollingNodeID);
 
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
 
@@ -53,6 +54,7 @@ public:
     const AbsolutePositionConstraints& layoutConstraints() const { return m_constraints; }
 
 private:
+    ScrollingStatePositionedNode(ScrollingNodeID);
     ScrollingStatePositionedNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStatePositionedNode(const ScrollingStatePositionedNode&, ScrollingStateTree&);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -34,9 +34,15 @@
 namespace WebCore {
 
 ScrollingStateScrollingNode::ScrollingStateScrollingNode(ScrollingStateTree& stateTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
-    : ScrollingStateNode(nodeType, stateTree, nodeID)
+    : ScrollingStateNode(nodeType, &stateTree, nodeID)
 {
     scrollingStateTree().scrollingNodeAdded();
+}
+
+ScrollingStateScrollingNode::ScrollingStateScrollingNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
+    : ScrollingStateNode(nodeType, nullptr, nodeID)
+{
+    // scrollingNodeAdded will be called in attachAfterDeserialization.
 }
 
 ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScrollingNode& stateNode, ScrollingStateTree& adoptiveTree)

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -137,6 +137,7 @@ public:
     const MouseLocationState& mouseLocationState() const { return m_mouseLocationState; }
 
 protected:
+    ScrollingStateScrollingNode(ScrollingNodeType, ScrollingNodeID);
     ScrollingStateScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
     ScrollingStateScrollingNode(const ScrollingStateScrollingNode&, ScrollingStateTree&);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -45,8 +45,18 @@ Ref<ScrollingStateStickyNode> ScrollingStateStickyNode::create(ScrollingStateTre
     return adoptRef(*new ScrollingStateStickyNode(stateTree, nodeID));
 }
 
+Ref<ScrollingStateStickyNode> ScrollingStateStickyNode::create(ScrollingNodeID nodeID)
+{
+    return adoptRef(*new ScrollingStateStickyNode(nodeID));
+}
+
+ScrollingStateStickyNode::ScrollingStateStickyNode(ScrollingNodeID nodeID)
+    : ScrollingStateNode(ScrollingNodeType::Sticky, nullptr, nodeID)
+{
+}
+
 ScrollingStateStickyNode::ScrollingStateStickyNode(ScrollingStateTree& tree, ScrollingNodeID nodeID)
-    : ScrollingStateNode(ScrollingNodeType::Sticky, tree, nodeID)
+    : ScrollingStateNode(ScrollingNodeType::Sticky, &tree, nodeID)
 {
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
@@ -39,6 +39,7 @@ class StickyPositionViewportConstraints;
 class ScrollingStateStickyNode final : public ScrollingStateNode {
 public:
     static Ref<ScrollingStateStickyNode> create(ScrollingStateTree&, ScrollingNodeID);
+    static WEBCORE_EXPORT Ref<ScrollingStateStickyNode> create(ScrollingNodeID);
 
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
 
@@ -48,6 +49,7 @@ public:
     const StickyPositionViewportConstraints& viewportConstraints() const { return m_constraints; }
 
 private:
+    ScrollingStateStickyNode(ScrollingNodeID);
     ScrollingStateStickyNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateStickyNode(const ScrollingStateStickyNode&, ScrollingStateTree&);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -48,7 +48,8 @@ public:
     WEBCORE_EXPORT ScrollingStateTree(ScrollingStateTree&&);
     WEBCORE_EXPORT ~ScrollingStateTree();
 
-    ScrollingStateFrameScrollingNode* rootStateNode() const { return m_rootStateNode.get(); }
+    WEBCORE_EXPORT RefPtr<ScrollingStateFrameScrollingNode> rootStateNode() const;
+    WEBCORE_EXPORT bool setRootStateNodeAfterReconstruction(RefPtr<ScrollingStateFrameScrollingNode>&&);
     WEBCORE_EXPORT RefPtr<ScrollingStateNode> stateNodeForID(ScrollingNodeID) const;
 
     ScrollingNodeID createUnparentedNode(ScrollingNodeType, ScrollingNodeID);
@@ -72,7 +73,7 @@ public:
     unsigned nodeCount() const { return m_stateNodeMap.size(); }
     unsigned scrollingNodeCount() const { return m_scrollingNodeCount; }
 
-    using StateNodeMap = HashMap<ScrollingNodeID, RefPtr<ScrollingStateNode>>;
+    using StateNodeMap = HashMap<ScrollingNodeID, Ref<ScrollingStateNode>>;
     const StateNodeMap& nodeMap() const { return m_stateNodeMap; }
 
     LayerRepresentation::Type preferredLayerRepresentation() const { return m_preferredLayerRepresentation; }

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -318,7 +318,7 @@ bool ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scroll
 
     LOG(ScrollingTree, "\nScrollingTree %p commitTreeState", this);
 
-    auto* rootNode = scrollingStateTree->rootStateNode();
+    auto rootNode = scrollingStateTree->rootStateNode();
     if (rootNode
         && (rootStateNodeChanged
             || rootNode->hasChangedProperty(ScrollingStateNode::Property::EventTrackingRegion)
@@ -360,7 +360,7 @@ bool ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scroll
     for (auto nodeID : m_nodeMap.keys())
         commitState.unvisitedNodes.add(nodeID);
 
-    bool succeeded = updateTreeFromStateNodeRecursive(rootNode, commitState);
+    bool succeeded = updateTreeFromStateNodeRecursive(rootNode.get(), commitState);
     if (!succeeded)
         return false;
 
@@ -442,6 +442,7 @@ bool ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
 
     // Now update the children if we have any.
     for (auto& child : stateNode->children()) {
+        ASSERT(child->parent().get() == stateNode);
         if (!updateTreeFromStateNodeRecursive(child.ptr(), state))
             return false;
     }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -123,7 +123,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
 
         switch (currNode->nodeType()) {
         case ScrollingNodeType::Overflow: {
-            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(*currNode);
+            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode);
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = PlatformLayerID { scrollingStateNode.scrollContainerLayer() };
@@ -138,7 +138,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
         };
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe: {
-            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(*currNode);
+            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode);
 
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
                 auto platformLayerID = PlatformLayerID { scrollingStateNode.scrollContainerLayer() };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -168,7 +168,7 @@ void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTr
         switch (currNode->nodeType()) {
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe: {
-            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(*currNode);
+            ScrollingStateFrameScrollingNode& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode);
             
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
                 scrollingStateNode.setScrollContainerLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrollContainerLayer() }));
@@ -203,7 +203,7 @@ void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTr
             break;
         }
         case ScrollingNodeType::Overflow: {
-            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(*currNode);
+            ScrollingStateOverflowScrollingNode& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode);
             if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
                 scrollingStateNode.setScrollContainerLayer(layerTreeHost.layerForID(PlatformLayerID { scrollingStateNode.scrollContainerLayer() }));
 


### PR DESCRIPTION
#### 08f8141737e23917c19660c0beaa9ea871e752e0
<pre>
Prepare RemoteScrollingCoordinatorTransaction pieces for generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=261622">https://bugs.webkit.org/show_bug.cgi?id=261622</a>
rdar://115573578

Reviewed by Simon Fraser.

This moves the manual C++ serialization code around so that each piece has a symmetric encode
and decode function that only encodes and decodes itself with no additional context.  To do this,
I needed to have the scrolling state nodes deserialize only the values they contain and then
attach to the scrolling state tree after all the nodes are deserialized.

* Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp:
(WebCore::ScrollingStateFixedNode::create):
(WebCore::ScrollingStateFixedNode::ScrollingStateFixedNode):
* Source/WebCore/page/scrolling/ScrollingStateFixedNode.h:
* Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp:
(WebCore::ScrollingStateFrameHostingNode::create):
(WebCore::ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::create):
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
(WebCore::ScrollingStateFrameScrollingNode::isMainFrame const):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::ScrollingStateNode):
(WebCore::ScrollingStateNode::attachAfterDeserialization):
(WebCore::ScrollingStateNode::setChildren):
(WebCore::ScrollingStateNode::recurse):
(WebCore::ScrollingStateNode::setLayer):
(WebCore::ScrollingStateNode::parentPointersAreCorrect const):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.cpp:
(WebCore::ScrollingStateOverflowScrollProxyNode::create):
(WebCore::ScrollingStateOverflowScrollProxyNode::ScrollingStateOverflowScrollProxyNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollProxyNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::create):
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp:
(WebCore::ScrollingStatePositionedNode::create):
(WebCore::ScrollingStatePositionedNode::ScrollingStatePositionedNode):
* Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::create):
(WebCore::ScrollingStateStickyNode::ScrollingStateStickyNode):
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::attachDeserializedNodes):
(WebCore::ScrollingStateTree::setDeserializedRootStateNode):
(WebCore::ScrollingStateTree::rootStateNode const):
(WebCore::ScrollingStateTree::insertNode):
(WebCore::ScrollingStateTree::clear):
(WebCore::ScrollingStateTree::addNode):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
(WebCore::ScrollingStateTree::rootStateNode const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::commitTreeState):
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;ScrollingStateNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateNode&gt;::decode):
(encodeNodeShared):
(decodeNodeShared):
(encodeScrollingStateScrollingNodeShared):
(decodeScrollingStateScrollingNodeShared):
(ArgumentCoder&lt;ScrollingStateFrameScrollingNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateFrameScrollingNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStateFrameHostingNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateFrameHostingNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStateOverflowScrollingNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateOverflowScrollingNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStateOverflowScrollProxyNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateOverflowScrollProxyNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStateFixedNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateFixedNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStateStickyNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateStickyNode&gt;::decode):
(ArgumentCoder&lt;ScrollingStatePositionedNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStatePositionedNode&gt;::decode):
(ArgumentCoder&lt;WebCore::ScrollingStateTree&gt;::encode):
(ArgumentCoder&lt;WebCore::ScrollingStateTree&gt;::decode):
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::encode): Deleted.
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::decode): Deleted.
(encodeNodeAndDescendants): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers):

Canonical link: <a href="https://commits.webkit.org/269648@main">https://commits.webkit.org/269648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06a7f26866af9b1a143b2774e4e0b9823e9b328d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23420 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25942 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27142 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/678 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/612 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1089 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2942 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->