### PR TITLE
Store fewer raw pointers in containers in Source/WebKit

### DIFF
--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -223,7 +223,7 @@ private:
 };
 
 template<typename MapFunction, typename T, typename WeakMapImpl>
-struct Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl> &, void> {
+struct Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl>&, void> {
     using SourceItemType = T&;
     using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
 
@@ -235,6 +235,10 @@ struct Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl> &, void> {
             result.uncheckedAppend(mapFunction(item));
         return result;
     }
+};
+
+template<typename MapFunction, typename T, typename WeakMapImpl>
+struct Mapper<MapFunction, WeakHashSet<T, WeakMapImpl>&, void> : Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl> &, void> {
 };
 
 template<typename T, typename WeakMapImpl>

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -47,6 +47,7 @@
 #include "TimingFunction.h"
 #include "TransformOperations.h"
 #include "WindRule.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/Function.h>
 #include <wtf/TypeCasts.h>
@@ -264,7 +265,7 @@ protected:
 // GraphicsLayer is an abstraction for a rendering surface with backing store,
 // which may have associated transformation and animations.
 
-class GraphicsLayer : public RefCounted<GraphicsLayer> {
+class GraphicsLayer : public RefCounted<GraphicsLayer>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type : uint8_t {

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -27,6 +27,7 @@
 
 #include "FloatRoundedRect.h"
 #include "GraphicsLayer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -85,7 +86,7 @@ enum class PlatformCALayerLayerType : uint8_t {
         LayerTypeHost,
 };
 
-class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCounted<PlatformCALayer, WTF::DestructionThread::Main> {
+class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCounted<PlatformCALayer, WTF::DestructionThread::Main>, public CanMakeCheckedPtr {
     friend class PlatformCALayerCocoa;
 public:
     static CFTimeInterval currentTimeToMediaTime(MonotonicTime);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -75,6 +75,7 @@
 #include <WebCore/ResourceError.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/WeakHashSet.h>
 
 #if ENABLE(SEC_ITEM_SHIM)
 #include "SecItemShimProxy.h"
@@ -109,17 +110,17 @@ using namespace WebCore;
 
 static constexpr Seconds networkProcessResponsivenessTimeout = 6_s;
 
-static HashSet<NetworkProcessProxy*>& networkProcessesSet()
+static WeakHashSet<NetworkProcessProxy>& networkProcessesSet()
 {
     ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashSet<NetworkProcessProxy*>> set;
+    static NeverDestroyed<WeakHashSet<NetworkProcessProxy>> set;
     return set;
 }
 
 Vector<Ref<NetworkProcessProxy>> NetworkProcessProxy::allNetworkProcesses()
 {
-    return WTF::map(networkProcessesSet(), [](auto* networkProcess) {
-        return Ref { *networkProcess };
+    return WTF::map(networkProcessesSet(), [](auto& networkProcess) {
+        return Ref { networkProcess };
     });
 }
 
@@ -239,7 +240,7 @@ NetworkProcessProxy::NetworkProcessProxy()
     connect();
     sendCreationParametersToNewProcess();
     updateProcessAssertion();
-    networkProcessesSet().add(this);
+    networkProcessesSet().add(*this);
 #if PLATFORM(IOS_FAMILY)
     addBackgroundStateObservers();
 #endif
@@ -248,13 +249,13 @@ NetworkProcessProxy::NetworkProcessProxy()
 NetworkProcessProxy::~NetworkProcessProxy()
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    for (auto* proxy : m_webUserContentControllerProxies)
+    for (Ref proxy : m_webUserContentControllerProxies)
         proxy->removeNetworkProcess(*this);
 #endif
 
     if (m_downloadProxyMap)
         m_downloadProxyMap->invalidate();
-    networkProcessesSet().remove(this);
+    networkProcessesSet().remove(*this);
 #if PLATFORM(IOS_FAMILY)
     removeBackgroundStateObservers();
 #endif
@@ -1447,7 +1448,7 @@ WebsiteDataStore* NetworkProcessProxy::websiteDataStoreFromSessionID(PAL::Sessio
 void NetworkProcessProxy::contentExtensionRules(UserContentControllerIdentifier identifier)
 {
     if (auto* webUserContentControllerProxy = WebUserContentControllerProxy::get(identifier)) {
-        m_webUserContentControllerProxies.add(webUserContentControllerProxy);
+        m_webUserContentControllerProxies.add(*webUserContentControllerProxy);
         webUserContentControllerProxy->addNetworkProcess(*this);
 
         auto rules = WTF::map(webUserContentControllerProxy->contentExtensionRules(), [](auto&& keyValue) -> std::pair<WebCompiledContentRuleListData, URL> {
@@ -1462,7 +1463,7 @@ void NetworkProcessProxy::contentExtensionRules(UserContentControllerIdentifier 
 void NetworkProcessProxy::didDestroyWebUserContentControllerProxy(WebUserContentControllerProxy& proxy)
 {
     send(Messages::NetworkContentRuleListManager::Remove { proxy.identifier() }, 0);
-    m_webUserContentControllerProxies.remove(&proxy);
+    m_webUserContentControllerProxies.remove(proxy);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -429,7 +429,7 @@ private:
     ProcessThrottler::ActivityVariant m_activityFromWebProcesses;
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    HashSet<WebUserContentControllerProxy*> m_webUserContentControllerProxies;
+    WeakHashSet<WebUserContentControllerProxy> m_webUserContentControllerProxies;
 #endif
 
     struct UploadActivity {

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -28,6 +28,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>
@@ -49,7 +50,7 @@ namespace WebKit {
 class WebBackForwardListItem;
 class WebPageProxy;
 
-class ViewSnapshot : public RefCounted<ViewSnapshot> {
+class ViewSnapshot : public RefCounted<ViewSnapshot>, public CanMakeCheckedPtr {
 public:
 #if HAVE(IOSURFACE)
     static Ref<ViewSnapshot> create(std::unique_ptr<WebCore::IOSurface>);
@@ -159,7 +160,7 @@ private:
 
     size_t m_snapshotCacheSize { 0 };
 
-    ListHashSet<ViewSnapshot*> m_snapshotsWithImages;
+    ListHashSet<CheckedPtr<ViewSnapshot>> m_snapshotsWithImages;
     bool m_disableSnapshotVolatility { false };
 };
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.h
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.h
@@ -38,7 +38,7 @@ namespace WebKit {
 
 class WebProcessProxy;
     
-class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, private IPC::MessageReceiver, public Identified<VisitedLinkStore>, private SharedStringHashStore::Client {
+class VisitedLinkStore final : public API::ObjectImpl<API::Object::Type::VisitedLinkStore>, public IPC::MessageReceiver, public Identified<VisitedLinkStore>, private SharedStringHashStore::Client {
 public:
     static Ref<VisitedLinkStore> create();
     VisitedLinkStore();

--- a/Source/WebKit/UIProcess/WebEditCommandProxy.h
+++ b/Source/WebKit/UIProcess/WebEditCommandProxy.h
@@ -38,7 +38,7 @@ namespace WebKit {
 
 class WebPageProxy;
 
-class WebEditCommandProxy : public API::ObjectImpl<API::Object::Type::EditCommandProxy> {
+class WebEditCommandProxy : public API::ObjectImpl<API::Object::Type::EditCommandProxy>, public CanMakeWeakPtr<WebEditCommandProxy> {
 public:
     static Ref<WebEditCommandProxy> create(WebUndoStepID commandID, const String& label, WebPageProxy& page)
     {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8372,12 +8372,12 @@ void WebPageProxy::registerEditCommand(Ref<WebEditCommandProxy>&& commandProxy, 
 
 void WebPageProxy::addEditCommand(WebEditCommandProxy& command)
 {
-    m_editCommandSet.add(&command);
+    m_editCommandSet.add(command);
 }
 
 void WebPageProxy::removeEditCommand(WebEditCommandProxy& command)
 {
-    m_editCommandSet.remove(&command);
+    m_editCommandSet.remove(command);
 
     if (!hasRunningProcess())
         return;
@@ -9174,7 +9174,7 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     m_webDeviceOrientationUpdateProviderProxy = nullptr;
 #endif
 
-    for (auto& editCommand : std::exchange(m_editCommandSet, { }))
+    for (Ref editCommand : std::exchange(m_editCommandSet, { }))
         editCommand->invalidate();
 
     m_activePopupMenu = nullptr;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -33,6 +33,7 @@
 #include <wtf/OptionSet.h>
 #include <wtf/ProcessID.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakHashSet.h>
 
 namespace API {
 class Attachment;
@@ -2962,7 +2963,7 @@ private:
     RetainPtr<NSArray> m_dataDetectionResults;
 #endif
 
-    HashSet<WebEditCommandProxy*> m_editCommandSet;
+    WeakHashSet<WebEditCommandProxy> m_editCommandSet;
 
 #if PLATFORM(COCOA)
     HashSet<String> m_knownKeypressCommandNames;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -58,6 +58,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/UUID.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
@@ -671,8 +672,8 @@ private:
     UserInitiatedActionMap m_userInitiatedActionMap;
     UserInitiatedActionByAuthorizationTokenMap m_userInitiatedActionByAuthorizationTokenMap;
 
-    HashMap<VisitedLinkStore*, HashSet<WebPageProxyIdentifier>> m_visitedLinkStoresWithUsers;
-    HashSet<WebUserContentControllerProxy*> m_webUserContentControllerProxies;
+    WeakHashMap<VisitedLinkStore, HashSet<WebPageProxyIdentifier>> m_visitedLinkStoresWithUsers;
+    WeakHashSet<WebUserContentControllerProxy> m_webUserContentControllerProxies;
 
     int m_numberOfTimesSuddenTerminationWasDisabled;
     ProcessThrottler m_throttler;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -68,13 +68,6 @@ static constexpr double defaultBrowserOriginQuotaRatio = 0.6;
 static constexpr double defaultAppTotalQuotaRatio = 0.2;
 static constexpr double defaultAppOriginQuotaRatio = 0.15;
 
-static HashSet<WebsiteDataStore*>& dataStores()
-{
-    static NeverDestroyed<HashSet<WebsiteDataStore*>> dataStores;
-
-    return dataStores;
-}
-
 #if ENABLE(APP_BOUND_DOMAINS)
 static WorkQueue& appBoundDomainQueue()
 {
@@ -234,8 +227,6 @@ bool WebsiteDataStore::useNetworkLoader()
 
 void WebsiteDataStore::platformInitialize()
 {
-    ASSERT(!dataStores().contains(this));
-    dataStores().add(this);
 #if ENABLE(APP_BOUND_DOMAINS)
     initializeAppBoundDomains();
 #endif
@@ -246,8 +237,6 @@ void WebsiteDataStore::platformInitialize()
 
 void WebsiteDataStore::platformDestroy()
 {
-    ASSERT(dataStores().contains(this));
-    dataStores().remove(this);
 }
 
 static String defaultWebsiteDataStoreRootDirectory()

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
@@ -29,8 +29,8 @@
 
 #include <WebCore/GamepadProvider.h>
 #include <wtf/Forward.h>
-#include <wtf/HashSet.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 enum class EventMakesGamepadsVisible : bool;
@@ -64,7 +64,7 @@ private:
     void playEffect(unsigned gamepadIndex, const String& gamepadID, WebCore::GamepadHapticEffectType, const WebCore::GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 
-    HashSet<WebCore::GamepadProviderClient*> m_clients;
+    WeakHashSet<WebCore::GamepadProviderClient> m_clients;
 
     Vector<std::unique_ptr<WebGamepad>> m_gamepads;
     Vector<WeakPtr<WebCore::PlatformGamepad>> m_rawGamepads;

--- a/Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm
+++ b/Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm
@@ -31,6 +31,7 @@
 #import "WebPage.h"
 #import "WebPageProxyMessages.h"
 #import <WebCore/GraphicsLayer.h>
+#import <wtf/WeakHashSet.h>
 
 namespace WebKit {
 
@@ -39,36 +40,36 @@ Ref<ARKitInlinePreviewModelPlayerIOS> ARKitInlinePreviewModelPlayerIOS::create(W
     return adoptRef(*new ARKitInlinePreviewModelPlayerIOS(page, client));
 }
 
-static HashSet<ARKitInlinePreviewModelPlayerIOS*>& instances()
+static WeakHashSet<ARKitInlinePreviewModelPlayerIOS>& instances()
 {
-    static NeverDestroyed<HashSet<ARKitInlinePreviewModelPlayerIOS*>> instances;
+    static NeverDestroyed<WeakHashSet<ARKitInlinePreviewModelPlayerIOS>> instances;
     return instances;
 }
 
 ARKitInlinePreviewModelPlayerIOS::ARKitInlinePreviewModelPlayerIOS(WebPage& page, WebCore::ModelPlayerClient& client)
     : ARKitInlinePreviewModelPlayer(page, client)
 {
-    instances().add(this);
+    instances().add(*this);
 }
 
 ARKitInlinePreviewModelPlayerIOS::~ARKitInlinePreviewModelPlayerIOS()
 {
-    instances().remove(this);
+    instances().remove(*this);
 }
 
 ARKitInlinePreviewModelPlayerIOS* ARKitInlinePreviewModelPlayerIOS::modelPlayerForPageAndLayerID(WebPage& page, PlatformLayerIdentifier layerID)
 {
-    for (auto* modelPlayer : instances()) {
-        if (!modelPlayer || !modelPlayer->client())
+    for (auto& modelPlayer : instances()) {
+        if (!modelPlayer.client())
             continue;
 
-        if (&page != modelPlayer->page())
+        if (&page != modelPlayer.page())
             continue;
 
-        if (modelPlayer->client()->platformLayerID() != layerID)
+        if (modelPlayer.client()->platformLayerID() != layerID)
             continue;
 
-        return modelPlayer;
+        return &modelPlayer;
     }
 
     return nullptr;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -221,13 +221,13 @@ PluginView::PluginView(HTMLPlugInElement& element, const URL& mainResourceURL, c
     , m_shouldUseManualLoader(shouldUseManualLoader)
     , m_pendingResourceRequestTimer(RunLoop::main(), this, &PluginView::pendingResourceRequestTimerFired)
 {
-    m_webPage->addPluginView(this);
+    m_webPage->addPluginView(*this);
 }
 
 PluginView::~PluginView()
 {
     if (m_webPage)
-        m_webPage->removePluginView(this);
+        m_webPage->removePluginView(*this);
     if (m_stream)
         m_stream->cancel();
     m_plugin->destroy();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -34,6 +34,7 @@
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/LayerPool.h>
 #include <WebCore/PlatformCALayer.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
@@ -109,13 +110,13 @@ private:
     HashMap<WebCore::PlatformLayerIdentifier, RemoteLayerTreeTransaction::LayerCreationProperties> m_createdLayers;
     Vector<WebCore::PlatformLayerIdentifier> m_destroyedLayers;
 
-    HashMap<WebCore::PlatformLayerIdentifier, PlatformCALayerRemote*> m_livePlatformLayers;
-    HashMap<WebCore::PlatformLayerIdentifier, PlatformCALayerRemote*> m_layersWithAnimations;
+    HashMap<WebCore::PlatformLayerIdentifier, CheckedPtr<PlatformCALayerRemote>> m_livePlatformLayers;
+    HashMap<WebCore::PlatformLayerIdentifier, CheckedPtr<PlatformCALayerRemote>> m_layersWithAnimations;
 #if HAVE(AVKIT)
     HashMap<WebCore::PlatformLayerIdentifier, PlaybackSessionContextIdentifier> m_videoLayers;
 #endif
 
-    HashSet<GraphicsLayerCARemote*> m_liveGraphicsLayers;
+    HashSet<CheckedPtr<GraphicsLayerCARemote>> m_liveGraphicsLayers;
 
     std::unique_ptr<RemoteLayerBackingStoreCollection> m_backingStoreCollection;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -59,20 +59,26 @@ RemoteLayerTreeContext::~RemoteLayerTreeContext()
     for (auto& layer : m_livePlatformLayers.values())
         layer->clearContext();
 
+
     auto graphicsLayers = m_liveGraphicsLayers;
     for (auto& layer : graphicsLayers)
-        layer->clearContext();
+        RefPtr { layer.get() }->clearContext();
+
+    // Make sure containers are empty before destruction to avoid hitting the assertion in CanMakeCheckedPtr.
+    m_livePlatformLayers.clear();
+    m_liveGraphicsLayers.clear();
+    m_layersWithAnimations.clear();
 }
 
 void RemoteLayerTreeContext::adoptLayersFromContext(RemoteLayerTreeContext& oldContext)
 {
     auto& platformLayers = oldContext.m_livePlatformLayers;
     while (!platformLayers.isEmpty())
-        platformLayers.begin()->value->moveToContext(*this);
+        RefPtr { platformLayers.begin()->value.get() }->moveToContext(*this);
 
     auto& graphicsLayers = oldContext.m_liveGraphicsLayers;
     while (!graphicsLayers.isEmpty())
-        (*graphicsLayers.begin())->moveToContext(*this);
+        RefPtr { (*graphicsLayers.begin()).get() }->moveToContext(*this);
 }
 
 float RemoteLayerTreeContext::deviceScaleFactor() const
@@ -214,14 +220,14 @@ void RemoteLayerTreeContext::animationDidStart(WebCore::PlatformLayerIdentifier 
 {
     auto it = m_layersWithAnimations.find(layerID);
     if (it != m_layersWithAnimations.end())
-        it->value->animationStarted(key, startTime);
+        RefPtr { it->value.get() }->animationStarted(key, startTime);
 }
 
 void RemoteLayerTreeContext::animationDidEnd(WebCore::PlatformLayerIdentifier layerID, const String& key)
 {
     auto it = m_layersWithAnimations.find(layerID);
     if (it != m_layersWithAnimations.end())
-        it->value->animationEnded(key);
+        RefPtr { it->value.get() }->animationEnded(key);
 }
 
 RemoteRenderingBackendProxy& RemoteLayerTreeContext::ensureRemoteRenderingBackendProxy()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1259,8 +1259,8 @@ WebPage::~WebPage()
     m_sandboxExtensionTracker.invalidate();
 
 #if ENABLE(PDFKIT_PLUGIN)
-    for (auto* pluginView : m_pluginViews)
-        pluginView->webPageDestroyed();
+    for (auto& pluginView : m_pluginViews)
+        pluginView.webPageDestroyed();
 #endif
 
 #if !PLATFORM(IOS_FAMILY)
@@ -2449,8 +2449,8 @@ void WebPage::scalePage(double scale, const IntPoint& origin)
         // Otherwise, we can end up with an immutable but non-1 page scale applied by WebCore on top of whatever the plugin does.
         if (m_page->pageScaleFactor() != 1) {
             m_page->setPageScaleFactor(1, origin);
-            for (auto* pluginView : m_pluginViews)
-                pluginView->pageScaleFactorDidChange();
+            for (auto& pluginView : m_pluginViews)
+                pluginView.pageScaleFactorDidChange();
         }
         pluginView->setPageScaleFactor(totalScale);
         return;
@@ -2464,8 +2464,8 @@ void WebPage::scalePage(double scale, const IntPoint& origin)
         return;
 
 #if ENABLE(PDFKIT_PLUGIN)
-    for (auto* pluginView : m_pluginViews)
-        pluginView->pageScaleFactorDidChange();
+    for (auto& pluginView : m_pluginViews)
+        pluginView.pageScaleFactorDidChange();
 #endif
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
@@ -2547,8 +2547,8 @@ void WebPage::setDeviceScaleFactor(float scaleFactor)
 
     // Tell all our plug-in views that the device scale factor changed.
 #if PLATFORM(MAC)
-    for (auto* pluginView : m_pluginViews)
-        pluginView->setDeviceScaleFactor(scaleFactor);
+    for (auto& pluginView : m_pluginViews)
+        pluginView.setDeviceScaleFactor(scaleFactor);
 
     updateHeaderAndFooterLayersForDeviceScaleChange(scaleFactor);
 #endif
@@ -3810,8 +3810,8 @@ void WebPage::setTopContentInset(float contentInset)
     m_page->setTopContentInset(contentInset);
 
 #if ENABLE(PDFKIT_PLUGIN)
-    for (auto* pluginView : m_pluginViews)
-        pluginView->topContentInsetDidChange();
+    for (auto& pluginView : m_pluginViews)
+        pluginView.topContentInsetDidChange();
 #endif
 }
 
@@ -5677,13 +5677,13 @@ void WebPage::mainFrameDidLayout()
 
 #if ENABLE(PDFKIT_PLUGIN)
 
-void WebPage::addPluginView(PluginView* pluginView)
+void WebPage::addPluginView(PluginView& pluginView)
 {
     ASSERT(!m_pluginViews.contains(pluginView));
     m_pluginViews.add(pluginView);
 }
 
-void WebPage::removePluginView(PluginView* pluginView)
+void WebPage::removePluginView(PluginView& pluginView)
 {
     ASSERT(m_pluginViews.contains(pluginView));
     m_pluginViews.remove(pluginView);
@@ -7686,11 +7686,11 @@ WebURLSchemeHandlerProxy* WebPage::urlSchemeHandlerForScheme(StringView scheme)
 
 void WebPage::stopAllURLSchemeTasks()
 {
-    HashSet<WebURLSchemeHandlerProxy*> handlers;
+    HashSet<RefPtr<WebURLSchemeHandlerProxy>> handlers;
     for (auto& handler : m_schemeToURLSchemeHandlerProxyMap.values())
         handlers.add(handler.get());
 
-    for (auto* handler : handlers)
+    for (auto& handler : handlers)
         handler->stopAllTasks();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -699,8 +699,8 @@ public:
     void exitAcceleratedCompositingMode(WebCore::Frame&);
 
 #if ENABLE(PDFKIT_PLUGIN)
-    void addPluginView(PluginView*);
-    void removePluginView(PluginView*);
+    void addPluginView(PluginView&);
+    void removePluginView(PluginView&);
 #endif
 
     inline bool isVisible() const;
@@ -2136,7 +2136,7 @@ private:
     DrawingAreaType m_drawingAreaType;
 
 #if ENABLE(PDFKIT_PLUGIN)
-    HashSet<PluginView*> m_pluginViews;
+    WeakHashSet<PluginView> m_pluginViews;
 #endif
 
     HashMap<TextCheckerRequestID, RefPtr<WebCore::TextCheckingRequest>> m_pendingTextCheckingRequestMap;


### PR DESCRIPTION
#### 8c5df5e0c83e6eb97b868d2461c4c843e9485173
<pre>
Store fewer raw pointers in containers in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261700">https://bugs.webkit.org/show_bug.cgi?id=261700</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/WeakHashSet.h:
(WTF:: const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::networkProcessesSet):
(WebKit::NetworkProcessProxy::allNetworkProcesses):
(WebKit::NetworkProcessProxy::NetworkProcessProxy):
(WebKit::NetworkProcessProxy::~NetworkProcessProxy):
(WebKit::NetworkProcessProxy::contentExtensionRules):
(WebKit::NetworkProcessProxy::didDestroyWebUserContentControllerProxy):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::allSuspendedPages):
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::~SuspendedPageProxy):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::proxies):
(WebKit::UserMediaPermissionRequestManagerProxy::forEach):
(WebKit::UserMediaPermissionRequestManagerProxy::UserMediaPermissionRequestManagerProxy):
(WebKit::UserMediaPermissionRequestManagerProxy::~UserMediaPermissionRequestManagerProxy):
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
* Source/WebKit/UIProcess/VisitedLinkStore.h:
* Source/WebKit/UIProcess/WebEditCommandProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::addEditCommand):
(WebKit::WebPageProxy::removeEditCommand):
(WebKit::WebPageProxy::resetState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::liveProcessesLRU):
(WebKit::WebProcessProxy::hasReachedProcessCountLimit):
(WebKit::WebProcessProxy::create):
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::addVisitedLinkStoreUser):
(WebKit::WebProcessProxy::removeVisitedLinkStoreUser):
(WebKit::WebProcessProxy::addWebUserContentControllerProxy):
(WebKit::WebProcessProxy::didDestroyWebUserContentControllerProxy):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::markProcessAsRecentlyUsed):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformInitialize):
(WebKit::WebsiteDataStore::platformDestroy):
(): Deleted.
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::gamepadConnected):
(WebKit::WebGamepadProvider::gamepadDisconnected):
(WebKit::WebGamepadProvider::gamepadActivity):
(WebKit::WebGamepadProvider::startMonitoringGamepads):
(WebKit::WebGamepadProvider::stopMonitoringGamepads):
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h:
* Source/WebKit/WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm:
(WebKit::instances):
(WebKit::ARKitInlinePreviewModelPlayerIOS::ARKitInlinePreviewModelPlayerIOS):
(WebKit::ARKitInlinePreviewModelPlayerIOS::~ARKitInlinePreviewModelPlayerIOS):
(WebKit::ARKitInlinePreviewModelPlayerIOS::modelPlayerForPageAndLayerID):
(): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::PluginView):
(WebKit::PluginView::~PluginView):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::~RemoteLayerTreeContext):
(WebKit::RemoteLayerTreeContext::adoptLayersFromContext):
(WebKit::RemoteLayerTreeContext::animationDidStart):
(WebKit::RemoteLayerTreeContext::animationDidEnd):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::~WebPage):
(WebKit::WebPage::scalePage):
(WebKit::WebPage::setDeviceScaleFactor):
(WebKit::WebPage::setTopContentInset):
(WebKit::WebPage::addPluginView):
(WebKit::WebPage::removePluginView):
(WebKit::WebPage::stopAllURLSchemeTasks):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/268154@main">https://commits.webkit.org/268154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36353cd1189443d953f99ec57e83a3b92a03068a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19328 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19208 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16420 "1 api test failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21602 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17183 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16359 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21542 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18178 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17945 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22226 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17011 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4482 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21378 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23471 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17781 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5265 "Passed tests") | 
<!--EWS-Status-Bubble-End-->