### PR TITLE
Add support for Web Extension browser.tabs events.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -531,20 +531,28 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 
 /*!
  @abstract Should be called by the app when a tab is activated to notify only this specific extension.
- @param activatedTab The activated tab.
+ @param activatedTab The tab that has become active.
+ @param previousTab The tab that was active before. This parameter can be \c nil if there was no previously active tab.
  @discussion This method informs only the specific extension of the tab activation. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
-- (void)didActivateTab:(id <_WKWebExtensionTab>)activatedTab;
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<_WKWebExtensionTab>)previousTab;
 
 /*!
  @abstract Should be called by the app when tabs are selected to fire appropriate events with only this extension.
- @param selectedTabs The set of tabs that were selected. An empty set indicates that no tabs are currently selected or that the
- selected tabs are not visible to this extension.
+ @param selectedTabs The set of tabs that were selected.
  @discussion This method informs only the specific extension that tabs have been selected. If the intention is to inform all loaded
  extensions consistently, you should use the respective method on the extension controller instead.
  */
 - (void)didSelectTabs:(NSSet<id <_WKWebExtensionTab>> *)selectedTabs;
+
+/*!
+ @abstract Should be called by the app when tabs are deselected to fire appropriate events with only this extension.
+ @param deselectedTabs The set of tabs that were deselected.
+ @discussion This method informs only the specific extension that tabs have been deselected. If the intention is to inform all loaded
+ extensions consistently, you should use the respective method on the extension controller instead.
+ */
+- (void)didDeselectTabs:(NSSet<id <_WKWebExtensionTab>> *)deselectedTabs;
 
 /*!
  @abstract Should be called by the app when a tab is moved to fire appropriate events with only this extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -581,18 +581,27 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSSet<id<_WKWebExtensio
     _webExtensionContext->didCloseTab(toImpl(closedTab, *_webExtensionContext), windowIsClosing ? WebKit::WebExtensionContext::WindowIsClosing::Yes : WebKit::WebExtensionContext::WindowIsClosing::No);
 }
 
-- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab previousActiveTab:(id<_WKWebExtensionTab>)previousTab
 {
     NSParameterAssert([activatedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+    if (previousTab)
+        NSParameterAssert([previousTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
 
-    _webExtensionContext->didActivateTab(toImpl(activatedTab, *_webExtensionContext));
+    _webExtensionContext->didActivateTab(toImpl(activatedTab, *_webExtensionContext), previousTab ? toImpl(previousTab, *_webExtensionContext).ptr() : nullptr);
 }
 
 - (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
 {
     NSParameterAssert([selectedTabs isKindOfClass:NSSet.class]);
 
-    _webExtensionContext->didSelectTabs(toImpl(selectedTabs, *_webExtensionContext));
+    _webExtensionContext->didSelectOrDeselectTabs(toImpl(selectedTabs, *_webExtensionContext));
+}
+
+- (void)didDeselectTabs:(NSSet<id<_WKWebExtensionTab>> *)deselectedTabs
+{
+    NSParameterAssert([deselectedTabs isKindOfClass:NSSet.class]);
+
+    _webExtensionContext->didSelectOrDeselectTabs(toImpl(deselectedTabs, *_webExtensionContext));
 }
 
 - (void)didMoveTab:(id<_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<_WKWebExtensionWindow>)oldWindow
@@ -931,11 +940,15 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 {
 }
 
-- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab previousActiveTab:(id<_WKWebExtensionTab>)previousTab
 {
 }
 
 - (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
+{
+}
+
+- (void)didDeselectTabs:(NSSet<id<_WKWebExtensionTab>> *)deselectedTabs
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -159,20 +159,28 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 
 /*!
  @abstract Should be called by the app when a tab is activated to notify all loaded web extensions.
- @param activatedTab The activated tab.
+ @param activatedTab The tab that has become active.
+ @param previousTab The tab that was active before. This parameter can be \c nil if there was no previously active tab.
  @discussion This method informs all loaded extensions of the tab activation, ensuring consistent state awareness across extensions.
  If the intention is to inform only a specific extension, use the respective method on that extension's context instead.
  */
-- (void)didActivateTab:(id <_WKWebExtensionTab>)activatedTab;
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<_WKWebExtensionTab>)previousTab;
 
 /*!
  @abstract Should be called by the app when tabs are selected to fire appropriate events with all loaded web extensions.
- @param selectedTabs The set of tabs that were selected. An empty set indicates that no tabs are currently selected or that the
- selected tabs are not visible to extensions.
- @discussion This method informs all loaded extensions of the selection of tabs, ensuring consistent understanding across extensions.
+ @param selectedTabs The set of tabs that were selected.
+ @discussion This method informs all loaded extensions that tabs have been selected, ensuring consistent understanding across extensions.
  If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
  */
 - (void)didSelectTabs:(NSSet<id <_WKWebExtensionTab>> *)selectedTabs;
+
+/*!
+ @abstract Should be called by the app when tabs are deselected to fire appropriate events with all loaded web extensions.
+ @param deselectedTabs The set of tabs that were deselected.
+ @discussion This method informs all loaded extensions that tabs have been deselected, ensuring consistent understanding across extensions.
+ If the intention is to inform only a specific extension, you should use the respective method on that extension's context instead.
+ */
+- (void)didDeselectTabs:(NSSet<id <_WKWebExtensionTab>> *)deselectedTabs;
 
 /*!
  @abstract Should be called by the app when a tab is moved to fire appropriate events with all loaded web extensions.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -164,12 +164,14 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
         [context->wrapper() didCloseTab:closedTab windowIsClosing:windowIsClosing];
 }
 
-- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<_WKWebExtensionTab>)previousTab
 {
     NSParameterAssert([activatedTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
+    if (previousTab)
+        NSParameterAssert([previousTab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
 
     for (auto& context : _webExtensionController->extensionContexts())
-        [context->wrapper() didActivateTab:activatedTab];
+        [context->wrapper() didActivateTab:activatedTab previousActiveTab:previousTab];
 }
 
 - (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
@@ -178,6 +180,14 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
     for (auto& context : _webExtensionController->extensionContexts())
         [context->wrapper() didSelectTabs:selectedTabs];
+}
+
+- (void)didDeselectTabs:(NSSet<id<_WKWebExtensionTab>> *)deselectedTabs
+{
+    NSParameterAssert([deselectedTabs isKindOfClass:NSSet.class]);
+
+    for (auto& context : _webExtensionController->extensionContexts())
+        [context->wrapper() didDeselectTabs:deselectedTabs];
 }
 
 - (void)didMoveTab:(id<_WKWebExtensionTab>)movedTab fromIndex:(NSUInteger)index inWindow:(id<_WKWebExtensionWindow>)oldWindow
@@ -281,11 +291,15 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 {
 }
 
-- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab
+- (void)didActivateTab:(id<_WKWebExtensionTab>)activatedTab previousActiveTab:(nullable id<_WKWebExtensionTab>)previousTab
 {
 }
 
 - (void)didSelectTabs:(NSSet<id<_WKWebExtensionTab>> *)selectedTabs
+{
+}
+
+- (void)didDeselectTabs:(NSSet<id<_WKWebExtensionTab>> *)deselectedTabs
 {
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
@@ -80,7 +80,7 @@ void WebExtensionContext::alarmsClearAll(CompletionHandler<void()>&& completionH
 
 void WebExtensionContext::fireAlarmsEventIfNeeded(const WebExtensionAlarm& alarm)
 {
-    auto type = WebExtensionEventListenerType::AlarmsOnAlarm;
+    constexpr auto type = WebExtensionEventListenerType::AlarmsOnAlarm;
     wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
         sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchAlarmsEvent(alarm.parameters()));
     });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -432,6 +432,78 @@ void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdenti
     }
 }
 
+void WebExtensionContext::fireTabsCreatedEventIfNeeded(const WebExtensionTabParameters& parameters)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnCreated;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsCreatedEvent(parameters));
+    });
+}
+
+void WebExtensionContext::fireTabsUpdatedEventIfNeeded(const WebExtensionTabParameters& parameters, const WebExtensionTabParameters& changedParameters)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnUpdated;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsUpdatedEvent(parameters, changedParameters));
+    });
+}
+
+void WebExtensionContext::fireTabsReplacedEventIfNeeded(WebExtensionTabIdentifier replacedTabIdentifier, WebExtensionTabIdentifier newTabIdentifier)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnReplaced;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsReplacedEvent(replacedTabIdentifier, newTabIdentifier));
+    });
+}
+
+void WebExtensionContext::fireTabsDetachedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier oldWindowIdentifier, size_t oldIndex)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnDetached;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsDetachedEvent(tabIdentifier, oldWindowIdentifier, oldIndex));
+    });
+}
+
+void WebExtensionContext::fireTabsMovedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, size_t oldIndex, size_t newIndex)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnMoved;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsMovedEvent(tabIdentifier, windowIdentifier, oldIndex, newIndex));
+    });
+}
+
+void WebExtensionContext::fireTabsAttachedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier newWindowIdentifier, size_t newIndex)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnAttached;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsAttachedEvent(tabIdentifier, newWindowIdentifier, newIndex));
+    });
+}
+
+void WebExtensionContext::fireTabsActivatedEventIfNeeded(WebExtensionTabIdentifier previousActiveTabIdentifier, WebExtensionTabIdentifier newActiveTabIdentifier, WebExtensionWindowIdentifier windowIdentifier)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnActivated;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsActivatedEvent(previousActiveTabIdentifier, newActiveTabIdentifier, windowIdentifier));
+    });
+}
+
+void WebExtensionContext::fireTabsHighlightedEventIfNeeded(Vector<WebExtensionTabIdentifier> tabIdentifiers, WebExtensionWindowIdentifier windowIdentifier)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnHighlighted;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsHighlightedEvent(tabIdentifiers, windowIdentifier));
+    });
+}
+
+void WebExtensionContext::fireTabsRemovedEventIfNeeded(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, WindowIsClosing windowIsClosing)
+{
+    constexpr auto type = WebExtensionEventListenerType::TabsOnRemoved;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchTabsRemovedEvent(tabIdentifier, windowIdentifier, windowIsClosing));
+    });
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -249,10 +249,10 @@ public:
 
     void didOpenTab(const WebExtensionTab&);
     void didCloseTab(const WebExtensionTab&, WindowIsClosing = WindowIsClosing::No);
-    void didActivateTab(const WebExtensionTab&);
-    void didSelectTabs(const TabSet&);
+    void didActivateTab(const WebExtensionTab&, const WebExtensionTab* previousTab = nullptr);
+    void didSelectOrDeselectTabs(const TabSet&);
 
-    void didMoveTab(const WebExtensionTab&, uint64_t index, WebExtensionWindow* oldWindow = nullptr);
+    void didMoveTab(const WebExtensionTab&, size_t oldIndex, const WebExtensionWindow* oldWindow = nullptr);
     void didReplaceTab(const WebExtensionTab& oldTab, const WebExtensionTab& newTab);
     void didChangeTabProperties(const WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
 
@@ -370,6 +370,15 @@ private:
     void tabsGetZoom(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(std::optional<double>, WebExtensionTab::Error)>&&);
     void tabsSetZoom(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, double, CompletionHandler<void(WebExtensionTab::Error)>&&);
     void tabsRemove(Vector<WebExtensionTabIdentifier>, CompletionHandler<void(WebExtensionTab::Error)>&&);
+    void fireTabsCreatedEventIfNeeded(const WebExtensionTabParameters&);
+    void fireTabsUpdatedEventIfNeeded(const WebExtensionTabParameters&, const WebExtensionTabParameters& changedParameters);
+    void fireTabsReplacedEventIfNeeded(WebExtensionTabIdentifier replacedTabIdentifier, WebExtensionTabIdentifier newTabIdentifier);
+    void fireTabsDetachedEventIfNeeded(WebExtensionTabIdentifier, WebExtensionWindowIdentifier oldWindowIdentifier, size_t oldIndex);
+    void fireTabsMovedEventIfNeeded(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, size_t oldIndex, size_t newIndex);
+    void fireTabsAttachedEventIfNeeded(WebExtensionTabIdentifier, WebExtensionWindowIdentifier newWindowIdentifier, size_t newIndex);
+    void fireTabsActivatedEventIfNeeded(WebExtensionTabIdentifier previousActiveTabIdentifier, WebExtensionTabIdentifier newActiveTabIdentifier, WebExtensionWindowIdentifier);
+    void fireTabsHighlightedEventIfNeeded(Vector<WebExtensionTabIdentifier>, WebExtensionWindowIdentifier);
+    void fireTabsRemovedEventIfNeeded(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, WindowIsClosing);
 
     // Windows APIs
     void windowsCreate(const WebExtensionWindowParameters&, CompletionHandler<void(std::optional<WebExtensionWindowParameters>, WebExtensionWindow::Error)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -72,12 +72,13 @@ public:
     };
 
     enum class AssumeWindowMatches : bool { No, Yes };
+    enum class SkipContainsCheck : bool { No, Yes };
 
     using Error = std::optional<String>;
 
     WebExtensionTabIdentifier identifier() const { return m_identifier; }
     WebExtensionTabParameters parameters() const;
-    WebExtensionTabParameters minimalParameters() const;
+    WebExtensionTabParameters changedParameters(OptionSet<ChangedProperties>) const;
 
     WebExtensionContext* extensionContext() const;
 
@@ -87,7 +88,7 @@ public:
 
     bool extensionHasAccess() const;
 
-    RefPtr<WebExtensionWindow> window() const;
+    RefPtr<WebExtensionWindow> window(SkipContainsCheck = SkipContainsCheck::No) const;
     size_t index() const;
 
     RefPtr<WebExtensionTab> parentTab() const;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -82,6 +82,22 @@ static NSString * const windowTypeKey = @"windowType";
 
 static NSString * const bypassCacheKey = @"bypassCache";
 
+static NSString * const oldWindowIdKey = @"oldWindowId";
+static NSString * const oldPositionKey = @"oldPosition";
+
+static NSString * const newWindowIdKey = @"newWindowId";
+static NSString * const newPositionKey = @"newPosition";
+
+static NSString * const previousTabIdKey = @"previousTabId";
+static NSString * const tabIdKey = @"tabId";
+
+static NSString * const fromIndexKey = @"fromIndex";
+static NSString * const toIndexKey = @"toIndex";
+
+static NSString * const isWindowClosingKey = @"isWindowClosing";
+
+static NSString * const tabIdsKey = @"tabIds";
+
 static NSString * const emptyURLValue = @"";
 static NSString * const emptyTitleValue = @"";
 static NSString * const unknownLanguageValue = @"und";
@@ -90,28 +106,21 @@ namespace WebKit {
 
 NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
 {
-    ASSERT(parameters.identifier);
-
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab
 
     auto *result = [NSMutableDictionary dictionary];
 
-    result[idKey] = @(toWebAPI(parameters.identifier.value()));
+    if (parameters.identifier)
+        result[idKey] = @(toWebAPI(parameters.identifier.value()));
 
     if (parameters.url)
-        result[urlKey] = (NSString *)parameters.url.value().string();
-    else
-        result[urlKey] = emptyURLValue;
+        result[urlKey] = !parameters.url.value().isNull() ? (NSString *)parameters.url.value().string() : emptyURLValue;
 
     if (parameters.title)
-        result[titleKey] = (NSString *)parameters.title.value();
-    else
-        result[titleKey] = emptyTitleValue;
+        result[titleKey] = !parameters.title.value().isNull() ? (NSString *)parameters.title.value() : emptyTitleValue;
 
     if (parameters.windowIdentifier)
         result[windowIdKey] = @(toWebAPI(parameters.windowIdentifier.value()));
-    else
-        result[windowIdKey] = @(toWebAPI(WebExtensionWindowConstants::NoneIdentifier));
 
     if (parameters.index)
         result[indexKey] = @(parameters.index.value());
@@ -127,15 +136,10 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
 
     if (parameters.active)
         result[activeKey] = @(parameters.active.value());
-    else
-        result[activeKey] = @NO;
 
     if (parameters.selected) {
         result[selectedKey] = @(parameters.selected.value());
         result[highlightedKey] = @(parameters.selected.value());
-    } else {
-        result[selectedKey] = result[activeKey];
-        result[highlightedKey] = result[activeKey];
     }
 
     if (parameters.pinned)
@@ -844,6 +848,108 @@ WebExtensionAPIEvent& WebExtensionAPITabs::onUpdated()
         m_onUpdated = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::TabsOnUpdated);
 
     return *m_onUpdated;
+}
+
+void WebExtensionContextProxy::dispatchTabsCreatedEvent(const WebExtensionTabParameters& parameters)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onCreated().invokeListenersWithArgument(toWebAPI(parameters));
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsUpdatedEvent(const WebExtensionTabParameters& parameters, const WebExtensionTabParameters& changedParameters)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onUpdated().invokeListenersWithArgument(@(toWebAPI(parameters.identifier.value())), toWebAPI(changedParameters), toWebAPI(parameters));
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsReplacedEvent(WebExtensionTabIdentifier replacedTabIdentifier, WebExtensionTabIdentifier newTabIdentifier)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onReplaced
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onReplaced().invokeListenersWithArgument(@(toWebAPI(newTabIdentifier)), @(toWebAPI(replacedTabIdentifier)));
+    });
+}
+
+static inline NSNumber *toWebAPI(size_t index)
+{
+    return index != notFound ? @(index) : @(std::numeric_limits<double>::quiet_NaN());
+}
+
+void WebExtensionContextProxy::dispatchTabsDetachedEvent(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier oldWindowIdentifier, size_t oldIndex)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onDetached
+
+    auto *detachInfo = @{ oldWindowIdKey: @(toWebAPI(oldWindowIdentifier)), oldPositionKey: toWebAPI(oldIndex) };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onDetached().invokeListenersWithArgument(@(toWebAPI(tabIdentifier)), detachInfo);
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsMovedEvent(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, size_t oldIndex, size_t newIndex)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onMoved
+
+    auto *moveInfo = @{ windowIdKey: @(toWebAPI(windowIdentifier)), fromIndexKey: toWebAPI(oldIndex), toIndexKey: toWebAPI(newIndex) };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onMoved().invokeListenersWithArgument(@(toWebAPI(tabIdentifier)), moveInfo);
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsAttachedEvent(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier newWindowIdentifier, size_t newIndex)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onAttached
+
+    auto *attachInfo = @{ newWindowIdKey: @(toWebAPI(newWindowIdentifier)), newPositionKey: toWebAPI(newIndex) };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onAttached().invokeListenersWithArgument(@(toWebAPI(tabIdentifier)), attachInfo);
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsActivatedEvent(WebExtensionTabIdentifier previousActiveTabIdentifier, WebExtensionTabIdentifier newActiveTabIdentifier, WebExtensionWindowIdentifier windowIdentifier)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onActivated
+
+    auto *activateInfo = @{ previousTabIdKey: @(toWebAPI(previousActiveTabIdentifier)), tabIdKey: @(toWebAPI(newActiveTabIdentifier)), windowIdKey: @(toWebAPI(windowIdentifier)) };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onActivated().invokeListenersWithArgument(activateInfo);
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsHighlightedEvent(const Vector<WebExtensionTabIdentifier>& tabs, WebExtensionWindowIdentifier windowIdentifier)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onHighlighted
+
+    auto *tabIds = createNSArray(tabs, [](auto& tabIdentifier) {
+        return @(toWebAPI(tabIdentifier));
+    }).get();
+
+    auto *highlightInfo = @{ windowIdKey: @(toWebAPI(windowIdentifier)), tabIdsKey: tabIds };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onHighlighted().invokeListenersWithArgument(highlightInfo);
+    });
+}
+
+void WebExtensionContextProxy::dispatchTabsRemovedEvent(WebExtensionTabIdentifier tabIdentifier, WebExtensionWindowIdentifier windowIdentifier, WebExtensionContext::WindowIsClosing windowIsClosing)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved
+
+    auto *removeInfo = @{ windowIdKey: @(toWebAPI(windowIdentifier)), isWindowClosingKey: @(windowIsClosing == WebExtensionContext::WindowIsClosing::Yes) };
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        namespaceObject.tabs().onRemoved().invokeListenersWithArgument(@(toWebAPI(tabIdentifier)), removeInfo);
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -108,7 +108,7 @@ inline NSString *debugString(JSValue *value)
     return value._toSortedJSONString ?: @"undefined";
 }
 
-void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *expectedValue, JSValue *actualValue, NSString *message)
+void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message)
 {
     NSString *expectedJSONValue = debugString(expectedValue);
     NSString *actualJSONValue = debugString(actualValue);
@@ -137,7 +137,7 @@ static void assertEquals(WebExtensionContextProxy& extensionContext, JSContextRe
     WebProcess::singleton().send(Messages::WebExtensionContext::TestEqual(result, expectedString, actualString, message, location.first, location.second), extensionContext.identifier());
 }
 
-void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *expectedValue, JSValue *actualValue, NSString *message)
+void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message)
 {
     NSString *expectedJSONValue = debugString(expectedValue);
     NSString *actualJSONValue = debugString(actualValue);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -325,8 +325,14 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
     if (!validateDictionary(options, sourceKey, nil, types, outExceptionString))
         return false;
 
-    if (NSString *state = objectForKey<NSString>(options, stateKey, true))
+    if (NSString *state = objectForKey<NSString>(options, stateKey, true)) {
         parameters.state = toStateImpl(state);
+
+        if (!parameters.state) {
+            *outExceptionString = toErrorString(nil, stateKey, @"it must specify 'normal', 'minimized', 'maximized', or 'fullscreen'");
+            return false;
+        }
+    }
 
     if (NSNumber *focused = objectForKey<NSNumber>(options, focusedKey))
         parameters.focused = focused.boolValue;
@@ -338,7 +344,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
 
     if (left || top || width || height) {
         if (parameters.state && parameters.state.value() != WebExtensionWindow::State::Normal) {
-            *outExceptionString = toErrorString(nil, sourceKey, @"when 'top', 'left', 'width', or 'height' are specified, 'state' must be 'normal'.");
+            *outExceptionString = toErrorString(nil, sourceKey, @"when 'top', 'left', 'width', or 'height' are specified, 'state' must specify 'normal'.");
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -56,8 +56,8 @@ public:
     void assertTrue(JSContextRef, bool testValue, NSString *message);
     void assertFalse(JSContextRef, bool testValue, NSString *message);
 
-    void assertDeepEq(JSContextRef, JSValue *expectedValue, JSValue *actualValue, NSString *message);
-    void assertEq(JSContextRef, JSValue *expectedValue, JSValue *actualValue, NSString *message);
+    void assertDeepEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message);
+    void assertEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message);
 
     JSValue *assertRejects(JSContextRef, JSValue *promise, JSValue *expectedError, NSString *message);
     JSValue *assertResolves(JSContextRef, JSValue *promise, NSString *message);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -53,10 +53,10 @@
     [NeedsScriptContext] void assertFalse(boolean actualValue, [Optional] DOMString message);
 
     // Asserts the test value is deeply equal to the expected value.
-    [NeedsScriptContext] void assertDeepEq([ValuesAllowed] any expectedValue, [ValuesAllowed] any actualValue, [Optional] DOMString message);
+    [NeedsScriptContext] void assertDeepEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
 
     // Asserts the test value is equal to the expected value.
-    [NeedsScriptContext] void assertEq([ValuesAllowed] any expectedValue, [ValuesAllowed] any actualValue, [Optional] DOMString message);
+    [NeedsScriptContext] void assertEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
 
     // Asserts the promise is rejected.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] any assertRejects(any promise, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -28,8 +28,11 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "MessageReceiver.h"
+#include "WebExtensionContext.h"
 #include "WebExtensionContextParameters.h"
 #include "WebExtensionEventListenerType.h"
+#include "WebExtensionTabIdentifier.h"
+#include "WebExtensionWindowIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/FrameIdentifier.h>
@@ -45,7 +48,9 @@ namespace WebKit {
 class WebExtensionAPINamespace;
 class WebExtensionMatchPattern;
 class WebFrame;
+
 struct WebExtensionAlarmParameters;
+struct WebExtensionTabParameters;
 struct WebExtensionWindowParameters;
 
 class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, public IPC::MessageReceiver {
@@ -95,6 +100,17 @@ private:
 
     // Permissions
     void dispatchPermissionsEvent(WebExtensionEventListenerType, HashSet<String> permissions, HashSet<String> origins);
+
+    // Tabs
+    void dispatchTabsCreatedEvent(const WebExtensionTabParameters&);
+    void dispatchTabsUpdatedEvent(const WebExtensionTabParameters&, const WebExtensionTabParameters& changedParameters);
+    void dispatchTabsReplacedEvent(WebExtensionTabIdentifier replacedTabIdentifier, WebExtensionTabIdentifier newTabIdentifier);
+    void dispatchTabsDetachedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier oldWindowIdentifier, size_t oldIndex);
+    void dispatchTabsMovedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, size_t oldIndex, size_t newIndex);
+    void dispatchTabsAttachedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier newWindowIdentifier, size_t newIndex);
+    void dispatchTabsActivatedEvent(WebExtensionTabIdentifier previousActiveTabIdentifier, WebExtensionTabIdentifier newActiveTabIdentifier, WebExtensionWindowIdentifier);
+    void dispatchTabsHighlightedEvent(const Vector<WebExtensionTabIdentifier>&, WebExtensionWindowIdentifier);
+    void dispatchTabsRemovedEvent(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, WebExtensionContext::WindowIsClosing);
 
     // Web Navigation
     void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -32,6 +32,17 @@ messages -> WebExtensionContextProxy {
     // Permissions
     DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
 
+    // Tabs Events
+    DispatchTabsCreatedEvent(WebKit::WebExtensionTabParameters tabParameters)
+    DispatchTabsUpdatedEvent(WebKit::WebExtensionTabParameters tabParameters, WebKit::WebExtensionTabParameters changedParameters)
+    DispatchTabsReplacedEvent(WebKit::WebExtensionTabIdentifier replacedTabIdentifier, WebKit::WebExtensionTabIdentifier newTabIdentifier)
+    DispatchTabsDetachedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier oldWindowIdentifier, size_t oldIndex)
+    DispatchTabsMovedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, size_t oldIndex, size_t newIndex)
+    DispatchTabsAttachedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier newWindowIdentifier, size_t newIndex)
+    DispatchTabsActivatedEvent(WebKit::WebExtensionTabIdentifier previousActiveTabIdentifier, WebKit::WebExtensionTabIdentifier newActiveTabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier)
+    DispatchTabsHighlightedEvent(Vector<WebKit::WebExtensionTabIdentifier> tabs, WebKit::WebExtensionWindowIdentifier windowIdentifier)
+    DispatchTabsRemovedEvent(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionWindowIdentifier windowIdentifier, WebKit::WebExtensionContext::WindowIsClosing windowIsClosing)
+
     // Web Navigation
     DispatchWebNavigationEvent(WebKit::WebExtensionEventListenerType type, WebKit::WebPageProxyIdentifier pageID, WebCore::FrameIdentifier frameID, URL targetURL)
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "WebExtensionUtilities.h"
 #import <WebKit/_WKWebExtensionController.h>
 #import <WebKit/_WKWebExtensionMatchPattern.h>
 #import <WebKit/_WKWebExtensionPermission.h>
@@ -63,7 +64,20 @@
     if (_openNewTab)
         return _openNewTab(options, extensionContext, completionHandler);
 
-    completionHandler(nil, nil);
+    auto *openWindows = [self webExtensionController:controller openWindowsForExtensionContext:extensionContext];
+    if (!openWindows.count) {
+        completionHandler(nil, nil);
+        return;
+    }
+
+    TestWebExtensionWindow *window = openWindows.firstObject;
+    auto newTab = adoptNS([[TestWebExtensionTab alloc] initWithWindow:window extensionController:controller]);
+
+    window.tabs = [window.tabs arrayByAddingObject:newTab.get()];
+
+    [controller didOpenTab:newTab.get()];
+
+    completionHandler(newTab.get(), nil);
 }
 
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+
 #include "TestCocoa.h"
 #include "Utilities.h"
 #include "WTFTestUtilities.h"
@@ -38,6 +40,10 @@
 
 #ifdef __OBJC__
 
+@class TestWebExtensionTab;
+@class TestWebExtensionWindow;
+@class TestWebExtensionsDelegate;
+
 @interface TestWebExtensionManager : NSObject
 
 - (instancetype)initForExtension:(_WKWebExtension *)extension;
@@ -46,6 +52,15 @@
 @property (nonatomic, strong) _WKWebExtensionContext *context;
 @property (nonatomic, strong) _WKWebExtensionController *controller;
 @property (nonatomic, weak) id <_WKWebExtensionControllerDelegate> controllerDelegate;
+
+@property (nonatomic, readonly, strong) TestWebExtensionsDelegate *internalDelegate;
+@property (nonatomic, readonly, strong) TestWebExtensionWindow *defaultWindow;
+@property (nonatomic, readonly, strong) TestWebExtensionTab *defaultTab;
+@property (nonatomic, readonly, copy) NSArray<TestWebExtensionWindow *> *windows;
+
+- (TestWebExtensionWindow *)openNewWindow;
+- (void)focusWindow:(TestWebExtensionWindow *)window;
+- (void)closeWindow:(TestWebExtensionWindow *)window;
 
 @property (nonatomic, readonly, strong) NSString *yieldMessage;
 
@@ -57,7 +72,7 @@
 
 @interface TestWebExtensionTab : NSObject <_WKWebExtensionTab>
 
-- (instancetype)initWithWindow:(id<_WKWebExtensionWindow>)window extensionController:(_WKWebExtensionController *)extensionController;
+- (instancetype)initWithWindow:(id<_WKWebExtensionWindow>)window extensionController:(_WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, weak) id<_WKWebExtensionWindow> window;
 @property (nonatomic, strong) WKWebView *mainWebView;
@@ -82,10 +97,17 @@
 
 @interface TestWebExtensionWindow : NSObject <_WKWebExtensionWindow>
 
+- (instancetype)initWithExtensionController:(_WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
+
 @property (nonatomic, copy) NSArray<id<_WKWebExtensionTab>> *tabs;
 @property (nonatomic, strong) id<_WKWebExtensionTab> activeTab;
 
+- (TestWebExtensionTab *)openNewTab;
+- (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index;
+
 - (void)closeTab:(id<_WKWebExtensionTab>)tab;
+- (void)replaceTab:(id<_WKWebExtensionTab>)oldTab withTab:(id<_WKWebExtensionTab>)newTab;
+- (void)moveTab:(id<_WKWebExtensionTab>)oldTab toIndex:(NSUInteger)newIndex;
 
 @property (nonatomic) _WKWebExtensionWindowState windowState;
 @property (nonatomic) _WKWebExtensionWindowType windowType;
@@ -123,3 +145,5 @@ RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources);
 RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL);
 
 } // namespace TestWebKitAPI::Util
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -28,14 +28,21 @@
 #endif
 
 #import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestWebExtensionsDelegate.h"
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/_WKWebExtensionTabCreationOptions.h>
+#import <WebKit/_WKWebExtensionWindowCreationOptions.h>
 
 @interface TestWebExtensionManager () <_WKWebExtensionControllerDelegatePrivate>
 @end
 
 @implementation TestWebExtensionManager {
     bool _done;
+    NSMutableArray *_windows;
 }
 
 - (instancetype)initForExtension:(_WKWebExtension *)extension
@@ -53,6 +60,82 @@
     // Delegate method calls will be forwarded to the controllerDelegate.
     _controller.delegate = self;
 
+    _internalDelegate = [[TestWebExtensionsDelegate alloc] init];
+
+    auto *window = [[TestWebExtensionWindow alloc] initWithExtensionController:_controller];
+    auto *windows = [NSMutableArray arrayWithObject:window];
+
+    __weak TestWebExtensionManager *weakSelf = self;
+
+    _internalDelegate.openWindows = ^NSArray<id<_WKWebExtensionWindow>> *(_WKWebExtensionContext *) {
+        return [windows copy];
+    };
+
+    _internalDelegate.focusedWindow = ^id<_WKWebExtensionWindow>(_WKWebExtensionContext *) {
+        return window;
+    };
+
+    _internalDelegate.openNewWindow = ^(_WKWebExtensionWindowCreationOptions *options, _WKWebExtensionContext *, void (^completionHandler)(id<_WKWebExtensionWindow>, NSError *)) {
+        auto *newWindow = [weakSelf openNewWindow];
+
+        newWindow.windowType = options.desiredWindowType;
+        newWindow.windowState = options.desiredWindowState;
+        newWindow.usingPrivateBrowsing = options.shouldUsePrivateBrowsing;
+
+        CGRect currentFrame = newWindow.frame;
+        CGRect desiredFrame = options.desiredFrame;
+
+        if (std::isnan(desiredFrame.size.width))
+            desiredFrame.size.width = currentFrame.size.width;
+
+        if (std::isnan(desiredFrame.size.height))
+            desiredFrame.size.height = currentFrame.size.height;
+
+        if (std::isnan(desiredFrame.origin.x))
+            desiredFrame.origin.x = currentFrame.origin.x;
+
+#if PLATFORM(MAC)
+        CGRect screenFrame = newWindow.screenFrame;
+        CGFloat screenTop = screenFrame.size.height + screenFrame.origin.y;
+        if (std::isnan(desiredFrame.origin.y)) {
+            // Calculate the current top to keep the top-left corner of the window at the same position if the height changed.
+            CGFloat currentTop = screenTop - currentFrame.size.height - currentFrame.origin.y;
+            desiredFrame.origin.y = screenTop - desiredFrame.size.height - currentTop;
+        }
+#else
+        if (std::isnan(desiredFrame.origin.y))
+            desiredFrame.origin.y = currentFrame.origin.y;
+#endif
+
+        newWindow.frame = desiredFrame;
+
+        completionHandler(newWindow, nil);
+    };
+
+    _internalDelegate.openNewTab = ^(_WKWebExtensionTabCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
+        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.desiredWindow) ?: window;
+        auto *newTab = [desiredWindow openNewTabAtIndex:options.desiredIndex];
+
+        if (options.desiredURL)
+            [newTab.mainWebView loadRequest:[NSURLRequest requestWithURL:options.desiredURL]];
+
+        newTab.parentTab = options.desiredParentTab;
+        newTab.pinned = options.shouldPin;
+        newTab.muted = options.shouldMute;
+        newTab.showingReaderMode = options.shouldShowReaderMode;
+        newTab.selected = options.shouldSelect;
+
+        if (options.shouldActivate)
+            desiredWindow.activeTab = newTab;
+
+        completionHandler(newTab, nil);
+    };
+
+    _windows = windows;
+    _defaultWindow = window;
+    _defaultTab = window.tabs.firstObject;
+    _controllerDelegate = _internalDelegate;
+
     return self;
 }
 
@@ -66,6 +149,43 @@
     return [_controllerDelegate respondsToSelector:selector] ? _controllerDelegate : [super forwardingTargetForSelector:selector];
 }
 
+- (TestWebExtensionWindow *)openNewWindow
+{
+    auto *newWindow = [[TestWebExtensionWindow alloc] initWithExtensionController:_controller];
+
+    __weak TestWebExtensionManager *weakSelf = self;
+    __weak TestWebExtensionWindow *weakWindow = newWindow;
+
+    newWindow.didFocus = ^{
+        [weakSelf focusWindow:weakWindow];
+    };
+
+    newWindow.didClose = ^{
+        [weakSelf closeWindow:weakWindow];
+    };
+
+    [_windows addObject:newWindow];
+    [_controller didOpenWindow:newWindow];
+
+    return newWindow;
+}
+
+- (void)focusWindow:(TestWebExtensionWindow *)window
+{
+    if (window) {
+        [_windows removeObject:window];
+        [_windows insertObject:window atIndex:0];
+    }
+
+    [_controller didFocusWindow:window];
+}
+
+- (void)closeWindow:(TestWebExtensionWindow *)window
+{
+    [_windows removeObject:window];
+    [_controller didCloseWindow:window];
+}
+
 - (void)load
 {
     NSError *error;
@@ -76,6 +196,7 @@
 - (void)run
 {
     _done = false;
+
     TestWebKitAPI::Util::run(&_done);
 }
 
@@ -140,6 +261,11 @@
     __weak _WKWebExtensionController *_extensionController;
 }
 
+- (instancetype)init
+{
+    return [self initWithWindow:nil extensionController:nil];
+}
+
 - (instancetype)initWithWindow:(id<_WKWebExtensionWindow>)window extensionController:(_WKWebExtensionController *)extensionController
 {
     if (!(self = [super init]))
@@ -147,11 +273,13 @@
 
     _window = window;
 
-    WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
-    configuration._webExtensionController = extensionController;
+    if (extensionController) {
+        WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
+        configuration._webExtensionController = extensionController;
 
-    _mainWebView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
-    _extensionController = extensionController;
+        _mainWebView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
+        _extensionController = extensionController;
+    }
 
     return self;
 }
@@ -178,6 +306,8 @@
 
     _showingReaderMode = !_showingReaderMode;
 
+    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesReaderMode forTab:self];
+
     completionHandler(nil);
 }
 
@@ -193,6 +323,8 @@
 {
     if (_reload)
         _reload();
+    else
+        [_mainWebView reload];
 
     completionHandler(nil);
 }
@@ -201,6 +333,8 @@
 {
     if (_reloadFromOrigin)
         _reloadFromOrigin();
+    else
+        [_mainWebView reloadFromOrigin];
 
     completionHandler(nil);
 }
@@ -209,6 +343,8 @@
 {
     if (_goBack)
         _goBack();
+    else
+        [_mainWebView goBack];
 
     completionHandler(nil);
 }
@@ -217,6 +353,8 @@
 {
     if (_goForward)
         _goForward();
+    else
+        [_mainWebView goForward];
 
     completionHandler(nil);
 }
@@ -242,12 +380,16 @@
 {
     _pinned = YES;
 
+    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesPinned forTab:self];
+
     completionHandler(nil);
 }
 
 - (void)unpinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
     _pinned = NO;
+
+    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesPinned forTab:self];
 
     completionHandler(nil);
 }
@@ -261,12 +403,16 @@
 {
     _muted = YES;
 
+    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesMuted forTab:self];
+
     completionHandler(nil);
 }
 
 - (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
     _muted = NO;
+
+    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesMuted forTab:self];
 
     completionHandler(nil);
 }
@@ -281,10 +427,15 @@
 
 - (void)activateForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (auto *window = dynamic_objc_cast<TestWebExtensionWindow>(_window))
+    id<_WKWebExtensionTab> previousActiveTab;
+    if (auto *window = dynamic_objc_cast<TestWebExtensionWindow>(_window)) {
+        previousActiveTab = window.activeTab;
         window.activeTab = self;
+    }
 
     _selected = YES;
+
+    [_extensionController didActivateTab:self previousActiveTab:previousActiveTab];
 
     completionHandler(nil);
 }
@@ -298,12 +449,16 @@
 {
     _selected = YES;
 
+    [_extensionController didSelectTabs:[NSSet setWithObject:self]];
+
     completionHandler(nil);
 }
 
 - (void)deselectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
     _selected = NO;
+
+    [_extensionController didDeselectTabs:[NSSet setWithObject:self]];
 
     completionHandler(nil);
 }
@@ -321,16 +476,25 @@
 @end
 
 @implementation TestWebExtensionWindow {
+    __weak _WKWebExtensionController *_extensionController;
     CGRect _previousFrame;
     NSMutableArray *_tabs;
 }
 
 - (instancetype)init
 {
+    return [self initWithExtensionController:nil];
+}
+
+- (instancetype)initWithExtensionController:(_WKWebExtensionController *)extensionController
+{
     if (!(self = [super init]))
         return nil;
 
+    _extensionController = extensionController;
+
     _tabs = [NSMutableArray array];
+    _activeTab = [self openNewTab];
     _windowState = _WKWebExtensionWindowStateNormal;
     _windowType = _WKWebExtensionWindowTypeNormal;
 
@@ -359,9 +523,81 @@
     _activeTab = _tabs.firstObject;
 }
 
+- (TestWebExtensionTab *)openNewTab
+{
+    return [self openNewTabAtIndex:_tabs.count];
+}
+
+- (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index
+{
+    ASSERT(index <= _tabs.count);
+
+    auto *newTab = [[TestWebExtensionTab alloc] initWithWindow:self extensionController:_extensionController];
+
+    __weak TestWebExtensionTab *weakTab = newTab;
+
+    newTab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
+        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.desiredWindow) ?: weakTab.window;
+        auto *duplicatedTab = [desiredWindow openNewTabAtIndex:options.desiredIndex];
+
+        [duplicatedTab.mainWebView loadRequest:[NSURLRequest requestWithURL:weakTab.mainWebView.URL]];
+
+        duplicatedTab.selected = options.shouldSelect;
+
+        if (options.shouldActivate)
+            desiredWindow.activeTab = duplicatedTab;
+
+        completionHandler(duplicatedTab, nil);
+    };
+
+    [_tabs insertObject:newTab atIndex:index];
+    [_extensionController didOpenTab:newTab];
+
+    return newTab;
+}
+
 - (void)closeTab:(id<_WKWebExtensionTab>)tab
 {
     [_tabs removeObject:tab];
+    [_extensionController didCloseTab:tab windowIsClosing:NO];
+}
+
+- (void)replaceTab:(id<_WKWebExtensionTab>)oldTab withTab:(id<_WKWebExtensionTab>)newTab
+{
+    ASSERT([_tabs containsObject:oldTab]);
+    ASSERT(![_tabs containsObject:newTab]);
+
+    [_tabs replaceObjectAtIndex:[_tabs indexOfObject:oldTab] withObject:newTab];
+    [_extensionController didReplaceTab:oldTab withTab:newTab];
+}
+
+- (void)moveTab:(id<_WKWebExtensionTab>)tab toIndex:(NSUInteger)newIndex
+{
+    if (auto *testTab = dynamic_objc_cast<TestWebExtensionTab>(tab)) {
+        if (testTab.window != self) {
+            TestWebExtensionWindow *oldWindow = testTab.window;
+
+            auto oldIndex = [oldWindow->_tabs indexOfObject:tab];
+            ASSERT(oldIndex != NSNotFound);
+
+            [oldWindow->_tabs removeObjectAtIndex:oldIndex];
+            [_tabs insertObject:tab atIndex:newIndex];
+
+            testTab.window = self;
+
+            [_extensionController didMoveTab:tab fromIndex:oldIndex inWindow:oldWindow];
+
+            return;
+        }
+    }
+
+    auto oldIndex = [_tabs indexOfObject:tab];
+    ASSERT(oldIndex != NSNotFound);
+
+    [_tabs removeObjectAtIndex:oldIndex];
+    [_tabs insertObject:tab atIndex:newIndex];
+
+    [_extensionController didMoveTab:tab fromIndex:oldIndex inWindow:nil];
 }
 
 - (NSArray<id<_WKWebExtensionTab>> *)tabsForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -466,3 +702,5 @@ RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL)
 
 } // namespace Util
 } // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 2c6a9a12e9abd0dec08fc0dfaad2c27493b62b7a
<pre>
Add support for Web Extension browser.tabs events.
<a href="https://webkit.org/b/261681">https://webkit.org/b/261681</a>
rdar://problem/115663241

Reviewed by Brian Weinstein.

* Implement all the tabs events that are supported by Safari.
* Internalize and share more of the windows and tabs test code in TestWebKitAPI so
  individual tests are simplier and don&apos;t need to repeat the same stuff.
* Flip the actual and expected arguments on test.assertEq and assertDeepEq to
  match the actual usage in the tests and make logging bad results make sense.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext didActivateTab:previousActiveTab:]): Added previousActiveTab param.
(-[_WKWebExtensionContext didSelectTabs:]): Call renamed didSelectOrDeselectTabs method.
(-[_WKWebExtensionContext didDeselectTabs:]): Added. Call didSelectOrDeselectTabs method.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController didActivateTab:previousActiveTab:]): Added previousActiveTab param.
(-[_WKWebExtensionController didDeselectTabs:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm:
(WebKit::WebExtensionContext::fireAlarmsEventIfNeeded): Use constexpr.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::fireTabsCreatedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsUpdatedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsReplacedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsDetachedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsMovedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsAttachedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsActivatedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsHighlightedEventIfNeeded): Added.
(WebKit::WebExtensionContext::fireTabsRemovedEventIfNeeded): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didOpenTab): Fire the event.
(WebKit::WebExtensionContext::didCloseTab): Fire the event.
(WebKit::WebExtensionContext::didActivateTab): Fire the event.
(WebKit::WebExtensionContext::didSelectOrDeselectTabs): Fire the event.
(WebKit::WebExtensionContext::didMoveTab): Fire the event.
(WebKit::WebExtensionContext::didReplaceTab): Fire the event.
(WebKit::WebExtensionContext::didChangeTabProperties): Fire the event.
(WebKit::WebExtensionContext::didSelectTabs): Deleted. Renamed to didSelectOrDeselectTabs.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::parameters const):
(WebKit::WebExtensionTab::changedParameters const): Added.
(WebKit::WebExtensionTab::window const):
(WebKit::WebExtensionTab::minimalParameters const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::toWebAPI): Only incldue properties that have values so changedParameters only includes what changed.
(WebKit::WebExtensionContextProxy::dispatchTabsCreatedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsUpdatedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsReplacedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsDetachedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsMovedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsAttachedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsActivatedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsHighlightedEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchTabsRemovedEvent): Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::assertDeepEq): Flipped arguments.
(WebKit::WebExtensionAPITest::assertEq): Flipped arguments.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowUpdateOptions): Added an exception for bad state.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h: Flipped arguments.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl: Flipped arguments.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in: Added tab events.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST): Added new event tests and simplified existing tests.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TestWebKitAPI::TEST): Simplified.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:openNewTabWithOptions:forExtensionContext:completionHandler:]):
Added default window opening logic.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:]): Added default block implementations.
(-[TestWebExtensionManager openNewWindow]): Added.
(-[TestWebExtensionManager focusWindow:]): Added.
(-[TestWebExtensionManager closeWindow:]): Added.
(-[TestWebExtensionManager run]): Added whitespace.
(-[TestWebExtensionTab init]): Added to keep other tests working.
(-[TestWebExtensionTab initWithWindow:extensionController:]): Don&apos;t make web view is no extension controller,
this is needed for some tests still and it avoids an exception.
(-[TestWebExtensionTab toggleReaderModeForWebExtensionContext:completionHandler:]): Call didChangeTabProperties:.
(-[TestWebExtensionTab reloadForWebExtensionContext:completionHandler:]): Added default implementation.
(-[TestWebExtensionTab reloadFromOriginForWebExtensionContext:completionHandler:]): Added default implementation.
(-[TestWebExtensionTab goBackForWebExtensionContext:completionHandler:]): Added default implementation.
(-[TestWebExtensionTab goForwardForWebExtensionContext:completionHandler:]): Added default implementation.
(-[TestWebExtensionTab pinForWebExtensionContext:completionHandler:]): Call didChangeTabProperties:.
(-[TestWebExtensionTab unpinForWebExtensionContext:completionHandler:]): Call didChangeTabProperties:.
(-[TestWebExtensionTab muteForWebExtensionContext:completionHandler:]): Call didChangeTabProperties:.
(-[TestWebExtensionTab unmuteForWebExtensionContext:completionHandler:]): Call didChangeTabProperties:.
(-[TestWebExtensionTab activateForWebExtensionContext:completionHandler:]): Call didActivateTab:.
(-[TestWebExtensionTab selectForWebExtensionContext:completionHandler:]): Call didSelectTabs:.
(-[TestWebExtensionTab deselectForWebExtensionContext:completionHandler:]): Call didDeselectTabs:.
(-[TestWebExtensionWindow init]): Call initWithExtensionController:.
(-[TestWebExtensionWindow initWithExtensionController:]): Added.
(-[TestWebExtensionWindow openNewTab]): Added.
(-[TestWebExtensionWindow openNewTabAtIndex:]): Added.
(-[TestWebExtensionWindow closeTab:]): Added.
(-[TestWebExtensionWindow replaceTab:withTab:]): Added.
(-[TestWebExtensionWindow moveTab:toIndex:]): Added.

Canonical link: <a href="https://commits.webkit.org/268091@main">https://commits.webkit.org/268091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a188f455f64df545641e580f95388d99ed4b9707

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18662 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19144 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21402 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17009 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21353 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15094 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21203 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2286 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->