### PR TITLE
Add 'mutable' member to Notification JSON

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.h
@@ -41,6 +41,7 @@ struct NotificationPayload {
     String title;
     std::optional<unsigned long long> appBadge;
     std::optional<NotificationOptionsPayload> options;
+    bool isMutable { false };
 
     WEBCORE_EXPORT static ExceptionOr<NotificationPayload> parseJSON(const String&);
 

--- a/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
@@ -32,6 +32,7 @@ static NSString * const WebNotificationDefaultActionKey = @"WebNotificationDefau
 static NSString * const WebNotificationTitleKey = @"WebNotificationTitleKey";
 static NSString * const WebNotificationAppBadgeKey = @"WebNotificationAppBadgeKey";
 static NSString * const WebNotificationOptionsKey = @"WebNotificationOptionsKey";
+static NSString * const WebNotificationMutableKey = @"WebNotificationMutableKey";
 
 namespace WebCore {
 
@@ -67,7 +68,11 @@ std::optional<NotificationPayload> NotificationPayload::fromDictionary(NSDiction
             return std::nullopt;
     }
 
-    return NotificationPayload { defaultAction, title, WTFMove(rawAppBadge), WTFMove(rawOptions) };
+    NSNumber *isMutable = dictionary[WebNotificationMutableKey];
+    if (!isMutable)
+        return std::nullopt;
+
+    return NotificationPayload { defaultAction, title, WTFMove(rawAppBadge), WTFMove(rawOptions), [isMutable boolValue] };
 }
 
 NSDictionary *NotificationPayload::dictionaryRepresentation() const
@@ -80,6 +85,7 @@ NSDictionary *NotificationPayload::dictionaryRepresentation() const
         WebNotificationTitleKey : (NSString *)title,
         WebNotificationAppBadgeKey : nsAppBadge,
         WebNotificationOptionsKey : nsOptions,
+        WebNotificationMutableKey : @(isMutable),
     };
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5897,6 +5897,7 @@ struct WebCore::LinkDecorationFilteringData {
     String title;
     std::optional<unsigned long long> appBadge;
     std::optional<WebCore::NotificationOptionsPayload> options;
+    bool isMutable;
 };
 
 [WebKitPlatform] struct WebCore::NotificationOptionsPayload {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1443,6 +1443,34 @@ static constexpr ASCIILiteral json34 = R"JSONRESOURCE(
     "app_badge": "18446744073709551616"
 }
 )JSONRESOURCE"_s;
+static constexpr ASCIILiteral json35 = R"JSONRESOURCE(
+{
+    "default_action_url": "https://example.com/",
+    "title": "Hello world!",
+    "mutable": 39
+}
+)JSONRESOURCE"_s;
+static constexpr ASCIILiteral json36 = R"JSONRESOURCE(
+{
+    "default_action_url": "https://example.com/",
+    "title": "Hello world!",
+    "mutable": { }
+}
+)JSONRESOURCE"_s;
+static constexpr ASCIILiteral json37 = R"JSONRESOURCE(
+{
+    "default_action_url": "https://example.com/",
+    "title": "Hello world!",
+    "mutable": "true"
+}
+)JSONRESOURCE"_s;
+static constexpr ASCIILiteral json38 = R"JSONRESOURCE(
+{
+    "default_action_url": "https://example.com/",
+    "title": "Hello world!",
+    "mutable": true
+}
+)JSONRESOURCE"_s;
 
 static constexpr ASCIILiteral errors[] = {
     "does not contain valid JSON"_s,
@@ -1462,7 +1490,8 @@ static constexpr ASCIILiteral errors[] = {
     "'options' JSON is not valid: 'icon' member is specified but is not a string"_s,
     "'options' JSON is not valid: 'icon' member is specified but does not represent a valid URL"_s,
     "'options' JSON is not valid: 'silent' member is specified but is not a boolean"_s,
-    "'app_badge' member is specified as a string that did not parse to a valid unsigned long long"_s
+    "'app_badge' member is specified as a string that did not parse to a valid unsigned long long"_s,
+    "'mutable' member is specified but is not a boolean"_s
 };
 
 static std::pair<ASCIILiteral, ASCIILiteral> jsonAndErrors[] = {
@@ -1501,6 +1530,11 @@ static std::pair<ASCIILiteral, ASCIILiteral> jsonAndErrors[] = {
     { json32, { " "_s } },
     { json33, { " "_s } },
     { json34, errors[17] },
+    { json35, errors[18] },
+    { json36, errors[18] },
+    { json37, errors[18] },
+    { json38, { " "_s } },
+
     { { }, { } }
 };
 


### PR DESCRIPTION
#### 010581c0ec10914fdf7618f75cdc69fc734cc9ec
<pre>
Add &apos;mutable&apos; member to Notification JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=261648">https://bugs.webkit.org/show_bug.cgi?id=261648</a>

Reviewed by Jean-Yves Avenard.

* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
(WebCore::mutableKey):
(WebCore::NotificationJSONParser::parseNotificationPayload):
* Source/WebCore/Modules/notifications/NotificationPayload.h:
* Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm:
(WebCore::NotificationPayload::fromDictionary):
(WebCore::NotificationPayload::dictionaryRepresentation const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/268066@main">https://commits.webkit.org/268066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc69cc6c07c9092491fdba0d3a74451681eaa31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18576 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19241 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21311 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23387 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21282 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15000 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16751 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4413 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->