### PR TITLE
PGO profiling should take Speedometer3 into account.

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -61,7 +61,8 @@ fi
 
 rm -rf "$BASE/*"
 
-mkdir -p "$BASE/speedometer"
+mkdir -p "$BASE/speedometer2"
+mkdir -p "$BASE/speedometer3"
 mkdir -p "$BASE/jetstream"
 mkdir -p "$BASE/motionmark"
 mkdir -p "$BASE/output"
@@ -89,9 +90,16 @@ jsargs=(
     --count 1
 )
 
-spargs=(
+sp2args=(
     --plan speedometer2
-    --diagnose-directory="$BASE/speedometer"
+    --diagnose-directory="$BASE/speedometer2"
+    --generate-pgo-profiles
+    --count 1
+)
+
+sp3args=(
+    --plan speedometer3
+    --diagnose-directory="$BASE/speedometer3"
     --generate-pgo-profiles
     --count 1
 )
@@ -105,12 +113,14 @@ mmargs=(
 
 if [[ -n $APP ]] ; then
    jsargs+=(--browser-path "$APP")
-   spargs+=(--browser-path "$APP")
+   sp2args+=(--browser-path "$APP")
+   sp3args+=(--browser-path "$APP")
    mmargs+=(--browser-path "$APP")
    deployment_target=$(vtool -show-build "$APP"/Contents/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore | grep -m1 minos | tr -d -c .0-9)
 else
    jsargs+=(--build-directory $BUILD)
-   spargs+=(--build-directory $BUILD)
+   sp2args+=(--build-directory $BUILD)
+   sp3args+=(--build-directory $BUILD)
    mmargs+=(--build-directory $BUILD)
    deployment_target=$(vtool -show-build "$BUILD"/JavaScriptCore.framework/Versions/A/JavaScriptCore | grep -m1 minos | tr -d -c .0-9)
 fi
@@ -124,15 +134,18 @@ SPTH='OpenSource/Tools/Scripts'
 $SPTH/run-benchmark "${jsargs[@]}"
 $SPTH/pgo-profile merge "$BASE/jetstream"
 
-$SPTH/run-benchmark "${spargs[@]}"
-$SPTH/pgo-profile merge "$BASE/speedometer"
+$SPTH/run-benchmark "${sp2args[@]}"
+$SPTH/pgo-profile merge "$BASE/speedometer2"
+
+$SPTH/run-benchmark "${sp3args[@]}"
+$SPTH/pgo-profile merge "$BASE/speedometer3"
 
 $SPTH/run-benchmark "${mmargs[@]}"
 $SPTH/pgo-profile merge "$BASE/motionmark"
 
 rm *.result
 
-$SPTH/pgo-profile combine --jetstream "$BASE/jetstream" --speedometer "$BASE/speedometer" --motionmark "$BASE/motionmark" --output "$BASE/output"
+$SPTH/pgo-profile combine --jetstream "$BASE/jetstream" --speedometer2 "$BASE/speedometer2" --speedometer3 "$BASE/speedometer3" --motionmark "$BASE/motionmark" --output "$BASE/output"
 
 mkdir -p "$BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"
 $SPTH/pgo-profile compress --input "$BASE/output" --output "$BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"

--- a/Tools/Scripts/pgo-profile
+++ b/Tools/Scripts/pgo-profile
@@ -7,7 +7,8 @@ import subprocess
 import os
 
 PROFILED_DYLIBS = ["JavaScriptCore", "WebCore", "WebKit"]
-BENCHMARK_GROUP_WEIGHTS = [("speedometer", 0.6), ("jetstream", 0.2), ("motionmark", 0.2)]
+BENCHMARK_GROUP_WEIGHTS = [("speedometer2", 0.4), ("speedometer3", 0.2), ("jetstream", 0.2), ("motionmark", 0.2)]
+
 
 def pad(string, max_length):
     if len(string) > max_length:


### PR DESCRIPTION
#### 3e68b1d06e4d8f320e7964ba7b316473ea704b80
<pre>
PGO profiling should take Speedometer3 into account.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261689">https://bugs.webkit.org/show_bug.cgi?id=261689</a>
rdar://111352676

Reviewed by Yusuke Suzuki and Wenson Hsieh.

Inlcude Speedometer3 into PGO profile collection process.
Assigning 20% weight to Speedometer3 and reduce Speedometer2 weight from
60% to 40% so that overall Speeodmeter famility weight stays unchanged.
New weight is derived from experiment which tried couple different formulas.

* Tools/Scripts/build-and-collect-pgo-profiles:
* Tools/Scripts/pgo-profile:

Canonical link: <a href="https://commits.webkit.org/268104@main">https://commits.webkit.org/268104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b866b3d54f0e09fce1539f78843338f8f6f197b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20564 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19182 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21442 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17042 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21387 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17815 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16874 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4439 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->