### PR TITLE
Use more smart pointers in Source/WebKit

### DIFF
--- a/Source/WebKit/Shared/UserData.h
+++ b/Source/WebKit/Shared/UserData.h
@@ -50,6 +50,7 @@ public:
     static RefPtr<API::Object> transform(API::Object*, const Transformer&);
 
     API::Object* object() const { return m_object.get(); }
+    RefPtr<API::Object> protectedObject() const { return m_object; }
 
     void encode(IPC::Encoder&) const;
     static bool decode(IPC::Decoder&, UserData&) WARN_UNUSED_RETURN;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -109,7 +109,7 @@ UserMediaPermissionRequestManagerProxy::~UserMediaPermissionRequestManagerProxy(
 {
     m_page.sendWithAsyncReply(Messages::WebPage::StopMediaCapture { MediaProducerMediaCaptureKind::EveryKind }, [] { });
 #if ENABLE(MEDIA_STREAM)
-    UserMediaProcessManager::singleton().revokeSandboxExtensionsIfNeeded(page().process());
+    UserMediaProcessManager::singleton().revokeSandboxExtensionsIfNeeded(page().protectedProcess());
     proxies().remove(this);
 #endif
     invalidatePendingRequests();

--- a/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
@@ -140,8 +140,9 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
     // On iOS, WebKit normally provides the location. However, if the client sets a coreLocationProvider, then we use that one instead.
     // This is useful for WebKitTestRunner to provide a dummy geolocation provider. It is also used by certain apps to deny all
     // geolocation authorization as a way to disable support for geolocation.
-    if (wrapper(processPool)._coreLocationProvider) {
-        _geolocationManager = processPool.supplement<WebKit::WebGeolocationManagerProxy>();
+    Ref protectedProcessPool { processPool };
+    if (wrapper(protectedProcessPool.get())._coreLocationProvider) {
+        _geolocationManager = protectedProcessPool->supplement<WebKit::WebGeolocationManagerProxy>();
         WKGeolocationProviderV1 providerCallback = {
             { 1, self },
             startUpdatingCallback,
@@ -149,7 +150,7 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
             setEnableHighAccuracy
         };
         WKGeolocationManagerSetProvider(toAPI(_geolocationManager.get()), &providerCallback.base);
-        _coreLocationProvider = wrapper(processPool)._coreLocationProvider;
+        _coreLocationProvider = wrapper(protectedProcessPool.get())._coreLocationProvider;
         [_coreLocationProvider setListener:self];
     }
     return self;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -196,8 +196,10 @@ private:
     void initializeEncoderInternal(Encoder&, uint16_t width, uint16_t height, unsigned startBitrate, unsigned maxBitrate, unsigned minBitrate, uint32_t maxFramerate);
 
 private:
-    HashMap<VideoDecoderIdentifier, std::unique_ptr<Decoder>> m_decoders WTF_GUARDED_BY_CAPABILITY(workQueue());
+    RefPtr<IPC::Connection> protectedConnection() const WTF_REQUIRES_LOCK(m_connectionLock) { return m_connection; }
+    RefPtr<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const WTF_REQUIRES_LOCK(m_connectionLock);
 
+    HashMap<VideoDecoderIdentifier, std::unique_ptr<Decoder>> m_decoders WTF_GUARDED_BY_CAPABILITY(workQueue());
     Lock m_encodersConnectionLock;
     HashMap<VideoEncoderIdentifier, std::unique_ptr<Encoder>> m_encoders WTF_GUARDED_BY_CAPABILITY(workQueue());
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/ChromeClient.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 class HTMLImageElement;
@@ -48,7 +49,8 @@ public:
     WebChromeClient(WebPage&);
     ~WebChromeClient();
 
-    WebPage& page() const { return m_page; }
+    WebPage& page() const { return m_page.get(); }
+    Ref<WebPage> protectedPage() const;
 
 private:
     void chromeDestroyed() final;
@@ -491,7 +493,7 @@ private:
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 
-    WebPage& m_page;
+    CheckedRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
@@ -44,7 +44,7 @@ WebDataListSuggestionPicker::WebDataListSuggestionPicker(WebPage& page, WebCore:
 
 void WebDataListSuggestionPicker::handleKeydownWithIdentifier(const String& key)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::HandleKeydownInDataList(key), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::HandleKeydownInDataList(key), m_page.get().identifier());
 }
 
 void WebDataListSuggestionPicker::didSelectOption(const String& selectedOption)
@@ -59,7 +59,7 @@ void WebDataListSuggestionPicker::didCloseSuggestions()
 
 void WebDataListSuggestionPicker::close()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::EndDataListSuggestions(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::EndDataListSuggestions(), m_page.get().identifier());
 }
 
 void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSuggestionActivationType type)
@@ -70,10 +70,11 @@ void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSug
         return;
     }
 
-    m_page.setActiveDataListSuggestionPicker(*this);
+    Ref page { m_page.get() };
+    page->setActiveDataListSuggestionPicker(*this);
 
     WebCore::DataListSuggestionInformation info { type, WTFMove(suggestions), m_client.elementRectInRootViewCoordinates() };
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowDataListSuggestions(info), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowDataListSuggestions(info), page->identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
@@ -28,6 +28,7 @@
 #if ENABLE(DATALIST_ELEMENT)
 
 #include <WebCore/DataListSuggestionPicker.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 class DataListSuggestionsClient;
@@ -50,7 +51,7 @@ private:
     void close() final;
 
     WebCore::DataListSuggestionsClient& m_client;
-    WebPage& m_page;
+    CheckedRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
@@ -54,13 +54,14 @@ void WebDateTimeChooser::didEndChooser()
 
 void WebDateTimeChooser::endChooser()
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::EndDateTimePicker(), m_page.identifier());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::EndDateTimePicker(), m_page.get().identifier());
 }
 
 void WebDateTimeChooser::showChooser(const WebCore::DateTimeChooserParameters& params)
 {
-    m_page.setActiveDateTimeChooser(*this);
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowDateTimePicker(params), m_page.identifier());
+    Ref page { m_page.get() };
+    page->setActiveDateTimeChooser(*this);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPageProxy::ShowDateTimePicker(params), page->identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h
@@ -28,6 +28,7 @@
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)
 
 #include <WebCore/DateTimeChooser.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 class DateTimeChooserClient;
@@ -50,7 +51,7 @@ private:
     void showChooser(const WebCore::DateTimeChooserParameters&) final;
 
     WebCore::DateTimeChooserClient& m_client;
-    WebPage& m_page;
+    CheckedRef<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -44,7 +44,7 @@ public:
 
     WebPage* page();
 
-    void disconnectFromPage() { m_page = 0; }
+    void disconnectFromPage() { m_page = nullptr; }
     void didChangeSelectedIndex(int newIndex);
     void setTextForIndex(int newIndex);
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
@@ -53,7 +53,7 @@ using namespace WebCore;
 
 void WebChromeClient::didPreventDefaultForEvent()
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page().mainFrame());
     if (!localMainFrame)
         return;
     ContentChangeObserver::didPreventDefaultForEvent(*localMainFrame);
@@ -63,7 +63,7 @@ void WebChromeClient::didPreventDefaultForEvent()
 
 void WebChromeClient::didReceiveMobileDocType(bool isMobileDoctype)
 {
-    m_page.didReceiveMobileDocType(isMobileDoctype);
+    protectedPage()->didReceiveMobileDocType(isMobileDoctype);
 }
 
 void WebChromeClient::setNeedsScrollNotifications(WebCore::LocalFrame&, bool)
@@ -73,12 +73,12 @@ void WebChromeClient::setNeedsScrollNotifications(WebCore::LocalFrame&, bool)
 
 void WebChromeClient::didFinishContentChangeObserving(WebCore::LocalFrame&, WKContentChange observedContentChange)
 {
-    m_page.didFinishContentChangeObserving(observedContentChange);
+    protectedPage()->didFinishContentChangeObserving(observedContentChange);
 }
 
 void WebChromeClient::notifyRevealedSelectionByScrollingFrame(WebCore::LocalFrame&)
 {
-    m_page.didScrollSelection();
+    protectedPage()->didScrollSelection();
 }
 
 bool WebChromeClient::isStopping()
@@ -90,24 +90,24 @@ bool WebChromeClient::isStopping()
 void WebChromeClient::didLayout(LayoutType type)
 {
     if (type == Scroll)
-        m_page.didScrollSelection();
+        protectedPage()->didScrollSelection();
 }
 
 void WebChromeClient::didStartOverflowScroll()
 {
     // FIXME: This is only relevant for legacy touch-driven overflow in the web process (see ScrollAnimatorIOS::handleTouchEvent), and should be removed.
-    m_page.send(Messages::WebPageProxy::ScrollingNodeScrollWillStartScroll(0));
+    protectedPage()->send(Messages::WebPageProxy::ScrollingNodeScrollWillStartScroll(0));
 }
 
 void WebChromeClient::didEndOverflowScroll()
 {
     // FIXME: This is only relevant for legacy touch-driven overflow in the web process (see ScrollAnimatorIOS::handleTouchEvent), and should be removed.
-    m_page.send(Messages::WebPageProxy::ScrollingNodeScrollDidEndScroll(0));
+    protectedPage()->send(Messages::WebPageProxy::ScrollingNodeScrollDidEndScroll(0));
 }
 
 bool WebChromeClient::hasStablePageScaleFactor() const
 {
-    return m_page.hasStablePageScaleFactor();
+    return protectedPage()->hasStablePageScaleFactor();
 }
 
 void WebChromeClient::suppressFormNotifications()
@@ -137,18 +137,19 @@ void WebChromeClient::webAppOrientationsUpdated()
 
 void WebChromeClient::showPlaybackTargetPicker(bool hasVideo, WebCore::RouteSharingPolicy policy, const String& routingContextUID)
 {
-    m_page.send(Messages::WebPageProxy::ShowPlaybackTargetPicker(hasVideo, m_page.rectForElementAtInteractionLocation(), policy, routingContextUID));
+    auto page = protectedPage();
+    page->send(Messages::WebPageProxy::ShowPlaybackTargetPicker(hasVideo, page->rectForElementAtInteractionLocation(), policy, routingContextUID));
 }
 
 Seconds WebChromeClient::eventThrottlingDelay()
 {
-    return m_page.eventThrottlingDelay();
+    return protectedPage()->eventThrottlingDelay();
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
 IntDegrees WebChromeClient::deviceOrientation() const
 {
-    return m_page.deviceOrientation();
+    return protectedPage()->deviceOrientation();
 }
 #endif
 
@@ -172,8 +173,9 @@ bool WebChromeClient::showDataDetectorsUIForElement(const Element& element, cons
     auto& mouseEvent = downcast<MouseEvent>(event);
     auto request = InteractionInformationRequest { roundedIntPoint(mouseEvent.locationInRootViewCoordinates()) };
     request.includeLinkIndicator = true;
-    auto positionInformation = m_page.positionInformation(request);
-    m_page.send(Messages::WebPageProxy::ShowDataDetectorsUIForPositionInformation(positionInformation));
+    auto page = protectedPage();
+    auto positionInformation = page->positionInformation(request);
+    page->send(Messages::WebPageProxy::ShowDataDetectorsUIForPositionInformation(positionInformation));
     return true;
 }
 


### PR DESCRIPTION
#### 06194e66e4b5bb2ef422002a61bd2667ec86d840
<pre>
Use more smart pointers in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261697">https://bugs.webkit.org/show_bug.cgi?id=261697</a>

Reviewed by Darin Adler.

* Source/WebKit/Shared/UserData.h:
(WebKit::UserData::protectedObject const):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::~UserMediaPermissionRequestManagerProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMessage):
(WebKit::WebPageProxy::handleSynchronousMessage):
(WebKit::WebPageProxy::waitForDidUpdateActivityState):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
(WebKit::WebPageProxy::didDisplayInsecureContentForFrame):
(WebKit::WebPageProxy::didRunInsecureContentForFrame):
(WebKit::WebPageProxy::willSubmitForm):
(WebKit::WebPageProxy::mouseDidMoveOverElement):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::handleAutoFillButtonClick):
(WebKit::WebPageProxy::didResignInputElementStrongPasswordAppearance):
* Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm:
(-[WKGeolocationProviderIOS initWithProcessPool:]):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::ensureGPUProcessConnectionOnMainThreadWithLock):
(WebKit::LibWebRTCCodecs::createDecoderInternal):
(WebKit::LibWebRTCCodecs::completedDecoding):
(WebKit::LibWebRTCCodecs::protectedVideoFrameObjectHeapProxy const):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::WTF_REQUIRES_LOCK):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::protectedPage const):
(WebKit::WebChromeClient::setWindowRect):
(WebKit::WebChromeClient::windowRect const):
(WebKit::WebChromeClient::pageRect const):
(WebKit::WebChromeClient::focus):
(WebKit::WebChromeClient::unfocus):
(WebKit::WebChromeClient::elementDidFocus):
(WebKit::WebChromeClient::elementDidRefocus):
(WebKit::WebChromeClient::elementDidBlur):
(WebKit::WebChromeClient::focusedElementDidChangeInputMode):
(WebKit::WebChromeClient::makeFirstResponder):
(WebKit::WebChromeClient::assistiveTechnologyMakeFirstResponder):
(WebKit::WebChromeClient::takeFocus):
(WebKit::WebChromeClient::focusedElementChanged):
(WebKit::WebChromeClient::focusedFrameChanged):
(WebKit::WebChromeClient::createWindow):
(WebKit::WebChromeClient::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
(WebKit::WebChromeClient::show):
(WebKit::WebChromeClient::canRunModal const):
(WebKit::WebChromeClient::runModal):
(WebKit::WebChromeClient::setToolbarsVisible):
(WebKit::WebChromeClient::toolbarsVisible const):
(WebKit::WebChromeClient::setStatusbarVisible):
(WebKit::WebChromeClient::statusbarVisible const):
(WebKit::WebChromeClient::setMenubarVisible):
(WebKit::WebChromeClient::menubarVisible const):
(WebKit::WebChromeClient::setResizable):
(WebKit::WebChromeClient::addMessageToConsole):
(WebKit::WebChromeClient::addMessageWithArgumentsToConsole):
(WebKit::WebChromeClient::canRunBeforeUnloadConfirmPanel):
(WebKit::WebChromeClient::runBeforeUnloadConfirmPanel):
(WebKit::WebChromeClient::closeWindow):
(WebKit::WebChromeClient::runJavaScriptAlert):
(WebKit::WebChromeClient::runJavaScriptConfirm):
(WebKit::WebChromeClient::runJavaScriptPrompt):
(WebKit::WebChromeClient::setStatusbarText):
(WebKit::WebChromeClient::keyboardUIMode):
(WebKit::WebChromeClient::hoverSupportedByPrimaryPointingDevice const):
(WebKit::WebChromeClient::hoverSupportedByAnyAvailablePointingDevice const):
(WebKit::WebChromeClient::pointerCharacteristicsOfPrimaryPointingDevice const):
(WebKit::WebChromeClient::pointerCharacteristicsOfAllAvailablePointingDevices const):
(WebKit::WebChromeClient::requestPointerLock):
(WebKit::WebChromeClient::requestPointerUnlock):
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
(WebKit::WebChromeClient::scroll):
(WebKit::WebChromeClient::screenToRootView const):
(WebKit::WebChromeClient::rootViewToScreen const):
(WebKit::WebChromeClient::accessibilityScreenToRootView const):
(WebKit::WebChromeClient::rootViewToAccessibilityScreen const):
(WebKit::WebChromeClient::didFinishLoadingImageForElement):
(WebKit::WebChromeClient::intrinsicContentsSizeChanged const):
(WebKit::WebChromeClient::contentsSizeChanged const):
(WebKit::WebChromeClient::scrollMainFrameToRevealRect const):
(WebKit::WebChromeClient::mouseDidMoveOverElement):
(WebKit::WebChromeClient::print):
(WebKit::WebChromeClient::reachedApplicationCacheOriginQuota):
(WebKit::WebChromeClient::createColorChooser):
(WebKit::WebChromeClient::createDataListSuggestionPicker):
(WebKit::WebChromeClient::createDateTimeChooser):
(WebKit::WebChromeClient::runOpenPanel):
(WebKit::WebChromeClient::showShareSheet):
(WebKit::WebChromeClient::showContactPicker):
(WebKit::WebChromeClient::setCursor):
(WebKit::WebChromeClient::setCursorHiddenUntilMouseMoves):
(WebKit::WebChromeClient::didAssociateFormControls):
(WebKit::WebChromeClient::shouldNotifyOnFormChanges):
(WebKit::WebChromeClient::createPopupMenu const):
(WebKit::WebChromeClient::createSearchPopupMenu const):
(WebKit::WebChromeClient::graphicsLayerFactory const):
(WebKit::WebChromeClient::displayRefreshMonitorFactory const):
(WebKit::WebChromeClient::createImageBuffer const):
(WebKit::WebChromeClient::sinkIntoImageBuffer):
(WebKit::WebChromeClient::createWorkerClient):
(WebKit::WebChromeClient::createGraphicsContextGL const):
(WebKit::WebChromeClient::createGPUForWebGPU const):
(WebKit::WebChromeClient::createBarcodeDetector const):
(WebKit::WebChromeClient::getBarcodeDetectorSupportedFormats const):
(WebKit::WebChromeClient::createFaceDetector const):
(WebKit::WebChromeClient::createTextDetector const):
(WebKit::WebChromeClient::attachRootGraphicsLayer):
(WebKit::WebChromeClient::attachViewOverlayGraphicsLayer):
(WebKit::WebChromeClient::shouldTriggerRenderingUpdate const):
(WebKit::WebChromeClient::triggerRenderingUpdate):
(WebKit::WebChromeClient::scheduleRenderingUpdate):
(WebKit::WebChromeClient::renderingUpdateFramesPerSecondChanged):
(WebKit::WebChromeClient::remoteImagesCountForTesting const):
(WebKit::WebChromeClient::contentRuleListNotification):
(WebKit::WebChromeClient::layerTreeStateIsFrozen const):
(WebKit::WebChromeClient::createScrollingCoordinator const):
(WebKit::WebChromeClient::createScrollbarsController const):
(WebKit::WebChromeClient::prepareForVideoFullscreen):
(WebKit::WebChromeClient::canEnterVideoFullscreen const):
(WebKit::WebChromeClient::supportsVideoFullscreen):
(WebKit::WebChromeClient::supportsVideoFullscreenStandby):
(WebKit::WebChromeClient::setMockVideoPresentationModeEnabled):
(WebKit::WebChromeClient::enterVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::exitVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::setUpPlaybackControlsManager):
(WebKit::WebChromeClient::clearPlaybackControlsManager):
(WebKit::WebChromeClient::playbackControlsMediaEngineChanged):
(WebKit::WebChromeClient::addMediaUsageManagerSession):
(WebKit::WebChromeClient::updateMediaUsageManagerSessionState):
(WebKit::WebChromeClient::removeMediaUsageManagerSession):
(WebKit::WebChromeClient::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::WebChromeClient::supportsFullScreenForElement):
(WebKit::WebChromeClient::enterFullScreenForElement):
(WebKit::WebChromeClient::exitFullScreenForElement):
(WebKit::WebChromeClient::screenSize const):
(WebKit::WebChromeClient::availableScreenSize const):
(WebKit::WebChromeClient::overrideScreenSize const):
(WebKit::WebChromeClient::screenSizeForFingerprintingProtections const):
(WebKit::WebChromeClient::dispatchDisabledAdaptationsDidChange const):
(WebKit::WebChromeClient::dispatchViewportPropertiesDidChange const):
(WebKit::WebChromeClient::notifyScrollerThumbIsVisibleInRect):
(WebKit::WebChromeClient::recommendedScrollbarStyleDidChange):
(WebKit::WebChromeClient::preferredScrollbarOverlayStyle):
(WebKit::WebChromeClient::underlayColor const):
(WebKit::WebChromeClient::themeColorChanged const):
(WebKit::WebChromeClient::pageExtendedBackgroundColorDidChange const):
(WebKit::WebChromeClient::sampledPageTopColorChanged const):
(WebKit::WebChromeClient::appHighlightsVisiblility const):
(WebKit::WebChromeClient::wheelEventHandlersChanged):
(WebKit::WebChromeClient::plugInStartLabelTitle const):
(WebKit::WebChromeClient::plugInStartLabelSubtitle const):
(WebKit::WebChromeClient::plugInExtraStyleSheet const):
(WebKit::WebChromeClient::plugInExtraScript const):
(WebKit::WebChromeClient::enableSuddenTermination):
(WebKit::WebChromeClient::disableSuddenTermination):
(WebKit::WebChromeClient::didAddHeaderLayer):
(WebKit::WebChromeClient::didAddFooterLayer):
(WebKit::WebChromeClient::shouldUseTiledBackingForFrameView const):
(WebKit::WebChromeClient::isAnyAnimationAllowedToPlayDidChange):
(WebKit::WebChromeClient::isPlayingMediaDidChange):
(WebKit::WebChromeClient::handleAutoplayEvent):
(WebKit::WebChromeClient::wrapCryptoKey const):
(WebKit::WebChromeClient::unwrapCryptoKey const):
(WebKit::WebChromeClient::storeAppHighlight const):
(WebKit::WebChromeClient::setTextIndicator const):
(WebKit::WebChromeClient::handleTelephoneNumberClick):
(WebKit::WebChromeClient::handleClickForDataDetectionResult):
(WebKit::WebChromeClient::handleSelectionServiceClick):
(WebKit::WebChromeClient::handleImageServiceClick):
(WebKit::WebChromeClient::handlePDFServiceClick):
(WebKit::WebChromeClient::shouldDispatchFakeMouseMoveEvents const):
(WebKit::WebChromeClient::handleAutoFillButtonClick):
(WebKit::WebChromeClient::inputElementDidResignStrongPasswordAppearance):
(WebKit::WebChromeClient::addPlaybackTargetPickerClient):
(WebKit::WebChromeClient::removePlaybackTargetPickerClient):
(WebKit::WebChromeClient::showPlaybackTargetPicker):
(WebKit::WebChromeClient::playbackTargetPickerClientStateDidChange):
(WebKit::WebChromeClient::setMockMediaPlaybackTargetPickerEnabled):
(WebKit::WebChromeClient::setMockMediaPlaybackTargetPickerState):
(WebKit::WebChromeClient::mockMediaPlaybackTargetPickerDismissPopup):
(WebKit::WebChromeClient::imageOrMediaDocumentSizeChanged):
(WebKit::WebChromeClient::didInvalidateDocumentMarkerRects):
(WebKit::WebChromeClient::hasStorageAccess):
(WebKit::WebChromeClient::requestStorageAccess):
(WebKit::WebChromeClient::hasPageLevelStorageAccess const):
(WebKit::WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::WebChromeClient::configureLoggingChannel):
(WebKit::WebChromeClient::userIsInteracting const):
(WebKit::WebChromeClient::setUserIsInteracting):
(WebKit::WebChromeClient::setMockWebAuthenticationConfiguration):
(WebKit::WebChromeClient::animationDidFinishForElement):
(WebKit::WebChromeClient::changeUniversalAccessZoomFocus):
(WebKit::WebChromeClient::requestTextRecognition):
(WebKit::WebChromeClient::applyLinkDecorationFiltering const):
(WebKit::WebChromeClient::allowedQueryParametersForAdvancedPrivacyProtections const):
(WebKit::WebChromeClient::textAutosizingUsesIdempotentModeChanged):
(WebKit::WebChromeClient::showMediaControlsContextMenu):
(WebKit::WebChromeClient::enumerateImmersiveXRDevices):
(WebKit::WebChromeClient::requestPermissionOnXRSessionFeatures):
(WebKit::WebChromeClient::startApplePayAMSUISession):
(WebKit::WebChromeClient::abortApplePayAMSUISession):
(WebKit::WebChromeClient::beginSystemPreview):
(WebKit::WebChromeClient::requestCookieConsent):
(WebKit::WebChromeClient::isUsingUISideCompositing const):
(WebKit::WebChromeClient::isInStableState const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp:
(WebKit::WebDataListSuggestionPicker::handleKeydownWithIdentifier):
(WebKit::WebDataListSuggestionPicker::close):
(WebKit::WebDataListSuggestionPicker::displayWithActivationType):
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp:
(WebKit::WebDateTimeChooser::endChooser):
(WebKit::WebDateTimeChooser::showChooser):
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
(WebKit::WebPopupMenu::disconnectFromPage):
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
(WebKit::WebChromeClient::didPreventDefaultForEvent):
(WebKit::WebChromeClient::didReceiveMobileDocType):
(WebKit::WebChromeClient::didFinishContentChangeObserving):
(WebKit::WebChromeClient::notifyRevealedSelectionByScrollingFrame):
(WebKit::WebChromeClient::didLayout):
(WebKit::WebChromeClient::didStartOverflowScroll):
(WebKit::WebChromeClient::didEndOverflowScroll):
(WebKit::WebChromeClient::hasStablePageScaleFactor const):
(WebKit::WebChromeClient::showPlaybackTargetPicker):
(WebKit::WebChromeClient::eventThrottlingDelay):
(WebKit::WebChromeClient::deviceOrientation const):
(WebKit::WebChromeClient::showDataDetectorsUIForElement):

Canonical link: <a href="https://commits.webkit.org/268135@main">https://commits.webkit.org/268135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4956e40590e5f2d6edda3e3fda862bbfed4a9f9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17611 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19291 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21560 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16397 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21495 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17916 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16979 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->