### PR TITLE
Add “one-time-code” as an allowed autocomplete field name

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt
@@ -15,7 +15,7 @@ PASS nickname is an allowed autocomplete field name
 PASS username is an allowed autocomplete field name
 PASS new-password is an allowed autocomplete field name
 PASS current-password is an allowed autocomplete field name
-FAIL one-time-code is an allowed autocomplete field name assert_equals: expected "one-time-code" but got ""
+PASS one-time-code is an allowed autocomplete field name
 PASS organization-title is an allowed autocomplete field name
 PASS organization is an allowed autocomplete field name
 PASS street-address is an allowed autocomplete field name

--- a/Source/WebCore/html/Autofill.cpp
+++ b/Source/WebCore/html/Autofill.cpp
@@ -81,6 +81,7 @@ static constexpr std::pair<ComparableLettersLiteral, AutofillFieldNameMapping> f
     { "nickname", { AutofillFieldName::Nickname, AutofillCategory::Normal } },
     { "off", { AutofillFieldName::None, AutofillCategory::Off } },
     { "on", { AutofillFieldName::None, AutofillCategory::Automatic } },
+    { "one-time-code", { AutofillFieldName::OneTimeCode, AutofillCategory::Normal } },
     { "organization", { AutofillFieldName::Organization, AutofillCategory::Normal } },
     { "organization-title", { AutofillFieldName::OrganizationTitle, AutofillCategory::Normal } },
     { "photo", { AutofillFieldName::Photo, AutofillCategory::Normal } },

--- a/Source/WebCore/html/Autofill.h
+++ b/Source/WebCore/html/Autofill.h
@@ -96,7 +96,8 @@ enum class AutofillFieldName : uint8_t {
     TelExtension,
     Email,
     Impp,
-    WebAuthn
+    WebAuthn,
+    OneTimeCode
 };
 
 WEBCORE_EXPORT AutofillFieldName toAutofillFieldName(const AtomString&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -308,7 +308,8 @@ enum class WebCore::AutofillFieldName : uint8_t {
     TelExtension,
     Email,
     Impp,
-    WebAuthn
+    WebAuthn,
+    OneTimeCode
 };
 
 enum class WebCore::NonAutofillCredentialType : bool;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6113,6 +6113,8 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
     case WebCore::AutofillFieldName::Username:
     case WebCore::AutofillFieldName::WebAuthn:
         return UITextContentTypeUsername;
+    case WebCore::AutofillFieldName::OneTimeCode:
+        return UITextContentTypeOneTimeCode;
     case WebCore::AutofillFieldName::None:
     case WebCore::AutofillFieldName::NewPassword:
     case WebCore::AutofillFieldName::CurrentPassword:


### PR DESCRIPTION
#### 6f43d02b3e6f00359418c06c2f810b6994dc2519
<pre>
Add “one-time-code” as an allowed autocomplete field name
<a href="https://bugs.webkit.org/show_bug.cgi?id=261687">https://bugs.webkit.org/show_bug.cgi?id=261687</a>

Reviewed by Aditya Keerthi.

This change allows documents to use “one-time-code” as an allowed field
name in the autocomplete attribute.

Per <a href="https://html.spec.whatwg.org/#autofill-processing-model">https://html.spec.whatwg.org/#autofill-processing-model</a>:attr-fe-autocomplete-one-time-code
the autofill category for “one-time-code” is “Normal”.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt:
* Source/WebCore/html/Autofill.cpp:
* Source/WebCore/html/Autofill.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(contentTypeFromFieldName):

Canonical link: <a href="https://commits.webkit.org/268097@main">https://commits.webkit.org/268097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc6517a9cb3984bb49d11cdac376b6321bd77c5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19320 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21408 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17015 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17187 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15097 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16841 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4437 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->