### PR TITLE
SharedMemory::Handle should always be valid

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -318,14 +318,13 @@ void RemoteGraphicsContextGL::readPixelsSharedMemory(WebCore::IntRect rect, uint
 {
     assertIsCurrent(workQueue());
     std::optional<WebCore::IntSize> readArea;
-    if (!handle.isNull()) {
-        handle.setOwnershipOfMemory(m_resourceOwner, WebKit::MemoryLedger::Default);
-        if (auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite))
-            readArea = m_context->readPixelsWithStatus(rect, format, type, std::span<uint8_t>(static_cast<uint8_t*>(buffer->data()), buffer->size()));
-        else
-            m_context->addError(GCGLErrorCode::InvalidOperation);
-    } else
+
+    handle.setOwnershipOfMemory(m_resourceOwner, WebKit::MemoryLedger::Default);
+    if (auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite))
+        readArea = m_context->readPixelsWithStatus(rect, format, type, std::span<uint8_t>(static_cast<uint8_t*>(buffer->data()), buffer->size()));
+    else
         m_context->addError(GCGLErrorCode::InvalidOperation);
+
     completionHandler(readArea);
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -57,7 +57,9 @@ RemoteAudioSourceProviderProxy::~RemoteAudioSourceProviderProxy() = default;
 
 std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configureAudioStorage(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
-    auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, frameCount);
+    auto result = ProducerSharedCARingBuffer::allocate(format, frameCount);
+    RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
+    auto [ringBuffer, handle] = WTFMove(*result);
     m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
     // Use a redundant variable to avoid move in return position and to obtain copy elision. Clang or libc++ does not allow returning covariant of Ts from std::unique_ptr<T>s in this position.
     std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTFMove(ringBuffer);  // NOLINT: see above.

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -122,6 +122,14 @@ JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, O
     return result;
 }
 
+template<typename U>
+JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, std::optional<U>&& value)
+{
+    if (!value)
+        return JSC::JSValue();
+    return jsValueForDecodedArgumentValue(globalObject, std::forward<U>(*value));
+}
+
 bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalObject*, JSC::JSArray*, unsigned index, JSC::JSValue, DataReference buffer);
 
 template<typename... Elements>

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -41,7 +41,6 @@ class StreamConnectionWorkQueue;
 
 struct StreamServerConnectionHandle {
     WTF_MAKE_NONCOPYABLE(StreamServerConnectionHandle);
-    StreamServerConnectionHandle() = default;
     StreamServerConnectionHandle(Connection::Handle&& connection, StreamConnectionBuffer::Handle&& bufferHandle)
         : outOfStreamConnection(WTFMove(connection))
         , buffer(WTFMove(bufferHandle))

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -188,10 +188,13 @@ bool Connection::processMessage()
             return false;
         }
 
-        WebKit::SharedMemory::Handle handle;
-        handle.m_size = messageInfo.bodySize();
-        handle.m_handle = UnixFileDescriptor { m_fileDescriptors[attachmentFileDescriptorCount - 1], UnixFileDescriptor::Adopt };
+        auto fd = UnixFileDescriptor { m_fileDescriptors[attachmentFileDescriptorCount - 1], UnixFileDescriptor::Adopt };
+        if (!fd) {
+            ASSERT_NOT_REACHED();
+            return false;
+        }
 
+        auto handle = WebKit::SharedMemory::Handle { WTFMove(fd), messageInfo.bodySize() };
         oolMessageBody = WebKit::SharedMemory::map(WTFMove(handle), WebKit::SharedMemory::Protection::ReadOnly);
         if (!oolMessageBody) {
             ASSERT_NOT_REACHED();

--- a/Source/WebKit/Platform/SharedMemory.cpp
+++ b/Source/WebKit/Platform/SharedMemory.cpp
@@ -37,11 +37,7 @@ SharedMemoryHandle::SharedMemoryHandle(SharedMemoryHandle::Type&& handle, size_t
     : m_handle(WTFMove(handle))
     , m_size(size)
 {
-}
-
-bool SharedMemoryHandle::isNull() const
-{
-    return !m_handle;
+    RELEASE_ASSERT(!!m_handle);
 }
 
 RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buffer)

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -71,13 +71,10 @@ public:
         Win32Handle;
 #endif
 
-    SharedMemoryHandle() = default;
     SharedMemoryHandle(SharedMemoryHandle&&) = default;
     SharedMemoryHandle(SharedMemoryHandle::Type&&, size_t);
 
     SharedMemoryHandle& operator=(SharedMemoryHandle&&) = default;
-
-    bool isNull() const;
 
     size_t size() const { return m_size; }
 

--- a/Source/WebKit/Platform/SharedMemory.serialization.in
+++ b/Source/WebKit/Platform/SharedMemory.serialization.in
@@ -33,13 +33,13 @@ webkit_platform_header: <wtf/win/Win32Handle.h> "ArgumentCodersWin.h"
 
 [CustomHeader, RValue, WebKitPlatform] class WebKit::SharedMemoryHandle {
 #if USE(UNIX_DOMAIN_SOCKETS)
-    UnixFileDescriptor m_handle;
+    [Validator='!!m_handle'] UnixFileDescriptor m_handle;
 #endif
 #if OS(DARWIN)
-    MachSendRight m_handle;
+    [Validator='!!m_handle'] MachSendRight m_handle;
 #endif
 #if OS(WINDOWS)
-    Win32Handle m_handle;
+    [Validator='!!m_handle'] Win32Handle m_handle;
 #endif
     size_t m_size;
 };

--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -181,9 +181,6 @@ RefPtr<SharedMemory> SharedMemory::wrapMap(void* data, size_t size, Protection p
 
 RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
 {
-    if (handle.isNull())
-        return nullptr;
-
     vm_prot_t vmProtection = machProtection(protection);
     mach_vm_address_t mappedAddress = 0;
 
@@ -214,18 +211,10 @@ SharedMemory::~SharedMemory()
     
 auto SharedMemory::createHandle(Protection protection) -> std::optional<Handle>
 {
-    Handle handle;
-    ASSERT(!handle.m_handle);
-    ASSERT(!handle.m_size);
-
     auto sendRight = createSendRight(protection);
     if (!sendRight)
         return std::nullopt;
-
-    handle.m_handle = WTFMove(sendRight);
-    handle.m_size = m_size;
-
-    return WTFMove(handle);
+    return { Handle(WTFMove(sendRight), m_size) };
 }
 
 WTF::MachSendRight SharedMemory::createSendRight(Protection protection) const

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -139,7 +139,6 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 
 RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
 {
-    ASSERT(!handle.isNull());
     void* data = mmap(0, handle.size(), accessModeMMap(protection), MAP_SHARED, handle.m_handle.value(), 0);
     if (data == MAP_FAILED)
         return nullptr;
@@ -173,10 +172,6 @@ SharedMemory::~SharedMemory()
 
 auto SharedMemory::createHandle(Protection) -> std::optional<Handle>
 {
-    Handle handle;
-    ASSERT_ARG(handle, handle.isNull());
-    ASSERT(m_fileDescriptor);
-
     // FIXME: Handle the case where the passed Protection is ReadOnly.
     // See https://bugs.webkit.org/show_bug.cgi?id=131542.
 
@@ -185,9 +180,7 @@ auto SharedMemory::createHandle(Protection) -> std::optional<Handle>
         ASSERT_NOT_REACHED();
         return std::nullopt;
     }
-    handle.m_handle = WTFMove(duplicate);
-    handle.m_size = m_size;
-    return { WTFMove(handle) };
+    return { Handle(WTFMove(duplicate), m_size) };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -160,6 +160,7 @@ def types_that_must_be_moved():
         'std::optional<MachSendRight>',
         'std::optional<WebKit::ShareableBitmap::Handle>',
         'std::optional<WebKit::ShareableResource::Handle>',
+        'std::optional<WebKit::SharedMemory::Handle>',
         'std::optional<WebKit::SharedVideoFrame::Buffer>',
         'std::optional<Win32Handle>'
     ]

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint
     return result;
 }
 
-ProducerSharedCARingBuffer::Pair ProducerSharedCARingBuffer::allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
+std::optional<ProducerSharedCARingBuffer::Pair> ProducerSharedCARingBuffer::allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
     frameCount = WTF::roundUpToPowerOfTwo(frameCount);
     auto bytesPerFrame = format.bytesPerFrame();
@@ -73,20 +73,20 @@ ProducerSharedCARingBuffer::Pair ProducerSharedCARingBuffer::allocate(const WebC
     auto checkedSharedMemorySize = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams) + sizeof(TimeBoundsBuffer);
     if (checkedSharedMemorySize.hasOverflowed()) {
         RELEASE_LOG_FAULT(Media, "ProducerSharedCARingBuffer::allocate: Overflowed when trying to compute the storage size");
-        return { nullptr, { } };
+        return std::nullopt;
     }
     auto sharedMemory = SharedMemory::allocate(checkedSharedMemorySize.value());
     if (!sharedMemory)
-        return { nullptr, { } };
+        return std::nullopt;
 
     auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
     if (!handle)
-        return { nullptr, { } };
+        return std::nullopt;
 
     new (NotNull, sharedMemory->data()) TimeBoundsBuffer;
     std::unique_ptr<ProducerSharedCARingBuffer> result { new ProducerSharedCARingBuffer { bytesPerFrame, frameCount, numChannelStreams, sharedMemory.releaseNonNull() } };
     result->initialize();
-    return { WTFMove(result), { WTFMove(*handle), frameCount } };
+    return Pair { WTFMove(result), { WTFMove(*handle), frameCount } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -69,7 +69,7 @@ public:
         std::unique_ptr<ProducerSharedCARingBuffer> producer;
         ConsumerSharedCARingBuffer::Handle consumer;
     };
-    static Pair allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount);
+    static std::optional<Pair> allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount);
 protected:
     using SharedCARingBufferBase::SharedCARingBufferBase;
 };

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -440,11 +440,10 @@ void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder& encoder, const We
     const auto& creationData = platformData.creationData();
     encoder << static_cast<bool>(creationData);
     if (creationData) {
-        WebKit::SharedMemory::Handle handle;
+        std::optional<WebKit::SharedMemory::Handle> handle;
         {
             auto sharedMemoryBuffer = WebKit::SharedMemory::copyBuffer(creationData->fontFaceData);
-            if (auto memoryHandle = sharedMemoryBuffer->createHandle(WebKit::SharedMemory::Protection::ReadOnly))
-                handle = WTFMove(*memoryHandle);
+            handle = sharedMemoryBuffer->createHandle(WebKit::SharedMemory::Protection::ReadOnly);
         }
         encoder << creationData->fontFaceData->size();
         encoder << WTFMove(handle);
@@ -507,12 +506,14 @@ std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePla
         if (!bufferSize)
             return std::nullopt;
 
-        std::optional<WebKit::SharedMemory::Handle> handle;
-        decoder >> handle;
-        if (!handle)
+        auto handle = decoder.decode<std::optional<WebKit::SharedMemory::Handle>>();
+        if (UNLIKELY(!decoder.isValid()))
             return std::nullopt;
 
-        auto sharedMemoryBuffer = WebKit::SharedMemory::map(WTFMove(*handle), WebKit::SharedMemory::Protection::ReadOnly);
+        if (!*handle)
+            return std::nullopt;
+
+        auto sharedMemoryBuffer = WebKit::SharedMemory::map(WTFMove(**handle), WebKit::SharedMemory::Protection::ReadOnly);
         if (!sharedMemoryBuffer)
             return std::nullopt;
 

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -76,15 +76,15 @@ void IPCStreamTester::stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnecti
     workQueue().stopAndWaitForCompletion();
 }
 
-void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::Handle)>&& completionHandler)
+void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
 {
-    auto result = [&]() -> SharedMemory::Handle {
+    auto result = [&]() -> std::optional<SharedMemory::Handle> {
         auto sharedMemory = WebKit::SharedMemory::allocate(byteCount);
         if (!sharedMemory)
-            return { };
+            return std::nullopt;
         auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
         if (!handle)
-            return { };
+            return std::nullopt;
         uint8_t* data = static_cast<uint8_t*>(sharedMemory->data());
         for (size_t i = 0; i < sharedMemory->size(); ++i)
             data[i] = i;

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -58,7 +58,7 @@ private:
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
 
     // Messages.
-    void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(SharedMemory::Handle)>&&);
+    void syncMessageReturningSharedMemory1(uint32_t byteCount, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);
     void checkAutoreleasePool(CompletionHandler<void(int32_t)>&&);
     void asyncMessage(bool value, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(IPC_TESTING_API)
 
 messages -> IPCStreamTester NotRefCounted Stream {
-    SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (WebKit::SharedMemory::Handle handle) Synchronous NotStreamEncodableReply
+    SyncMessageReturningSharedMemory1(uint32_t byteCount) -> (std::optional<WebKit::SharedMemory::Handle> handle) Synchronous NotStreamEncodableReply
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous
 
     CheckAutoreleasePool() -> (int32_t previousUseCount) Synchronous

--- a/Source/WebKit/Shared/ShareableBitmap.serialization.in
+++ b/Source/WebKit/Shared/ShareableBitmap.serialization.in
@@ -34,7 +34,7 @@ header: "ShareableBitmap.h"
 }
 
 [CustomHeader, RValue] class WebKit::ShareableBitmapHandle {
-    [Validator='!m_handle->isNull()'] WebKit::SharedMemoryHandle m_handle;
+    WebKit::SharedMemoryHandle m_handle;
     [Validator='!m_configuration->sizeInBytes().hasOverflowed() && m_handle->size() >= m_configuration->sizeInBytes()'] WebKit::ShareableBitmapConfiguration m_configuration;
 }
 

--- a/Source/WebKit/Shared/ShareableBitmapHandle.cpp
+++ b/Source/WebKit/Shared/ShareableBitmapHandle.cpp
@@ -38,7 +38,6 @@ ShareableBitmapHandle::ShareableBitmapHandle(SharedMemory::Handle&& handle, cons
     : m_handle(WTFMove(handle))
     , m_configuration(config)
 {
-    ASSERT(!m_handle.isNull());
 }
 
 void ShareableBitmapHandle::takeOwnershipOfMemory(MemoryLedger ledger) const

--- a/Source/WebKit/Shared/ShareableResource.cpp
+++ b/Source/WebKit/Shared/ShareableResource.cpp
@@ -40,7 +40,6 @@ ShareableResourceHandle::ShareableResourceHandle(SharedMemory::Handle&& handle, 
     , m_offset(offset)
     , m_size(size)
 {
-    ASSERT(!m_handle.isNull());
 }
 
 RefPtr<SharedBuffer> ShareableResource::wrapInSharedBuffer()

--- a/Source/WebKit/Shared/ShareableResource.serialization.in
+++ b/Source/WebKit/Shared/ShareableResource.serialization.in
@@ -24,7 +24,7 @@ header: "ShareableResource.h"
 
 #if ENABLE(SHAREABLE_RESOURCE)
 [CustomHeader, RValue] class WebKit::ShareableResourceHandle {
-    [Validator='!m_handle->isNull()'] WebKit::SharedMemoryHandle m_handle;
+    WebKit::SharedMemoryHandle m_handle;
     unsigned m_offset;
     [Validator='!(Checked<unsigned> { *m_offset } + *m_size).hasOverflowed() && (*m_offset + *m_size <= m_handle->size())'] unsigned m_size;
 }

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -157,7 +157,7 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , dictionaryPopupInfo(dictionaryPopupInfo)
         , linkTextIndicator(linkTextIndicator)
 {
-    if (imageHandle && !imageHandle->isNull())
+    if (imageHandle)
         imageSharedMemory = WebKit::SharedMemory::map(WTFMove(*imageHandle), WebKit::SharedMemory::Protection::ReadOnly);
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -235,7 +235,9 @@ private:
             m_frameChunkSize = std::max(WebCore::AudioUtilities::renderQuantumSize, AudioSession::sharedSession().preferredBufferSize());
 
             // Allocate a ring buffer large enough to contain 2 seconds of audio.
-            auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(*m_description, m_description->sampleRate() * 2);
+            auto result = ProducerSharedCARingBuffer::allocate(*m_description, m_description->sampleRate() * 2);
+            RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
+            auto [ringBuffer, handle] = WTFMove(*result);
             m_ringBuffer = WTFMove(ringBuffer);
             m_connection->send(Messages::RemoteCaptureSampleManager::AudioStorageChanged(m_id, WTFMove(handle), *m_description, *m_captureSemaphore, m_startTime, m_frameChunkSize), 0);
         }

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -612,7 +612,6 @@ void WebPageProxy::performActionOnElements(uint32_t action, Vector<WebCore::Elem
 
 void WebPageProxy::saveImageToLibrary(SharedMemory::Handle&& imageHandle, const String& authorizationToken)
 {
-    MESSAGE_CHECK(!imageHandle.isNull());
     MESSAGE_CHECK(isValidPerformActionOnElementAuthorizationToken(authorizationToken));
 
     auto sharedMemoryBuffer = SharedMemory::map(WTFMove(imageHandle), SharedMemory::Protection::ReadOnly);

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -252,7 +252,6 @@ void WebPageProxy::setPromisedDataForImage(const String& pasteboardName, SharedM
 {
     MESSAGE_CHECK_URL(url);
     MESSAGE_CHECK_URL(visibleURL);
-    MESSAGE_CHECK(!imageHandle.isNull());
     MESSAGE_CHECK(extension == FileSystem::lastComponentOfPathIgnoringTrailingSlash(extension));
 
     auto sharedMemoryImage = SharedMemory::map(WTFMove(imageHandle), SharedMemory::Protection::ReadOnly);
@@ -261,12 +260,10 @@ void WebPageProxy::setPromisedDataForImage(const String& pasteboardName, SharedM
     auto imageBuffer = sharedMemoryImage->createSharedBuffer(sharedMemoryImage->size());
 
     RefPtr<FragmentedSharedBuffer> archiveBuffer;
-    if (!archiveHandle.isNull()) {
-        auto sharedMemoryArchive = SharedMemory::map(WTFMove(archiveHandle), SharedMemory::Protection::ReadOnly);
-        if (!sharedMemoryArchive)
-            return;
-        archiveBuffer = sharedMemoryArchive->createSharedBuffer(sharedMemoryArchive->size());
-    }
+    auto sharedMemoryArchive = SharedMemory::map(WTFMove(archiveHandle), SharedMemory::Protection::ReadOnly);
+    if (!sharedMemoryArchive)
+        return;
+    archiveBuffer = sharedMemoryArchive->createSharedBuffer(sharedMemoryArchive->size());
     pageClient().setPromisedDataForImage(pasteboardName, WTFMove(imageBuffer), ResourceResponseBase::sanitizeSuggestedFilename(filename), extension, title, url, visibleURL, WTFMove(archiveBuffer), originIdentifier);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -388,7 +388,7 @@ void RemoteGraphicsContextGLProxy::readPixels(IntRect rect, GCGLenum format, GCG
         if (!replyBuffer)
             goto inlineCase;
         auto handle = replyBuffer->createHandle(SharedMemory::Protection::ReadWrite);
-        if (!handle || handle->isNull())
+        if (!handle)
             goto inlineCase;
         auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ReadPixelsSharedMemory(rect, format, type, WTFMove(*handle)));
         if (!sendResult.succeeded()) {

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -181,7 +181,9 @@ void AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start()
     m_isPlaying = true;
 
     m_numberOfFrames = m_description->sampleRate() * 2;
-    auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(*m_description, m_numberOfFrames);
+    auto result = ProducerSharedCARingBuffer::allocate(*m_description, m_numberOfFrames);
+    RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
+    auto [ringBuffer, handle] = WTFMove(*result);
     m_ringBuffer = WTFMove(ringBuffer);
     WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { m_identifier, WTFMove(handle), *m_semaphore }, 0);
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -123,7 +123,9 @@ void MediaRecorderPrivate::audioSamplesAvailable(const MediaTime& time, const Pl
         // Allocate a ring buffer large enough to contain 2 seconds of audio.
         m_numberOfFrames = m_description->sampleRate() * 2;
         auto& format = m_description->streamDescription();
-        auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, m_numberOfFrames);
+        auto result = ProducerSharedCARingBuffer::allocate(format, m_numberOfFrames);
+        RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
+        auto [ringBuffer, handle] = WTFMove(*result);
         m_ringBuffer = WTFMove(ringBuffer);
         m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format }, m_identifier);
         m_silenceAudioBuffer = nullptr;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -103,7 +103,9 @@ private:
             m_description = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
             size_t numberOfFrames = m_description->sampleRate() * 2;
             auto& format = m_description->streamDescription();
-            auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, numberOfFrames);
+            auto result = ProducerSharedCARingBuffer::allocate(format, numberOfFrames);
+            RELEASE_ASSERT(result); // FIXME(https://bugs.webkit.org/show_bug.cgi?id=262690): Handle allocation failure.
+            auto [ringBuffer, handle] = WTFMove(*result);
             m_ringBuffer = WTFMove(ringBuffer);
             m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::SetStorage(m_identifier, WTFMove(handle), format), 0);
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -216,7 +216,6 @@ int64_t WebPlatformStrategies::setTypes(const Vector<String>& pasteboardTypes, c
 
 int64_t WebPlatformStrategies::setBufferForType(SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
-    SharedMemory::Handle handle;
     // FIXME: Null check prevents crashing, but it is not great that we will have empty pasteboard content for this type,
     // because we've already set the types.
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardBufferForType(pasteboardName, pasteboardType, buffer ? RefPtr { buffer } : SharedBuffer::create(), pageIdentifier(context)), 0);

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -307,7 +307,7 @@ public:
     }
 
     size_t size() const { return m_sharedMemory->size(); }
-    SharedMemory::Handle createHandle(SharedMemory::Protection);
+    std::optional<SharedMemory::Handle> createHandle(SharedMemory::Protection);
 
     JSObjectRef createJSWrapper(JSContextRef);
     static JSSharedMemory* toWrapped(JSContextRef, JSValueRef);
@@ -1357,11 +1357,9 @@ JSValueRef JSIPCSemaphore::waitFor(JSContextRef context, JSObjectRef, JSObjectRe
     return JSValueMakeBoolean(context, result);
 }
 
-SharedMemory::Handle JSSharedMemory::createHandle(SharedMemory::Protection protection)
+std::optional<SharedMemory::Handle> JSSharedMemory::createHandle(SharedMemory::Protection protection)
 {
-    if (auto handle = m_sharedMemory->createHandle(protection))
-        return WTFMove(*handle);
-    return { };
+    return m_sharedMemory->createHandle(protection);
 }
 
 JSObjectRef JSSharedMemory::createJSWrapper(JSContextRef context)
@@ -2008,8 +2006,10 @@ static bool encodeSharedMemory(IPC::Encoder& encoder, JSC::JSGlobalObject* globa
         protection = SharedMemory::Protection::ReadOnly;
     else if (!equalLettersIgnoringASCIICase(protectionValue, "readwrite"_s))
         return false;
-
-    encoder << jsSharedMemory->createHandle(protection);
+    auto handle = jsSharedMemory->createHandle(protection);
+    if (!handle)
+        return false;
+    encoder << WTFMove(*handle);
     return true;
 }
 
@@ -2985,13 +2985,7 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* glob
     using SharedMemory = WebKit::SharedMemory;
     using Protection = WebKit::SharedMemory::Protection;
 
-    auto& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype());
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue());
-    object->putDirect(vm, JSC::Identifier::fromString(vm, "type"_s), JSC::jsNontrivialString(vm, "SharedMemory"_s));
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue());
-
+    auto dataSize = value.size();
     auto protection = Protection::ReadWrite;
     auto sharedMemory = SharedMemory::map(WTFMove(value), protection);
     if (!sharedMemory) {
@@ -3001,11 +2995,18 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* glob
             return JSC::JSValue();
     }
 
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype());
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue());
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "type"_s), JSC::jsNontrivialString(vm, "SharedMemory"_s));
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue());
+
     auto jsValue = toJS(globalObject, WebKit::IPCTestingAPI::JSSharedMemory::create(sharedMemory.releaseNonNull())->createJSWrapper(toRef(globalObject)));
     object->putDirect(vm, JSC::Identifier::fromString(vm, "value"_s), jsValue);
     RETURN_IF_EXCEPTION(scope, JSC::JSValue());
 
-    object->putDirect(vm, JSC::Identifier::fromString(vm, "dataSize"_s), JSC::JSValue(value.size()));
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "dataSize"_s), JSC::JSValue(dataSize));
     RETURN_IF_EXCEPTION(scope, JSC::JSValue());
 
     object->putDirect(vm, JSC::Identifier::fromString(vm, "protection"_s), JSC::jsNontrivialString(vm, protection == Protection::ReadWrite ? "ReadWrite"_s : "ReadOnly"_s));

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3505,15 +3505,16 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
         RefPtr<FragmentedSharedBuffer> buffer = cachedImage->resourceBuffer();
         if (!buffer)
             return;
-        SharedMemory::Handle handle;
+        std::optional<SharedMemory::Handle> handle;
         {
             auto sharedMemoryBuffer = SharedMemory::copyBuffer(*buffer);
             if (!sharedMemoryBuffer)
                 return;
-            if (auto memoryHandle = sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly))
-                handle = WTFMove(*memoryHandle);
+            handle = sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly);
         }
-        send(Messages::WebPageProxy::SaveImageToLibrary(WTFMove(handle), authorizationToken));
+        if (!handle)
+            return;
+        send(Messages::WebPageProxy::SaveImageToLibrary(WTFMove(*handle), authorizationToken));
     }
 
     handleAnimationActions(element, action);


### PR DESCRIPTION
#### ca84d41f56be91a82968e7464eb0d1379178767f
<pre>
SharedMemory::Handle should always be valid
<a href="https://bugs.webkit.org/show_bug.cgi?id=261695">https://bugs.webkit.org/show_bug.cgi?id=261695</a>

Reviewed by Kimmo Kinnunen.

A `SharedMemory::Handle` should always be valid. Remove the `isNull`
method and default constructor. Instead of `isNull` checks use
`std::optional&lt;SharedMemory::Handle&gt;`. Validate the handle within the
generated serialization.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::readPixelsSharedMemory):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(RemoteAudioDestinationManager::createAudioDestination):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::configureAudioStorage):
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::jsValueForDecodedArgumentValue):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::encode const):
(IPC::SharedBufferReference::decode):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::processMessage):
* Source/WebKit/Platform/SharedMemory.cpp:
(WebKit::SharedMemoryHandle::SharedMemoryHandle):
(WebKit::SharedMemoryHandle::isNull const): Deleted.
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/SharedMemory.serialization.in:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::createHandle):
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::createHandle):
* Source/WebKit/Platform/win/SharedMemoryWin.cpp:
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::createHandle):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ProducerSharedCARingBuffer::allocate):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::encodePlatformData):
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::decodePlatformData):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncMessageReturningSharedMemory1):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Source/WebKit/Shared/ShareableBitmap.serialization.in:
* Source/WebKit/Shared/ShareableBitmapHandle.cpp:
(WebKit::ShareableBitmapHandle::ShareableBitmapHandle):
* Source/WebKit/Shared/ShareableResource.cpp:
(WebKit::ShareableResourceHandle::ShareableResourceHandle):
* Source/WebKit/Shared/ShareableResource.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encode):
(IPC::ArgumentCoder&lt;FontCustomPlatformData&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::decode):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::saveImageToLibrary):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::setPromisedDataForImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::readPixels):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::connection):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::audioSamplesAvailable):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::setBufferForType):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSSharedMemory::createHandle):
(WebKit::IPCTestingAPI::encodeSharedMemory):
(IPC::jsValueForDecodedArgumentValue):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::performActionOnElement):

Canonical link: <a href="https://commits.webkit.org/269164@main">https://commits.webkit.org/269164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2556f71e5cefa92891ada45c4b9e4a5712e7434e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21749 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/22004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20137 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22282 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21977 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/21579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24470 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/21927 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/19787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23851 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19717 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5190 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->