### PR TITLE
Rename RenderSelectionInfo to RenderSelectionGeometry as part of rename work to clarify classes around highlights.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2312,7 +2312,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderOverflow.h
     rendering/RenderPtr.h
     rendering/RenderReplaced.h
-    rendering/RenderSelectionInfo.h
+    rendering/RenderSelectionGeometry.h
     rendering/RenderText.h
     rendering/RenderTextControl.h
     rendering/RenderTextLineBoxes.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2620,7 +2620,7 @@ rendering/RenderScrollbar.cpp
 rendering/RenderScrollbarPart.cpp
 rendering/RenderScrollbarTheme.cpp
 rendering/RenderSearchField.cpp
-rendering/RenderSelectionInfo.cpp
+rendering/RenderSelectionGeometry.cpp
 rendering/RenderSlider.cpp
 rendering/RenderTable.cpp
 rendering/RenderTableCaption.cpp

--- a/Source/WebCore/rendering/RenderSelectionGeometry.cpp
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.cpp
@@ -24,26 +24,26 @@
  */
 
 #include "config.h"
-#include "RenderSelectionInfo.h"
+#include "RenderSelectionGeometry.h"
 
 #include "RenderText.h"
 
 namespace WebCore {
 
-RenderSelectionInfoBase::RenderSelectionInfoBase(RenderObject& renderer)
+RenderSelectionGeometryBase::RenderSelectionGeometryBase(RenderObject& renderer)
     : m_renderer(renderer)
     , m_repaintContainer(renderer.containerForRepaint().renderer)
     , m_state(renderer.selectionState())
 {
 }
 
-void RenderSelectionInfoBase::repaintRectangle(const LayoutRect& repaintRect)
+void RenderSelectionGeometryBase::repaintRectangle(const LayoutRect& repaintRect)
 {
     m_renderer.repaintUsingContainer(m_repaintContainer, enclosingIntRect(repaintRect));
 }
 
-RenderSelectionInfo::RenderSelectionInfo(RenderObject& renderer, bool clipToVisibleContent)
-    : RenderSelectionInfoBase(renderer)
+RenderSelectionGeometry::RenderSelectionGeometry(RenderObject& renderer, bool clipToVisibleContent)
+    : RenderSelectionGeometryBase(renderer)
 {
     if (renderer.canUpdateSelectionOnRootLineBoxes()) {
         if (is<RenderText>(renderer))
@@ -53,18 +53,18 @@ RenderSelectionInfo::RenderSelectionInfo(RenderObject& renderer, bool clipToVisi
     }
 }
 
-void RenderSelectionInfo::repaint()
+void RenderSelectionGeometry::repaint()
 {
     repaintRectangle(m_rect);
 }
 
-RenderBlockSelectionInfo::RenderBlockSelectionInfo(RenderBlock& renderer)
-    : RenderSelectionInfoBase(renderer)
+RenderBlockSelectionGeometry::RenderBlockSelectionGeometry(RenderBlock& renderer)
+    : RenderSelectionGeometryBase(renderer)
     , m_rects(renderer.canUpdateSelectionOnRootLineBoxes() ? renderer.selectionGapRectsForRepaint(m_repaintContainer) : GapRects())
 {
 }
 
-void RenderBlockSelectionInfo::repaint()
+void RenderBlockSelectionGeometry::repaint()
 {
     repaintRectangle(m_rects);
 }

--- a/Source/WebCore/rendering/RenderSelectionGeometry.h
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.h
@@ -30,10 +30,10 @@
 
 namespace WebCore {
 
-class RenderSelectionInfoBase {
-    WTF_MAKE_NONCOPYABLE(RenderSelectionInfoBase); WTF_MAKE_FAST_ALLOCATED;
+class RenderSelectionGeometryBase {
+    WTF_MAKE_NONCOPYABLE(RenderSelectionGeometryBase); WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit RenderSelectionInfoBase(RenderObject& renderer);
+    explicit RenderSelectionGeometryBase(RenderObject& renderer);
     const RenderLayerModelObject* repaintContainer() const { return m_repaintContainer; }
     RenderObject::HighlightState state() const { return m_state; }
 
@@ -48,9 +48,9 @@ private:
 };
 
 // This struct is used when the selection changes to cache the old and new state of the selection for each RenderObject.
-class RenderSelectionInfo : public RenderSelectionInfoBase {
+class RenderSelectionGeometry : public RenderSelectionGeometryBase {
 public:
-    RenderSelectionInfo(RenderObject& renderer, bool clipToVisibleContent);
+    RenderSelectionGeometry(RenderObject& renderer, bool clipToVisibleContent);
 
     void repaint();
     const Vector<FloatQuad>& collectedSelectionQuads() const { return m_collectedSelectionQuads; }
@@ -63,9 +63,9 @@ private:
 
 
 // This struct is used when the selection changes to cache the old and new state of the selection for each RenderBlock.
-class RenderBlockSelectionInfo : public RenderSelectionInfoBase {
+class RenderBlockSelectionGeometry : public RenderSelectionGeometryBase {
 public:
-    explicit RenderBlockSelectionInfo(RenderBlock& renderer);
+    explicit RenderBlockSelectionGeometry(RenderBlock& renderer);
 
     void repaint();
     GapRects rects() const { return m_rects; }

--- a/Source/WebCore/rendering/SelectionRangeData.h
+++ b/Source/WebCore/rendering/SelectionRangeData.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include "HighlightData.h"
-#include "RenderSelectionInfo.h"
+#include "RenderSelectionGeometry.h"
 
 #if ENABLE(SERVICE_CONTROLS)
 #include "SelectionGeometryGatherer.h"


### PR DESCRIPTION
#### 5b2b95668aa27f1659143dd2509ce2495bc42cd1
<pre>
Rename RenderSelectionInfo to RenderSelectionGeometry as part of rename work to clarify classes around highlights.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261625">https://bugs.webkit.org/show_bug.cgi?id=261625</a>
rdar://115575135

Reviewed by Simon Fraser.

Several classes associated with Highlights have a very confusing naming
structure. This is the second rename of several to help clarify
what these classes are and their relationship to each other.

* Source/WebCore/rendering/RenderSelectionGeometry.cpp: Renamed from Source/WebCore/rendering/RenderSelectionInfo.cpp.
(WebCore::RenderSelectionGeometryBase::RenderSelectionGeometryBase):
(WebCore::RenderSelectionGeometryBase::repaintRectangle):
(WebCore::RenderSelectionGeometry::RenderSelectionGeometry):
(WebCore::RenderSelectionGeometry::repaint):
(WebCore::RenderBlockSelectionGeometry::RenderBlockSelectionGeometry):
(WebCore::RenderBlockSelectionGeometry::repaint):
* Source/WebCore/rendering/RenderSelectionGeometry.h: Renamed from Source/WebCore/rendering/RenderSelectionInfo.h.
(WebCore::RenderSelectionGeometryBase::repaintContainer const):
(WebCore::RenderSelectionGeometryBase::state const):
(WebCore::RenderSelectionGeometry::collectedSelectionQuads const):
(WebCore::RenderSelectionGeometry::rect const):
(WebCore::RenderBlockSelectionGeometry::rects const):

Canonical link: <a href="https://commits.webkit.org/268051@main">https://commits.webkit.org/268051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc6a8e792fff99affffce15bb43589b6d91c6e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19002 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21255 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23348 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17642 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16702 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4402 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->