### PR TITLE
Unreviewed build fix after 268066@main

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm
@@ -72,7 +72,7 @@ std::optional<NotificationPayload> NotificationPayload::fromDictionary(NSDiction
     if (!isMutable)
         return std::nullopt;
 
-    return NotificationPayload { defaultAction, title, WTFMove(rawAppBadge), WTFMove(rawOptions), [isMutable boolValue] };
+    return NotificationPayload { defaultAction, title, WTFMove(rawAppBadge), WTFMove(rawOptions), !![isMutable boolValue] };
 }
 
 NSDictionary *NotificationPayload::dictionaryRepresentation() const


### PR DESCRIPTION
#### ed989da9575ed7e7f27f693527fe705c5d4d4700
<pre>
Unreviewed build fix after 268066@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=261678">https://bugs.webkit.org/show_bug.cgi?id=261678</a>
rdar://115655949

* Source/WebCore/Modules/notifications/NotificationPayloadCocoa.mm:
(WebCore::NotificationPayload::fromDictionary):

Canonical link: <a href="https://commits.webkit.org/268082@main">https://commits.webkit.org/268082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9af6d8a66ec1ccd8fff5d178a96032d32d3391

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20508 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18872 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21384 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/16991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21188 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2283 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->