### PR TITLE
[iOS] Support rendering native <meter> in vertical writing mode

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1179,8 +1179,6 @@ css3/color-filters/color-filter-caret-color.html [ Skip ]
 # Not relevant for iOS.
 css3/color-filters/color-filter-ignore-semantic.html [ Skip ]
 
-webkit.org/b/261593 fast/forms/vertical-writing-mode/meter.html [ ImageOnlyFailure ]
-
 # WebCryptoAPI features that enabled only for iOS 11/High Sierra+
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha1.html [ Pass ]
 crypto/subtle/rsa-pss-generate-export-key-jwk-sha224.html [ Pass ]

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -2140,6 +2140,7 @@ bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& p
     GraphicsContextStateSaver stateSaver(context);
 
     auto styleColorOptions = renderer.styleColorOptions();
+    auto isHorizontalWritingMode = renderer.style().isHorizontalWritingMode();
 
     float cornerRadius = std::min(rect.width(), rect.height()) / 2.0f;
     FloatRoundedRect roundedFillRect(rect, FloatRoundedRect::Radii(cornerRadius));
@@ -2151,10 +2152,17 @@ bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& p
     context.clipRoundedRect(roundedFillRect);
 
     FloatRect fillRect(roundedFillRect.rect());
-    if (renderMeter.style().isLeftToRightDirection())
-        fillRect.move(fillRect.width() * (element->valueRatio() - 1), 0);
-    else
-        fillRect.move(fillRect.width() * (1 - element->valueRatio()), 0);
+
+    auto fillRectInlineSize = isHorizontalWritingMode ? fillRect.width() : fillRect.height();
+    FloatSize gaugeRegionPosition(fillRectInlineSize * (element->valueRatio() - 1), 0);
+
+    if (!isHorizontalWritingMode)
+        gaugeRegionPosition = gaugeRegionPosition.transposedSize();
+
+    if (!renderer.style().isLeftToRightDirection())
+        gaugeRegionPosition = -gaugeRegionPosition;
+
+    fillRect.move(gaugeRegionPosition);
     roundedFillRect.setRect(fillRect);
 
     switch (element->gaugeRegion()) {


### PR DESCRIPTION
#### 84c3c7804104b84d9342813266f6e4c91e8d26b4
<pre>
[iOS] Support rendering native &lt;meter&gt; in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261593">https://bugs.webkit.org/show_bug.cgi?id=261593</a>
rdar://115536615

Reviewed by Wenson Hsieh.

Adjust painting code to draw a vertical &lt;meter&gt; when using a vertical
writing mode. The &quot;track&quot; is already drawn vertically, this patch fixes the
filled area.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintMeter):

Canonical link: <a href="https://commits.webkit.org/268074@main">https://commits.webkit.org/268074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43350cb748d2166bd7562020095cce912c1ae478

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19265 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21347 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23409 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21304 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15033 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16785 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->