### PR TITLE
Fix resizer behavior with `writing-mode: vertical-rl` or `direction: rtl`

### DIFF
--- a/LayoutTests/fast/css/resize-rtl-expected.txt
+++ b/LayoutTests/fast/css/resize-rtl-expected.txt
@@ -1,0 +1,6 @@
+'target' resized as expected to (50px, 100px).
+'target' resized as expected to (55px, 150px).
+'target' resized as expected to (50px, 100px).
+'target' resized as expected to (55px, 150px).
+'target' resized as expected to (55px, 15px).
+

--- a/LayoutTests/fast/css/resize-rtl.html
+++ b/LayoutTests/fast/css/resize-rtl.html
@@ -1,0 +1,103 @@
+<style>
+    div {
+        width: 50px;
+        height: 50px;
+        overflow: hidden;
+        box-sizing: border-box;
+        border: solid;
+        margin: 10px;
+        resize: both;
+    }
+</style>
+
+<pre id="console"></pre>
+<div id="target" dir="rtl"></div>
+
+<script type="text/javascript">
+    var mouseX = 0;
+    var mouseY = 0;
+
+    function log(message)
+    {
+        document.getElementById("console").appendChild(document.createTextNode(message + "\n"));
+    }
+
+    function beginResize(target)
+    {
+        var x = document.body.offsetLeft + target.offsetLeft;
+        var y = document.body.offsetTop + target.offsetTop + target.offsetHeight;
+
+        mouseX = x + 6;
+        mouseY = y - 6;
+
+        eventSender.mouseMoveTo(mouseX, mouseY);
+        eventSender.mouseDown();
+    }
+
+    function endResize()
+    {
+        eventSender.mouseUp();
+    }
+
+    function resize(deltaX, deltaY)
+    {
+        mouseX += deltaX;
+        mouseY += deltaY;
+
+        eventSender.mouseMoveTo(mouseX, mouseY);
+    }
+
+    function assertSize(target, width, height)
+    {
+        var computedStyle = getComputedStyle(target);
+        var actualWidth = computedStyle.width;
+        var actualHeight = computedStyle.height;
+
+        if (actualWidth === width && actualHeight === height)
+            log("'" + target.id + "' resized as expected to (" + width + ", " + height + ").");
+        else
+            log("FAIL: '" + target.id + "' resized to (" + actualWidth + ", " + actualHeight + ") instead of (" + width + ", " + height + ").");
+    }
+
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+
+        var target = document.getElementById("target");
+
+        beginResize(target);
+        resize(0, 50);
+        endResize();
+
+        assertSize(target, "50px", "100px");
+
+        beginResize(target);
+        resize(-5, 50);
+        endResize();
+
+        assertSize(target, "55px", "150px");
+
+        beginResize(target);
+        resize(5, -50);
+        endResize();
+
+        assertSize(target, "50px", "100px");
+
+        beginResize(target);
+        resize(-5, 0);
+        resize(0, 10);
+        resize(0, 10);
+        resize(0, 10);
+        resize(0, 10);
+        resize(0, 10);
+        endResize();
+
+        assertSize(target, "55px", "150px");
+
+        beginResize(target);
+        resize(-5, -160);
+        resize(5, 10);
+        endResize();
+
+        assertSize(target, "55px", "15px");
+    }
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1140,6 +1140,7 @@ fast/css/resize-below-min-size-zoomed.html [ Skip ]
 fast/css/resize-below-min-size.html [ Skip ]
 fast/css/resize-corner-tracking.html [ Skip ]
 fast/css/resize-orthogonal-containing-block.html [ Skip ]
+fast/css/resize-rtl.html [ Skip ]
 fast/css/resize-single-axis.html [ Skip ]
 fast/events/mouse-events-on-textarea-resize.html [ Skip ]
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2108,9 +2108,15 @@ HandleMouseEventResult EventHandler::handleMouseMoveEvent(const PlatformMouseEve
     if (hitTestResult)
         *hitTestResult = mouseEvent.hitTestResult();
 
-    if (m_resizeLayer && m_resizeLayer->inResizeMode())
+    if (m_resizeLayer && m_resizeLayer->inResizeMode()) {
         m_resizeLayer->resize(platformMouseEvent, m_offsetFromResizeCorner);
-    else {
+
+        if (m_resizeLayer->renderer().shouldPlaceVerticalScrollbarOnLeft()) {
+            auto absolutePoint = m_frame.view()->windowToContents(platformMouseEvent.position());
+            auto localPoint = roundedIntPoint(m_resizeLayer->absoluteToContents(absolutePoint));
+            m_offsetFromResizeCorner.setWidth(m_resizeLayer->offsetFromResizeCorner(localPoint).width());
+        }
+    } else {
         Scrollbar* scrollbar = mouseEvent.scrollbar();
         updateLastScrollbarUnderMouse(scrollbar, m_mousePressed ? SetOrClearLastScrollbar::Clear : SetOrClearLastScrollbar::Set);
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -243,6 +243,9 @@ public:
 
     bool willCompositeClipPath() const;
 
+    // Convert a point in absolute coords into layer coords, taking transforms into account
+    LayoutPoint absoluteToContents(const LayoutPoint&) const;
+
 protected:
     void destroy();
 
@@ -1171,9 +1174,6 @@ private:
     ClipRect backgroundClipRect(const ClipRectsContext&) const;
 
     RenderLayer* enclosingTransformedAncestor() const;
-
-    // Convert a point in absolute coords into layer coords, taking transforms into account
-    LayoutPoint absoluteToContents(const LayoutPoint&) const;
 
     inline bool hasNonOpacityTransparency() const;
 


### PR DESCRIPTION
#### 51184f8a009b08ee6599c933c435507c2359f495
<pre>
Fix resizer behavior with `writing-mode: vertical-rl` or `direction: rtl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=248261">https://bugs.webkit.org/show_bug.cgi?id=248261</a>
rdar://102620110

Reviewed by Simon Fraser.

Resizing behavior is implemented by storing the original offset from the mouse
position to the resizer on mouse down. Then, as the mouse moves, the new offset
from the resizer is compared to the stored offset to determine the overall size
change. This approach ensures that the size of the element does not change when
the mouse position and resizer become detached, which can happen when resizing
the element to its minimum size and continuing to move the mouse away from the resizer.

For elements with right-to-left directionality, the resizer is positioned at
the bottom left. Dragging the resizer along the x-axis adjusts the width of the
element inverse to the movement direction. Unlike left-to-right elements, this
means that it is possible for the mouse position and resizer to become detached
as the width of the element is increasing due to dragging on the resizer.
Specifically, if a resize if started and the mouse is moved is moved to the left
by X pixels, and then down by Y pixels, there will be a constant difference
of X between the original offset (on mouse down) and the new offset. This means
that as the user continues to drag down Y pixels, the offset along the x-axis
continues to increase the width of the element, even though there is no
further movement along the x-axis.

To fix, update the original offset that was stored on mouse down each time a
resize occurs. This ensures that the difference along the x-axis does not
continue accumulating.

* LayoutTests/fast/css/resize-rtl-expected.txt: Added.
* LayoutTests/fast/css/resize-rtl.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMouseMoveEvent):

Update the original offset that was stored on mouse down each time a resize
occurs. Note that following restrictions on the update:

1. The offset is only updated for elements with right-to-left directionality.
   This is neccessary so that the width of left-to-right elements is not
   changed when the mouse position becomes detached from the resizer. Without
   this restriction, beginning a resize and moving the mouse beyond the left of
   the element (forcing its minimum width and detaching from the resizer), and
   then moving the mouse back towards the resizer, would incorrectly increase
   the width of the element.

2. Only the offset in the x-axis is updated. This is because height resizes
   the same for both left-to-right and right-to-left elements, and the
   detachment issue described in (1) should be prevented on the y-axis.
   Detachment on the x-axis is fine, since that is the only way right-to-left
   elements can be resized.

* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/268157@main">https://commits.webkit.org/268157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/210f9049a7bbe7567f7f421533af3018d08858f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19348 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21451 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23496 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16877 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4483 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->