### PR TITLE
[scroll-anchoring] Implement anchor node selection algorithm

### DIFF
--- a/LayoutTests/fast/repaint/absolute-position-changed.html
+++ b/LayoutTests/fast/repaint/absolute-position-changed.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <link rel="stylesheet" href="resources/default.css">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/descend-into-container-with-float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/descend-into-container-with-float-expected.txt
@@ -1,4 +1,4 @@
 after
 
-FAIL Zero-height container with float. assert_equals: expected 100 but got 50
+PASS Zero-height container with float.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/exclude-fixed-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/exclude-fixed-position-expected.txt
@@ -1,5 +1,5 @@
 fixed
 content
 
-FAIL Fixed-position header. assert_equals: expected 150 but got 100
+PASS Fixed-position header.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/exclude-sticky-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/exclude-sticky-expected.txt
@@ -1,5 +1,5 @@
 sticky
 content
 
-FAIL Sticky-positioned headers shouldn't be chosen as scroll anchors (we should use 'content' instead) assert_equals: expected 200 but got 150
+PASS Sticky-positioned headers shouldn't be chosen as scroll anchors (we should use 'content' instead)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-ib-split-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-ib-split-expected.txt
@@ -2,5 +2,5 @@ Some title
 Sticky header
 Some actual content.
 
-FAIL Scroll offset adjustments are correctly suppressed when changing the position of an inline assert_equals: Element should become and remain fixed expected "fixed" but got "static"
+PASS Scroll offset adjustments are correctly suppressed when changing the position of an inline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/subtree-exclusion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/subtree-exclusion-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Subtree exclusion with overflow-anchor. assert_equals: expected 200 but got 150
+PASS Subtree exclusion with overflow-anchor.
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -25,9 +25,13 @@
 
 #include "config.h"
 #include "ScrollAnchoringController.h"
+#include "ElementChildIteratorInlines.h"
 #include "ElementIterator.h"
 #include "HTMLHtmlElement.h"
+#include "Logging.h"
 #include "RenderBox.h"
+#include "RenderLayerScrollableArea.h"
+#include "RenderObjectInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/text/TextStream.h>
 
@@ -43,42 +47,146 @@ void ScrollAnchoringController::invalidateAnchorElement()
     }
 }
 
-ScrollOffset ScrollAnchoringController::computeOffset(RenderBox& candidate)
+ScrollOffset ScrollAnchoringController::computeOffset(RenderObject& candidate)
 {
     // TODO: investigate this for zoom/rtl
     // make sure this works for subscrollers
     return ScrollOffset(FloatPoint(candidate.absoluteBoundingBoxRect().location() - m_frameView.layoutViewportRect().location()));
 }
 
-void ScrollAnchoringController::chooseAnchorElement()
+static RefPtr<Element> anchorElementForPriorityCandidate(Element* element)
 {
-    // TODO: fully implement anchor node selection algorithm in spec
-    // (specifically excluded subtrees and priority nodes)
-    // https://drafts.csswg.org/css-scroll-anchoring/#anchor-node-selection
-
-    auto* document = m_frameView.frame().document();
-    if (!document)
-        return;
-
-    Element* candidateAnchor = nullptr;
-    auto layoutViewport = m_frameView.layoutViewportRect();
-
-    // TODO: iterate from the current scroller not document root
-    for (auto& element : descendantsOfType<Element>(document->rootNode())) {
-        if (auto renderer = element.renderBox()) {
-            if (renderer->style().overflowAnchor() == OverflowAnchor::None || &element == document->bodyOrFrameset() || is<HTMLHtmlElement>(&element))
-                continue;
-            auto boxRect = renderer->absoluteBoundingBoxRect();
-            if (layoutViewport.intersects(boxRect))
-                candidateAnchor = &element;
-            if (layoutViewport.contains(boxRect))
-                break;
+    while (element) {
+        if (auto renderer = element->renderer()) {
+            if (!renderer->isAnonymousBlock() && (!renderer->isInline() || renderer->isAtomicInlineLevelBox()))
+                return element;
         }
+        element = element->parentElement();
     }
-    if (!candidateAnchor)
+    return nullptr;
+}
+
+bool ScrollAnchoringController::didFindPriorityCandidate(Document& document)
+{
+    auto viablePriorityCandidateForElement = [](Element* element) -> RefPtr<Element> {
+        RefPtr candidateElement = anchorElementForPriorityCandidate(element);
+        if (!candidateElement)
+            return nullptr;
+
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::viablePriorityCandidateForElement()");
+        RefPtr iterElement = candidateElement;
+
+        // TODO: iterate up to owning scroller
+        while (iterElement) {
+            if (auto renderer = element->renderer()) {
+                if (renderer->style().overflowAnchor() == OverflowAnchor::None)
+                    return nullptr;
+            }
+            iterElement = iterElement->parentElement();
+        }
+        return iterElement;
+    };
+
+    // TODO: need to check if focused element is text editable
+    // TODO: need to figure out how to get element that is the current find-in-page element (look into FindController)
+    if (RefPtr priorityCandidate = viablePriorityCandidateForElement(document.focusedElement())) {
+        m_anchorElement = priorityCandidate;
+        m_lastOffsetForAnchorElement = computeOffset(*m_anchorElement->renderer());
+        return true;
+    }
+    return false;
+}
+
+CandidateExaminationResult ScrollAnchoringController::examineCandidate(Element& element)
+{
+    auto layoutViewport = m_frameView.layoutViewportRect();
+    auto* document = m_frameView.frame().document();
+
+    if (auto renderer = element.renderer()) {
+        // TODO: we need to think about position: absolute
+        // TODO: figure out how to get scrollable area for renderer to check if it is maintaining scroll anchor
+        if (renderer->style().overflowAnchor() == OverflowAnchor::None || renderer->isStickilyPositioned() || renderer->isFixedPositioned() || renderer->isPseudoElement() || renderer->isAnonymousBlock())
+            return CandidateExaminationResult::Exclude;
+        if (&element == document->bodyOrFrameset() || is<HTMLHtmlElement>(&element) || (renderer->isInline() && !renderer->isAtomicInlineLevelBox()))
+            return CandidateExaminationResult::Skip;
+        auto boxRect = renderer->absoluteBoundingBoxRect();
+        if (!boxRect.width() || !boxRect.height())
+            return CandidateExaminationResult::Skip;
+        if (layoutViewport.contains(boxRect))
+            return CandidateExaminationResult::Select;
+        if (layoutViewport.intersects(boxRect))
+            return CandidateExaminationResult::Descend;
+    }
+    return CandidateExaminationResult::Skip;
+}
+
+#if !LOG_DISABLED
+static TextStream& operator<<(TextStream& ts, CandidateExaminationResult result)
+{
+    switch (result) {
+    case CandidateExaminationResult::Exclude:
+        ts << "Exclude";
+        break;
+    case CandidateExaminationResult::Select:
+        ts << "Select";
+        break;
+    case CandidateExaminationResult::Descend:
+        ts << "Descend";
+        break;
+    case CandidateExaminationResult::Skip:
+        ts << "Skip";
+        break;
+    }
+    return ts;
+}
+#endif
+
+Element* ScrollAnchoringController::findAnchorElementRecursive(Element* element)
+{
+    if (!element)
+        return nullptr;
+
+    auto result = examineCandidate(*element);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::findAnchorElementRecursive() element: "<< *element<<" examination result: " << result);
+
+    switch (result) {
+    case CandidateExaminationResult::Select:
+        return element;
+    case CandidateExaminationResult::Exclude:
+        return nullptr;
+    case CandidateExaminationResult::Skip:
+    case CandidateExaminationResult::Descend: {
+        for (auto& child : childrenOfType<Element>(*element)) {
+            if (auto* anchorElement = findAnchorElementRecursive(&child))
+                return anchorElement;
+        }
+        break;
+    }
+    }
+    if (result == CandidateExaminationResult::Skip)
+        return nullptr;
+    return element;
+}
+
+void ScrollAnchoringController::chooseAnchorElement(Document& document)
+{
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() starting findAnchorElementRecursive: ");
+
+    if (didFindPriorityCandidate(document))
         return;
-    m_anchorElement = candidateAnchor;
-    m_lastOffsetForAnchorElement = computeOffset(*m_anchorElement->renderBox());
+
+    RefPtr<Element> anchorElement;
+
+    // TODO: iterate from owning scroller not root
+    if (!m_anchorElement) {
+        anchorElement = findAnchorElementRecursive(document.documentElement());
+        if (!anchorElement)
+            return;
+    }
+
+    m_anchorElement = anchorElement;
+    m_lastOffsetForAnchorElement = computeOffset(*m_anchorElement->renderer());
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() found anchor node: " << *anchorElement << " offset: " << computeOffset(*m_anchorElement->renderer()));
 }
 
 void ScrollAnchoringController::updateAnchorElement()
@@ -87,8 +195,15 @@ void ScrollAnchoringController::updateAnchorElement()
     if (frameView().scrollPosition().isZero() || m_isQueuedForScrollPositionUpdate)
         return;
 
-    if (!m_anchorElement || !m_anchorElement->renderBox()) {
-        chooseAnchorElement();
+    RefPtr document = m_frameView.frame().document();
+    if (!document)
+        return;
+
+    if (m_anchorElement && !m_anchorElement->renderer())
+        invalidateAnchorElement();
+
+    if (!m_anchorElement) {
+        chooseAnchorElement(*document);
         if (!m_anchorElement)
             return;
     }
@@ -102,7 +217,7 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     auto queued = std::exchange(m_isQueuedForScrollPositionUpdate, false);
     if (!m_anchorElement || !queued)
         return;
-    auto renderBox = m_anchorElement->renderBox();
+    auto renderBox = m_anchorElement->renderer();
     if (!renderBox) {
         invalidateAnchorElement();
         return;
@@ -110,6 +225,7 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     FloatSize adjustment = computeOffset(*renderBox) - m_lastOffsetForAnchorElement;
     if (!adjustment.isZero()) {
         auto newScrollPosition = frameView().scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for frame: " << m_frameView << " adjusting from: " << frameView().scrollPosition() << " to: " << newScrollPosition);
         auto options = ScrollPositionChangeOptions::createProgrammatic();
         options.originalScrollDelta = adjustment;
         m_frameView.setScrollPosition(newScrollPosition, options);

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -32,23 +32,33 @@ namespace WebCore {
 
 class Element;
 
+enum class CandidateExaminationResult {
+    Exclude, Select, Descend, Skip
+};
+
 class ScrollAnchoringController final : public CanMakeWeakPtr<ScrollAnchoringController> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ScrollAnchoringController(LocalFrameView& frameView)
         : m_frameView(frameView)
     { }
+
     void invalidateAnchorElement();
     void adjustScrollPositionForAnchoring();
     void selectAnchorElement();
-    void chooseAnchorElement();
+    void chooseAnchorElement(Document&);
     void updateAnchorElement();
     LocalFrameView& frameView() { return m_frameView; }
 
 private:
+    Element* findAnchorElementRecursive(Element*);
+    CandidateExaminationResult examineCandidate(Element&);
+    bool didFindPriorityCandidate(Document&);
+    ScrollOffset computeOffset(RenderObject& candidate);
+
+    // TODO: add owning scrollable area
     LocalFrameView& m_frameView;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_anchorElement;
-    ScrollOffset computeOffset(RenderBox& candidate);
     ScrollOffset m_lastOffsetForAnchorElement;
     bool m_midUpdatingScrollPositionForAnchorElement { false };
     bool m_isQueuedForScrollPositionUpdate { false };

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -112,6 +112,7 @@ namespace WebCore {
     M(ResourceLoadObserver) \
     M(ResourceLoadStatistics) \
     M(ScrollAnimations) \
+    M(ScrollAnchoring) \
     M(ScrollSnap) \
     M(Scrolling) \
     M(ScrollingTree) \


### PR DESCRIPTION
#### 0cd807347378c72b30ee428774daeaf2b04cff07
<pre>
[scroll-anchoring] Implement anchor node selection algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=261628">https://bugs.webkit.org/show_bug.cgi?id=261628</a>
rdar://115583079

Reviewed by Simon Fraser.

Implement anchor node selection algorithm outlined in the spec.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/descend-into-container-with-float-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/exclude-fixed-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/exclude-sticky-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-ib-split-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/subtree-exclusion-expected.txt:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::anchorElementForPriorityCandidate):
(WebCore::elementIsScrollableArea):
(WebCore::ScrollAnchoringController::examinePriorityCandidate):
(WebCore::ScrollAnchoringController::findPriorityCandidate):
(WebCore::ScrollAnchoringController::examineCandidate):
(WebCore::operator&lt;&lt;):
(WebCore::ScrollAnchoringController::findAnchorElementRecursive):
(WebCore::ScrollAnchoringController::chooseAnchorElement):
(WebCore::ScrollAnchoringController::updateAnchorElement):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:

Canonical link: <a href="https://commits.webkit.org/268348@main">https://commits.webkit.org/268348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43940edb75a6ef190ce9141b241db3e4c773c4b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18138 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19939 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19654 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22147 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17648 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17484 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21910 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2379 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->