### PR TITLE
Drop some dead code according to the clang static analyzer

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm
@@ -90,7 +90,6 @@ void configureRequestToUseCPUOrGPU(VNRequest *request)
             for (id<MLComputeDeviceProtocol> device in supportedComputeStageDevices[computeStage]) {
                 if ([device isKindOfClass:PAL::getMLGPUComputeDeviceClass()]) {
                     [request setComputeDevice:device forComputeStage:computeStage];
-                    set = true;
                     break;
                 }
             }

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -227,7 +227,6 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
 
         unsigned rangeLength = rangeStringView.length();
         unsigned rangeSubtagsStartIndex = 0;
-        unsigned rangeSubtagsEndIndex = rangeLength;
         unsigned lastMatchedLanguageSubtagIndex = 0;
 
         bool matchedRange = true;
@@ -236,7 +235,7 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
                 rangeSubtagsStartIndex += 1;
             if (rangeSubtagsStartIndex > languageLength)
                 return false;
-            rangeSubtagsEndIndex = std::min<unsigned>(rangeStringView.find('-', rangeSubtagsStartIndex), rangeLength);
+            unsigned rangeSubtagsEndIndex = std::min<unsigned>(rangeStringView.find('-', rangeSubtagsStartIndex), rangeLength);
             StringView rangeSubtag = rangeStringView.substring(rangeSubtagsStartIndex, rangeSubtagsEndIndex - rangeSubtagsStartIndex);
             if (!containslanguageSubtagMatchingRange(languageStringView, rangeSubtag, languageLength, lastMatchedLanguageSubtagIndex)) {
                 matchedRange = false;

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -379,7 +379,6 @@ RefPtr<CSSCalcOperationNode> CSSCalcOperationNode::createSum(Vector<Ref<CSSCalcE
     auto newCategory = determineCategory(values, CalcOperator::Add);
     if (newCategory == CalculationCategory::Other) {
         LOG_WITH_STREAM(Calc, stream << "Failed to create sum node because unable to determine category from " << prettyPrintNodes(values));
-        newCategory = determineCategory(values, CalcOperator::Add);
         return nullptr;
     }
 

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -596,16 +596,13 @@ NSArray *DataDetection::detectContentInRange(const SimpleRange& contextRange, Op
             if (lastTextNodeToUpdate != &currentTextNode) {
                 if (lastTextNodeToUpdate)
                     lastTextNodeToUpdate->setData(lastNodeContent);
-                contentOffset = 0;
                 if (range.start.offset > 0)
                     textNodeData = currentTextNode.data().left(range.start.offset);
             } else
                 textNodeData = currentTextNode.data().substring(contentOffset, range.start.offset - contentOffset);
 
-            if (!textNodeData.isEmpty()) {
+            if (!textNodeData.isEmpty())
                 parentNode->insertBefore(Text::create(document, WTFMove(textNodeData)), &currentTextNode);
-                contentOffset = range.start.offset;
-            }
 
             // Create the actual anchor node and insert it before the current node.
             textNodeData = currentTextNode.data().substring(range.start.offset, range.end.offset - range.start.offset);

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -268,10 +268,8 @@ void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
         }
     }
 
-    if (!canvasIsDirty) {
-        canvasIsDirty = true;
+    if (!canvasIsDirty)
         canvasBase().didDraw({ });
-    }
 
     if (!isAccelerated())
         return;

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -312,25 +312,23 @@ void InspectorFrontendClientLocal::moveWindowBy(float x, float y)
 
 void InspectorFrontendClientLocal::setAttachedWindow(DockSide dockSide)
 {
-    const char* side = "undocked";
-    switch (dockSide) {
-    case DockSide::Undocked:
-        side = "undocked";
-        break;
-    case DockSide::Right:
-        side = "right";
-        break;
-    case DockSide::Left:
-        side = "left";
-        break;
-    case DockSide::Bottom:
-        side = "bottom";
-        break;
-    }
+    ASCIILiteral side = [&] {
+        switch (dockSide) {
+        case DockSide::Right:
+            return "right"_s;
+        case DockSide::Left:
+            return "left"_s;
+        case DockSide::Bottom:
+            return "bottom"_s;
+        case DockSide::Undocked:
+            break;
+        }
+        return "undocked"_s;
+    }();
 
     m_dockSide = dockSide;
 
-    m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockSide"_s, { JSON::Value::create(makeString(side)) });
+    m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockSide"_s, { JSON::Value::create(String { side }) });
 }
 
 void InspectorFrontendClientLocal::restoreAttachedWindowHeight()

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -143,7 +143,6 @@ static bool outputMismatchingComplexLineInformationIfNeeded(TextStream& stream, 
             
             if (is<RenderLineBreak>(inlineBox->renderer())) {
                 // <br> positioning is weird at this point. It needs proper baseline.
-                matchingRuns = true;
                 ++boxIndex;
                 continue;
             }
@@ -290,7 +289,7 @@ static bool verifyAndOutputSubtree(TextStream& stream, const LayoutState& contex
 {
     // Rendering code does not have the concept of table wrapper box. Skip it by verifying the first child(table box) instead. 
     if (layoutBox.isTableWrapperBox())
-        return verifyAndOutputSubtree(stream, context, renderer, *downcast<ElementBox>(layoutBox).firstChild()); 
+        return verifyAndOutputSubtree(stream, context, renderer, *downcast<ElementBox>(layoutBox).firstChild());
 
     auto mismtachingGeometry = outputMismatchingBlockBoxInformationIfNeeded(stream, context, renderer, layoutBox);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4393,9 +4393,11 @@ bool LocalFrameView::isScrollable(Scrollability definitionOfScrollable)
     if (!didFirstLayout())
         return false;
 
+#if HAVE(RUBBER_BANDING)
     bool requiresActualOverflowToBeConsideredScrollable = !m_frame->isMainFrame() || definitionOfScrollable != Scrollability::ScrollableOrRubberbandable;
-#if !HAVE(RUBBER_BANDING)
-    requiresActualOverflowToBeConsideredScrollable = true;
+#else
+    UNUSED_PARAM(definitionOfScrollable);
+    bool requiresActualOverflowToBeConsideredScrollable = true;
 #endif
 
     // Covers #1

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -156,11 +156,7 @@ void ReverbConvolver::backgroundThreadEntry()
         // Process all of the stages until their read indices reach the input buffer's write index
         int writeIndex = m_inputBuffer.writeIndex();
 
-        // Even though it doesn't seem like every stage needs to maintain its own version of readIndex 
-        // we do this in case we want to run in more than one background thread.
-        int readIndex;
-
-        while ((readIndex = m_backgroundStages[0]->inputReadIndex()) != writeIndex) { // FIXME: do better to detect buffer overrun...
+        while (m_backgroundStages[0]->inputReadIndex() != writeIndex) { // FIXME: do better to detect buffer overrun...
             // The ReverbConvolverStages need to process in amounts which evenly divide half the FFT size
             const int SliceSize = MinFFTSize / 2;
 

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -287,7 +287,6 @@ void CARingBuffer::fetchInternal(AudioBufferList* list, size_t nFrames, uint64_t
         FetchABL(list, destStartByteOffset, m_pointers, offset0, nbytes, mode, !offset1);
         if (offset1)
             FetchABL(list, destStartByteOffset + nbytes, m_pointers, 0, offset1, mode, true);
-        nbytes += offset1;
     }
 }
 

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -218,18 +218,17 @@ void AudioSessionIOS::setCategory(CategoryType newCategory, Mode newMode, RouteS
         break;
     }
 
-    NSString *modeString = AVAudioSessionModeDefault;
-    switch (newMode) {
-    case Mode::Default:
-        modeString = AVAudioSessionModeDefault;
-        break;
-    case Mode::MoviePlayback:
-        modeString = AVAudioSessionModeMoviePlayback;
-        break;
-    case Mode::VideoChat:
-        modeString = AVAudioSessionModeVideoChat;
-        break;
-    }
+    NSString *modeString = [&] {
+        switch (newMode) {
+        case Mode::MoviePlayback:
+            return AVAudioSessionModeMoviePlayback;
+        case Mode::VideoChat:
+            return AVAudioSessionModeVideoChat;
+        case Mode::Default:
+            break;
+        }
+        return AVAudioSessionModeDefault;
+    }();
 
     bool needDeviceUpdate = false;
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -183,7 +183,9 @@ void Font::platformInit()
 #endif
 
     // Compute line spacing before the line metrics hacks are applied.
-    float lineSpacing = lroundf(ascent) + lroundf(descent) + lroundf(lineGap);
+#if !PLATFORM(IOS_FAMILY)
+    float lineSpacing = std::lround(ascent) + std::lround(descent) + std::lround(lineGap);
+#endif
 
 #if PLATFORM(MAC)
     // Hack Hiragino line metrics to allow room for marked text underlines.
@@ -201,7 +203,7 @@ void Font::platformInit()
     CGFloat adjustment = shouldUseAdjustment(m_platformData.font()) ? ceil((ascent + descent) * kLineHeightAdjustment) : 0;
 
     lineGap = ceilf(lineGap);
-    lineSpacing = ceil(ascent) + adjustment + ceil(descent) + lineGap;
+    float lineSpacing = std::ceil(ascent) + adjustment + std::ceil(descent) + lineGap;
     ascent = ceilf(ascent + adjustment);
     descent = ceilf(descent);
 

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -409,7 +409,9 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 }
             } else if (allColsArePercent) {
                 // In this case, we just split the colspan's min amd max widths following the percentage.
+#if ASSERT_ENABLED
                 float allocatedMinLogicalWidth = 0;
+#endif
                 float allocatedMaxLogicalWidth = 0;
                 for (unsigned pos = effCol; pos < lastCol; ++pos) {
                     ASSERT(m_layoutStruct[pos].logicalWidth.isPercent() || m_layoutStruct[pos].effectiveLogicalWidth.isPercent());
@@ -419,12 +421,13 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                     float columnMaxLogicalWidth = percent * cellMaxLogicalWidth / totalPercent;
                     m_layoutStruct[pos].effectiveMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, columnMinLogicalWidth);
                     m_layoutStruct[pos].effectiveMaxLogicalWidth = columnMaxLogicalWidth;
+#if ASSERT_ENABLED
                     allocatedMinLogicalWidth += columnMinLogicalWidth;
+#endif
                     allocatedMaxLogicalWidth += columnMaxLogicalWidth;
                 }
                 ASSERT(allocatedMinLogicalWidth < cellMinLogicalWidth || WTF::areEssentiallyEqual(allocatedMinLogicalWidth, cellMinLogicalWidth));
                 ASSERT(allocatedMaxLogicalWidth < cellMaxLogicalWidth || WTF::areEssentiallyEqual(allocatedMaxLogicalWidth, cellMaxLogicalWidth));
-                cellMinLogicalWidth -= allocatedMinLogicalWidth;
                 cellMaxLogicalWidth -= allocatedMaxLogicalWidth;
             } else {
                 float remainingMaxLogicalWidth = spanMaxLogicalWidth;

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -1174,14 +1174,12 @@ static inline void constructBidiRunsForSegment(InlineBidiResolver& topResolver, 
     // of the resolver owning the runs.
     ASSERT(&topResolver.runs() == &bidiRuns);
     ASSERT(topResolver.position() != endOfRuns);
-    RenderObject* currentRoot = topResolver.position().root();
     topResolver.createBidiRunsForLine(endOfRuns, override, previousLineBrokeCleanly);
 
     while (!topResolver.isolatedRuns().isEmpty()) {
         // It does not matter which order we resolve the runs as long as we resolve them all.
         auto isolatedRun = WTFMove(topResolver.isolatedRuns().last());
         topResolver.isolatedRuns().removeLast();
-        currentRoot = &isolatedRun.root;
 
         RenderObject& startObject = isolatedRun.object;
 
@@ -1190,7 +1188,7 @@ static inline void constructBidiRunsForSegment(InlineBidiResolver& topResolver, 
         // tree to see which parent inline is the isolate. We could change enterIsolate
         // to take a RenderObject and do this logic there, but that would be a layering
         // violation for BidiResolver (which knows nothing about RenderObject).
-        RenderInline* isolatedInline = downcast<RenderInline>(highestContainingIsolateWithinRoot(startObject, currentRoot));
+        RenderInline* isolatedInline = downcast<RenderInline>(highestContainingIsolateWithinRoot(startObject, &isolatedRun.root));
         ASSERT(isolatedInline);
 
         InlineBidiResolver isolatedResolver;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1770,7 +1770,8 @@ float RenderText::width(unsigned from, unsigned length, const FontCascade& fontC
                 // The rare case of when we switch between IFC and legacy preferred width computation.
                 if (!m_maxWidth)
                     width = maxLogicalWidth();
-                width = *m_maxWidth;
+                else
+                    width = *m_maxWidth;
             } else
                 width = maxLogicalWidth();
         } else

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -410,10 +410,6 @@ void MathOperator::calculateStretchyData(const RenderStyle& style, bool calculat
         for (unsigned index = 0; index < maxIndex; ++index) {
             if (stretchyCharacters[index].character == m_baseCharacter) {
                 stretchyCharacter = &stretchyCharacters[index];
-                if (!style.isLeftToRightDirection() && index < leftRightPairsCount * 2) {
-                    // If we are in right-to-left direction we select the mirrored form by adding -1 or +1 according to the parity of index.
-                    index += index % 2 ? -1 : 1;
-                }
                 break;
             }
         }

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -746,7 +746,7 @@ static std::pair<FloatPoint, FloatPoint> endPointsFromAngle(float angleDeg, cons
 static std::pair<FloatPoint, FloatPoint> endPointsFromAngleForPrefixedVariants(float angleDeg, const FloatSize& size)
 {
     // Prefixed gradients use "polar coordinate" angles, rather than "bearing" angles.
-    return endPointsFromAngle(angleDeg = 90 - angleDeg, size);
+    return endPointsFromAngle(90 - angleDeg, size);
 }
 
 static float resolveRadius(CSSPrimitiveValue& radius, const CSSToLengthConversionData& conversionData, float widthOrHeight)

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -167,7 +167,7 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
     auto underlineOffset = context.lineStyle.textUnderlineOffset();
     auto& fontMetrics = context.lineStyle.metricsOfPrimaryFont();
 
-    float computedUnderlineOffset = fontMetrics.ascent() + gap;
+    float computedUnderlineOffset;
     switch (context.resolvedUnderlinePosition) {
     case TextUnderlinePosition::Auto:
         computedUnderlineOffset = fontMetrics.ascent() + underlineOffset.lengthOr(gap);
@@ -183,6 +183,7 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
         break;
     }
     default:
+        computedUnderlineOffset = fontMetrics.ascent() + gap;
         ASSERT_NOT_REACHED();
         break;
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2638,7 +2638,7 @@ String Internals::parserMetaData(JSC::JSValue code)
     else
         return String();
 
-    const char* prefix = "";
+    const char* prefix;
     String functionName;
     const char* suffix = "";
 
@@ -2653,7 +2653,7 @@ String Internals::parserMetaData(JSC::JSValue code)
     else if (executable->isProgramExecutable())
         prefix = "program";
     else
-        ASSERT_NOT_REACHED();
+        RELEASE_ASSERT_NOT_REACHED();
 
     return makeString(prefix, functionName, suffix, " { ",
         executable->firstLine(), ':', executable->startColumn(), " - ",

--- a/Source/WebCore/xml/XSLTUnicodeSort.cpp
+++ b/Source/WebCore/xml/XSLTUnicodeSort.cpp
@@ -254,7 +254,6 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts, in
     }
 
     for (j = 0; j < nbsorts; j++) {
-        comp = static_cast<xsltStylePreComp*>(sorts[j]->psvi);
         if (resultsTab[j] != NULL) {
             for (i = 0;i < len;i++)
                 xmlXPathFreeObject(resultsTab[j][i]);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1256,9 +1256,10 @@ void WebPageProxy::didAttachToRunningProcess()
     m_webDeviceOrientationUpdateProviderProxy = makeUnique<WebDeviceOrientationUpdateProviderProxy>(*this);
 #endif
 
+#if !PLATFORM(IOS_FAMILY)
     auto currentOrientation = WebCore::naturalScreenOrientationType();
-#if PLATFORM(IOS_FAMILY)
-    currentOrientation = toScreenOrientationType(m_deviceOrientation);
+#else
+    auto currentOrientation = toScreenOrientationType(m_deviceOrientation);
 #endif
     m_screenOrientationManager = makeUnique<WebScreenOrientationManagerProxy>(*this, currentOrientation);
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4436,10 +4436,8 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
             send(Messages::WebPageProxy::PageScaleFactorDidChange(scaleFromUIProcess.value()));
         }
 
-        if (!hasSetPageScale && m_isInStableState) {
+        if (!hasSetPageScale && m_isInStableState)
             m_page->setPageScaleFactor(scaleToUse, scrollPosition, true);
-            hasSetPageScale = true;
-        }
     }
 
     if (scrollPosition != frameView.scrollPosition())


### PR DESCRIPTION
#### e311e6b7fce5059373b719341561a759f6bae7d1
<pre>
Drop some dead code according to the clang static analyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=261658">https://bugs.webkit.org/show_bug.cgi?id=261658</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/VisionUtilities.mm:
(WebCore::ShapeDetection::configureRequestToUseCPUOrGPU):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLangPseudoClass):
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::createSum):
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::DataDetection::detectContentInRange):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::setAttachedWindow):
* Source/WebCore/layout/Verification.cpp:
(WebCore::Layout::outputMismatchingComplexLineInformationIfNeeded):
(WebCore::Layout::verifyAndOutputSubtree):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::isScrollable):
* Source/WebCore/platform/audio/ReverbConvolver.cpp:
(WebCore::ReverbConvolver::backgroundThreadEntry):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::fetchInternal):
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::setCategory):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformInit):
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::constructBidiRunsForSegment):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::width const):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::calculateStretchyData):
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::endPointsFromAngleForPrefixedVariants):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::computedUnderlineOffset):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::parserMetaData):
* Source/WebCore/xml/XSLTUnicodeSort.cpp:
(WebCore::xsltUnicodeSortFunction):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/268092@main">https://commits.webkit.org/268092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05f756ea1cc0ef559442035986e8b49fdf2fe22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18652 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19308 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21390 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23448 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21341 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17773 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15082 "4 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16826 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4435 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21193 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/2287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->