### PR TITLE
Re-run meta@name=color-scheme processing when name attribute or content attribute changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-attribute-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-attribute-changes-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Meta color-scheme initially 'dark'.
-FAIL Removed name attribute from meta color-scheme. assert_equals: expected "light" but got "dark"
+PASS Removed name attribute from meta color-scheme.
 PASS Set meta name to color-scheme.
 PASS Set content attribute of meta color-scheme to empty string.
 PASS Set content attribute of meta color-scheme to an invalid value.
 PASS Set content attribute of meta color-scheme to 'light'.
 PASS Set content attribute of meta color-scheme to 'dark'.
-FAIL Removed the content attribute of meta color-scheme. assert_equals: expected "light" but got "dark"
+PASS Removed the content attribute of meta color-scheme.
 

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -66,6 +66,14 @@ Ref<HTMLMetaElement> HTMLMetaElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLMetaElement(tagName, document));
 }
 
+#if ENABLE(DARK_MODE_CSS)
+static bool isNameColorScheme(const AtomString& nameValue)
+{
+    return equalLettersIgnoringASCIICase(nameValue, "color-scheme"_s) || equalLettersIgnoringASCIICase(nameValue, "supported-color-schemes"_s);
+}
+#endif
+
+
 bool HTMLMetaElement::mediaAttributeMatches()
 {
     auto& document = this->document();
@@ -102,7 +110,7 @@ void HTMLMetaElement::attributeChanged(const QualifiedName& name, const AtomStri
 
     switch (name.nodeName()) {
     case AttributeNames::nameAttr:
-        process();
+        process(oldValue);
         if (isInDocumentTree()) {
             if (equalLettersIgnoringASCIICase(oldValue, "theme-color"_s) && !equalLettersIgnoringASCIICase(newValue, "theme-color"_s))
                 document().metaElementThemeColorChanged(*this);
@@ -144,16 +152,24 @@ void HTMLMetaElement::removedFromAncestor(RemovalType removalType, ContainerNode
     if (removalType.disconnectedFromDocument && equalLettersIgnoringASCIICase(name(), "theme-color"_s))
         oldParentOfRemovedTree.document().metaElementThemeColorChanged(*this);
 #if ENABLE(DARK_MODE_CSS)
-    else if (removalType.disconnectedFromDocument && (equalLettersIgnoringASCIICase(name(), "color-scheme"_s) || equalLettersIgnoringASCIICase(name(), "supported-color-schemes"_s)))
+    else if (removalType.disconnectedFromDocument && isNameColorScheme(name()))
         oldParentOfRemovedTree.document().metaElementColorSchemeChanged();
 #endif
 }
 
-void HTMLMetaElement::process()
+void HTMLMetaElement::process(const AtomString& oldValue)
 {
     // Changing a meta tag while it's not in the document tree shouldn't have any effect on the document.
     if (!isInDocumentTree())
         return;
+
+    const AtomString& nameValue = attributeWithoutSynchronization(nameAttr);
+#if ENABLE(DARK_MODE_CSS)
+    if (isNameColorScheme(nameValue) || (!oldValue.isNull() && isNameColorScheme(oldValue)))
+        document().metaElementColorSchemeChanged();
+#else
+    UNUSED_PARAM(oldValue);
+#endif
 
     // https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element
     // All below situations require a content attribute (which can be the empty string).
@@ -168,7 +184,6 @@ void HTMLMetaElement::process()
     if (!httpEquivValue.isNull())
         document().processMetaHttpEquiv(httpEquivValue, contentValue, isDescendantOf(document().head()));
     
-    const AtomString& nameValue = attributeWithoutSynchronization(nameAttr);
     if (nameValue.isNull())
         return;
 
@@ -176,10 +191,6 @@ void HTMLMetaElement::process()
         document().processViewport(contentValue, ViewportArguments::Type::ViewportMeta);
     else if (document().settings().disabledAdaptationsMetaTagEnabled() && equalLettersIgnoringASCIICase(nameValue, "disabled-adaptations"_s))
         document().processDisabledAdaptations(contentValue);
-#if ENABLE(DARK_MODE_CSS)
-    else if (equalLettersIgnoringASCIICase(nameValue, "color-scheme"_s) || equalLettersIgnoringASCIICase(nameValue, "supported-color-schemes"_s))
-        document().metaElementColorSchemeChanged();
-#endif
     else if (equalLettersIgnoringASCIICase(nameValue, "theme-color"_s))
         document().metaElementThemeColorChanged(*this);
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/html/HTMLMetaElement.h
+++ b/Source/WebCore/html/HTMLMetaElement.h
@@ -50,7 +50,7 @@ private:
     void didFinishInsertingNode();
     void removedFromAncestor(RemovalType, ContainerNode&) final;
 
-    void process();
+    void process(const AtomString& oldValue = nullAtom());
 
     std::optional<MQ::MediaQueryList> m_mediaQueryList;
 


### PR DESCRIPTION
#### 3afefcc5f9348463406812ccd2ffab3dae4749a4
<pre>
Re-run meta@name=color-scheme processing when name attribute or content attribute changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261654">https://bugs.webkit.org/show_bug.cgi?id=261654</a>

Reviewed by Aditya Keerthi.

This change makes WebKit conform to the requirement at
<a href="https://html.spec.whatwg.org/#standard-metadata-names">https://html.spec.whatwg.org/#standard-metadata-names</a>:attr-meta-name-15,
which states that:

&gt; [if] existing meta elements have their name or content attributes
changed, user agents must re-run the above algorithm

…where “above algorithm” is the algorithm at
<a href="https://html.spec.whatwg.org/#standard-metadata-names">https://html.spec.whatwg.org/#standard-metadata-names</a>:page&apos;s-supported-color-schemes-2

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/color-scheme/meta-color-scheme-attribute-changes-expected.txt:
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::isNameColorScheme):
(WebCore::HTMLMetaElement::attributeChanged):
(WebCore::HTMLMetaElement::removedFromAncestor):
(WebCore::HTMLMetaElement::process):
* Source/WebCore/html/HTMLMetaElement.h:

Canonical link: <a href="https://commits.webkit.org/270092@main">https://commits.webkit.org/270092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/643ff57070b04730f7e7bf2eedbef568e2774ca5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21340 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22197 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25840 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27066 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24933 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/507 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->