### PR TITLE
[style-checker] PlatformMouseEvent.h:42: Code inside a namespace should not be indented.

### DIFF
--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -36,100 +36,100 @@ namespace WebCore {
 const double ForceAtClick = 1;
 const double ForceAtForceClick = 2;
 
-    // These button numbers match the ones used in the DOM API, 0 through 2, except for None and Other which aren't specified.
-    // We reserve -2 for the former and -1 to represent pointermove events that indicate that the pressed mouse button hasn't
-    // changed since the last event, as specified in the DOM API for Pointer Events.
-    // https://w3c.github.io/uievents/#dom-mouseevent-button
-    // https://w3c.github.io/pointerevents/#the-button-property
-    enum class MouseButton : int8_t { None = -2, PointerMove, Left, Middle, Right, Other };
-    enum class SyntheticClickType : uint8_t { NoTap, OneFingerTap, TwoFingerTap };
+// These button numbers match the ones used in the DOM API, 0 through 2, except for None and Other which aren't specified.
+// We reserve -2 for the former and -1 to represent pointermove events that indicate that the pressed mouse button hasn't
+// changed since the last event, as specified in the DOM API for Pointer Events.
+// https://w3c.github.io/uievents/#dom-mouseevent-button
+// https://w3c.github.io/pointerevents/#the-button-property
+enum class MouseButton : int8_t { None = -2, PointerMove, Left, Middle, Right, Other };
+enum class SyntheticClickType : uint8_t { NoTap, OneFingerTap, TwoFingerTap };
 
-    class PlatformMouseEvent : public PlatformEvent {
-    public:
-        PlatformMouseEvent()
-            : PlatformEvent(Type::MouseMoved)
-        {
-        }
+class PlatformMouseEvent : public PlatformEvent {
+public:
+    PlatformMouseEvent()
+        : PlatformEvent(Type::MouseMoved)
+    {
+    }
 
-        PlatformMouseEvent(const IntPoint& position, const IntPoint& globalPosition, MouseButton button, PlatformEvent::Type type, int clickCount, OptionSet<PlatformEvent::Modifier> modifiers, WallTime timestamp, double force, SyntheticClickType syntheticClickType, PointerID pointerId = mousePointerID)
-            : PlatformEvent(type, modifiers, timestamp)
-            , m_button(button)
-            , m_syntheticClickType(syntheticClickType)
-            , m_position(position)
-            , m_globalPosition(globalPosition)
-            , m_force(force)
-            , m_pointerId(pointerId)
-            , m_clickCount(clickCount)
-        {
-        }
+    PlatformMouseEvent(const IntPoint& position, const IntPoint& globalPosition, MouseButton button, PlatformEvent::Type type, int clickCount, OptionSet<PlatformEvent::Modifier> modifiers, WallTime timestamp, double force, SyntheticClickType syntheticClickType, PointerID pointerId = mousePointerID)
+        : PlatformEvent(type, modifiers, timestamp)
+        , m_button(button)
+        , m_syntheticClickType(syntheticClickType)
+        , m_position(position)
+        , m_globalPosition(globalPosition)
+        , m_force(force)
+        , m_pointerId(pointerId)
+        , m_clickCount(clickCount)
+    {
+    }
 
-        // This position is relative to the enclosing NSWindow in WebKit1, and is WKWebView-relative in WebKit2.
-        // Use ScrollView::windowToContents() to convert it to into the contents of a given view.
-        const IntPoint& position() const { return m_position; }
-        const IntPoint& globalPosition() const { return m_globalPosition; }
-        const IntPoint& movementDelta() const { return m_movementDelta; }
+    // This position is relative to the enclosing NSWindow in WebKit1, and is WKWebView-relative in WebKit2.
+    // Use ScrollView::windowToContents() to convert it to into the contents of a given view.
+    const IntPoint& position() const { return m_position; }
+    const IntPoint& globalPosition() const { return m_globalPosition; }
+    const IntPoint& movementDelta() const { return m_movementDelta; }
 
-        MouseButton button() const { return m_button; }
-        unsigned short buttons() const { return m_buttons; }
-        int clickCount() const { return m_clickCount; }
-        unsigned modifierFlags() const { return m_modifierFlags; }
-        double force() const { return m_force; }
-        SyntheticClickType syntheticClickType() const { return m_syntheticClickType; }
-        PointerID pointerId() const { return m_pointerId; }
-        const String& pointerType() const { return m_pointerType; }
+    MouseButton button() const { return m_button; }
+    unsigned short buttons() const { return m_buttons; }
+    int clickCount() const { return m_clickCount; }
+    unsigned modifierFlags() const { return m_modifierFlags; }
+    double force() const { return m_force; }
+    SyntheticClickType syntheticClickType() const { return m_syntheticClickType; }
+    PointerID pointerId() const { return m_pointerId; }
+    const String& pointerType() const { return m_pointerType; }
 
 #if PLATFORM(MAC)
-        int eventNumber() const { return m_eventNumber; }
-        int menuTypeForEvent() const { return m_menuTypeForEvent; }
+    int eventNumber() const { return m_eventNumber; }
+    int menuTypeForEvent() const { return m_menuTypeForEvent; }
 #endif
 
 #if PLATFORM(WIN)
-        WEBCORE_EXPORT PlatformMouseEvent(HWND, UINT, WPARAM, LPARAM, bool didActivateWebView = false);
-        void setClickCount(int count) { m_clickCount = count; }
-        bool didActivateWebView() const { return m_didActivateWebView; }
+    WEBCORE_EXPORT PlatformMouseEvent(HWND, UINT, WPARAM, LPARAM, bool didActivateWebView = false);
+    void setClickCount(int count) { m_clickCount = count; }
+    bool didActivateWebView() const { return m_didActivateWebView; }
 #endif
 
 #if PLATFORM(GTK)
-        enum class IsTouch : bool { No, Yes };
+    enum class IsTouch : bool { No, Yes };
 
-        bool isTouchEvent() const { return m_isTouchEvent == IsTouch::Yes; }
+    bool isTouchEvent() const { return m_isTouchEvent == IsTouch::Yes; }
 #endif
 
-    protected:
-        MouseButton m_button { MouseButton::None };
-        SyntheticClickType m_syntheticClickType { SyntheticClickType::NoTap };
+protected:
+    MouseButton m_button { MouseButton::None };
+    SyntheticClickType m_syntheticClickType { SyntheticClickType::NoTap };
 
-        IntPoint m_position;
-        IntPoint m_globalPosition;
-        IntPoint m_movementDelta;
-        double m_force { 0 };
-        PointerID m_pointerId { mousePointerID };
-        String m_pointerType { "mouse"_s };
-        int m_clickCount { 0 };
-        unsigned m_modifierFlags { 0 };
-        unsigned short m_buttons { 0 };
+    IntPoint m_position;
+    IntPoint m_globalPosition;
+    IntPoint m_movementDelta;
+    double m_force { 0 };
+    PointerID m_pointerId { mousePointerID };
+    String m_pointerType { "mouse"_s };
+    int m_clickCount { 0 };
+    unsigned m_modifierFlags { 0 };
+    unsigned short m_buttons { 0 };
 #if PLATFORM(MAC)
-        int m_eventNumber { 0 };
-        int m_menuTypeForEvent { 0 };
+    int m_eventNumber { 0 };
+    int m_menuTypeForEvent { 0 };
 #elif PLATFORM(WIN)
-        bool m_didActivateWebView { false };
+    bool m_didActivateWebView { false };
 #elif PLATFORM(GTK)
-        IsTouch m_isTouchEvent { IsTouch::No };
+    IsTouch m_isTouchEvent { IsTouch::No };
 #endif
-    };
+};
 
 #if COMPILER(MSVC)
-    // These functions are necessary to work around the fact that MSVC will not find a most-specific
-    // operator== to use after implicitly converting MouseButton to a short.
-    inline bool operator==(short a, MouseButton b)
-    {
-        return a == static_cast<short>(b);
-    }
+// These functions are necessary to work around the fact that MSVC will not find a most-specific
+// operator== to use after implicitly converting MouseButton to a short.
+inline bool operator==(short a, MouseButton b)
+{
+    return a == static_cast<short>(b);
+}
 
-    inline bool operator!=(short a, MouseButton b)
-    {
-        return a != static_cast<short>(b);
-    }
+inline bool operator!=(short a, MouseButton b)
+{
+    return a != static_cast<short>(b);
+}
 #endif
 
 } // namespace WebCore


### PR DESCRIPTION
#### d536c41672d0f62d0a480255d07b129668c6fbfb
<pre>
[style-checker] PlatformMouseEvent.h:42: Code inside a namespace should not be indented.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261636">https://bugs.webkit.org/show_bug.cgi?id=261636</a>
rdar://115590961

Reviewed by Wenson Hsieh.

This commit simply unindents the content of `PlatformMouseEvent.h`
inside the `WebCore` namespace, as it was unnecessarily indented before.

* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
(WebCore::PlatformMouseEvent::position const):
(WebCore::PlatformMouseEvent::globalPosition const):
(WebCore::PlatformMouseEvent::movementDelta const):
(WebCore::PlatformMouseEvent::button const):
(WebCore::PlatformMouseEvent::buttons const):
(WebCore::PlatformMouseEvent::clickCount const):
(WebCore::PlatformMouseEvent::modifierFlags const):
(WebCore::PlatformMouseEvent::force const):
(WebCore::PlatformMouseEvent::syntheticClickType const):
(WebCore::PlatformMouseEvent::pointerId const):
(WebCore::PlatformMouseEvent::pointerType const):
(WebCore::PlatformMouseEvent::eventNumber const):
(WebCore::PlatformMouseEvent::menuTypeForEvent const):
(WebCore::PlatformMouseEvent::setClickCount):
(WebCore::PlatformMouseEvent::didActivateWebView const):
(WebCore::PlatformMouseEvent::isTouchEvent const):
(WebCore::operator==):
(WebCore::operator!=):

Canonical link: <a href="https://commits.webkit.org/268070@main">https://commits.webkit.org/268070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fe0df0197001ee8f875180d4ccef45ef3c96b81

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21335 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23400 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21295 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15021 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16774 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4415 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->