### PR TITLE
Further porting of types to the new serialization format.

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2763,10 +2763,14 @@ target_precompile_headers(WebCore PRIVATE WebCorePrefix.h)
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/InternalAPI/WebGPU.serialization.in
 
+    Modules/indexeddb/IndexedDB.serialization.in
+
     page/ActivityState.serialization.in
     page/DragActions.serialization.in
     page/LayoutMilestones.serialization.in
     page/MediaProducer.serialization.in
+
+    platform/graphics/ca/PlatformCALayer.messages.in
 
     platform/PlatformEvent.serialization.in
     platform/PlatformScreen.serialization.in

--- a/Source/WebCore/Modules/indexeddb/IndexedDB.serialization.in
+++ b/Source/WebCore/Modules/indexeddb/IndexedDB.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+enum class WebCore::IndexedDB::IndexRecordType : bool;
+
+enum class WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer : bool;
+
+enum class WebCore::IndexedDB::CursorIterateOption : bool;
+
+enum class WebCore::IndexedDB::CursorSource : bool;
+
+enum class WebCore::IndexedDB::CursorType : bool;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -280,14 +280,14 @@ static PlatformCALayer::FilterType toPlatformCALayerFilterType(GraphicsLayer::Sc
 {
     switch (filter) {
     case GraphicsLayer::ScalingFilter::Linear:
-        return PlatformCALayer::Linear;
+        return PlatformCALayer::FilterType::Linear;
     case GraphicsLayer::ScalingFilter::Nearest:
-        return PlatformCALayer::Nearest;
+        return PlatformCALayer::FilterType::Nearest;
     case GraphicsLayer::ScalingFilter::Trilinear:
-        return PlatformCALayer::Trilinear;
+        return PlatformCALayer::FilterType::Trilinear;
     }
     ASSERT_NOT_REACHED();
-    return PlatformCALayer::Linear;
+    return PlatformCALayer::FilterType::Linear;
 }
 
 bool GraphicsLayer::supportsLayerType(Type type)
@@ -344,20 +344,20 @@ Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(PlatformLayer* platf
 Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner)
 {
     // By default, just make a plain layer; subclasses can override to provide a custom PlatformCALayer for Model.
-    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerTypeLayer, owner);
+    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
 }
 #endif
 
 Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayerHost(LayerHostingContextIdentifier, PlatformCALayerClient* owner)
 {
     ASSERT_NOT_REACHED_WITH_MESSAGE("GraphicsLayerCARemote::createPlatformCALayerHost should always be called instead of this, but this symbol is needed to compile WebKitLegacy.");
-    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerTypeLayer, owner);
+    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
 }
 
 Ref<PlatformCALayer> GraphicsLayerCA::createPlatformVideoLayer(HTMLVideoElement&, PlatformCALayerClient* owner)
 {
     // By default, just make a plain layer; subclasses can override to provide a custom PlatformCALayer for hosting context id.
-    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerTypeLayer, owner);
+    return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
 }
 
 Ref<PlatformCAAnimation> GraphicsLayerCA::createPlatformCAAnimation(PlatformCAAnimation::AnimationType type, const String& keyPath)
@@ -1186,7 +1186,7 @@ void GraphicsLayerCA::setContentsToSolidColor(const Color& color)
     if (m_contentsSolidColor.isVisible()) {
         if (!m_contentsLayer || m_contentsLayerPurpose != ContentsLayerPurpose::BackgroundColor) {
             m_contentsLayerPurpose = ContentsLayerPurpose::BackgroundColor;
-            m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerTypeLayer, this);
+            m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
 #if ENABLE(TREE_DEBUGGING)
             m_contentsLayer->setName(makeString("contents color ", m_contentsLayer->layerID().object()));
 #else
@@ -1349,7 +1349,7 @@ void GraphicsLayerCA::setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDis
     m_contentsDisplayDelegate = nullptr;
     m_contentsLayerPurpose = ContentsLayerPurpose::None;
     if (delegate) {
-        m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerTypeContentsProvidedLayer, this);
+        m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer, this);
         m_contentsDisplayDelegate = WTFMove(delegate);
         m_contentsLayerPurpose = purpose;
         // Currently delegated display is only useful when delegatee calls setContents, so set the
@@ -1866,7 +1866,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
     bool hadDirtyRects = m_uncommittedChanges & DirtyRectsChanged;
     commitLayerChangesAfterSublayers(childCommitState);
 
-    if (affectedByTransformAnimation && m_layer->layerType() == PlatformCALayer::LayerTypeTiledBackingLayer)
+    if (affectedByTransformAnimation && m_layer->layerType() == PlatformCALayer::LayerType::LayerTypeTiledBackingLayer)
         client().notifySubsequentFlushRequired(this);
 
     if (layerTypeChanged)
@@ -1986,9 +1986,9 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
     PlatformCALayer::LayerType neededLayerType = currentLayerType;
 
     if (needTiledLayer)
-        neededLayerType = PlatformCALayer::LayerTypeTiledBackingLayer;
-    else if (currentLayerType == PlatformCALayer::LayerTypeTiledBackingLayer)
-        neededLayerType = PlatformCALayer::LayerTypeWebLayer;
+        neededLayerType = PlatformCALayer::LayerType::LayerTypeTiledBackingLayer;
+    else if (currentLayerType == PlatformCALayer::LayerType::LayerTypeTiledBackingLayer)
+        neededLayerType = PlatformCALayer::LayerType::LayerTypeWebLayer;
 
     if (neededLayerType != m_layer->layerType()) {
         changeLayerTypeTo(neededLayerType);
@@ -2490,7 +2490,7 @@ void GraphicsLayerCA::updateBackdropFilters(CommitState& commitState)
 
     bool madeLayer = !m_backdropLayer;
     if (!m_backdropLayer) {
-        m_backdropLayer = createPlatformCALayer(PlatformCALayer::LayerTypeBackdropLayer, this);
+        m_backdropLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeBackdropLayer, this);
         m_backdropLayer->setAnchorPoint(FloatPoint3D());
         m_backdropLayer->setMasksToBounds(true);
         m_backdropLayer->setName(MAKE_STATIC_STRING_IMPL("backdrop"));
@@ -2651,19 +2651,19 @@ bool GraphicsLayerCA::ensureStructuralLayer(StructuralLayerPurpose purpose)
     }
 
     if (purpose == StructuralLayerForPreserves3D) {
-        if (m_structuralLayer && m_structuralLayer->layerType() != PlatformCALayer::LayerTypeTransformLayer)
+        if (m_structuralLayer && m_structuralLayer->layerType() != PlatformCALayer::LayerType::LayerTypeTransformLayer)
             m_structuralLayer = nullptr;
         
         if (!m_structuralLayer) {
-            m_structuralLayer = createPlatformCALayer(PlatformCALayer::LayerTypeTransformLayer, this);
+            m_structuralLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeTransformLayer, this);
             structuralLayerChanged = true;
         }
     } else {
-        if (m_structuralLayer && m_structuralLayer->layerType() != PlatformCALayer::LayerTypeLayer)
+        if (m_structuralLayer && m_structuralLayer->layerType() != PlatformCALayer::LayerType::LayerTypeLayer)
             m_structuralLayer = nullptr;
 
         if (!m_structuralLayer) {
-            m_structuralLayer = createPlatformCALayer(PlatformCALayer::LayerTypeLayer, this);
+            m_structuralLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
             structuralLayerChanged = true;
         }
     }
@@ -2840,7 +2840,7 @@ void GraphicsLayerCA::updateContentsImage()
 {
     if (m_pendingContentsImage) {
         if (!m_contentsLayer.get()) {
-            m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerTypeLayer, this);
+            m_contentsLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
 #if ENABLE(TREE_DEBUGGING)
             m_contentsLayer->setName(makeString("contents image ", m_contentsLayer->layerID().object()));
 #else
@@ -2852,7 +2852,7 @@ void GraphicsLayerCA::updateContentsImage()
 
         // FIXME: maybe only do trilinear if the image is being scaled down,
         // but then what if the layer size changes?
-        m_contentsLayer->setMinificationFilter(PlatformCALayer::Trilinear);
+        m_contentsLayer->setMinificationFilter(PlatformCALayer::FilterType::Trilinear);
         m_contentsLayer->setContents(m_pendingContentsImage->platformImage().get());
         m_pendingContentsImage = nullptr;
 
@@ -2919,7 +2919,7 @@ void GraphicsLayerCA::updateClippingStrategy(PlatformCALayer& clippingLayer, Ref
     }
 
     if (!shapeMaskLayer) {
-        shapeMaskLayer = createPlatformCALayer(PlatformCALayer::LayerTypeShapeLayer, this);
+        shapeMaskLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeShapeLayer, this);
         shapeMaskLayer->setAnchorPoint({ });
         shapeMaskLayer->setName(MAKE_STATIC_STRING_IMPL("shape mask"));
     }
@@ -2951,7 +2951,7 @@ void GraphicsLayerCA::updateContentsRects()
     bool gainedOrLostClippingLayer = false;
     if (m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect)) {
         if (!m_contentsClippingLayer) {
-            m_contentsClippingLayer = createPlatformCALayer(PlatformCALayer::LayerTypeLayer, this);
+            m_contentsClippingLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
             m_contentsClippingLayer->setAnchorPoint({ });
 #if ENABLE(TREE_DEBUGGING)
             m_contentsClippingLayer->setName(makeString("contents clipping ", m_contentsClippingLayer->layerID().object()));
@@ -4500,8 +4500,8 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
     if (newLayerType == oldLayerType)
         return;
 
-    bool wasTiledLayer = oldLayerType == PlatformCALayer::LayerTypeTiledBackingLayer;
-    bool isTiledLayer = newLayerType == PlatformCALayer::LayerTypeTiledBackingLayer;
+    bool wasTiledLayer = oldLayerType == PlatformCALayer::LayerType::LayerTypeTiledBackingLayer;
+    bool isTiledLayer = newLayerType == PlatformCALayer::LayerType::LayerTypeTiledBackingLayer;
 
     RefPtr<PlatformCALayer> oldLayer = m_layer;
     m_layer = createPlatformCALayer(newLayerType, this);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -58,15 +58,13 @@ struct AcceleratedEffectValues;
 
 enum class MediaPlayerVideoGravity : uint8_t;
 
-class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCounted<PlatformCALayer, WTF::DestructionThread::Main> {
-    friend class PlatformCALayerCocoa;
-public:
-    static CFTimeInterval currentTimeToMediaTime(MonotonicTime);
+enum class PlatformCALayerFilterType : uint8_t {
+    Linear,
+    Nearest,
+    Trilinear
+};
 
-    // LayerTypeRootLayer is used on some platforms. It has no backing store, so setNeedsDisplay
-    // should not call CACFLayerSetNeedsDisplay, but rather just notify the renderer that it
-    // has changed and should be re-rendered.
-    enum LayerType {
+enum class PlatformCALayerLayerType : uint8_t {
         LayerTypeLayer,
         LayerTypeWebLayer,
         LayerTypeSimpleLayer,
@@ -85,8 +83,18 @@ public:
 #endif
         LayerTypeCustom,
         LayerTypeHost,
-    };
-    enum FilterType { Linear, Nearest, Trilinear };
+};
+
+class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCounted<PlatformCALayer, WTF::DestructionThread::Main> {
+    friend class PlatformCALayerCocoa;
+public:
+    static CFTimeInterval currentTimeToMediaTime(MonotonicTime);
+
+    // LayerTypeRootLayer is used on some platforms. It has no backing store, so setNeedsDisplay
+    // should not call CACFLayerSetNeedsDisplay, but rather just notify the renderer that it
+    // has changed and should be re-rendered.
+    using LayerType = PlatformCALayerLayerType;
+    using FilterType = PlatformCALayerFilterType;
 
     virtual Ref<PlatformCALayer> clone(PlatformCALayerClient*) const = 0;
 
@@ -109,9 +117,9 @@ public:
 
     virtual PlatformLayer* platformLayer() const { return m_layer.get(); }
 
-    bool usesTiledBackingLayer() const { return layerType() == LayerTypePageTiledBackingLayer || layerType() == LayerTypeTiledBackingLayer; }
+    bool usesTiledBackingLayer() const { return layerType() == LayerType::LayerTypePageTiledBackingLayer || layerType() == LayerType::LayerTypeTiledBackingLayer; } // NOLINT(build/webcore_export)
 
-    bool isPageTiledBackingLayer() const { return layerType() == LayerTypePageTiledBackingLayer; }
+    bool isPageTiledBackingLayer() const { return layerType() == LayerType::LayerTypePageTiledBackingLayer; } // NOLINT(build/webcore_export)
 
     PlatformCALayerClient* owner() const { return m_owner; }
     virtual void setOwner(PlatformCALayerClient* owner) { m_owner = owner; }
@@ -345,40 +353,3 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformCALayer::Fi
 SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \
     static bool isType(const WebCore::PlatformCALayer& layer) { return layer.predicate; } \
 SPECIALIZE_TYPE_TRAITS_END()
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformCALayer::FilterType> {
-    using values = EnumValues<
-        WebCore::PlatformCALayer::FilterType,
-        WebCore::PlatformCALayer::FilterType::Linear,
-        WebCore::PlatformCALayer::FilterType::Nearest,
-        WebCore::PlatformCALayer::FilterType::Trilinear
-    >;
-};
-
-template<> struct EnumTraits<WebCore::PlatformCALayer::LayerType> {
-    using values = EnumValues<
-        WebCore::PlatformCALayer::LayerType,
-        WebCore::PlatformCALayer::LayerType::LayerTypeLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeWebLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeSimpleLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeTransformLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeTiledBackingLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeRootLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeAVPlayerLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeBackdropLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeShapeLayer,
-        WebCore::PlatformCALayer::LayerType::LayerTypeScrollContainerLayer,
-#if ENABLE(MODEL_ELEMENT)
-        WebCore::PlatformCALayer::LayerType::LayerTypeModelLayer,
-#endif
-        WebCore::PlatformCALayer::LayerType::LayerTypeCustom,
-        WebCore::PlatformCALayer::LayerType::LayerTypeHost
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.messages.in
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.messages.in
@@ -1,0 +1,48 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+enum class WebCore::PlatformCALayerFilterType : uint8_t {
+    Linear,
+    Nearest,
+    Trilinear
+};
+
+enum class WebCore::PlatformCALayerLayerType : uint8_t {
+        LayerTypeLayer,
+        LayerTypeWebLayer,
+        LayerTypeSimpleLayer,
+        LayerTypeTransformLayer,
+        LayerTypeTiledBackingLayer,
+        LayerTypePageTiledBackingLayer,
+        LayerTypeTiledBackingTileLayer,
+        LayerTypeRootLayer,
+        LayerTypeAVPlayerLayer,
+        LayerTypeContentsProvidedLayer,
+        LayerTypeBackdropLayer,
+        LayerTypeShapeLayer,
+        LayerTypeScrollContainerLayer,
+#if ENABLE(MODEL_ELEMENT)
+        LayerTypeModelLayer,
+#endif
+        LayerTypeCustom,
+        LayerTypeHost,
+};

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -227,50 +227,50 @@ void PlatformCALayer::dumpAdditionalProperties(TextStream&, OptionSet<PlatformLa
 TextStream& operator<<(TextStream& ts, PlatformCALayer::LayerType layerType)
 {
     switch (layerType) {
-    case PlatformCALayer::LayerTypeLayer:
-    case PlatformCALayer::LayerTypeWebLayer:
-    case PlatformCALayer::LayerTypeSimpleLayer:
+    case PlatformCALayer::LayerType::LayerTypeLayer:
+    case PlatformCALayer::LayerType::LayerTypeWebLayer:
+    case PlatformCALayer::LayerType::LayerTypeSimpleLayer:
         ts << "layer";
         break;
-    case PlatformCALayer::LayerTypeTransformLayer:
+    case PlatformCALayer::LayerType::LayerTypeTransformLayer:
         ts << "transform-layer";
         break;
-    case PlatformCALayer::LayerTypeTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingLayer:
         ts << "tiled-backing-layer";
         break;
-    case PlatformCALayer::LayerTypePageTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer:
         ts << "page-tiled-backing-layer";
         break;
-    case PlatformCALayer::LayerTypeTiledBackingTileLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer:
         ts << "tiled-backing-tile";
         break;
-    case PlatformCALayer::LayerTypeRootLayer:
+    case PlatformCALayer::LayerType::LayerTypeRootLayer:
         ts << "root-layer";
         break;
-    case PlatformCALayer::LayerTypeBackdropLayer:
+    case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         ts << "backdrop-layer";
         break;
-    case PlatformCALayer::LayerTypeAVPlayerLayer:
+    case PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
         ts << "av-player-layer";
         break;
-    case PlatformCALayer::LayerTypeContentsProvidedLayer:
+    case PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer:
         ts << "contents-provided-layer";
         break;
-    case PlatformCALayer::LayerTypeShapeLayer:
+    case PlatformCALayer::LayerType::LayerTypeShapeLayer:
         ts << "shape-layer";
         break;
-    case PlatformCALayer::LayerTypeScrollContainerLayer:
+    case PlatformCALayer::LayerType::LayerTypeScrollContainerLayer:
         ts << "scroll-container-layer";
         break;
-    case PlatformCALayer::LayerTypeCustom:
+    case PlatformCALayer::LayerType::LayerTypeCustom:
         ts << "custom-layer";
         break;
 #if ENABLE(MODEL_ELEMENT)
-    case PlatformCALayer::LayerTypeModelLayer:
+    case PlatformCALayer::LayerType::LayerTypeModelLayer:
         ts << "model-layer";
         break;
 #endif
-    case PlatformCALayer::LayerTypeHost:
+    case PlatformCALayer::LayerType::LayerTypeHost:
         ts << "host";
         break;
     }
@@ -280,13 +280,13 @@ TextStream& operator<<(TextStream& ts, PlatformCALayer::LayerType layerType)
 TextStream& operator<<(TextStream& ts, PlatformCALayer::FilterType filterType)
 {
     switch (filterType) {
-    case PlatformCALayer::Linear:
+    case PlatformCALayer::FilterType::Linear:
         ts << "linear";
         break;
-    case PlatformCALayer::Nearest:
+    case PlatformCALayer::FilterType::Nearest:
         ts << "nearest";
         break;
-    case PlatformCALayer::Trilinear:
+    case PlatformCALayer::FilterType::Trilinear:
         ts << "trilinear";
         break;
     default:

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -750,7 +750,7 @@ Ref<PlatformCALayer> TileController::createTileLayer(const IntRect& tileRect, Ti
     float temporaryScaleFactor = owningGraphicsLayer()->platformCALayerContentsScaleMultiplierForNewTiles(m_tileCacheLayer);
     m_hasTilesWithTemporaryScaleFactor |= temporaryScaleFactor != 1;
 
-    auto layer = m_tileCacheLayer->createCompatibleLayerOrTakeFromPool(PlatformCALayer::LayerTypeTiledBackingTileLayer, &grid, tileRect.size());
+    auto layer = m_tileCacheLayer->createCompatibleLayerOrTakeFromPool(PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer, &grid, tileRect.size());
     layer->setAnchorPoint(FloatPoint3D());
     layer->setPosition(tileRect.location());
     layer->setBorderColor(m_tileDebugBorderColor);

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
@@ -35,10 +35,10 @@ namespace WebCore {
 TileCoverageMap::TileCoverageMap(const TileController& controller)
     : m_controller(controller)
     , m_updateTimer(*this, &TileCoverageMap::updateTimerFired)
-    , m_layer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerTypeSimpleLayer, this))
-    , m_visibleViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerTypeLayer, nullptr))
-    , m_layoutViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerTypeLayer, nullptr))
-    , m_coverageRectIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerTypeLayer, nullptr))
+    , m_layer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeSimpleLayer, this))
+    , m_visibleViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_layoutViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_coverageRectIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_position(FloatPoint(0, controller.topContentInset()))
 {
     m_layer.get().setOpacity(0.75);

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -59,7 +59,7 @@ static String validationPolicyAsString(OptionSet<TileGrid::ValidationPolicyFlag>
 
 TileGrid::TileGrid(TileController& controller)
     : m_controller(controller)
-    , m_containerLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerTypeLayer, nullptr))
+    , m_containerLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_cohortRemovalTimer(*this, &TileGrid::cohortRemovalTimerFired)
     , m_tileSize(kDefaultTileSize, kDefaultTileSize)
 {

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -512,6 +512,7 @@ set(WebCore_SERIALIZATION_IN_FILES
     ActivityState.serialization.in
     DragActions.serialization.in
     InbandTextTrackPrivate.serialization.in
+    IndexedDB.serialization.in
     LayoutMilestones.serialization.in
     MDNSRegisterError.serialization.in
     MediaPlaybackTargetContext.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -487,10 +487,12 @@ $(WEBCORE_PRIVATE_HEADERS_DIR)/HTTPHeaderNames.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/HTTPHeaderNames.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/IDLParser.pm
 $(WEBCORE_PRIVATE_HEADERS_DIR)/InbandTextTrackPrivate.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/IndexedDB.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/LayoutMilestones.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/MDNSRegisterError.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/MediaPlaybackTargetContext.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/MediaProducer.serialization.in
+$(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformCALayer.messages.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformEvent.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformMediaSession.serialization.in
 $(WEBCORE_PRIVATE_HEADERS_DIR)/PlatformScreen.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -641,10 +641,12 @@ WEBCORE_SERIALIZATION_DESCRIPTION_FILES = \
 	ActivityState.serialization.in \
 	DragActions.serialization.in \
 	InbandTextTrackPrivate.serialization.in \
+	IndexedDB.serialization.in \
 	LayoutMilestones.serialization.in \
 	MediaPlaybackTargetContext.serialization.in \
 	MediaProducer.serialization.in \
 	MDNSRegisterError.serialization.in \
+	PlatformCALayer.messages.in \
 	PlatformEvent.serialization.in \
 	PlatformMediaSession.serialization.in \
 	PlatformScreen.serialization.in \

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -267,6 +267,7 @@ def forward_declarations_for_namespace(namespace, kind_and_types):
 # When updating this list, run "make -C Source/WebKit/Scripts/webkit/tests" to keep the webkitpy tests passing.
 def serialized_identifiers():
     return [
+        'IPC::AsyncReplyID',
         'WebCore::BackgroundFetchRecordIdentifier',
         'WebCore::BroadcastChannelIdentifier',
         'WebCore::DOMCacheIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(IPC_TESTING_API) || !LOG_DISABLED
 
 #include "AudioMediaStreamTrackRendererInternalUnitIdentifier.h"
+#include "Connection.h"
 #include "ContentWorldShared.h"
 #include "DataTaskIdentifier.h"
 #include "DownloadID.h"
@@ -434,6 +435,7 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
 
 Vector<ASCIILiteral> serializedIdentifiers()
 {
+    static_assert(sizeof(uint64_t) == sizeof(IPC::AsyncReplyID));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::BackgroundFetchRecordIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::BroadcastChannelIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::DOMCacheIdentifier));
@@ -533,6 +535,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebPageProxyIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebURLSchemeHandlerIdentifier));
     return {
+        "IPC::AsyncReplyID"_s,
         "WebCore::BackgroundFetchRecordIdentifier"_s,
         "WebCore::BroadcastChannelIdentifier"_s,
         "WebCore::DOMCacheIdentifier"_s,

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -643,28 +643,28 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context, WTF::Funct
     
     // FIXME: This should be moved to PlatformCALayerRemote for better layering.
     switch (m_layer->layerType()) {
-    case PlatformCALayer::LayerTypeSimpleLayer:
-    case PlatformCALayer::LayerTypeTiledBackingTileLayer:
+    case PlatformCALayer::LayerType::LayerTypeSimpleLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer:
         m_layer->owner()->platformCALayerPaintContents(m_layer, context, dirtyBounds, paintBehavior);
         break;
-    case PlatformCALayer::LayerTypeWebLayer:
-    case PlatformCALayer::LayerTypeBackdropLayer:
+    case PlatformCALayer::LayerType::LayerTypeWebLayer:
+    case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         PlatformCALayer::drawLayerContents(context, m_layer, m_paintingRects, paintBehavior);
         break;
-    case PlatformCALayer::LayerTypeLayer:
-    case PlatformCALayer::LayerTypeTransformLayer:
-    case PlatformCALayer::LayerTypeTiledBackingLayer:
-    case PlatformCALayer::LayerTypePageTiledBackingLayer:
-    case PlatformCALayer::LayerTypeRootLayer:
-    case PlatformCALayer::LayerTypeAVPlayerLayer:
-    case PlatformCALayer::LayerTypeContentsProvidedLayer:
-    case PlatformCALayer::LayerTypeShapeLayer:
-    case PlatformCALayer::LayerTypeScrollContainerLayer:
+    case PlatformCALayer::LayerType::LayerTypeLayer:
+    case PlatformCALayer::LayerType::LayerTypeTransformLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypeRootLayer:
+    case PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
+    case PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer:
+    case PlatformCALayer::LayerType::LayerTypeShapeLayer:
+    case PlatformCALayer::LayerType::LayerTypeScrollContainerLayer:
 #if ENABLE(MODEL_ELEMENT)
-    case PlatformCALayer::LayerTypeModelLayer:
+    case PlatformCALayer::LayerType::LayerTypeModelLayer:
 #endif
-    case PlatformCALayer::LayerTypeCustom:
-    case PlatformCALayer::LayerTypeHost:
+    case PlatformCALayer::LayerType::LayerTypeCustom:
+    case PlatformCALayer::LayerType::LayerTypeHost:
         ASSERT_NOT_REACHED();
         break;
     };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -117,11 +117,11 @@ static RetainPtr<CGColorRef> cgColorFromColor(const Color& color)
 static NSString *toCAFilterType(PlatformCALayer::FilterType type)
 {
     switch (type) {
-    case PlatformCALayer::Linear:
+    case PlatformCALayer::FilterType::Linear:
         return kCAFilterLinear;
-    case PlatformCALayer::Nearest:
+    case PlatformCALayer::FilterType::Nearest:
         return kCAFilterNearest;
-    case PlatformCALayer::Trilinear:
+    case PlatformCALayer::FilterType::Trilinear:
         return kCAFilterTrilinear;
     };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -95,7 +95,7 @@ public:
         >;
 
         WebCore::PlatformLayerIdentifier layerID;
-        WebCore::PlatformCALayer::LayerType type { WebCore::PlatformCALayer::LayerTypeLayer };
+        WebCore::PlatformCALayer::LayerType type { WebCore::PlatformCALayer::LayerType::LayerTypeLayer };
         std::optional<VideoElementData> videoElementData;
         AdditionalData additionalData;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -290,14 +290,14 @@ String RemoteLayerTreeTransaction::description() const
             TextStream::GroupScope group(ts);
             ts << createdLayer.type <<" " << createdLayer.layerID;
             switch (createdLayer.type) {
-            case WebCore::PlatformCALayer::LayerTypeAVPlayerLayer:
+            case WebCore::PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
                 ts << " (context-id " << createdLayer.hostingContextID() << ")";
                 break;
-            case WebCore::PlatformCALayer::LayerTypeCustom:
+            case WebCore::PlatformCALayer::LayerType::LayerTypeCustom:
                 ts << " (context-id " << createdLayer.hostingContextID() << ")";
                 break;
 #if ENABLE(MODEL_ELEMENT)
-            case WebCore::PlatformCALayer::LayerTypeModelLayer:
+            case WebCore::PlatformCALayer::LayerType::LayerTypeModelLayer:
                 if (auto* model = std::get_if<Ref<WebCore::Model>>(&createdLayer.additionalData))
                     ts << " (model " << model->get() << ")";
                 break;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5864,6 +5864,8 @@ struct WebCore::PrewarmInformation {
     WebCore::FontCachePrewarmInformation fontCache;
 };
 
+using WebCore::PlatformLayerIdentifier = ProcessQualified<ObjectIdentifier<WebCore::PlatformLayerIdentifierType>>;
+
 header: <WebCore/FontSelectionAlgorithm.h>
 using WebCore::FontSelectionValue::BackingType = int16_t;
 [CustomHeader] class WebCore::FontSelectionValue {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -372,38 +372,38 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
     };
 
     switch (properties.type) {
-    case PlatformCALayer::LayerTypeLayer:
-    case PlatformCALayer::LayerTypeWebLayer:
-    case PlatformCALayer::LayerTypeRootLayer:
-    case PlatformCALayer::LayerTypeSimpleLayer:
-    case PlatformCALayer::LayerTypeTiledBackingLayer:
-    case PlatformCALayer::LayerTypePageTiledBackingLayer:
-    case PlatformCALayer::LayerTypeTiledBackingTileLayer:
-    case PlatformCALayer::LayerTypeScrollContainerLayer:
+    case PlatformCALayer::LayerType::LayerTypeLayer:
+    case PlatformCALayer::LayerType::LayerTypeWebLayer:
+    case PlatformCALayer::LayerType::LayerTypeRootLayer:
+    case PlatformCALayer::LayerType::LayerTypeSimpleLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer:
+    case PlatformCALayer::LayerType::LayerTypeScrollContainerLayer:
 #if ENABLE(MODEL_ELEMENT)
-    case PlatformCALayer::LayerTypeModelLayer:
+    case PlatformCALayer::LayerType::LayerTypeModelLayer:
 #endif
-    case PlatformCALayer::LayerTypeHost:
-    case PlatformCALayer::LayerTypeContentsProvidedLayer: {
+    case PlatformCALayer::LayerType::LayerTypeHost:
+    case PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer: {
         auto layer = RemoteLayerTreeNode::createWithPlainLayer(properties.layerID);
         // So that the scrolling thread's performance logging code can find all the tiles, mark this as being a tile.
-        if (properties.type == PlatformCALayer::LayerTypeTiledBackingTileLayer)
+        if (properties.type == PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer)
             [layer->layer() setValue:@YES forKey:@"isTile"];
         return layer;
     }
 
-    case PlatformCALayer::LayerTypeTransformLayer:
+    case PlatformCALayer::LayerType::LayerTypeTransformLayer:
         return makeWithLayer(adoptNS([[CATransformLayer alloc] init]));
 
-    case PlatformCALayer::LayerTypeBackdropLayer:
+    case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
 #if ENABLE(FILTERS_LEVEL_2)
         return makeWithLayer(adoptNS([[CABackdropLayer alloc] init]));
 #else
         ASSERT_NOT_REACHED();
         return RemoteLayerTreeNode::createWithPlainLayer(properties.layerID);
 #endif
-    case PlatformCALayer::LayerTypeCustom:
-    case PlatformCALayer::LayerTypeAVPlayerLayer:
+    case PlatformCALayer::LayerType::LayerTypeCustom:
+    case PlatformCALayer::LayerType::LayerTypeAVPlayerLayer:
         if (m_isDebugLayerTreeHost)
             return RemoteLayerTreeNode::createWithPlainLayer(properties.layerID);
 
@@ -418,7 +418,7 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
 
         return makeWithLayer([CALayer _web_renderLayerWithContextID:properties.hostingContextID() shouldPreserveFlip:properties.preservesFlip()]);
 
-    case PlatformCALayer::LayerTypeShapeLayer:
+    case PlatformCALayer::LayerType::LayerTypeShapeLayer:
         return makeWithLayer(adoptNS([[CAShapeLayer alloc] init]));
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -51,27 +51,27 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
     };
 
     switch (properties.type) {
-    case PlatformCALayer::LayerTypeLayer:
-    case PlatformCALayer::LayerTypeWebLayer:
-    case PlatformCALayer::LayerTypeRootLayer:
-    case PlatformCALayer::LayerTypeSimpleLayer:
-    case PlatformCALayer::LayerTypeTiledBackingLayer:
-    case PlatformCALayer::LayerTypePageTiledBackingLayer:
-    case PlatformCALayer::LayerTypeContentsProvidedLayer:
-    case PlatformCALayer::LayerTypeHost:
+    case PlatformCALayer::LayerType::LayerTypeLayer:
+    case PlatformCALayer::LayerType::LayerTypeWebLayer:
+    case PlatformCALayer::LayerType::LayerTypeRootLayer:
+    case PlatformCALayer::LayerType::LayerTypeSimpleLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer:
+    case PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer:
+    case PlatformCALayer::LayerType::LayerTypeHost:
         return makeWithView(adoptNS([[WKCompositingView alloc] init]));
 
-    case PlatformCALayer::LayerTypeTiledBackingTileLayer:
+    case PlatformCALayer::LayerType::LayerTypeTiledBackingTileLayer:
         return RemoteLayerTreeNode::createWithPlainLayer(properties.layerID);
 
-    case PlatformCALayer::LayerTypeBackdropLayer:
+    case PlatformCALayer::LayerType::LayerTypeBackdropLayer:
         return makeWithView(adoptNS([[WKBackdropView alloc] init]));
 
-    case PlatformCALayer::LayerTypeTransformLayer:
+    case PlatformCALayer::LayerType::LayerTypeTransformLayer:
         return makeWithView(adoptNS([[WKTransformView alloc] init]));
 
-    case PlatformCALayer::LayerTypeCustom:
-    case PlatformCALayer::LayerTypeAVPlayerLayer: {
+    case PlatformCALayer::LayerType::LayerTypeCustom:
+    case PlatformCALayer::LayerType::LayerTypeAVPlayerLayer: {
         if (m_isDebugLayerTreeHost)
             return makeWithView(adoptNS([[WKCompositingView alloc] init]));
 
@@ -87,17 +87,17 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
         auto view = adoptNS([[WKUIRemoteView alloc] initWithFrame:CGRectZero pid:m_drawingArea->page().processID() contextID:properties.hostingContextID()]);
         return makeWithView(WTFMove(view));
     }
-    case PlatformCALayer::LayerTypeShapeLayer:
+    case PlatformCALayer::LayerType::LayerTypeShapeLayer:
         return makeWithView(adoptNS([[WKShapeView alloc] init]));
 
-    case PlatformCALayer::LayerTypeScrollContainerLayer:
+    case PlatformCALayer::LayerType::LayerTypeScrollContainerLayer:
         if (!m_isDebugLayerTreeHost)
             return makeWithView(adoptNS([[WKChildScrollView alloc] init]));
         // The debug indicator parents views under layers, which can cause crashes with UIScrollView.
         return makeWithView(adoptNS([[UIView alloc] init]));
 
 #if ENABLE(MODEL_ELEMENT)
-    case PlatformCALayer::LayerTypeModelLayer:
+    case PlatformCALayer::LayerType::LayerTypeModelLayer:
         if (m_drawingArea->page().preferences().modelElementEnabled()) {
             if (auto* model = std::get_if<Ref<Model>>(&properties.additionalData)) {
 #if ENABLE(SEPARATED_MODEL)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -52,11 +52,11 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(LayerType layerType, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(PlatformCALayer::LayerType layerType, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {
     RefPtr<PlatformCALayerRemote> layer;
 
-    if (layerType == LayerTypeTiledBackingLayer ||  layerType == LayerTypePageTiledBackingLayer)
+    if (layerType == WebCore::PlatformCALayer::LayerType::LayerTypeTiledBackingLayer ||  layerType == WebCore::PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer)
         layer = adoptRef(new PlatformCALayerRemoteTiledBacking(layerType, owner, context));
     else
         layer = adoptRef(new PlatformCALayerRemote(layerType, owner, context));
@@ -98,7 +98,7 @@ PlatformCALayerRemote::PlatformCALayerRemote(LayerType layerType, PlatformCALaye
     : PlatformCALayer(layerType, owner)
     , m_context(&context)
 {
-    if (owner && layerType != LayerTypeContentsProvidedLayer && layerType != LayerTypeTransformLayer) {
+    if (owner && layerType != PlatformCALayer::LayerType::LayerTypeContentsProvidedLayer && layerType != PlatformCALayer::LayerType::LayerTypeTransformLayer) {
         m_properties.contentsScale = owner->platformCALayerDeviceScaleFactor();
         m_properties.notePropertiesChanged(LayerChange::ContentsScaleChanged);
     }
@@ -854,7 +854,7 @@ float PlatformCALayerRemote::contentsScale() const
 
 void PlatformCALayerRemote::setContentsScale(float value)
 {
-    if (m_layerType == LayerTypeTransformLayer)
+    if (m_layerType == PlatformCALayer::LayerType::LayerTypeTransformLayer)
         return;
 
     m_properties.contentsScale = value;
@@ -916,26 +916,26 @@ void PlatformCALayerRemote::setShapeRoundedRect(const FloatRoundedRect& roundedR
 
 Path PlatformCALayerRemote::shapePath() const
 {
-    ASSERT(m_layerType == LayerTypeShapeLayer);
+    ASSERT(m_layerType == PlatformCALayer::LayerType::LayerTypeShapeLayer);
     return m_properties.shapePath;
 }
 
 void PlatformCALayerRemote::setShapePath(const Path& path)
 {
-    ASSERT(m_layerType == LayerTypeShapeLayer);
+    ASSERT(m_layerType == PlatformCALayer::LayerType::LayerTypeShapeLayer);
     m_properties.shapePath = path;
     m_properties.notePropertiesChanged(LayerChange::ShapePathChanged);
 }
 
 WindRule PlatformCALayerRemote::shapeWindRule() const
 {
-    ASSERT(m_layerType == LayerTypeShapeLayer);
+    ASSERT(m_layerType == PlatformCALayer::LayerType::LayerTypeShapeLayer);
     return m_properties.windRule;
 }
 
 void PlatformCALayerRemote::setShapeWindRule(WindRule windRule)
 {
-    ASSERT(m_layerType == LayerTypeShapeLayer);
+    ASSERT(m_layerType == PlatformCALayer::LayerType::LayerTypeShapeLayer);
     m_properties.windRule = windRule;
     m_properties.notePropertiesChanged(LayerChange::WindRuleChanged);
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -62,7 +62,7 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(WebCore::HTMLVide
 #endif
 
 PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
-    : PlatformCALayerRemote(LayerTypeAVPlayerLayer, owner, context)
+    : PlatformCALayerRemote(PlatformCALayer::LayerType::LayerTypeAVPlayerLayer, owner, context)
 {
     m_layerHostingContext = LayerHostingContext::createTransportLayerForRemoteHosting(videoElement.layerHostingContextID());
     m_hasVideo = true;
@@ -124,7 +124,7 @@ Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteCustom::clone(PlatformCALayer
     RetainPtr<CALayer> clonedLayer;
     bool copyContents = true;
 
-    if (layerType() == LayerTypeAVPlayerLayer) {
+    if (layerType() == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         
         if (PAL::isAVFoundationFrameworkAvailable() && [platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()]) {
             clonedLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm
@@ -36,7 +36,7 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemoteHost::create(WebCore::LayerHosti
 }
 
 PlatformCALayerRemoteHost::PlatformCALayerRemoteHost(WebCore::LayerHostingContextIdentifier identifier, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
-    : PlatformCALayerRemote(WebCore::PlatformCALayer::LayerTypeHost, owner, context)
+    : PlatformCALayerRemote(WebCore::PlatformCALayer::LayerType::LayerTypeHost, owner, context)
     , m_identifier(identifier)
 {
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
@@ -44,7 +44,7 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemoteModelHosting::create(Ref<WebCore
 }
 
 PlatformCALayerRemoteModelHosting::PlatformCALayerRemoteModelHosting(Ref<WebCore::Model> model, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
-    : PlatformCALayerRemote(WebCore::PlatformCALayer::LayerTypeModelLayer, owner, context)
+    : PlatformCALayerRemote(WebCore::PlatformCALayer::LayerType::LayerTypeModelLayer, owner, context)
     , m_model(model)
 {
 }


### PR DESCRIPTION
#### 0d08386264b67fba9a7b426a9e3d23edf9c9b896
<pre>
Further porting of types to the new serialization format.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261631">https://bugs.webkit.org/show_bug.cgi?id=261631</a>
rdar://115585739

Reviewed by Alex Christensen.

Port types including WebCore::PlatformLayerIdentifier.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Modules/indexeddb/IndexedDB.serialization.in: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::toPlatformCALayerFilterType):
(WebCore::GraphicsLayerCA::createPlatformCALayer):
(WebCore::GraphicsLayerCA::createPlatformCALayerHost):
(WebCore::GraphicsLayerCA::createPlatformVideoLayer):
(WebCore::GraphicsLayerCA::setContentsToSolidColor):
(WebCore::GraphicsLayerCA::setContentsDisplayDelegate):
(WebCore::GraphicsLayerCA::recursiveCommitChanges):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::updateBackdropFilters):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
(WebCore::GraphicsLayerCA::updateContentsImage):
(WebCore::GraphicsLayerCA::updateClippingStrategy):
(WebCore::GraphicsLayerCA::updateContentsRects):
(WebCore::GraphicsLayerCA::changeLayerTypeTo):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.messages.in: Added.
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::createTileLayer):
* Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp:
(WebCore::TileCoverageMap::TileCoverageMap):
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::TileGrid):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::toCAFilterType):
(WebCore::PlatformCALayerCocoa::layerTypeForPlatformLayer):
(WebCore::PlatformCALayerCocoa::PlatformCALayerCocoa):
(WebCore::PlatformCALayerCocoa::commonInit):
(WebCore::PlatformCALayerCocoa::clone const):
(WebCore::PlatformCALayerCocoa::setContentsScale):
(WebCore::PlatformCALayerCocoa::shapeRoundedRect const):
(WebCore::PlatformCALayerCocoa::setShapeRoundedRect):
(WebCore::PlatformCALayerCocoa::shapeWindRule const):
(WebCore::PlatformCALayerCocoa::setShapeWindRule):
(WebCore::PlatformCALayerCocoa::shapePath const):
(WebCore::PlatformCALayerCocoa::setShapePath):
(WebCore::PlatformCALayerCocoa::updateContentsFormat):
(WebCore::PlatformCALayerCocoa::avPlayerLayer const):
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::toCAFilterType):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::create):
(WebKit::PlatformCALayerRemote::PlatformCALayerRemote):
(WebKit::PlatformCALayerRemote::setContentsScale):
(WebKit::PlatformCALayerRemote::shapePath const):
(WebKit::PlatformCALayerRemote::setShapePath):
(WebKit::PlatformCALayerRemote::shapeWindRule const):
(WebKit::PlatformCALayerRemote::setShapeWindRule):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):
(WebKit::PlatformCALayerRemoteCustom::clone const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm:
(WebKit::PlatformCALayerRemoteHost::PlatformCALayerRemoteHost):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm:
(WebKit::PlatformCALayerRemoteModelHosting::PlatformCALayerRemoteModelHosting):

Canonical link: <a href="https://commits.webkit.org/268084@main">https://commits.webkit.org/268084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21fd44e668e1c22aab0f089565c0b95099950bf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19237 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21306 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18737 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23382 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14993 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16746 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21114 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2284 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->