### PR TITLE
[GTK] Remove the code to keep previous layer tree host alive

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -97,7 +97,6 @@ private:
 
     void exitAcceleratedCompositingModeSoon();
     bool exitAcceleratedCompositingModePending() const { return m_exitCompositingTimer.isActive(); }
-    void discardPreviousLayerTreeHost();
 
     void suspendPainting();
     void resumePainting();
@@ -132,9 +131,6 @@ private:
 
     // The layer tree host that handles accelerated compositing.
     std::unique_ptr<LayerTreeHost> m_layerTreeHost;
-
-    std::unique_ptr<LayerTreeHost> m_previousLayerTreeHost;
-    RunLoop::Timer m_discardPreviousLayerTreeHostTimer;
 
     WebCore::Region m_dirtyRegion;
     WebCore::IntRect m_scrollRect;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -100,8 +100,6 @@ public:
     void contentsSizeChanged(const WebCore::IntSize&);
     void didChangeViewportAttributes(WebCore::ViewportAttributes&&);
 
-    void setIsDiscardable(bool);
-
     void deviceOrPageScaleFactorChanged();
 
 #if !HAVE(DISPLAY_LINK)
@@ -153,11 +151,6 @@ private:
     void applyTransientZoomToLayers(double, WebCore::FloatPoint);
 #endif
 
-    enum class DiscardableSyncActions {
-        UpdateSize = 1 << 1,
-        UpdateViewport = 1 << 2,
-        UpdateScale = 1 << 3
-    };
 #endif // USE(COORDINATED_GRAPHICS)
 
     WebPage& m_webPage;
@@ -170,8 +163,6 @@ private:
     bool m_scheduledWhileWaitingForRenderer { false };
     float m_lastPageScaleFactor { 1 };
     WebCore::IntPoint m_lastScrollPosition;
-    bool m_isDiscardable { false };
-    OptionSet<DiscardableSyncActions> m_discardableSyncActions;
     WebCore::GraphicsLayer* m_viewOverlayRootLayer { nullptr };
     std::unique_ptr<AcceleratedSurface> m_surface;
     RefPtr<ThreadedCompositor> m_compositor;
@@ -219,7 +210,6 @@ inline void LayerTreeHost::resumeRendering() { }
 inline WebCore::GraphicsLayerFactory* LayerTreeHost::graphicsLayerFactory() { return nullptr; }
 inline void LayerTreeHost::contentsSizeChanged(const WebCore::IntSize&) { }
 inline void LayerTreeHost::didChangeViewportAttributes(WebCore::ViewportAttributes&&) { }
-inline void LayerTreeHost::setIsDiscardable(bool) { }
 inline void LayerTreeHost::deviceOrPageScaleFactorChanged() { }
 #if PLATFORM(GTK)
 inline void LayerTreeHost::adjustTransientZoom(double, WebCore::FloatPoint) { }


### PR DESCRIPTION
#### 825a7cc7c4248b0734254385456cfee637f4b3a2
<pre>
[GTK] Remove the code to keep previous layer tree host alive
<a href="https://bugs.webkit.org/show_bug.cgi?id=261672">https://bugs.webkit.org/show_bug.cgi?id=261672</a>

Reviewed by Alejandro G. Castro.

This was used for the ondemand mode when we allowed to exit accelerated compositing mode,
but now we force always compositing the first time we enter accelerated compositing mode.
The only way to exit accelerated compositing is by setting the policy to never, in which
case we don&apos;t want to keep the previous layer tree host since it&apos;s unlikely we enter it
again soon.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics):
(WebKit::DrawingAreaCoordinatedGraphics::scroll):
(WebKit::DrawingAreaCoordinatedGraphics::mainFrameContentSizeChanged):
(WebKit::DrawingAreaCoordinatedGraphics::deviceOrPageScaleFactorChanged):
(WebKit::DrawingAreaCoordinatedGraphics::didChangeViewportAttributes):
(WebKit::DrawingAreaCoordinatedGraphics::attachViewOverlayGraphicsLayer):
(WebKit::DrawingAreaCoordinatedGraphics::updateGeometry):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode):
(WebKit::DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode):
(WebKit::DrawingAreaCoordinatedGraphics::discardPreviousLayerTreeHost): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::scrollNonCompositedContents):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::contentsSizeChanged):
(WebKit::LayerTreeHost::didChangeViewportAttributes):
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged):
(WebKit::LayerTreeHost::setIsDiscardable): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
(WebKit::LayerTreeHost::didChangeViewportAttributes):
(WebKit::LayerTreeHost::setIsDiscardable): Deleted.

Canonical link: <a href="https://commits.webkit.org/269463@main">https://commits.webkit.org/269463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24588d3a94195ae276febacdabbfec420609e076

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23171 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22881 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25403 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26758 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24595 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/192 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2851 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->