### PR TITLE
[Multicol][IFC] Support floats in multicolumn content

### DIFF
--- a/LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html
+++ b/LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-13" />
+<meta name="fuzzy" content="maxDifference=0-31; totalPixels=0-34" />
 <title>This tests that paginated lines are painting properly when lines visually overflow.</title>
 <style>
 html {

--- a/LayoutTests/platform/glib/fast/multicol/float-paginate-complex-expected.txt
+++ b/LayoutTests/platform/glib/fast/multicol/float-paginate-complex-expected.txt
@@ -299,7 +299,7 @@ layer at (8,1268) size 769x404
 layer at (10,1270) size 375x643 backgroundClip at (0,0) size 1166x1680 clip at (0,0) size 1166x1680
   RenderMultiColumnFlowThread at (2,2) size 375x643
     RenderImage {IMG} at (0,0) size 375x380 [bgcolor=#0000FF]
-    RenderInline {SPAN} at (0,0) size 370x242
+    RenderInline {SPAN} at (0,0) size 375x636
       RenderImage {IMG} at (0,400) size 100x20 [bgcolor=#008000]
       RenderText {#text} at (100,400) size 211x26
         text run at (100,400) width 211: "Longer text designed "

--- a/LayoutTests/platform/ios/fast/multicol/float-paginate-complex-expected.txt
+++ b/LayoutTests/platform/ios/fast/multicol/float-paginate-complex-expected.txt
@@ -297,7 +297,7 @@ layer at (8,1268) size 784x404
 layer at (10,1270) size 382x670 backgroundClip at (0,0) size 1188x1680 clip at (0,0) size 1188x1680
   RenderMultiColumnFlowThread at (2,2) size 382x670
     RenderImage {IMG} at (0,0) size 382x380 [bgcolor=#0000FF]
-    RenderInline {SPAN} at (0,0) size 379x268
+    RenderInline {SPAN} at (0,0) size 382x664
       RenderImage {IMG} at (0,400) size 100x20 [bgcolor=#008000]
       RenderText {#text} at (100,401) size 209x28
         text run at (100,401) width 209: "Longer text designed "

--- a/LayoutTests/platform/mac/fast/multicol/float-paginate-complex-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/float-paginate-complex-expected.txt
@@ -299,7 +299,7 @@ layer at (8,1268) size 769x404
 layer at (10,1270) size 375x652 backgroundClip at (0,0) size 1166x1680 clip at (0,0) size 1166x1680
   RenderMultiColumnFlowThread at (2,2) size 375x652
     RenderImage {IMG} at (0,0) size 375x380 [bgcolor=#0000FF]
-    RenderInline {SPAN} at (0,0) size 367x252
+    RenderInline {SPAN} at (0,0) size 375x646
       RenderImage {IMG} at (0,400) size 100x20 [bgcolor=#008000]
       RenderText {#text} at (100,400) size 209x28
         text run at (100,400) width 209: "Longer text designed "

--- a/Source/WebCore/layout/floats/FloatingContext.cpp
+++ b/Source/WebCore/layout/floats/FloatingContext.cpp
@@ -497,12 +497,13 @@ FloatingContext::Constraints FloatingContext::constraints(LayoutUnit candidateTo
     return constraints;
 }
 
-FloatingState::FloatItem FloatingContext::toFloatItem(const Box& floatBox, const BoxGeometry& boxGeometry) const
+FloatingState::FloatItem FloatingContext::makeFloatItem(const Box& floatBox, const BoxGeometry& boxGeometry, std::optional<size_t> line) const
 {
     auto borderBoxTopLeft = BoxGeometry::borderBoxTopLeft(boxGeometry);
     auto absoluteBoxGeometry = BoxGeometry { boxGeometry };
     absoluteBoxGeometry.setLogicalTopLeft(mapTopLeftToFloatingStateRoot(floatBox, borderBoxTopLeft));
-    return { floatBox, isFloatingCandidateLeftPositionedInFloatingState(floatBox) ? FloatingState::FloatItem::Position::Left : FloatingState::FloatItem::Position::Right, absoluteBoxGeometry, borderBoxTopLeft };
+    auto position = isFloatingCandidateLeftPositionedInFloatingState(floatBox) ? FloatingState::FloatItem::Position::Left : FloatingState::FloatItem::Position::Right;
+    return { floatBox, position, absoluteBoxGeometry, borderBoxTopLeft, line };
 }
 
 void FloatingContext::findPositionForFormattingContextRoot(FloatAvoider& floatAvoider) const

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -70,7 +70,7 @@ public:
     enum class MayBeAboveLastFloat : bool { No, Yes };
     Constraints constraints(LayoutUnit candidateTop, LayoutUnit candidateBottom, MayBeAboveLastFloat) const;
 
-    FloatingState::FloatItem toFloatItem(const Box& floatBox, const BoxGeometry&) const;
+    FloatingState::FloatItem makeFloatItem(const Box& floatBox, const BoxGeometry&, std::optional<size_t> line = { }) const;
 
     bool isLogicalLeftPositioned(const Box& floatBox) const;
 

--- a/Source/WebCore/layout/floats/FloatingState.cpp
+++ b/Source/WebCore/layout/floats/FloatingState.cpp
@@ -37,12 +37,13 @@ namespace Layout {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(FloatingState);
 
-FloatingState::FloatItem::FloatItem(const Box& layoutBox, Position position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft)
+FloatingState::FloatItem::FloatItem(const Box& layoutBox, Position position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, std::optional<size_t> line)
     : m_layoutBox(layoutBox)
     , m_position(position)
     , m_absoluteBoxGeometry(absoluteBoxGeometry)
     , m_localTopLeft(localTopLeft)
     , m_shape(layoutBox.shape())
+    , m_placedByLine(line)
 {
 }
 

--- a/Source/WebCore/layout/floats/FloatingState.h
+++ b/Source/WebCore/layout/floats/FloatingState.h
@@ -53,7 +53,7 @@ public:
         // FIXME: This c'tor is only used by the render tree integation codepath.
         enum class Position { Left, Right };
         FloatItem(Position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, const Shape*);
-        FloatItem(const Box&, Position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft);
+        FloatItem(const Box&, Position, const BoxGeometry& absoluteBoxGeometry, LayoutPoint localTopLeft, std::optional<size_t> line);
 
         ~FloatItem();
 
@@ -69,6 +69,7 @@ public:
         PositionInContextRoot absoluteBottom() const { return { absoluteRectWithMargin().bottom() }; }
 
         const Shape* shape() const { return m_shape.get(); }
+        std::optional<size_t> placedByLine() const { return m_placedByLine; }
 
         const Box* layoutBox() const { return m_layoutBox.get(); }
 
@@ -78,6 +79,7 @@ public:
         BoxGeometry m_absoluteBoxGeometry;
         LayoutPoint m_localTopLeft;
         RefPtr<const Shape> m_shape;
+        std::optional<size_t> m_placedByLine;
     };
     using FloatList = Vector<FloatItem>;
     const FloatList& floats() const { return m_floats; }

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.cpp
@@ -140,7 +140,7 @@ void BlockFormattingContext::layoutInFlowContent(const ConstraintsForInFlowConte
             // All inflow descendants (if there are any) are laid out by now. Let's compute the box's height and vertical margin.
             computeHeightAndMargin(layoutBox, containingBlockConstraints);
             if (layoutBox.isFloatingPositioned())
-                floatingState.append(floatingContext.toFloatItem(layoutBox, geometryForBox(layoutBox)));
+                floatingState.append(floatingContext.makeFloatItem(layoutBox, geometryForBox(layoutBox)));
             else {
                 // Adjust the vertical position now that we've got final margin values for non-float avoider boxes.
                 // Float avoiders have pre-computed vertical positions when floats are present.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -225,7 +225,7 @@ void InlineFormattingContext::layoutFloatContentOnly(const ConstraintsForInlineC
 
             auto floatBoxTopLeft = floatingContext.positionForFloat(floatBox, floatBoxGeometry, constraints.horizontal());
             floatBoxGeometry.setLogicalTopLeft(floatBoxTopLeft);
-            floatingState.append(floatingContext.toFloatItem(floatBox, floatBoxGeometry));
+            floatingState.append(floatingContext.makeFloatItem(floatBox, floatBoxGeometry));
             continue;
         }
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -953,7 +953,8 @@ bool LineBuilder::tryPlacingFloatBox(const Box& floatBox, MayOverConstrainLine m
         return false;
 
     auto placeFloatBox = [&] {
-        auto floatItem = floatingContext.toFloatItem(floatBox, boxGeometry);
+        auto lineIndex = m_previousLine ? (m_previousLine->lineIndex + 1) : 0lu;
+        auto floatItem = floatingContext.makeFloatItem(floatBox, boxGeometry, lineIndex);
         // FIXME: Maybe FloatingContext should be able to preserve FloatItems and the caller should mutate the FloatingState instead.
         floatingState().append(floatItem);
         m_placedFloats.append(floatItem);

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -107,8 +107,8 @@ static void printReason(AvoidanceReason reason, TextStream& stream)
     case AvoidanceReason::MultiColumnFlowHasUnsupportedWritingMode:
         stream << "column has unsupported writing mode";
         break;
-    case AvoidanceReason::MultiColumnFlowHasFloatingOrOutOfFlowChild:
-        stream << "column with floating/out-of-flow boxes";
+    case AvoidanceReason::MultiColumnFlowHasOutOfFlowChild:
+        stream << "column with out-of-flow boxes";
         break;
     case AvoidanceReason::ContentIsSVG:
         stream << "SVG content";
@@ -285,8 +285,8 @@ static OptionSet<AvoidanceReason> canUseForChild(const RenderBlockFlow& flow, co
     }
 
     if (flow.fragmentedFlowState() != RenderObject::NotInsideFragmentedFlow) {
-        if (child.isFloating() || child.isOutOfFlowPositioned())
-            SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowHasFloatingOrOutOfFlowChild, reasons, includeReasons);
+        if (child.isOutOfFlowPositioned())
+            SET_REASON_AND_RETURN_IF_NEEDED(MultiColumnFlowHasOutOfFlowChild, reasons, includeReasons);
     }
 
     if (is<RenderLineBreak>(child))

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -89,7 +89,7 @@ enum class AvoidanceReason : uint64_t {
     MultiColumnFlowHasUnsupportedWritingMode     = 1LLU  << 47,
     // Unused                                    = 1LLU  << 48,
     // Unused                                    = 1LLU  << 49,
-    MultiColumnFlowHasFloatingOrOutOfFlowChild   = 1LLU  << 50,
+    MultiColumnFlowHasOutOfFlowChild             = 1LLU  << 50,
     // Unused                                    = 1LLU  << 51,
     // Unused                                    = 1LLU  << 52,
     // Unused                                    = 1LLU  << 53,

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
@@ -31,6 +31,10 @@ namespace WebCore {
 
 class RenderBlockFlow;
 
+namespace Layout {
+class FloatingState;
+}
+
 namespace LayoutIntegration {
 
 struct LineAdjustment {
@@ -38,7 +42,7 @@ struct LineAdjustment {
     bool isFirstAfterPageBreak { false };
 };
 
-Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent&, RenderBlockFlow&);
+Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent&, const Layout::FloatingState&, RenderBlockFlow&);
 void adjustLinePositionsForPagination(InlineContent&, const Vector<LineAdjustment>&);
 
 }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1985,7 +1985,7 @@ void RenderBlockFlow::adjustLinePositionForPagination(LegacyRootInlineBox* rootI
     delta += adjustment.strut;
 }
 
-RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator& lineBox, LayoutUnit delta)
+RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator& lineBox, LayoutUnit delta, LayoutUnit floatMinimumBottom)
 {
     // FIXME: For now we paginate using line overflow. This ensures that lines don't overlap at all when we
     // put a strut between them for pagination purposes. However, this really isn't the desired rendering, since
@@ -2023,7 +2023,7 @@ RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustment
     auto logicalOverflowHeight = logicalOverflowBottom - logicalOverflowTop;
     auto logicalTop = LayoutUnit { lineBox->logicalTop() };
     auto logicalOffset = std::min(logicalTop, logicalOverflowTop);
-    auto logicalBottom = std::max(LayoutUnit { lineBox->logicalBottom() }, logicalOverflowBottom);
+    auto logicalBottom = std::max(std::max(LayoutUnit { lineBox->logicalBottom() }, logicalOverflowBottom), floatMinimumBottom);
     auto lineHeight = logicalBottom - logicalOffset;
 
     updateMinimumPageHeight(logicalOffset, calculateMinimumPageHeight(style(), lineBox, logicalOffset, logicalBottom));
@@ -2078,7 +2078,7 @@ RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustment
 
         setPageBreak(logicalOffset, lineHeight - remainingLogicalHeight);
 
-        bool avoidFirstLinePageBreak = lineBox->isFirst() && totalLogicalHeight < pageLogicalHeightAtNewOffset;
+        bool avoidFirstLinePageBreak = lineBox->isFirst() && totalLogicalHeight < pageLogicalHeightAtNewOffset && !floatMinimumBottom;
         bool affectedByOrphans = !style().hasAutoOrphans() && style().orphans() >= lineNumber;
 
         if ((avoidFirstLinePageBreak || affectedByOrphans) && !isOutOfFlowPositioned() && !isTableCell()) {

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -561,7 +561,7 @@ public:
         LayoutUnit strut { 0_lu };
         bool isFirstAfterPageBreak { false };
     };
-    LinePaginationAdjustment computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator&, LayoutUnit deltaOffset);
+    LinePaginationAdjustment computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator&, LayoutUnit deltaOffset, LayoutUnit floatMinimumBottom = { });
     bool relayoutForPagination();
 
     bool hasRareBlockFlowData() const { return m_rareBlockFlowData.get(); }


### PR DESCRIPTION
#### c28da984b5ca8fb4bf7941f1b932dd6dd92c0724
<pre>
[Multicol][IFC] Support floats in multicolumn content
<a href="https://bugs.webkit.org/show_bug.cgi?id=261683">https://bugs.webkit.org/show_bug.cgi?id=261683</a>
rdar://115665905

Reviewed by Alan Baradlay.

* LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html:
* LayoutTests/platform/mac/fast/multicol/float-paginate-complex-expected.txt:
* Source/WebCore/layout/floats/FloatingContext.cpp:
(WebCore::Layout::FloatingContext::makeFloatItem const):
(WebCore::Layout::FloatingContext::toFloatItem const): Deleted.
* Source/WebCore/layout/floats/FloatingContext.h:
(WebCore::Layout::FloatingContext::makeFloatItem):
* Source/WebCore/layout/floats/FloatingState.cpp:
(WebCore::Layout::FloatingState::FloatItem::FloatItem):
* Source/WebCore/layout/floats/FloatingState.h:
(WebCore::Layout::FloatingState::FloatItem::placedByLine const):
* Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.cpp:
(WebCore::Layout::BlockFormattingContext::layoutInFlowContent):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::layoutFloatContentOnly):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::tryPlacingFloatBox):

Save the line index that placed the float.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::printReason):
(WebCore::LayoutIntegration::canUseForChild):

Enable floats in multicol.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Adjust the float render tree positions.

(WebCore::LayoutIntegration::LineLayout::adjustContent):
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):

Pass the float bottom to the pagination adjustment code so we don&apos;t break page in the middle of a float.
In case of a float containing inline content, breaking is allowed after the first line.

* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):

Apply the provided line height minimum from a float.
Allow breaking on the first line if the line contains a float.

Canonical link: <a href="https://commits.webkit.org/268128@main">https://commits.webkit.org/268128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28cca19cb7ca9596b1f161192b20676379daeb62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19386 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21522 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23554 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15168 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4458 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->