### PR TITLE
visionOS: Pixel cracks within layers at some content scales

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -204,6 +204,8 @@ private:
     void ensureFrontBuffer();
     void dirtyRepaintCounterIfNecessary();
 
+    WebCore::IntRect layerBounds() const;
+
     PlatformCALayerRemote* m_layer;
 
     Parameters m_parameters;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -303,12 +303,17 @@ bool RemoteLayerBackingStore::layerWillBeDisplayed()
 
 void RemoteLayerBackingStore::setNeedsDisplay(const IntRect rect)
 {
-    m_dirtyRegion.unite(rect);
+    m_dirtyRegion.unite(intersection(layerBounds(), rect));
 }
 
 void RemoteLayerBackingStore::setNeedsDisplay()
 {
-    setNeedsDisplay(IntRect(IntPoint(), expandedIntSize(m_parameters.size)));
+    m_dirtyRegion.unite(layerBounds());
+}
+
+WebCore::IntRect RemoteLayerBackingStore::layerBounds() const
+{
+    return IntRect { { }, expandedIntSize(m_parameters.size) };
 }
 
 bool RemoteLayerBackingStore::usesDeepColorBackingStore() const
@@ -607,7 +612,7 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context, WTF::Funct
         m_paintingRects.append(scaledRect);
     }
 
-    IntRect layerBounds(IntPoint(), expandedIntSize(m_parameters.size));
+    IntRect layerBounds = this->layerBounds();
     if (RefPtr imageBuffer = m_backBuffer.imageBuffer; !m_dirtyRegion.contains(layerBounds) && imageBuffer) {
         if (!m_previouslyPaintedRect)
             context.drawImageBuffer(*imageBuffer, { 0, 0 }, { CompositeOperator::Copy });


### PR DESCRIPTION
#### e4d8e9236f2add93fa83d8c13b8401df421155aa
<pre>
visionOS: Pixel cracks within layers at some content scales
<a href="https://bugs.webkit.org/show_bug.cgi?id=261693">https://bugs.webkit.org/show_bug.cgi?id=261693</a>
rdar://108139596

Reviewed by Dean Jackson.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::setNeedsDisplay):
(WebKit::RemoteLayerBackingStore::layerBounds const):
(WebKit::RemoteLayerBackingStore::drawInContext):
Dynamic content scaling doesn&apos;t support partial repaint, so we disable it.

We do this by calling setNeedsDisplay() on the layer, intending to make a
single repaint rect covering the whole layer.

However, RemoteLayerBackingStore&apos;s setNeedDisplay doesn&apos;t intersect incoming repaint
rects with the layer&apos;s bounds, so a very large repaint rect *outside* of the bounds
of the layer (like you might get with e.g. a large negative text-indent, which is
fairly common on the web), results in a m_dirtyRegion with rectangles far outside
the layer.

Then, depending on the shape of the extralayer repaint rects, the logic in
RemoteLayerBackingStore::drawInContext that decides whether or not to do a
partial repaint (based on the delta between the area covered by the repaint rects
and the bounds of a full repaint) can still decide to do a partial repaint.
(Despite the fact that we absolutely cannot perform partial repaints
for dynamic content scaling right now).

Fix this by intersecting incoming repaint rects with the layer&apos;s bounds, so that
calling setNeedsDisplay *always* results in RemoteLayerBackingStore::drawInContext
doing a full repaint.

Canonical link: <a href="https://commits.webkit.org/268098@main">https://commits.webkit.org/268098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d57df25ac7a85fb300d0440a6e8ecbe13866a0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17481 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19156 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21415 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16277 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23471 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17302 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21364 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15103 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4438 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->