### PR TITLE
Avoid computing layer bounds in BackingSharingState::isAdditionalProviderCandidate()

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -426,6 +426,9 @@ private:
     void updateOverlapMap(LayerOverlapMap&, const RenderLayer&, OverlapExtent&, bool didPushContainer, bool addLayerToOverlap, bool addDescendantsToOverlap = false) const;
     bool layerOverlaps(const LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
 
+    void updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
+    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor);
+
     void updateCompositingLayersTimerFired();
 
     void computeCompositingRequirements(RenderLayer* ancestorLayer, RenderLayer&, LayerOverlapMap&, CompositingState&, BackingSharingState&, bool& descendantHas3DTransform);


### PR DESCRIPTION
#### 9dcbb22277532b1b42cc6180b32ccacec07a68c1
<pre>
Avoid computing layer bounds in BackingSharingState::isAdditionalProviderCandidate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261630">https://bugs.webkit.org/show_bug.cgi?id=261630</a>
rdar://115584910

Reviewed by Alan Baradlay.

isAdditionalProviderCandidate() is called when we&apos;re asking if a given RenderLayer can be added to
the list of composted layers that may share their backing store with other sibling layers. This does
a traversal over the existing list checking for overlap by computing the bounds of the incoming and
the existing layers. When this list gets long (thousands of layers), this is very slow.

The compositing code has already computed layer bounds for overlap testing, so we can just use the
existing rects. These come in via &quot;OverlapExtent&quot; which manages the lazy computation of layer
bounds. In order to support this lazy computation via a call to
`RenderLayerCompositor::computeExtent()`, move `updateBeforeDescendantTraversal()` and
`updateAfterDescendantTraversal()` to be member functions of RenderLayerComopsitor, and pass them
the LayerOverlapMap and OverlapExtent; they can then ensure that the bounds is computed only when
needed. We store each candidate layer&apos;s bounds in `BackingSharingState::Provider`.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidates):
(WebCore::RenderLayerCompositor::BackingSharingState::backingSharingStackingContext const):
(WebCore::RenderLayerCompositor::BackingSharingState::startBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate):
(WebCore::RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate const):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::traverseUnchangedSubtree):
(WebCore::RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal):
(WebCore::RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal):
(WebCore::RenderLayerCompositor::layerRepaintTargetsBackingSharingLayer const):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidates const): Deleted.
(WebCore::RenderLayerCompositor::BackingSharingState::updateBeforeDescendantTraversal): Deleted.
(WebCore::RenderLayerCompositor::BackingSharingState::updateAfterDescendantTraversal): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/268056@main">https://commits.webkit.org/268056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4565afcea5801ab83bc93745598c11d7d773a3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18518 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19198 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21250 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21245 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14948 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16697 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4407 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->