### PR TITLE
Store fewer raw pointers in containers in Source/rendering/

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1687,10 +1687,10 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
 
     // If there are any position:fixed inside of us, game over.
     if (auto* viewPositionedObjects = renderBox.view().positionedObjects()) {
-        for (auto* positionedBox : *viewPositionedObjects) {
-            if (positionedBox == &renderBox)
+        for (auto& positionedBox : *viewPositionedObjects) {
+            if (positionedBox.get() == &renderBox)
                 continue;
-            if (positionedBox->isFixedPositioned() && renderBox.element()->contains(positionedBox->element()))
+            if (positionedBox.get()->isFixedPositioned() && renderBox.element()->contains(positionedBox.get()->element()))
                 return false;
         }
     }
@@ -1703,10 +1703,10 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
     // This renderer may have positioned descendants whose containing block is some ancestor.
     if (auto* containingBlock = RenderObject::containingBlockForPositionType(PositionType::Absolute, renderBox)) {
         if (auto* positionedObjects = containingBlock->positionedObjects()) {
-            for (auto* positionedBox : *positionedObjects) {
-                if (positionedBox == &renderBox)
+            for (auto& positionedBox : *positionedObjects) {
+                if (positionedBox.get() == &renderBox)
                     continue;
-                if (renderBox.element()->contains(positionedBox->element()))
+                if (renderBox.element()->contains(positionedBox.get()->element()))
                     return false;
             }
         }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -164,13 +164,12 @@ using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 class DocumentLoader
     : public RefCounted<DocumentLoader>
-    , public CanMakeCheckedPtr
     , public FrameDestructionObserver
     , public ContentSecurityPolicyClient
 #if ENABLE(CONTENT_FILTERING)
     , public ContentFilterClient
 #endif
-    , private CachedRawResourceClient {
+    , public CachedRawResourceClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentLoader);
     friend class ContentFilter;
 public:

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -33,7 +34,7 @@ namespace WebCore {
 class CachedResource;
 class NetworkLoadMetrics;
 
-class WEBCORE_EXPORT CachedResourceClient : public CanMakeWeakPtr<CachedResourceClient> {
+class WEBCORE_EXPORT CachedResourceClient : public CanMakeWeakPtr<CachedResourceClient>, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(CachedResourceClient);
 public:
     enum CachedResourceClientType {

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -39,7 +39,7 @@ class RenderText;
 struct BidiRun;
 struct PaintInfo;
 
-typedef ListHashSet<RenderBox*> TrackedRendererListHashSet;
+using TrackedRendererListHashSet = ListHashSet<CheckedPtr<RenderBox>>;
 
 enum CaretType { CursorCaret, DragCaret };
 enum ContainingBlockState { NewContainingBlock, SameContainingBlock };

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2138,7 +2138,7 @@ bool RenderFlexibleBox::childHasPercentHeightDescendants(const RenderBox& render
     // return false for a child of a <button> with a percentage height.
     if (hasPercentHeightDescendants() && skipContainingBlockForPercentHeightCalculation(renderer, isHorizontalWritingMode() != renderer.isHorizontalWritingMode())) {
         auto& descendants = *percentHeightDescendants();
-        for (auto* descendant : descendants) {
+        for (auto& descendant : descendants) {
             if (renderBlock.isContainingBlockAncestorFor(*descendant))
                 return true;
         }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -111,7 +111,7 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject> {
+struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject>, CanMakeCheckedPtr {
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.
 #if ASSERT_ENABLED
     WeakHashSet<void*> cachedResourceClientAssociatedResources;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -514,7 +514,7 @@ void RenderTableSection::relayoutCellIfFlexed(RenderTableCell& cell, int rowInde
 
     if (!cellChildrenFlex) {
         if (TrackedRendererListHashSet* percentHeightDescendants = cell.percentHeightDescendants()) {
-            for (auto* descendant : *percentHeightDescendants) {
+            for (auto& descendant : *percentHeightDescendants) {
                 if (flexAllChildren || shouldFlexCellChild(cell, *descendant)) {
                     cellChildrenFlex = true;
                     break;
@@ -1287,7 +1287,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             // To make sure we properly repaint the section, we repaint all the overflowing cells that we collected.
             auto cells = copyToVector(m_overflowingCells);
 
-            HashSet<RenderTableCell*> spanningCells;
+            HashSet<CheckedPtr<RenderTableCell>> spanningCells;
 
             for (unsigned r = dirtiedRows.start; r < dirtiedRows.end; r++) {
                 RenderTableRow* row = m_grid[r].rowRenderer;

--- a/Source/WebCore/rendering/SelectionRangeData.cpp
+++ b/Source/WebCore/rendering/SelectionRangeData.cpp
@@ -141,7 +141,7 @@ void SelectionRangeData::clear()
 
 void SelectionRangeData::repaint() const
 {
-    HashSet<RenderBlock*> processedBlocks;
+    HashSet<CheckedPtr<RenderBlock>> processedBlocks;
     RenderObject* end = nullptr;
     if (m_renderRange.end())
         end = rendererAfterOffset(*m_renderRange.end(), m_renderRange.endOffset());


### PR DESCRIPTION
#### 5458d03b50f277bfad3e7958e762be5b533c48bd
<pre>
Store fewer raw pointers in containers in Source/rendering/
<a href="https://bugs.webkit.org/show_bug.cgi?id=261545">https://bugs.webkit.org/show_bug.cgi?id=261545</a>
rdar://115506118

Reviewed by NOBODY (OOPS!).

Store fewer raw pointers in containers in Source/rendering/ by leveraging
CheckedPtr.

* Source/WebCore/dom/Element.cpp:
(WebCore::layoutOverflowRectContainsAllDescendants):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/cache/CachedResourceClient.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::insertIntoTrackedRendererMaps):
(WebCore::removeFromTrackedRendererMaps):
(WebCore::PositionedDescendantsMap::removeDescendant):
(WebCore::PositionedDescendantsMap::removeContainingBlock):
(WebCore::removeBlockFromPercentageDescendantAndContainerMaps):
(WebCore::RenderBlock::addOverflowFromPositionedObjects):
(WebCore::RenderBlock::dirtyForLayoutFromPercentageHeightDescendants):
(WebCore::RenderBlock::layoutPositionedObjects):
(WebCore::RenderBlock::markPositionedObjectsForLayout):
(WebCore::RenderBlock::addContinuationWithOutline):
(WebCore::RenderBlock::paintsContinuationOutline):
(WebCore::RenderBlock::paintContinuationOutlines):
(WebCore::clipOutPositionedObjects):
(WebCore::RenderBlock::removePositionedObjects):
(WebCore::RenderBlock::checkPositionedObjectsNeedLayout):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::childHasPercentHeightDescendants const):
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::relayoutCellIfFlexed):
(WebCore::RenderTableSection::paintObject):
* Source/WebCore/rendering/SelectionRangeData.cpp:
(WebCore::SelectionRangeData::repaint const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5458d03b50f277bfad3e7958e762be5b533c48bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20511 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17456 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19130 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19310 "4 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18875 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19030 "2 new passes 5 flakes 2 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16236 "1 api test failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21400 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16253 "4 flakes 5 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16996 "Exiting early after 60 failures. 728 tests run. 1 flakes 60 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23461 "1 flakes 5 failures") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17278 "6 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17168 "Exiting early after 60 failures. 688 tests run. 1 flakes 60 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21354 "10 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17771 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15079 "Exiting early after 60 failures. 755 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16824 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->