### PR TITLE
[GTK4] NativeWebWheelEvent crashes on wheel event tests

### DIFF
--- a/Source/WebCore/platform/gtk/GtkUtilities.cpp
+++ b/Source/WebCore/platform/gtk/GtkUtilities.cpp
@@ -128,6 +128,8 @@ WallTime wallTimeForEvent(const GdkEvent* event)
     // g_get_monotonic_time() continues to do so as well, and so long as
     // MonotonicTime continues to use g_get_monotonic_time().
 #if USE(GTK4)
+    if (!event)
+        return WallTime::now();
     auto time = gdk_event_get_time(const_cast<GdkEvent*>(event));
 #else
     auto time = gdk_event_get_time(event);

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -58,7 +58,7 @@ static inline OptionSet<WebEventModifier> modifiersForEvent(const GdkEvent* even
     GdkModifierType state;
 
     // Check for a valid state in GdkEvent.
-    if (!gdk_event_get_state(event, &state))
+    if (!event || !gdk_event_get_state(event, &state))
         return modifiers;
 
     if (state & GDK_CONTROL_MASK)


### PR DESCRIPTION
#### ab8e3bcac4804bcfb9af5394a962556985b3c201
<pre>
[GTK4] NativeWebWheelEvent crashes on wheel event tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=261674">https://bugs.webkit.org/show_bug.cgi?id=261674</a>

Reviewed by Michael Catanzaro.

The GdkEvent API in GTK4 won&apos;t play ball when given a NULL event.
When synthesizing wheel events we might pass a NULL event to the
event factory, so make sure that the methods that call GDK API
on it are NULL-safe.

* Source/WebCore/platform/gtk/GtkUtilities.cpp:
(WebCore::wallTimeForEvent):
* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::modifiersForEvent):

Canonical link: <a href="https://commits.webkit.org/268085@main">https://commits.webkit.org/268085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/952bb153b8b3fc3227c407ca946b943268154342

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19124 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21381 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23443 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21335 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15074 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16818 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4429 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->