### PR TITLE
[iOS] Stop using _UIHighlightView to show highlights over DOM elements when tapping

### DIFF
--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -358,6 +358,19 @@ Path PathUtilities::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, f
     return unionPath;
 }
 
+Path PathUtilities::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, const FloatRoundedRect::Radii& radii)
+{
+    if (radii.isUniformCornerRadius())
+        return pathWithShrinkWrappedRects(rects, radii.topLeft().width());
+
+    // FIXME: This could potentially take non-uniform radii into account when running the
+    // shrink-wrap algorithm above, by averaging corner radii between adjacent edges.
+    Path path;
+    for (auto& rect : rects)
+        path.addRoundedRect(FloatRoundedRect { rect, radii });
+    return path;
+}
+
 static std::pair<FloatPoint, FloatPoint> startAndEndPointsForCorner(const FloatPointGraph::Edge& fromEdge, const FloatPointGraph::Edge& toEdge, const FloatSize& radius)
 {
     FloatPoint startPoint;

--- a/Source/WebCore/platform/graphics/PathUtilities.h
+++ b/Source/WebCore/platform/graphics/PathUtilities.h
@@ -26,6 +26,7 @@
 #ifndef PathUtilities_h
 #define PathUtilities_h
 
+#include "FloatRoundedRect.h"
 #include "Path.h"
 #include "WritingMode.h"
 #include <wtf/Vector.h>
@@ -36,6 +37,7 @@ class BorderData;
 class PathUtilities {
 public:
     WEBCORE_EXPORT static Path pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, float radius);
+    WEBCORE_EXPORT static Path pathWithShrinkWrappedRects(const Vector<FloatRect>&, const FloatRoundedRect::Radii&);
     WEBCORE_EXPORT static Vector<Path> pathsWithShrinkWrappedRects(const Vector<FloatRect>& rects, float radius);
 
     static Path pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>&, const BorderData&, float outlineOffset, TextDirection, WritingMode, float deviceScaleFactor);

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -93,7 +93,6 @@
 #import <UIKit/UIWindowScene_Private.h>
 #import <UIKit/UIWindow_Private.h>
 #import <UIKit/_UIApplicationRotationFollowing.h>
-#import <UIKit/_UIHighlightView.h>
 #import <UIKit/_UINavigationInteractiveTransition.h>
 #import <UIKit/_UINavigationParallaxTransition.h>
 #import <UIKit/_UISheetPresentationController.h>
@@ -813,17 +812,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 @end
 
 @interface _UILookupGestureRecognizer : UIGestureRecognizer
-@end
-
-@interface _UIHighlightView : UIView
-@end
-
-@interface _UIHighlightView ()
-- (void)setColor:(UIColor *)aColor;
-- (void)setCornerRadii:(NSArray *)cornerRadii;
-- (void)setCornerRadius:(CGFloat)aCornerRadius;
-- (void)setFrames:(NSArray *)frames boundaryRect:(CGRect)aBoundarRect;
-- (void)setQuads:(NSArray *)quads boundaryRect:(CGRect)aBoundaryRect;
 @end
 
 @interface _UINavigationParallaxTransition : NSObject <UIViewControllerAnimatedTransitioningEx>

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -497,6 +497,7 @@ UIProcess/ios/WKScrollView.mm
 UIProcess/ios/WKStylusDeviceObserver.mm
 UIProcess/ios/WKSyntheticFlagsChangedWebEvent.mm
 UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
+UIProcess/ios/WKTapHighlightView.mm
 UIProcess/ios/WKTouchActionGestureRecognizer.mm
 UIProcess/ios/WKTouchEventsGestureRecognizer.mm
 UIProcess/ios/WKTextSelectionRect.mm

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -126,6 +126,7 @@ class WebPageProxy;
 @class WKHighlightLongPressGestureRecognizer;
 @class WKImageAnalysisGestureRecognizer;
 @class WKInspectorNodeSearchGestureRecognizer;
+@class WKTapHighlightView;
 @class WKTargetedPreviewContainer;
 @class WKTextRange;
 @class _WKTextInputContext;
@@ -138,7 +139,6 @@ class WebPageProxy;
 @class UIPointerRegion;
 @class UITargetedPreview;
 @class _UILookupGestureRecognizer;
-@class _UIHighlightView;
 
 #if HAVE(PEPPER_UI_CORE)
 @class PUICQuickboardViewController;
@@ -345,7 +345,7 @@ struct ImageAnalysisContextMenuActionData {
 
     RetainPtr<UITextInputTraits> _traits;
     RetainPtr<UIWebFormAccessory> _formAccessoryView;
-    RetainPtr<_UIHighlightView> _highlightView;
+    RetainPtr<WKTapHighlightView> _tapHighlightView;
     RetainPtr<UIView> _interactionViewsContainerView;
     RetainPtr<WKTargetedPreviewContainer> _contextMenuHintContainerView;
     WeakObjCPtr<UIScrollView> _scrollViewForTargetedPreview;

--- a/Source/WebKit/UIProcess/ios/WKTapHighlightView.h
+++ b/Source/WebKit/UIProcess/ios/WKTapHighlightView.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <UIKit/UIKit.h>
+#import <WebCore/FloatQuad.h>
+#import <WebCore/FloatRoundedRect.h>
+#import <wtf/Vector.h>
+
+@interface WKTapHighlightView : UIView
+
+- (void)setColor:(UIColor *)color;
+- (void)setMinimumCornerRadius:(float)radius;
+- (void)setCornerRadii:(WebCore::FloatRoundedRect::Radii&&)radii;
+- (void)setFrames:(Vector<WebCore::FloatRect>&&)frames;
+- (void)setQuads:(Vector<WebCore::FloatQuad>&&)quads boundaryRect:(const WebCore::FloatRect&)rect;
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
+++ b/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKTapHighlightView.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <WebCore/PathUtilities.h>
+#import <wtf/RetainPtr.h>
+
+@implementation WKTapHighlightView {
+    RetainPtr<UIColor> _color;
+    float _minimumCornerRadius;
+    WebCore::FloatRoundedRect::Radii _cornerRadii;
+    Vector<WebCore::FloatRect> _innerFrames;
+    Vector<WebCore::FloatQuad> _innerQuads;
+}
+
+- (id)initWithFrame:(CGRect)rect
+{
+    if (self = [super initWithFrame:rect])
+        self.layer.needsDisplayOnBoundsChange = YES;
+    return self;
+}
+
+- (void)cleanUp
+{
+    _innerFrames.clear();
+    _innerQuads.clear();
+}
+
+- (void)setColor:(UIColor *)color
+{
+    _color = color;
+}
+
+- (void)setMinimumCornerRadius:(float)radius
+{
+    _minimumCornerRadius = radius;
+}
+
+- (void)setCornerRadii:(WebCore::FloatRoundedRect::Radii&&)radii
+{
+    _cornerRadii = WTFMove(radii);
+}
+
+- (void)setFrames:(Vector<WebCore::FloatRect>&&)frames
+{
+    [self cleanUp];
+
+    if (frames.isEmpty())
+        [self setFrame:CGRectZero];
+
+    bool initialized = false;
+    WebCore::FloatRect viewFrame;
+
+    for (auto frame : frames) {
+        if (std::exchange(initialized, true))
+            viewFrame = WebCore::unionRect(viewFrame, frame);
+        else {
+            viewFrame = frame;
+            viewFrame.inflate(_minimumCornerRadius);
+        }
+    }
+
+    [super setFrame:viewFrame];
+
+    _innerFrames = WTFMove(frames);
+    for (auto& frame : _innerFrames)
+        frame.moveBy(-viewFrame.location());
+
+    if (self.layer.needsDisplayOnBoundsChange)
+        [self setNeedsDisplay];
+}
+
+- (void)setQuads:(Vector<WebCore::FloatQuad>&&)quads boundaryRect:(const WebCore::FloatRect&)boundaryRect
+{
+    [self cleanUp];
+
+    if (quads.isEmpty())
+        [self setFrame:CGRectZero];
+
+    bool initialized = false;
+    WebCore::FloatPoint minExtent;
+    WebCore::FloatPoint maxExtent;
+
+    for (auto& quad : quads) {
+        for (auto controlPoint : std::array { quad.p1(), quad.p2(), quad.p3(), quad.p4() }) {
+            if (std::exchange(initialized, true)) {
+                minExtent = minExtent.shrunkTo(controlPoint);
+                maxExtent = maxExtent.expandedTo(controlPoint);
+            } else {
+                minExtent = controlPoint;
+                maxExtent = controlPoint;
+            }
+        }
+    }
+
+    WebCore::FloatRect viewFrame { minExtent, maxExtent };
+
+    viewFrame.inflate(4 * _minimumCornerRadius);
+    viewFrame.intersect(boundaryRect);
+
+    [super setFrame:viewFrame];
+
+    _innerQuads = WTFMove(quads);
+    for (auto& quad : _innerQuads)
+        quad.move(-viewFrame.x(), -viewFrame.y());
+
+    if (self.layer.needsDisplayOnBoundsChange)
+        [self setNeedsDisplay];
+}
+
+- (void)setFrame:(CGRect)frame
+{
+    [self cleanUp];
+
+    [super setFrame:frame];
+}
+
+- (void)drawRect:(CGRect)aRect
+{
+    if (_innerFrames.isEmpty() && _innerQuads.isEmpty()) {
+        [_color set];
+        [[UIBezierPath bezierPathWithRoundedRect:self.bounds cornerRadius:_minimumCornerRadius] fill];
+        return;
+    }
+
+    auto path = [UIBezierPath bezierPath];
+
+    if (_innerFrames.size()) {
+        auto corePath = WebCore::PathUtilities::pathWithShrinkWrappedRects(_innerFrames, _cornerRadii);
+        [path appendPath:[UIBezierPath bezierPathWithCGPath:corePath.platformPath()]];
+    } else {
+        for (auto& quad : _innerQuads) {
+            UIBezierPath *subpath = [UIBezierPath bezierPath];
+            [subpath moveToPoint:quad.p1()];
+            [subpath addLineToPoint:quad.p2()];
+            [subpath addLineToPoint:quad.p3()];
+            [subpath addLineToPoint:quad.p4()];
+            [subpath closePath];
+            [path appendPath:subpath];
+        }
+    }
+
+    auto context = UIGraphicsGetCurrentContext();
+    CGContextSaveGState(context);
+
+    if (!_innerQuads.isEmpty())
+        CGContextSetLineWidth(context, 4 * _minimumCornerRadius);
+
+    CGContextSetLineJoin(context, kCGLineJoinRound);
+
+    auto alpha = CGColorGetAlpha([_color CGColor]);
+
+    [[_color colorWithAlphaComponent:1] set];
+
+    CGContextSetAlpha(context, alpha);
+    CGContextBeginTransparencyLayer(context, nil);
+    CGContextAddPath(context, path.CGPath);
+    CGContextDrawPath(context, kCGPathFillStroke);
+    CGContextEndTransparencyLayer(context);
+
+    CGContextRestoreGState(context);
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    return nil;
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm
@@ -28,10 +28,12 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "APIUIClient.h"
 #import "AccessibilitySupportSPI.h"
 #import "WKFullKeyboardAccessWatcher.h"
 #import "WKMouseDeviceObserver.h"
 #import "WKStylusDeviceObserver.h"
+#import "WebPageProxy.h"
 #import "WebProcessMessages.h"
 #import "WebProcessPool.h"
 #import <pal/system/cocoa/SleepDisablerCocoa.h>

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -87,6 +87,7 @@
 #import <WebCore/ActivityState.h>
 #import <WebCore/AttributedString.h>
 #import <WebCore/CaretRectComputation.h>
+#import <WebCore/CharacterRange.h>
 #import <WebCore/ColorMac.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/CompositionHighlight.h>
@@ -104,6 +105,7 @@
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/Pasteboard.h>
 #import <WebCore/PlatformEventFactoryMac.h>
+#import <WebCore/PlatformPlaybackSessionInterface.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PromisedAttachmentInfo.h>
@@ -2352,12 +2354,12 @@ void WebViewImpl::setUnderlayColor(NSColor *underlayColor)
 
 RetainPtr<NSColor> WebViewImpl::underlayColor() const
 {
-    return cocoaColorOrNil(m_page->underlayColor()).autorelease();
+    return WebCore::cocoaColorOrNil(m_page->underlayColor()).autorelease();
 }
 
 RetainPtr<NSColor> WebViewImpl::pageExtendedBackgroundColor() const
 {
-    return cocoaColorOrNil(m_page->pageExtendedBackgroundColor()).autorelease();
+    return WebCore::cocoaColorOrNil(m_page->pageExtendedBackgroundColor()).autorelease();
 }
 
 void WebViewImpl::setOverlayScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle)
@@ -5002,11 +5004,11 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
     Vector<WebCore::CompositionHighlight> highlights;
     [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:[&highlights](NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
         std::optional<WebCore::Color> backgroundHighlightColor;
-        if (CocoaColor *backgroundColor = attributes[NSBackgroundColorAttributeName])
+        if (WebCore::CocoaColor *backgroundColor = attributes[NSBackgroundColorAttributeName])
             backgroundHighlightColor = WebCore::colorFromCocoaColor(backgroundColor);
 
         std::optional<WebCore::Color> foregroundHighlightColor;
-        if (CocoaColor *foregroundColor = attributes[NSForegroundColorAttributeName])
+        if (WebCore::CocoaColor *foregroundColor = attributes[NSForegroundColorAttributeName])
             foregroundHighlightColor = WebCore::colorFromCocoaColor(foregroundColor);
 
         highlights.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), backgroundHighlightColor, foregroundHighlightColor });
@@ -5098,7 +5100,7 @@ static Vector<WebCore::CompositionUnderline> compositionUnderlines(NSAttributedS
     return mergedUnderlines;
 }
 
-static HashMap<String, Vector<CharacterRange>> compositionAnnotations(NSAttributedString *string)
+static HashMap<String, Vector<WebCore::CharacterRange>> compositionAnnotations(NSAttributedString *string)
 {
     if (!string.length)
         return { };
@@ -5111,7 +5113,7 @@ static HashMap<String, Vector<CharacterRange>> compositionAnnotations(NSAttribut
     });
 #endif
 
-    HashMap<String, Vector<CharacterRange>> annotations;
+    HashMap<String, Vector<WebCore::CharacterRange>> annotations;
     [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:[&annotations](NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
         [attributes enumerateKeysAndObjectsUsingBlock:[&annotations, &range](NSAttributedStringKey key, id value, BOOL *) {
 
@@ -5120,7 +5122,7 @@ static HashMap<String, Vector<CharacterRange>> compositionAnnotations(NSAttribut
 
             auto it = annotations.find(key);
             if (it == annotations.end())
-                it = annotations.add(key, Vector<CharacterRange> { }).iterator;
+                it = annotations.add(key, Vector<WebCore::CharacterRange> { }).iterator;
             auto& vector = it->value;
 
             // Coalesce this range into the previous one if possible
@@ -5147,7 +5149,7 @@ void WebViewImpl::setMarkedText(id string, NSRange selectedRange, NSRange replac
 
     Vector<WebCore::CompositionUnderline> underlines;
     Vector<WebCore::CompositionHighlight> highlights;
-    HashMap<String, Vector<CharacterRange>> annotations;
+    HashMap<String, Vector<WebCore::CharacterRange>> annotations;
     NSString *text;
 
     if (isAttributedString) {
@@ -6011,7 +6013,7 @@ void WebViewImpl::updateMediaPlaybackControlsManager()
         [m_playbackControlsManager setCanTogglePictureInPicture:NO];
     }
 
-    if (PlatformPlaybackSessionInterface* interface = m_page->playbackSessionManager()->controlsManagerInterface()) {
+    if (WebCore::PlatformPlaybackSessionInterface* interface = m_page->playbackSessionManager()->controlsManagerInterface()) {
         [m_playbackControlsManager setPlaybackSessionInterfaceMac:interface];
         interface->updatePlaybackControlsManagerCanTogglePictureInPicture();
     }
@@ -6155,7 +6157,7 @@ void WebViewImpl::updateCursorAccessoryPlacement()
 #if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
 static RetainPtr<_WKWebViewTextInputNotifications> subscribeToTextInputNotifications(WebViewImpl* webView)
 {
-    if (!redesignedTextCursorEnabled())
+    if (!WebCore::redesignedTextCursorEnabled())
         return nullptr;
 
     auto textInputNotifications = adoptNS([[_WKWebViewTextInputNotifications alloc] initWithWebView:webView]);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2209,6 +2209,7 @@
 		F430E94422473DFF005FE053 /* WebContentMode.h in Headers */ = {isa = PBXBuildFile; fileRef = F430E94322473DB8005FE053 /* WebContentMode.h */; };
 		F433C0A72958C22F00E771C2 /* NetworkIssueReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F433C0A52958C22F00E771C2 /* NetworkIssueReporter.h */; };
 		F4351B9E25EEC84C00D63892 /* ImageAnalysisUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F4351B9D25EEC84C00D63892 /* ImageAnalysisUtilities.h */; };
+		F43548382AB7C41E00150894 /* WKTapHighlightView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E8912E2AB7C344005AEBC3 /* WKTapHighlightView.h */; };
 		F438CD1C2241421400DE6DDA /* WKWebpagePreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = F438CD1B224140A600DE6DDA /* WKWebpagePreferences.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F438CD1F22414D4000DE6DDA /* WKWebpagePreferencesInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F438CD1E22414D4000DE6DDA /* WKWebpagePreferencesInternal.h */; };
 		F438CD212241F69500DE6DDA /* WKWebpagePreferencesPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F438CD202241F69500DE6DDA /* WKWebpagePreferencesPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7322,6 +7323,8 @@
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
 		F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTouchEventsGestureRecognizerTypes.h; path = ios/WKTouchEventsGestureRecognizerTypes.h; sourceTree = "<group>"; };
+		F4E8912E2AB7C344005AEBC3 /* WKTapHighlightView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTapHighlightView.h; path = ios/WKTapHighlightView.h; sourceTree = "<group>"; };
+		F4E8912F2AB7C344005AEBC3 /* WKTapHighlightView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKTapHighlightView.mm; path = ios/WKTapHighlightView.mm; sourceTree = "<group>"; };
 		F4EB4AFC269CD23600D297AE /* OSStateSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSStateSPI.h; sourceTree = "<group>"; };
 		F4ED2BBB29B9803E00B8AE22 /* PrivateClickMeasurementPersistentStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateClickMeasurementPersistentStore.h; sourceTree = "<group>"; };
 		F4ED2BBC29B9803E00B8AE22 /* PrivateClickMeasurementPersistentStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateClickMeasurementPersistentStore.cpp; sourceTree = "<group>"; };
@@ -9766,6 +9769,8 @@
 				CE5B4C8721B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.mm */,
 				26F10BE619187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.h */,
 				26F10BE719187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.mm */,
+				F4E8912E2AB7C344005AEBC3 /* WKTapHighlightView.h */,
+				F4E8912F2AB7C344005AEBC3 /* WKTapHighlightView.mm */,
 				CE21215D240EE571006ED443 /* WKTextPlaceholder.h */,
 				CE21215E240EE571006ED443 /* WKTextPlaceholder.mm */,
 				CE45945A240F85B90078019F /* WKTextSelectionRect.h */,
@@ -15554,6 +15559,7 @@
 				9593675F252E5E3100D3F0A0 /* WKStylusDeviceObserver.h in Headers */,
 				CE5B4C8821B73D870022E64F /* WKSyntheticFlagsChangedWebEvent.h in Headers */,
 				26F10BE819187E2E001D0E68 /* WKSyntheticTapGestureRecognizer.h in Headers */,
+				F43548382AB7C41E00150894 /* WKTapHighlightView.h in Headers */,
 				51F886A61F2C228100C193EF /* WKTestingSupport.h in Headers */,
 				31D755C11D91B81500843BD1 /* WKTextChecker.h in Headers */,
 				2DD67A351BD861060053B251 /* WKTextFinderClient.h in Headers */,


### PR DESCRIPTION
#### 44a0dfea8e7b82c1a64c0dcd5efe56d71abd5b5f
<pre>
[iOS] Stop using _UIHighlightView to show highlights over DOM elements when tapping
<a href="https://bugs.webkit.org/show_bug.cgi?id=261691">https://bugs.webkit.org/show_bug.cgi?id=261691</a>
rdar://115524347

Reviewed by Megan Gardner.

Replace uses of UIKit&apos;s `_UIHighlightView` with a WebKit-internal implementation instead:
`WKTapHighlightView`. This new view is (for the most part) a 1-1 drop-in replacement for
`_UIHighlightView`, and implements the same functionality.

See below for details.

* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::PathUtilities::pathWithShrinkWrappedRects):

Add a helper to create shrink-wrapped rects from a list of rects and corner radii. This falls back
to the existing `pathWithShrinkWrappedRects` implementation in the case where the corner radii all
have the same value, and otherwise returns a combined `WebCore::Path` that consists of multiple
rounded rects, each with the given corner radii.

* Source/WebCore/platform/graphics/PathUtilities.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove now-unused SPI declarations for `_UIHighlightView`.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):

Replace `_highlightView` with `_tapHighlightView` (I opted to rename this ivar, to make its purpose
more obvious).

(tapHighlightBorderRadius):
(-[WKContentView _updateTapHighlight]):
(-[WKContentView tapHighlightViewRect]):
(-[WKContentView _showTapHighlight]):
(-[WKContentView _cancelInteraction]):
(-[WKContentView _fadeTapHighlightViewIfNeeded]):
(nsSizeForTapHighlightBorderRadius): Deleted.
* Source/WebKit/UIProcess/ios/WKTapHighlightView.h: Added.
* Source/WebKit/UIProcess/ios/WKTapHighlightView.mm: Added.
(-[WKTapHighlightView initWithFrame:]):
(-[WKTapHighlightView cleanUp]):
(-[WKTapHighlightView setColor:]):
(-[WKTapHighlightView setMinimumCornerRadius:]):
(-[WKTapHighlightView setCornerRadii:]):
(-[WKTapHighlightView setFrames:]):
(-[WKTapHighlightView setQuads:boundaryRect:]):
(-[WKTapHighlightView setFrame:]):
(-[WKTapHighlightView drawRect:]):
(-[WKTapHighlightView hitTest:withEvent:]):

Implement the drop-in replacement. Note that there is a subtle behavioral difference here: in the
case where either the corner radii are not all equal, or there is only one rect to highlight,
`_UIHighlightView` would have previously used continuous corners for the rounded rect; otherwise,
we&apos;d fall back to WebKit&apos;s shrink-wrapping logic. This patch makes it so that we now only use the
WebKit shrink-wrapping codepath for both of the cases above.

* Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::underlayColor const):
(WebKit::WebViewImpl::pageExtendedBackgroundColor const):
(WebKit::compositionHighlights):
(WebKit::compositionAnnotations):
(WebKit::WebViewImpl::setMarkedText):
(WebKit::WebViewImpl::updateMediaPlaybackControlsManager):
(WebKit::subscribeToTextInputNotifications):

Add various missing includes and `WebCore` namespacing due to changes in source unification order.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/268099@main">https://commits.webkit.org/268099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbc74f0cce6ef4a26a3a7806666171e657f02682

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19325 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21417 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21365 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17795 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16850 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4440 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->