### PR TITLE
Add automatic handling of Declarative Web Push messages in the UIProcess

### DIFF
--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -408,6 +408,7 @@ NotificationData Notification::data() const
     RELEASE_ASSERT(sessionID);
 
     return {
+        { },
         m_title,
         m_body,
         m_icon.string(),

--- a/Source/WebCore/Modules/notifications/NotificationData.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationData.cpp
@@ -30,12 +30,12 @@ namespace WebCore {
 
 NotificationData NotificationData::isolatedCopy() const &
 {
-    return { title.isolatedCopy(), body.isolatedCopy(), iconURL.isolatedCopy(), tag.isolatedCopy(), language.isolatedCopy(), direction, originString.isolatedCopy(), serviceWorkerRegistrationURL.isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, data, silent };
+    return { defaultActionURL.isolatedCopy(), title.isolatedCopy(), body.isolatedCopy(), iconURL.isolatedCopy(), tag.isolatedCopy(), language.isolatedCopy(), direction, originString.isolatedCopy(), serviceWorkerRegistrationURL.isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, data, silent };
 }
 
 NotificationData NotificationData::isolatedCopy() &&
 {
-    return { WTFMove(title).isolatedCopy(), WTFMove(body).isolatedCopy(), WTFMove(iconURL).isolatedCopy(), WTFMove(tag).isolatedCopy(), WTFMove(language).isolatedCopy(), direction, WTFMove(originString).isolatedCopy(), WTFMove(serviceWorkerRegistrationURL).isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, WTFMove(data), silent };
+    return { WTFMove(defaultActionURL).isolatedCopy(), WTFMove(title).isolatedCopy(), WTFMove(body).isolatedCopy(), WTFMove(iconURL).isolatedCopy(), WTFMove(tag).isolatedCopy(), WTFMove(language).isolatedCopy(), direction, WTFMove(originString).isolatedCopy(), WTFMove(serviceWorkerRegistrationURL).isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, WTFMove(data), silent };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationData.h
+++ b/Source/WebCore/Modules/notifications/NotificationData.h
@@ -50,6 +50,7 @@ struct NotificationData {
 
     bool isPersistent() const { return !serviceWorkerRegistrationURL.isNull(); }
 
+    URL defaultActionURL;
     String title;
     String body;
     String iconURL;

--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -28,6 +28,7 @@
 
 #import "NotificationDirection.h"
 
+static NSString * const WebNotificationDefaultActionURLKey = @"WebNotificationDefaultActionURLKey";
 static NSString * const WebNotificationTitleKey = @"WebNotificationTitleKey";
 static NSString * const WebNotificationBodyKey = @"WebNotificationBodyKey";
 static NSString * const WebNotificationIconURLKey = @"WebNotificationIconURLKey";
@@ -54,6 +55,7 @@ static std::optional<bool> nsValueToOptionalBool(id value)
 
 std::optional<NotificationData> NotificationData::fromDictionary(NSDictionary *dictionary)
 {
+    NSString *defaultActionURL = dictionary[WebNotificationDefaultActionURLKey];
     NSString *title = dictionary[WebNotificationTitleKey];
     NSString *body = dictionary[WebNotificationBodyKey];
     NSString *iconURL = dictionary[WebNotificationIconURLKey];
@@ -87,13 +89,14 @@ std::optional<NotificationData> NotificationData::fromDictionary(NSDictionary *d
         return std::nullopt;
     }
 
-    NotificationData data { title, body, iconURL, tag, language, direction, originString, URL { String { serviceWorkerRegistrationURL } }, *uuid, contextIdentifier, PAL::SessionID { sessionID.unsignedLongLongValue }, { }, { static_cast<const uint8_t*>(notificationData.bytes), notificationData.length }, nsValueToOptionalBool(dictionary[WebNotificationSilentKey]) };
+    NotificationData data { URL { String { defaultActionURL } }, title, body, iconURL, tag, language, direction, originString, URL { String { serviceWorkerRegistrationURL } }, *uuid, contextIdentifier, PAL::SessionID { sessionID.unsignedLongLongValue }, { }, { static_cast<const uint8_t*>(notificationData.bytes), notificationData.length }, nsValueToOptionalBool(dictionary[WebNotificationSilentKey]) };
     return WTFMove(data);
 }
 
 NSDictionary *NotificationData::dictionaryRepresentation() const
 {
     NSMutableDictionary *result = @{
+        WebNotificationDefaultActionURLKey : (NSString *)defaultActionURL.string(),
         WebNotificationTitleKey : (NSString *)title,
         WebNotificationBodyKey : (NSString *)body,
         WebNotificationIconURLKey : (NSString *)iconURL,

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -109,6 +109,9 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << serviceWorkerRegistrationDirectory << serviceWorkerRegistrationDirectoryExtensionHandle << serviceWorkerProcessTerminationDelayEnabled << inspectionForServiceWorkersAllowed;
 #endif
     encoder << resourceLoadStatisticsParameters;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    encoder << isDeclarativeWebPushEnabled;
+#endif
 }
 
 std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters::decode(IPC::Decoder& decoder)
@@ -459,6 +462,13 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!resourceLoadStatisticsParameters)
         return std::nullopt;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    std::optional<bool> isDeclarativeWebPushEnabled;
+    decoder >> isDeclarativeWebPushEnabled;
+    if (!isDeclarativeWebPushEnabled)
+        return std::nullopt;
+#endif
+
     return {{
         *sessionID
         , WTFMove(*dataStoreIdentifier)
@@ -537,6 +547,9 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         , WTFMove(*serviceWorkerRegistrationDirectoryExtensionHandle)
         , *serviceWorkerProcessTerminationDelayEnabled
         , *inspectionForServiceWorkersAllowed
+#endif
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+        , *isDeclarativeWebPushEnabled
 #endif
         , WTFMove(*resourceLoadStatisticsParameters)
     }};

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -137,6 +137,9 @@ struct NetworkSessionCreationParameters {
     bool serviceWorkerProcessTerminationDelayEnabled { true };
     bool inspectionForServiceWorkersAllowed { true };
 #endif
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    bool isDeclarativeWebPushEnabled { false };
+#endif
 
     ResourceLoadStatisticsParameters resourceLoadStatisticsParameters;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1336,6 +1336,7 @@ struct WebCore::HTMLModelElementCamera {
 };
 
 struct WebCore::NotificationData {
+    URL defaultActionURL;
     String title;
     String body;
     String iconURL;

--- a/Source/WebKit/Shared/WebPushMessage.cpp
+++ b/Source/WebKit/Shared/WebPushMessage.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebPushMessage.h"
+
+#include <WebCore/NotificationData.h>
+
+namespace WebKit {
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
+{
+    RELEASE_ASSERT(notificationPayload);
+
+    static NeverDestroyed<WebCore::ScriptExecutionContextIdentifier> sharedScriptIdentifier = WebCore::ScriptExecutionContextIdentifier::generate();
+
+    String body, iconURL, tag, language;
+    WebCore::NotificationDirection direction = WebCore::NotificationDirection::Auto;
+    std::optional<bool> silent;
+
+    CString dataCString;
+    Vector<uint8_t> dataJSON;
+
+    if (notificationPayload->options) {
+        body = notificationPayload->options->body;
+        language = notificationPayload->options->lang;
+        tag = notificationPayload->options->tag;
+        iconURL = notificationPayload->options->icon;
+        direction = notificationPayload->options->dir;
+        silent = notificationPayload->options->silent;
+
+        dataCString = notificationPayload->options->dataJSONString.utf8();
+        dataJSON = { dataCString.dataAsUInt8Ptr(), dataCString.length() };
+    }
+
+    return {
+        notificationPayload->defaultActionURL,
+        notificationPayload->title,
+        body,
+        iconURL,
+        tag,
+        language,
+        direction,
+        WebCore::SecurityOriginData::fromURL(registrationURL).toString(),
+        registrationURL,
+        WTF::UUID::createVersion4(),
+        sharedScriptIdentifier,
+        PAL::SessionID::defaultSessionID(),
+        MonotonicTime::now(),
+        WTFMove(dataJSON),
+        silent
+    };
+}
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/WebPushMessage.h
+++ b/Source/WebKit/Shared/WebPushMessage.h
@@ -35,6 +35,10 @@
 
 OBJC_CLASS NSDictionary;
 
+namespace WebCore {
+struct NotificationData;
+}
+
 namespace WebKit {
 
 struct WebPushMessage {
@@ -43,6 +47,8 @@ struct WebPushMessage {
     URL registrationURL;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     std::optional<WebCore::NotificationPayload> notificationPayload;
+
+    WebCore::NotificationData notificationPayloadToCoreData() const;
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -265,8 +265,7 @@ Shared/WebPlatformTouchPoint.cpp
 Shared/WebPopupItem.cpp
 Shared/WebPreferencesDefaultValues.cpp
 Shared/WebPreferencesStore.cpp
-Shared/API/c/WKRenderLayer.cpp
-Shared/API/c/WKRenderObject.cpp
+Shared/WebPushMessage.cpp
 Shared/WebTouchEvent.cpp
 Shared/WebUserContentControllerDataTypes.cpp
 Shared/WebWheelEventCoalescer.cpp
@@ -294,6 +293,8 @@ Shared/API/c/WKMutableArray.cpp
 Shared/API/c/WKMutableDictionary.cpp
 Shared/API/c/WKNumber.cpp
 Shared/API/c/WKPluginInformation.cpp
+Shared/API/c/WKRenderLayer.cpp
+Shared/API/c/WKRenderObject.cpp
 Shared/API/c/WKSecurityOriginRef.cpp
 Shared/API/c/WKSerializedScriptValue.cpp
 Shared/API/c/WKString.cpp

--- a/Source/WebKit/UIProcess/API/APINotificationProvider.h
+++ b/Source/WebKit/UIProcess/API/APINotificationProvider.h
@@ -46,7 +46,7 @@ class NotificationProvider {
 public:
     virtual ~NotificationProvider() = default;
 
-    virtual void show(WebKit::WebPageProxy*, WebKit::WebNotification&, RefPtr<WebCore::NotificationResources>&&) { }
+    virtual bool show(WebKit::WebPageProxy*, WebKit::WebNotification&, RefPtr<WebCore::NotificationResources>&&) { return false; }
     virtual void cancel(WebKit::WebNotification&) { }
     virtual void didDestroyNotification(WebKit::WebNotification&) { }
     virtual void clearNotifications(const Vector<uint64_t>& /*notificationIDs*/) { }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1045,8 +1045,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         return;
     }
 
-    RELEASE_LOG(Push, "Sending push message for scope %" SENSITIVE_LOG_STRING " to network process to handle", pushMessage->registrationURL.string().utf8().data());
-    _websiteDataStore->networkProcess().processPushMessage(_websiteDataStore->sessionID(), *pushMessage, [completionHandler = makeBlockPtr(completionHandler)] (bool wasProcessed) {
+    _websiteDataStore->processPushMessage(WTFMove(*pushMessage), [completionHandler = makeBlockPtr(completionHandler)] (bool wasProcessed) {
         RELEASE_LOG(Push, "Push message processing complete. Callback result: %d", wasProcessed);
         completionHandler(wasProcessed);
     });

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -101,6 +101,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic, nullable, copy, setter=setWebPushPartitionString:) NSString *webPushPartitionString WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic) _WKUnifiedOriginStorageLevel unifiedOriginStorageLevel WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, nullable, copy) NSNumber *volumeCapacityOverride WK_API_AVAILABLE(macos(14.0), ios(17.0));
+@property (nonatomic) BOOL isDeclarativeWebPushEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -580,6 +580,23 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
     _configuration->setVolumeCapacityOverride(capacity);
 }
 
+- (BOOL)isDeclarativeWebPushEnabled
+{
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    return _configuration->isDeclarativeWebPushEnabled();
+#else
+    return NO;
+#endif
+}
+
+- (void)setIsDeclarativeWebPushEnabled:(BOOL)enabled
+{
+    UNUSED_PARAM(enabled);
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    _configuration->setIsDeclarativeWebPushEnabled(enabled);
+#endif
+}
+
 - (NSUInteger)testSpeedMultiplier
 {
     return _configuration->testSpeedMultiplier();

--- a/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNotificationProvider.cpp
@@ -49,9 +49,10 @@ public:
     }
 
 private:
-    void show(WebPageProxy* page, WebNotification& notification, RefPtr<WebCore::NotificationResources>&& resources) override
+    bool show(WebPageProxy* page, WebNotification& notification, RefPtr<WebCore::NotificationResources>&& resources) override
     {
         m_provider.show(page, notification, WTFMove(resources));
+        return true;
     }
 
     void cancel(WebNotification& notification) override

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -60,7 +60,7 @@ void ServiceWorkerNotificationHandler::showNotification(IPC::Connection& connect
         return;
 
     m_notificationToSessionMap.add(data.notificationID, data.sourceSession);
-    dataStore->showServiceWorkerNotification(connection, data);
+    dataStore->showPersistentNotification(&connection, data);
 }
 
 void ServiceWorkerNotificationHandler::cancelNotification(const WTF::UUID& notificationID)

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.cpp
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-WebNotification::WebNotification(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection& sourceConnection)
+WebNotification::WebNotification(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection* sourceConnection)
     : m_data(data)
     , m_origin(API::SecurityOrigin::createFromString(data.originString))
     , m_pageIdentifier(pageIdentifier)

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -46,10 +46,10 @@ public:
     static Ref<WebNotification> createNonPersistent(const WebCore::NotificationData& data, WebPageProxyIdentifier pageIdentifier, IPC::Connection& sourceConnection)
     {
         ASSERT(!data.isPersistent());
-        return adoptRef(*new WebNotification(data, pageIdentifier, std::nullopt, sourceConnection));
+        return adoptRef(*new WebNotification(data, pageIdentifier, std::nullopt, &sourceConnection));
     }
 
-    static Ref<WebNotification> createPersistent(const WebCore::NotificationData& data, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection& sourceConnection)
+    static Ref<WebNotification> createPersistent(const WebCore::NotificationData& data, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection* sourceConnection)
     {
         ASSERT(data.isPersistent());
         return adoptRef(*new WebNotification(data, WebPageProxyIdentifier(), dataStoreIdentifier, sourceConnection));
@@ -77,7 +77,7 @@ public:
     RefPtr<IPC::Connection> sourceConnection() const { return m_sourceConnection.get(); }
 
 private:
-    WebNotification(const WebCore::NotificationData&, WebPageProxyIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection&);
+    WebNotification(const WebCore::NotificationData&, WebPageProxyIdentifier, const std::optional<WTF::UUID>& dataStoreIdentifier, IPC::Connection*);
 
     WebCore::NotificationData m_data;
     RefPtr<API::SecurityOrigin> m_origin;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -112,19 +112,19 @@ void WebNotificationManagerProxy::show(WebPageProxy* webPage, IPC::Connection& c
     showImpl(webPage, WTFMove(notification), WTFMove(notificationResources));
 }
 
-void WebNotificationManagerProxy::show(const WebsiteDataStore& dataStore, IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
+bool WebNotificationManagerProxy::showPersistent(const WebsiteDataStore& dataStore, IPC::Connection* connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
     LOG(Notifications, "WebsiteDataStore (%p) asking to show notification (%s)", &dataStore, notificationData.notificationID.toString().utf8().data());
 
     auto notification = WebNotification::createPersistent(notificationData, dataStore.configuration().identifier(), connection);
-    showImpl(nullptr, WTFMove(notification), WTFMove(notificationResources));
+    return showImpl(nullptr, WTFMove(notification), WTFMove(notificationResources));
 }
 
-void WebNotificationManagerProxy::showImpl(WebPageProxy* webPage, Ref<WebNotification>&& notification, RefPtr<WebCore::NotificationResources>&& notificationResources)
+bool WebNotificationManagerProxy::showImpl(WebPageProxy* webPage, Ref<WebNotification>&& notification, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
     m_globalNotificationMap.set(notification->notificationID(), notification->coreNotificationID());
     m_notifications.set(notification->coreNotificationID(), notification);
-    m_provider->show(webPage, notification.get(), WTFMove(notificationResources));
+    return m_provider->show(webPage, notification.get(), WTFMove(notificationResources));
 }
 
 void WebNotificationManagerProxy::cancel(WebPageProxy* page, const WTF::UUID& pageNotificationID)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -66,7 +66,7 @@ public:
     HashMap<String, bool> notificationPermissions();
 
     void show(WebPageProxy*, IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
-    void show(const WebsiteDataStore&, IPC::Connection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
+    bool showPersistent(const WebsiteDataStore&, IPC::Connection*, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&);
     void cancel(WebPageProxy*, const WTF::UUID& pageNotificationID);
     void clearNotifications(WebPageProxy*);
     void clearNotifications(WebPageProxy*, const Vector<WTF::UUID>& pageNotificationIDs);
@@ -92,7 +92,7 @@ private:
     void refWebContextSupplement() override;
     void derefWebContextSupplement() override;
 
-    void showImpl(WebPageProxy*, Ref<WebNotification>&&, RefPtr<WebCore::NotificationResources>&&);
+    bool showImpl(WebPageProxy*, Ref<WebNotification>&&, RefPtr<WebCore::NotificationResources>&&);
 
     std::unique_ptr<API::NotificationProvider> m_provider;
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp
@@ -42,12 +42,13 @@ WebNotificationProvider::WebNotificationProvider(const WKNotificationProviderBas
     initialize(provider);
 }
 
-void WebNotificationProvider::show(WebPageProxy* page, WebNotification& notification, RefPtr<WebCore::NotificationResources>&&)
+bool WebNotificationProvider::show(WebPageProxy* page, WebNotification& notification, RefPtr<WebCore::NotificationResources>&&)
 {
     if (!m_client.show)
-        return;
+        return false;
 
     m_client.show(toAPI(page), toAPI(&notification), m_client.base.clientInfo);
+    return true;
 }
 
 void WebNotificationProvider::cancel(WebNotification& notification)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h
@@ -48,7 +48,7 @@ class WebNotificationProvider : public API::NotificationProvider, public API::Cl
 public:
     explicit WebNotificationProvider(const WKNotificationProviderBase*);
 
-    void show(WebPageProxy*, WebNotification&, RefPtr<WebCore::NotificationResources>&&) override;
+    bool show(WebPageProxy*, WebNotification&, RefPtr<WebCore::NotificationResources>&&) override;
     void cancel(WebNotification&) override;
     void didDestroyNotification(WebNotification&) override;
     void clearNotifications(const Vector<uint64_t>& notificationIDs) override;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -107,6 +107,7 @@ enum class WebsiteDataFetchOption : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
 struct NetworkProcessConnectionInfo;
+struct WebPushMessage;
 struct WebsiteDataRecord;
 struct WebsiteDataStoreParameters;
 
@@ -433,7 +434,7 @@ public:
 
     void countNonDefaultSessionSets(CompletionHandler<void(size_t)>&&);
 
-    void showServiceWorkerNotification(IPC::Connection&, const WebCore::NotificationData&);
+    bool showPersistentNotification(IPC::Connection*, const WebCore::NotificationData&);
     void cancelServiceWorkerNotification(const WTF::UUID& notificationID);
     void clearServiceWorkerNotification(const WTF::UUID& notificationID);
     void didDestroyServiceWorkerNotification(const WTF::UUID& notificationID);
@@ -474,7 +475,9 @@ public:
     void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&&);
 #endif
     void setCompletionHandlerForRemovalFromNetworkProcess(CompletionHandler<void(String&&)>&&);
-    
+
+    void processPushMessage(WebPushMessage&&, CompletionHandler<void(bool)>&&);
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -40,6 +40,7 @@ class SecurityOriginData;
 namespace WebKit {
 
 class WebPageProxy;
+class WebsiteDataStore;
 
 class WebsiteDataStoreClient {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -192,6 +192,9 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 #if !HAVE(NSURLSESSION_WEBSOCKET)
     copy->m_shouldAcceptInsecureCertificatesForWebSockets = this->m_shouldAcceptInsecureCertificatesForWebSockets;
 #endif
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    copy->m_isDeclarativeWebPushEnabled = this->m_isDeclarativeWebPushEnabled;
+#endif
 
     return copy;
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -78,6 +78,11 @@ public:
     std::optional<uint64_t> volumeCapacityOverride() const { return m_volumeCapacityOverride; }
     void setVolumeCapacityOverride(std::optional<uint64_t> capacity) { m_volumeCapacityOverride = capacity; }
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    bool isDeclarativeWebPushEnabled() const { return m_isDeclarativeWebPushEnabled; }
+    void setIsDeclarativeWebPushEnabled(bool enabled) { m_isDeclarativeWebPushEnabled = enabled; }
+#endif
+
     const String& applicationCacheDirectory() const { return m_applicationCacheDirectory; }
     void setApplicationCacheDirectory(String&& directory) { m_applicationCacheDirectory = WTFMove(directory); }
     
@@ -313,6 +318,9 @@ private:
     bool m_enableInAppBrowserPrivacyForTesting { false };
     bool m_allowsHSTSWithUntrustedRootCertificate { false };
     bool m_trackingPreventionDebugModeEnabled { false };
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    bool m_isDeclarativeWebPushEnabled { false };
+#endif
     String m_pcmMachServiceName;
     String m_webPushMachServiceName;
     String m_webPushPartitionString;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5108,6 +5108,7 @@
 		51F7BB7E274564A100C45A72 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		51F886A31F2C214A00C193EF /* WKTestingSupport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKTestingSupport.cpp; sourceTree = "<group>"; };
 		51F886A41F2C214A00C193EF /* WKTestingSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKTestingSupport.h; sourceTree = "<group>"; };
+		51F8FA3A2AB7549C00C8413B /* WebPushMessage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPushMessage.cpp; sourceTree = "<group>"; };
 		51FA2D541521118600C1BA0B /* WKBundleDOMWindowExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBundleDOMWindowExtension.h; sourceTree = "<group>"; };
 		51FA2D5A15211A1E00C1BA0B /* InjectedBundleDOMWindowExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedBundleDOMWindowExtension.h; sourceTree = "<group>"; };
 		51FA2D5C15211A5000C1BA0B /* InjectedBundleDOMWindowExtension.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InjectedBundleDOMWindowExtension.cpp; sourceTree = "<group>"; };
@@ -8228,6 +8229,7 @@
 				517B5F2D2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h */,
 				5CA133EE28F61C4100541DAE /* WebPushDaemonConnectionConfiguration.serialization.in */,
 				512CD6992721F04900F7F8EC /* WebPushDaemonConstants.h */,
+				51F8FA3A2AB7549C00C8413B /* WebPushMessage.cpp */,
 				517B5F96275EC5E5002DC22D /* WebPushMessage.h */,
 				5CABE07A28F60E8A00D83FD9 /* WebPushMessage.serialization.in */,
 				5C8DD37F1FE4519200F2A556 /* WebsiteAutoplayPolicy.h */,


### PR DESCRIPTION
#### e5b61a361d97c315d2a0ba17ae6d323798ba03d1
<pre>
Add automatic handling of Declarative Web Push messages in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=261694">https://bugs.webkit.org/show_bug.cgi?id=261694</a>
rdar://115675105

Reviewed by Andy Estes and Chris Dumez.

The goal of Declarative Web Push is to handle the push message automatically.

Eventually we&apos;ll be able to do so without even requiring the UIProcess to launch.
But for now, we can do so inside the UIProcess bypassing any JavaScript.

This patch implements that logic, and tests that both the declarative notification
was shown and that the declarative app badge was set.

* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::data const):
* Source/WebCore/Modules/notifications/NotificationData.cpp:
(WebCore::NotificationData::isolatedCopy const):
(WebCore::NotificationData::isolatedCopy):
* Source/WebCore/Modules/notifications/NotificationData.h:
* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::NotificationData::fromDictionary):
(WebCore::NotificationData::dictionaryRepresentation const):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPushMessage.cpp: Added.
(WebKit::WebPushMessage::notificationPayloadToCoreData const):
* Source/WebKit/Shared/WebPushMessage.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APINotificationProvider.h:
(API::NotificationProvider::show):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _processPushMessage:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration declarativeWebPushEnabled]):
(-[_WKWebsiteDataStoreConfiguration setDeclarativeWebPushEnabled:]):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::showNotification):
* Source/WebKit/UIProcess/Notifications/WebNotification.cpp:
(WebKit::WebNotification::WebNotification):
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
(WebKit::WebNotification::createNonPersistent):
(WebKit::WebNotification::createPersistent):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::showPersistent):
(WebKit::WebNotificationManagerProxy::showImpl):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.cpp:
(WebKit::WebNotificationProvider::show):
* Source/WebKit/UIProcess/Notifications/WebNotificationProvider.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::showPersistentNotification):
(WebKit::WebsiteDataStore::processPushMessage):
(WebKit::WebsiteDataStore::showServiceWorkerNotification): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::declarativeWebPushEnabled const):
(WebKit::WebsiteDataStoreConfiguration::setDeclarativeWebPushEnabled):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/mac/AppDelegate.m:
(enabledForFeature):
(-[BrowserAppDelegate persistentDataStore]):
(-[BrowserAppDelegate defaultConfiguration]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(-[PushNotificationDelegate websiteDataStore:showNotification:]):
(-[PushNotificationDelegate websiteDataStore:workerOrigin:updatedAppBadge:]):
(-[PushNotificationDelegate websiteDataStore:showNotification:]):
(-[NotificationPermissionDelegate _webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:]): Deleted.
(-[NotificationPermissionDelegate webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/268101@main">https://commits.webkit.org/268101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7ae54b998f7698d425c8d90548c7944d1f6b2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21441 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17038 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21385 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17814 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16873 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4442 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->