### PR TITLE
[iOS] Crash when closing and removing a WKWebView with an active find interaction

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4392,7 +4392,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (!_page || !_perProcessState.committedFindLayerID)
         return nil;
 
-    return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(_perProcessState.committedFindLayerID);
+    if (auto* drawingArea = _page->drawingArea())
+        return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*drawingArea).remoteLayerTreeHost().layerForID(_perProcessState.committedFindLayerID);
+
+    return nil;
 }
 
 #endif // HAVE(UIFINDINTERACTION)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -834,6 +834,29 @@ TEST(WebKit, CannotHaveMultipleFindOverlays)
     EXPECT_EQ(overlayCount(webView.get()), 1U);
 }
 
+TEST(WebKit, FindOverlayCloseWebViewCrash)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    [webView setFindInteractionEnabled:YES];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"lots-of-text" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    [webView loadRequest:request];
+    [webView _test_waitForDidFinishNavigation];
+
+    auto *findInteraction = [webView findInteraction];
+    [findInteraction presentFindNavigatorShowingReplace:NO];
+
+    // Wait for two presentation updates, as the document overlay root layer is
+    // created lazily.
+    [webView waitForNextPresentationUpdate];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(overlayCount(webView.get()), 1U);
+
+    [webView _close];
+    [webView removeFromSuperview];
+}
+
 TEST(WebKit, FindOverlaySPI)
 {
     auto findDelegate = adoptNS([[TestFindDelegate alloc] init]);


### PR DESCRIPTION
#### 4473b145e8373e09ae26f6550f2d5acbf745b9d9
<pre>
[iOS] Crash when closing and removing a WKWebView with an active find interaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=261623">https://bugs.webkit.org/show_bug.cgi?id=261623</a>
rdar://115543506

Reviewed by Wenson Hsieh.

In 267443@main, `WKWebView` began driving find overlay display logic from the
UI process, rather than the Web process. Specifically, the `CALayer` representing
the overlay is directly manipulated from `WKWebView`, rather than `PageOverlay`.

`-[WKWebView _layerForFindOverlay]` can be used to retrieve the current find
overlay layer, using the `DrawingAreaProxy` and a layer identifier.

The crashing scenario is as follows:
1. Begin a find interaction. This creates a find overlay layer, referenced as `_perProcessState.committedFindLayerID`.
2. Close the `WKWebView` using `-[WKWebView _close]`. This results in the `DrawingAreaProxy` being nulled out.
3. Remove the `WKWebView` from the view hierarchy. This triggers the end of the find interaction.
4. Since the find interaction is ending, the web view attempts to hide the overlay layer.
5. Null dereference of `_page-&gt;drawingArea()` as current layer is retrieved prior to hiding.

The underlying assumption that was incorrect here was that `_perProcessState`
gets reset when the `WKWebView` is closed. That would fix the crash, since
`committedFindLayerID` would be unavailable. However, this state is not reset,
presumably since the overall web view state no longer has useful meaning.

To fix, simply null-check the `DrawingAreaProxy` as is done in other parts of
the code. `committedFindLayerID` does not need to be reset, as a new search
cannot be initiated with a closed web view.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _layerForFindOverlay]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/268044@main">https://commits.webkit.org/268044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5fa193c9bf447ba5de9147ab5ce469477b2b3a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18959 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21203 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16851 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21213 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14926 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21031 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2275 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->