### PR TITLE
Parsed Declarative Web Push JSON should be remembered and round trip throughout various forms of IPC

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationDirection.h
+++ b/Source/WebCore/Modules/notifications/NotificationDirection.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/EnumTraits.h>
+
 namespace WebCore {
 
 enum class NotificationDirection : uint8_t {
@@ -33,4 +35,17 @@ enum class NotificationDirection : uint8_t {
     Rtl
 };
 
-}
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::NotificationDirection> {
+    using values = EnumValues<
+        WebCore::NotificationDirection,
+        WebCore::NotificationDirection::Auto,
+        WebCore::NotificationDirection::Ltr,
+        WebCore::NotificationDirection::Rtl
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
@@ -148,7 +148,7 @@ ExceptionOr<NotificationPayload> NotificationJSONParser::parseNotificationPayloa
         }
     }
 
-    std::optional<NotificationOptions> notificationOptions;
+    std::optional<NotificationOptionsPayload> notificationOptions;
     if (auto value = object.getValue(optionsKey())) {
         if (value->type() != JSON::Value::Type::Object)
             return Exception { SyntaxError, makeString("Push message with Notification disposition: '"_s, optionsKey(), "' member is specified but is not an object"_s) };
@@ -166,7 +166,7 @@ ExceptionOr<NotificationPayload> NotificationJSONParser::parseNotificationPayloa
     return NotificationPayload { WTFMove(defaultActionURL), WTFMove(title), WTFMove(appBadge), WTFMove(notificationOptions) };
 }
 
-ExceptionOr<NotificationOptions> NotificationJSONParser::parseNotificationOptions(const JSON::Object& object)
+ExceptionOr<NotificationOptionsPayload> NotificationJSONParser::parseNotificationOptions(const JSON::Object& object)
 {
     NotificationDirection direction = NotificationDirection::Auto;
     if (auto value = object.getValue(dirKey())) {
@@ -218,8 +218,9 @@ ExceptionOr<NotificationOptions> NotificationJSONParser::parseNotificationOption
     }
 
     RefPtr<JSON::Value> dataValue = object.getValue(dataKey());
+    String dataString = dataValue ? dataValue->toJSONString() : nullString();
 
-    return NotificationOptions { direction, WTFMove(lang), WTFMove(body), WTFMove(tag), iconURL.string(), JSC::jsNull(), nullptr, WTFMove(dataValue), WTFMove(silent) };
+    return NotificationOptionsPayload { direction, WTFMove(lang), WTFMove(body), WTFMove(tag), iconURL.string(), WTFMove(dataString), WTFMove(silent) };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.h
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.h
@@ -28,7 +28,7 @@
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
 #include "ExceptionOr.h"
-#include "NotificationOptions.h"
+#include "NotificationOptionsPayload.h"
 #include "NotificationPayload.h"
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
@@ -38,7 +38,7 @@ namespace WebCore {
 class NotificationJSONParser {
 public:
     WEBCORE_EXPORT static ExceptionOr<NotificationPayload> parseNotificationPayload(const JSON::Object&);
-    WEBCORE_EXPORT static ExceptionOr<NotificationOptions> parseNotificationOptions(const JSON::Object&);
+    WEBCORE_EXPORT static ExceptionOr<NotificationOptionsPayload> parseNotificationOptions(const JSON::Object&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationOptionsPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationOptionsPayload.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+#include "NotificationDirection.h"
+
+OBJC_CLASS NSDictionary;
+
+namespace WebCore {
+
+struct NotificationOptionsPayload {
+    NotificationDirection dir;
+    String lang;
+    String body;
+    String tag;
+    String icon;
+    String dataJSONString;
+    std::optional<bool> silent;
+
+#if PLATFORM(COCOA)
+    static std::optional<NotificationOptionsPayload> fromDictionary(NSDictionary *);
+    NSDictionary *dictionaryRepresentation() const;
+#endif
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "NotificationOptionsPayload.h"
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+static NSString * const WebDirKey = @"WebDirKey";
+static NSString * const WebLangKey = @"WebLangKey";
+static NSString * const WebBodyKey = @"WebBodyKey";
+static NSString * const WebTagKey = @"WebTagKey";
+static NSString * const WebIconKey = @"WebIconKey";
+static NSString * const WebDataJSONKey = @"WebDataJSONKey";
+static NSString * const WebSilentKey = @"WebSilentKey";
+
+namespace WebCore {
+
+std::optional<NotificationOptionsPayload> NotificationOptionsPayload::fromDictionary(NSDictionary *dictionary)
+{
+    if (![dictionary isKindOfClass:[NSDictionary class]])
+        return std::nullopt;
+
+    NSNumber *dir = dictionary[WebDirKey];
+    if (![dir isKindOfClass:[NSNumber class]])
+        return std::nullopt;
+
+    auto dirValue = [dir unsignedCharValue];
+    if (!isValidEnum<NotificationDirection>(dirValue))
+        return std::nullopt;
+    auto rawDir = (NotificationDirection)dirValue;
+
+    NSString *lang = dictionary[WebLangKey];
+    NSString *body = dictionary[WebBodyKey];
+    NSString *tag = dictionary[WebTagKey];
+    NSString *icon = dictionary[WebIconKey];
+    NSString *dataJSON = dictionary[WebDataJSONKey];
+
+    NSNumber *silent = dictionary[WebSilentKey];
+    if (!silent)
+        return std::nullopt;
+
+    std::optional<bool> rawSilent;
+    if (![silent isKindOfClass:[NSNull class]]) {
+        if (![silent isKindOfClass:[NSNumber class]])
+            return std::nullopt;
+
+        rawSilent = [silent boolValue];
+    }
+
+    return NotificationOptionsPayload { (NotificationDirection)rawDir, lang, body, tag, icon, dataJSON, rawSilent };
+}
+
+NSDictionary *NotificationOptionsPayload::dictionaryRepresentation() const
+{
+    return @{
+        WebDirKey : @((uint8_t)dir),
+        WebLangKey : (NSString *)lang,
+        WebBodyKey : (NSString *)body,
+        WebTagKey : (NSString *)tag,
+        WebIconKey : (NSString *)icon,
+        WebDataJSONKey : (NSString *)dataJSONString,
+        WebSilentKey : silent.has_value() ? @(*silent) : [NSNull null],
+    };
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/notifications/NotificationPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.h
@@ -28,7 +28,7 @@
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
 #include "ExceptionOr.h"
-#include "NotificationOptions.h"
+#include "NotificationOptionsPayload.h"
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,9 +40,14 @@ struct NotificationPayload {
     URL defaultActionURL;
     String title;
     std::optional<unsigned long long> appBadge;
-    std::optional<NotificationOptions> options;
+    std::optional<NotificationOptionsPayload> options;
 
     WEBCORE_EXPORT static ExceptionOr<NotificationPayload> parseJSON(const String&);
+
+#if PLATFORM(COCOA)
+    WEBCORE_EXPORT static std::optional<NotificationPayload> fromDictionary(NSDictionary *);
+    WEBCORE_EXPORT NSDictionary *dictionaryRepresentation() const;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "NotificationPayload.h"
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+static NSString * const WebNotificationDefaultActionKey = @"WebNotificationDefaultActionKey";
+static NSString * const WebNotificationTitleKey = @"WebNotificationTitleKey";
+static NSString * const WebNotificationAppBadgeKey = @"WebNotificationAppBadgeKey";
+static NSString * const WebNotificationOptionsKey = @"WebNotificationOptionsKey";
+
+namespace WebCore {
+
+std::optional<NotificationPayload> NotificationPayload::fromDictionary(NSDictionary *dictionary)
+{
+    NSURL *defaultAction = dictionary[WebNotificationDefaultActionKey];
+    if (!defaultAction)
+        return std::nullopt;
+
+    NSString *title = dictionary[WebNotificationTitleKey];
+    if (!title)
+        return std::nullopt;
+
+    NSNumber *appBadge = dictionary[WebNotificationAppBadgeKey];
+    if (!appBadge)
+        return std::nullopt;
+
+    std::optional<uint64_t> rawAppBadge;
+    if (![appBadge isKindOfClass:[NSNull class]]) {
+        if (![appBadge isKindOfClass:[NSNumber class]])
+            return std::nullopt;
+        rawAppBadge = [appBadge unsignedLongLongValue];
+    }
+
+    NSDictionary *options = dictionary[WebNotificationOptionsKey];
+    if (!options)
+        return std::nullopt;
+
+    std::optional<NotificationOptionsPayload> rawOptions;
+    if (![options isKindOfClass:[NSNull class]]) {
+        rawOptions = NotificationOptionsPayload::fromDictionary(options);
+        if (!rawOptions)
+            return std::nullopt;
+    }
+
+    return NotificationPayload { defaultAction, title, WTFMove(rawAppBadge), WTFMove(rawOptions) };
+}
+
+NSDictionary *NotificationPayload::dictionaryRepresentation() const
+{
+    id nsAppBadge = appBadge ? @(*appBadge) : [NSNull null];
+    id nsOptions = options ? options->dictionaryRepresentation() : [NSNull null];
+
+    return @{
+        WebNotificationDefaultActionKey : (NSURL *)defaultActionURL,
+        WebNotificationTitleKey : (NSString *)title,
+        WebNotificationAppBadgeKey : nsAppBadge,
+        WebNotificationOptionsKey : nsOptions,
+    };
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -124,6 +124,8 @@ Modules/model-element/scenekit/SceneKitModelLoaderClient.mm
 Modules/model-element/scenekit/SceneKitModelLoaderUSD.mm
 Modules/model-element/scenekit/SceneKitModelPlayer.mm
 Modules/notifications/NotificationDataCocoa.mm
+Modules/notifications/NotificationOptionsPayloadCocoa.mm
+Modules/notifications/NotificationPayloadCocoa.mm
 Modules/push-api/cocoa/PushCryptoCocoa.cpp
 Modules/plugins/YouTubePluginReplacement.cpp
 Modules/speech/cocoa/SpeechRecognizerCocoa.mm

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -220,6 +220,7 @@ $(PROJECT_DIR)/Shared/Pasteboard.serialization.in
 $(PROJECT_DIR)/Shared/PlatformPopupMenuData.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/PolicyDecision.serialization.in
+$(PROJECT_DIR)/Shared/PushMessageForTesting.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerType.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -527,6 +527,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Pasteboard.serialization.in \
 	Shared/PlatformPopupMenuData.serialization.in \
 	Shared/PolicyDecision.serialization.in \
+	Shared/PushMessageForTesting.serialization.in \
 	Shared/RemoteWorkerType.serialization.in \
 	Shared/SameDocumentNavigationType.serialization.in \
 	Shared/SessionState.serialization.in \

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -28,8 +28,6 @@
 
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
-#include "PushMessageForTesting.h"
-#include "WebPushMessage.h"
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/ExceptionData.h>
 #include <WebCore/PrivateClickMeasurement.h>
@@ -349,35 +347,6 @@ std::optional<WebCore::PCM::AttributionTriggerData> Coder<WebCore::PCM::Attribut
         WTFMove(*ephemeralDestinationNonce),
         WTFMove(*destinationSite),
         // destinationUnlinkableToken and destinationSecretToken are not serialized.
-    } };
-}
-
-void Coder<WebPushMessage, void>::encode(Encoder& encoder, const WebPushMessage& instance)
-{
-    encoder << instance.pushData << instance.registrationURL << instance.pushPartitionString;
-}
-
-std::optional<WebPushMessage> Coder<WebPushMessage, void>::decode(Decoder& decoder)
-{
-    std::optional<std::optional<Vector<uint8_t>>> pushData;
-    decoder >> pushData;
-    if (!pushData)
-        return std::nullopt;
-
-    std::optional<URL> registrationURL;
-    decoder >> registrationURL;
-    if (!registrationURL)
-        return std::nullopt;
-
-    std::optional<String> pushPartitionString;
-    decoder >> pushPartitionString;
-    if (!pushPartitionString)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*pushData),
-        WTFMove(*pushPartitionString),
-        WTFMove(*registrationURL)
     } };
 }
 

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ArgumentCoders.h"
-#include "PushMessageForTesting.h"
 #include <WebCore/PushSubscriptionIdentifier.h>
 #include <optional>
 #include <wtf/Forward.h>
@@ -50,10 +49,7 @@ struct EphemeralNonce;
 
 namespace WebKit {
 
-struct WebPushMessage;
-
 namespace WebPushD {
-struct PushMessageForTesting;
 struct WebPushDaemonConnectionConfiguration;
 }
 
@@ -123,18 +119,10 @@ DECLARE_CODER(WebCore::PushSubscriptionData);
 DECLARE_CODER(WebCore::PushSubscriptionIdentifier);
 DECLARE_CODER(WebCore::RegistrableDomain);
 DECLARE_CODER(WebCore::SecurityOriginData);
-DECLARE_CODER(WebKit::WebPushMessage);
 DECLARE_CODER(WebPushD::WebPushDaemonConnectionConfiguration);
 DECLARE_CODER(WTF::WallTime);
 
 #undef DECLARE_CODER
-
-template<> struct Coder<WebPushD::PushMessageForTesting> {
-    template<typename Encoder>
-    static void encode(Encoder& encoder, const WebPushD::PushMessageForTesting& instance) { instance.encode(encoder); }
-    template<typename Decoder>
-    static std::optional<WebPushD::PushMessageForTesting> decode(Decoder& decoder) { return WebPushD::PushMessageForTesting::decode(decoder); }
-};
 
 template<> struct Coder<WTF::URL> {
     template<typename Encoder>

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -167,6 +167,8 @@ class SerializedEnum(object):
     def is_nested(self):
         return 'Nested' in self.attributes
 
+    def is_webkit_platform(self):
+        return 'WebKitPlatform' in self.attributes
 
 class MemberVariable(object):
     def __init__(self, type, name, condition, attributes, namespace=None, is_subclass=False):
@@ -739,7 +741,7 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             result.append('#endif')
 
     for enum in serialized_enums:
-        if generating_webkit_platform_impl:
+        if enum.is_webkit_platform() != generating_webkit_platform_impl:
             continue
         if enum.underlying_type == 'bool':
             continue
@@ -918,7 +920,7 @@ def parse_serialized_types(file):
                 type = SerializedType(struct_or_class, namespace, name, parent_class_name, members, type_condition, attributes, metadata)
                 serialized_types.append(type)
                 if namespace is not None and (attributes is None or ('CustomHeader' not in attributes and 'Nested' not in attributes)):
-                    if namespace == 'WebKit':
+                    if namespace == 'WebKit' or namespace == 'WebKit::WebPushD':
                         headers.append(ConditionalHeader('"' + name + '.h"', type_condition))
                     elif namespace == 'WTF':
                         headers.append(ConditionalHeader('<wtf/' + name + '.h>', type_condition))

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -33,6 +33,7 @@ namespace WebKit {
 #define WebKitPushDataKey @"WebKitPushData"
 #define WebKitPushRegistrationURLKey @"WebKitPushRegistrationURL"
 #define WebKitPushPartitionKey @"WebKitPushPartition"
+#define WebKitNotificationPayloadKey @"WebKitNotificationPayload"
 
 std::optional<WebPushMessage> WebPushMessage::fromDictionary(NSDictionary *dictionary)
 {
@@ -51,7 +52,25 @@ std::optional<WebPushMessage> WebPushMessage::fromDictionary(NSDictionary *dicti
     if (!pushPartition || ![pushPartition isKindOfClass:[NSString class]])
         return std::nullopt;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    id payloadDictionary = [dictionary objectForKey:WebKitNotificationPayloadKey];
+    isNull = [payloadDictionary isEqual:[NSNull null]];
+    BOOL isCorrectType = [payloadDictionary isKindOfClass:[NSDictionary class]];
+
+    if (!isNull && !isCorrectType)
+        return std::nullopt;
+
+    std::optional<WebCore::NotificationPayload> payload;
+    if (isCorrectType) {
+        payload = WebCore::NotificationPayload::fromDictionary(payloadDictionary);
+        if (!payload)
+            return std::nullopt;
+    }
+
+    WebPushMessage message { { }, String { pushPartition }, URL { url }, WTFMove(payload) };
+#else
     WebPushMessage message { { }, String { pushPartition }, URL { url } };
+#endif
 
     if (isData) {
         NSData *data = (NSData *)pushData;
@@ -67,10 +86,17 @@ NSDictionary *WebPushMessage::toDictionary() const
     if (pushData)
         nsData = nsData = adoptNS([[NSData alloc] initWithBytes:pushData->data() length:pushData->size()]);
 
+    NSDictionary *nsPayload = nil;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    if (notificationPayload)
+        nsPayload = notificationPayload->dictionaryRepresentation();
+#endif
+
     return @{
         WebKitPushDataKey : nsData ? nsData.get() : [NSNull null],
         WebKitPushRegistrationURLKey : (NSURL *)registrationURL,
-        WebKitPushPartitionKey : (NSString *)pushPartitionString
+        WebKitPushPartitionKey : (NSString *)pushPartitionString,
+        WebKitNotificationPayloadKey : nsPayload ? nsPayload : [NSNull null]
     };
 }
 

--- a/Source/WebKit/Shared/PushMessageForTesting.h
+++ b/Source/WebKit/Shared/PushMessageForTesting.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/NotificationPayload.h>
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
@@ -36,58 +37,14 @@ enum class PushMessageDisposition : bool {
 };
 
 struct PushMessageForTesting {
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<PushMessageForTesting> decode(Decoder&);
-
     String targetAppCodeSigningIdentifier;
     String pushPartitionString;
     URL registrationURL;
     String payload;
     PushMessageDisposition disposition;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    std::optional<WebCore::NotificationPayload> parsedPayload;
+#endif
 };
-
-template<class Encoder>
-void PushMessageForTesting::encode(Encoder& encoder) const
-{
-    encoder << targetAppCodeSigningIdentifier << pushPartitionString << registrationURL << payload << disposition;
-}
-
-template<class Decoder>
-std::optional<PushMessageForTesting> PushMessageForTesting::decode(Decoder& decoder)
-{
-    std::optional<String> targetAppCodeSigningIdentifier;
-    decoder >> targetAppCodeSigningIdentifier;
-    if (!targetAppCodeSigningIdentifier)
-        return std::nullopt;
-
-    std::optional<String> pushPartitionString;
-    decoder >> pushPartitionString;
-    if (!pushPartitionString)
-        return std::nullopt;
-
-    std::optional<URL> registrationURL;
-    decoder >> registrationURL;
-    if (!registrationURL)
-        return std::nullopt;
-
-    std::optional<String> payload;
-    decoder >> payload;
-    if (!payload)
-        return std::nullopt;
-
-    std::optional<PushMessageDisposition> disposition;
-    decoder >> disposition;
-    if (!disposition)
-        return std::nullopt;
-
-
-    return { {
-        WTFMove(*targetAppCodeSigningIdentifier),
-        WTFMove(*pushPartitionString),
-        WTFMove(*registrationURL),
-        WTFMove(*payload),
-        WTFMove(*disposition),
-    } };
-}
 
 } // namespace WebKit::WebPushD

--- a/Source/WebKit/Shared/PushMessageForTesting.serialization.in
+++ b/Source/WebKit/Shared/PushMessageForTesting.serialization.in
@@ -1,0 +1,34 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+webkit_platform_headers: "ArgumentCoders.h" "PushMessageForTesting.h"
+
+[CustomHeader, WebKitPlatform] struct WebKit::WebPushD::PushMessageForTesting {
+    String targetAppCodeSigningIdentifier;
+    String pushPartitionString;
+    URL registrationURL;
+    String payload;
+    WebKit::WebPushD::PushMessageDisposition disposition;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    std::optional<WebCore::NotificationPayload> parsedPayload;
+#endif
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1644,12 +1644,6 @@ enum class WebCore::InputMode : uint8_t {
     Search
 };
 
-enum class WebCore::NotificationDirection : uint8_t {
-    Auto,
-    Ltr,
-    Rtl
-};
-
 enum class WebCore::IndexedDB::GetAllType : bool
 
 enum class WebCore::WorkerType : bool
@@ -5896,3 +5890,22 @@ struct WebCore::LinkDecorationFilteringData {
     WebCore::RegistrableDomain domain;
     String linkDecoration;
 };
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+[WebKitPlatform] struct WebCore::NotificationPayload {
+    URL defaultActionURL;
+    String title;
+    std::optional<unsigned long long> appBadge;
+    std::optional<WebCore::NotificationOptionsPayload> options;
+};
+
+[WebKitPlatform] struct WebCore::NotificationOptionsPayload {
+    WebCore::NotificationDirection dir;
+    String lang;
+    String body;
+    String tag;
+    String icon;
+    String dataJSONString;
+    std::optional<bool> silent;
+};
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebKit/Shared/WebPushMessage.h
+++ b/Source/WebKit/Shared/WebPushMessage.h
@@ -29,6 +29,10 @@
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+#include <WebCore/NotificationPayload.h>
+#endif
+
 OBJC_CLASS NSDictionary;
 
 namespace WebKit {
@@ -37,6 +41,9 @@ struct WebPushMessage {
     std::optional<Vector<uint8_t>> pushData;
     String pushPartitionString;
     URL registrationURL;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    std::optional<WebCore::NotificationPayload> notificationPayload;
+#endif
 
 #if PLATFORM(COCOA)
     static std::optional<WebPushMessage> fromDictionary(NSDictionary *);

--- a/Source/WebKit/Shared/WebPushMessage.serialization.in
+++ b/Source/WebKit/Shared/WebPushMessage.serialization.in
@@ -20,8 +20,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-struct WebKit::WebPushMessage {
+webkit_platform_headers: "ArgumentCoders.h" "WebPushMessage.h"
+
+[CustomHeader, WebKitPlatform] struct WebKit::WebPushMessage {
     std::optional<Vector<uint8_t>> pushData;
     String pushPartitionString;
     URL registrationURL;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    std::optional<WebCore::NotificationPayload> notificationPayload;
+#endif
 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1113,7 +1113,6 @@
 		517B5F7F275E97B6002DC22D /* WebPushDaemon.h in Headers */ = {isa = PBXBuildFile; fileRef = 512CD69D2723393A00F7F8EC /* WebPushDaemon.h */; };
 		517B5F95275EBA63002DC22D /* PushMessageForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 517B5F94275EBA62002DC22D /* PushMessageForTesting.h */; };
 		517B5F97275EC5E5002DC22D /* WebPushMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 517B5F96275EC5E5002DC22D /* WebPushMessage.h */; };
-		517B5F99275EC601002DC22D /* WebPushMessageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */; };
 		517CF0E3163A486C00C2950E /* NetworkProcessConnectionMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 517CF0E1163A486C00C2950E /* NetworkProcessConnectionMessageReceiver.cpp */; };
 		517CF0E3163A486C00C2950F /* CacheStorageEngineConnectionMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 517CF0E1163A486C00C2950F /* CacheStorageEngineConnectionMessageReceiver.cpp */; };
 		517CF0E4163A486C00C2950E /* NetworkProcessConnectionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 517CF0E2163A486C00C2950E /* NetworkProcessConnectionMessages.h */; };
@@ -1125,6 +1124,7 @@
 		518D2CAE12D5153B003BB93B /* WebBackForwardListItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 518D2CAC12D5153B003BB93B /* WebBackForwardListItem.h */; };
 		518E8EF916B2091C00E91429 /* AuthenticationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 518E8EF416B2091C00E91429 /* AuthenticationManager.h */; };
 		519261782950EA3F00A975D1 /* WKSecurityOriginPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 519261772950EA3E00A975D1 /* WKSecurityOriginPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5192DDB92AB54ED700E88DE7 /* WebPushMessageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517B5F98275EC600002DC22D /* WebPushMessageCocoa.mm */; };
 		51933DEF1965EB31008AC3EA /* MenuUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51933DEB1965EB24008AC3EA /* MenuUtilities.h */; };
 		519DFBE7281387C1003FF6AD /* WKNotificationPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 519DFBE528138756003FF6AD /* WKNotificationPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51A555F6128C6C47009ABCEC /* WKContextMenuItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 51A555F4128C6C47009ABCEC /* WKContextMenuItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4949,6 +4949,7 @@
 		51452702271FBA36000467B6 /* NotificationManagerMessageHandlerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NotificationManagerMessageHandlerMessageReceiver.cpp; sourceTree = "<group>"; };
 		51452706271FBEC1000467B6 /* WebNotificationManagerMessageHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebNotificationManagerMessageHandler.cpp; sourceTree = "<group>"; };
 		51452707271FBEC1000467B6 /* WebNotificationManagerMessageHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebNotificationManagerMessageHandler.h; sourceTree = "<group>"; };
+		514899722AB4BCFC00943741 /* PushMessageForTesting.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushMessageForTesting.serialization.in; sourceTree = "<group>"; };
 		51489CC12370DACC0044E68A /* WKFindResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKFindResult.h; sourceTree = "<group>"; };
 		51489CC22370DACC0044E68A /* WKFindResult.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKFindResult.mm; sourceTree = "<group>"; };
 		51489CC6237237780044E68A /* WKFindResultInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKFindResultInternal.h; sourceTree = "<group>"; };
@@ -8089,6 +8090,7 @@
 				0FEC6E05280915CF008082AC /* ProcessTerminationReason.cpp */,
 				463FD4811EB94EAD00A2982C /* ProcessTerminationReason.h */,
 				517B5F94275EBA62002DC22D /* PushMessageForTesting.h */,
+				514899722AB4BCFC00943741 /* PushMessageForTesting.serialization.in */,
 				9B1229D023FF2A5E008CA751 /* RemoteAudioDestinationIdentifier.h */,
 				5C80B3DD23690F100086E6DE /* RemoteWorkerInitializationData.cpp */,
 				5C80B3DB23690D8D0086E6DE /* RemoteWorkerInitializationData.h */,
@@ -17045,6 +17047,7 @@
 				7B9FC5D228A53018007570E7 /* PlatformUnifiedSource4.cpp in Sources */,
 				7B9FC5DC28A53C24007570E7 /* PlatformUnifiedSource5.cpp in Sources */,
 				5C9E0F992A577EDD00FC2664 /* WebKitPlatformGeneratedSerializers.mm in Sources */,
+				5192DDB92AB54ED700E88DE7 /* WebPushMessageCocoa.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -17509,7 +17512,6 @@
 				BCEE7AD012817988009827DA /* WebProcessProxyMessageReceiver.cpp in Sources */,
 				517B5F7A275E97A4002DC22D /* WebPushDaemon.mm in Sources */,
 				517B5F79275E97A1002DC22D /* WebPushDaemonMain.mm in Sources */,
-				517B5F99275EC601002DC22D /* WebPushMessageCocoa.mm in Sources */,
 				51BE6C5B2AA92519001745C1 /* WebPushToolConnection.mm in Sources */,
 				51BE6C572AA92480001745C1 /* WebPushToolMain.mm in Sources */,
 				51F060E11654318500F3281B /* WebResourceLoaderMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -687,8 +687,11 @@ void PushService::didReceivePushMessage(NSString* topic, NSDictionary* userInfo,
         auto record = WTFMove(*recordResult);
 
         if (message.encoding == ContentEncoding::Empty) {
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+            m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { { }, record.subscriptionSetIdentifier.pushPartition, URL { record.scope }, { } });
+#else
             m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { { }, record.subscriptionSetIdentifier.pushPartition, URL { record.scope } });
-
+#endif
             completionHandler();
             return;
         }
@@ -712,8 +715,11 @@ void PushService::didReceivePushMessage(NSString* topic, NSDictionary* userInfo,
 
         RELEASE_LOG(Push, "Decoded incoming push message for %{public}s %{sensitive}s", record.subscriptionSetIdentifier.debugDescription().utf8().data(), record.scope.utf8().data());
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+        m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { WTFMove(*decryptedPayload), record.subscriptionSetIdentifier.pushPartition, URL { record.scope }, { } });
+#else
         m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { WTFMove(*decryptedPayload), record.subscriptionSetIdentifier.pushPartition, URL { record.scope } });
-
+#endif
         completionHandler();
     });
 }

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -77,7 +77,7 @@ public:
     // Message handlers
     void setPushAndNotificationsEnabledForOrigin(PushClientConnection&, const String& originString, bool, CompletionHandler<void()>&& replySender);
     void deletePushAndNotificationRegistration(PushClientConnection&, const String& originString, CompletionHandler<void(const String&)>&& replySender);
-    void injectPushMessageForTesting(PushClientConnection&, const PushMessageForTesting&, CompletionHandler<void(const String&)>&&);
+    void injectPushMessageForTesting(PushClientConnection&, PushMessageForTesting&&, CompletionHandler<void(const String&)>&&);
     void injectEncryptedPushMessageForTesting(PushClientConnection&, const String&, CompletionHandler<void(bool)>&&);
     void getPendingPushMessages(PushClientConnection&, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
     void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -85,7 +85,12 @@ static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumera
     if (!message)
         return nullptr;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    PushMessageForTesting pushMessage = { appIdentifier, pushPartition, registrationURL, message, WebKit::WebPushD::PushMessageDisposition::Legacy, std::nullopt };
+#else
     PushMessageForTesting pushMessage = { appIdentifier, pushPartition, registrationURL, message, WebKit::WebPushD::PushMessageDisposition::Legacy };
+#endif
+
     return makeUniqueWithoutFastMallocCheck<PushMessageForTesting>(WTFMove(pushMessage));
 }
 


### PR DESCRIPTION
#### 5043150257293a0e89dd2166d45592e9ac1cc379
<pre>
Parsed Declarative Web Push JSON should be remembered and round trip throughout various forms of IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=261632">https://bugs.webkit.org/show_bug.cgi?id=261632</a>
rdar://115585968

Reviewed by Alex Christensen.

webpushd knows how to validate Declarative Notification JSON into a NotificationPayload

But now:
- Once validated, it saves the NotificationPayload into the push message that will be fetched by the client later
- NotificationPayload and related all know how to serialize, both in the CoreIPC sense and Obj-C SPI client sense
- Tests validate that all that serialization happens.

* Source/WebCore/Modules/notifications/NotificationDirection.h:
* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
(WebCore::NotificationJSONParser::parseNotificationPayload):
(WebCore::NotificationJSONParser::parseNotificationOptions):
* Source/WebCore/Modules/notifications/NotificationJSONParser.h:
* Source/WebCore/Modules/notifications/NotificationOptionsPayload.h: Copied from Source/WebCore/Modules/notifications/NotificationPayload.h.
* Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm: Added.
(WebCore::NotificationOptionsPayload::fromDictionary):
(WebCore::NotificationOptionsPayload::dictionaryRepresentation const):
* Source/WebCore/Modules/notifications/NotificationPayload.h:
* Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm: Added.
(WebCore::NotificationPayload::fromDictionary):
(WebCore::NotificationPayload::dictionaryRepresentation const):
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WebPushD::PushMessageForTesting&gt;::encode): Deleted.
(WebKit::Daemon::Coder&lt;WebPushD::PushMessageForTesting&gt;::decode): Deleted.
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedEnum.is_webkit_platform):
(generate_impl):
(parse_serialized_types):
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::fromDictionary):
(WebKit::WebPushMessage::toDictionary const):
* Source/WebKit/Shared/PushMessageForTesting.h:
(WebKit::WebPushD::PushMessageForTesting::encode const): Deleted.
(WebKit::WebPushD::PushMessageForTesting::decode): Deleted.
* Source/WebKit/Shared/PushMessageForTesting.serialization.in: Copied from Source/WebKit/Shared/WebPushMessage.serialization.in.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPushMessage.h:
* Source/WebKit/Shared/WebPushMessage.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::didReceivePushMessage):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::getPendingPushMessages):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(pushMessageFromArguments):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/268052@main">https://commits.webkit.org/268052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7453a3eb048bdf6baa0e3a4172eab485c2136b50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19005 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/18925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21258 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/18691 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16898 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14954 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16705 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->