### PR TITLE
[macOS] Support rendering native <meter> in vertical writing mode

### DIFF
--- a/LayoutTests/fast/forms/vertical-writing-mode/meter-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/meter-expected.html
@@ -1,0 +1,10 @@
+<style>
+
+meter {
+    transform: rotate(90deg) translate(0, -100%);
+    transform-origin: left top;
+}
+
+</style>
+<meter min="0" max="100" low="33" high="66" optimum="80" value="50"></meter>
+

--- a/LayoutTests/fast/forms/vertical-writing-mode/meter.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/meter.html
@@ -1,0 +1,9 @@
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-47"/>
+<style>
+
+meter {
+    writing-mode: vertical-lr;
+}
+
+</style>
+<meter min="0" max="100" low="33" high="66" optimum="80" value="50"></meter>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt
@@ -1,6 +1,6 @@
 
 
 FAIL meter[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width assert_equals: expected "16px" but got "18px"
-PASS meter[style="writing-mode: vertical-lr"] block size should match width and inline size should match height
-PASS meter[style="writing-mode: vertical-rl"] block size should match width and inline size should match height
+FAIL meter[style="writing-mode: vertical-lr"] block size should match width and inline size should match height assert_equals: expected "16px" but got "18px"
+FAIL meter[style="writing-mode: vertical-rl"] block size should match width and inline size should match height assert_equals: expected "16px" but got "18px"
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -722,6 +722,7 @@ webkit.org/b/216853 css3/font-synthesis-small-caps.html [ ImageOnlyFailure ]
 webkit.org/b/221308 [ Debug ] fast/selectors/matches-backtracking.html [ Timeout ]
 webkit.org/b/221308 [ Debug ] fast/selectors/is-backtracking.html [ Timeout ]
 
+fast/forms/vertical-writing-mode/meter.html [ ImageOnlyFailure ]
 fast/forms/vertical-writing-mode/progress.html [ ImageOnlyFailure ]
 
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/line-box-height-vlr-011.xht [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1179,6 +1179,8 @@ css3/color-filters/color-filter-caret-color.html [ Skip ]
 # Not relevant for iOS.
 css3/color-filters/color-filter-ignore-semantic.html [ Skip ]
 
+webkit.org/b/261593 fast/forms/vertical-writing-mode/meter.html [ ImageOnlyFailure ]
+
 # WebCryptoAPI features that enabled only for iOS 11/High Sierra+
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha1.html [ Pass ]
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha224.html [ Pass ]

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -550,6 +550,7 @@ fast/gradients/conic-from-angle.html [ Pass ]
 fast/gradients/conic-two-hints.html [ Pass ]
 fast/gradients/conic-gradient-alpha.html [ ImageOnlyFailure ]
 
+fast/forms/vertical-writing-mode/meter.html [ ImageOnlyFailure ]
 fast/forms/vertical-writing-mode/progress.html [ ImageOnlyFailure ]
 
 [ Debug ] animations/CSSKeyframesRule-name-null.html [ Pass Timeout ]

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -56,7 +56,7 @@ FloatSize ControlPart::sizeForBounds(const FloatRect& bounds, const ControlStyle
         return bounds.size();
 
     platformControl->updateCellStates(bounds, style);
-    return platformControl->sizeForBounds(bounds);
+    return platformControl->sizeForBounds(bounds, style);
 }
 
 FloatRect ControlPart::rectForBounds(const FloatRect& bounds, const ControlStyle& style)

--- a/Source/WebCore/platform/graphics/controls/PlatformControl.h
+++ b/Source/WebCore/platform/graphics/controls/PlatformControl.h
@@ -50,7 +50,7 @@ public:
 
     virtual void updateCellStates(const FloatRect&, const ControlStyle&) { }
 
-    virtual FloatSize sizeForBounds(const FloatRect& bounds) const { return bounds.size(); }
+    virtual FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&) const { return bounds.size(); }
 
     virtual FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const { return bounds; }
 

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -41,7 +41,7 @@ private:
 
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 
-    FloatSize sizeForBounds(const FloatRect& bounds) const override;
+    FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 


### PR DESCRIPTION
#### 61e2bf8a7a108046d848b944f487c665a25bab28
<pre>
[macOS] Support rendering native &lt;meter&gt; in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261592">https://bugs.webkit.org/show_bug.cgi?id=261592</a>
rdar://115536577

Reviewed by Tim Nguyen.

* LayoutTests/fast/forms/vertical-writing-mode/meter-expected.html: Added.
* LayoutTests/fast/forms/vertical-writing-mode/meter.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt:

This is a false failure, as our default size differs from the one that the test
expects. However, the default size is not a spec requirement, nor is it relevant
to the test. This test is currently being updated upstream.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::sizeForBounds):
* Source/WebCore/platform/graphics/controls/PlatformControl.h:
(WebCore::PlatformControl::sizeForBounds const):
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
(WebCore::MeterMac::sizeForBounds const):

`NSLevelIndicatorCell` only knows how to size itself horizontally. Transpose the
size to obtain a vertical size.

(WebCore::MeterMac::draw):

Rotate the graphics context by 90 degrees, relative to the top left of the cell
to render `&lt;meter&gt;` with `appearance: auto` with a vertical writing mode.

This approach is viable since the image does not have any shadows or
orientation specific behaviors.

Canonical link: <a href="https://commits.webkit.org/268059@main">https://commits.webkit.org/268059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0339b86b9739c821a2433430b317684cb82c13ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18778 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18947 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21288 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23370 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21265 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/14980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16750 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4409 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21096 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2280 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->