### PR TITLE
Stop storing raw pointers in a HashSet in GlyphDisplayListCache

### DIFF
--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -47,8 +47,9 @@ struct GlyphDisplayListCacheKeyTranslator {
         return computeHash(key);
     }
 
-    static bool equal(GlyphDisplayListCacheEntry* entry, const GlyphDisplayListCacheKey& key)
+    static bool equal(const CheckedPtr<GlyphDisplayListCacheEntry>& entryPtr, const GlyphDisplayListCacheKey& key)
     {
+        auto* entry = entryPtr.get();
         return entry->m_textRun == key.textRun
             && entry->m_scaleFactor == key.context.scaleFactor()
             && entry->m_fontCascadeGeneration == key.font.generation()

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -31,6 +31,7 @@
 #include "Logging.h"
 #include "TextRun.h"
 #include "TextRunHash.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
@@ -43,7 +44,7 @@ namespace InlineDisplay {
 struct Box;
 }
 
-class GlyphDisplayListCacheEntry : public RefCounted<GlyphDisplayListCacheEntry>, public CanMakeWeakPtr<GlyphDisplayListCacheEntry> {
+class GlyphDisplayListCacheEntry : public RefCounted<GlyphDisplayListCacheEntry>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
     friend struct GlyphDisplayListCacheKeyTranslator;
     friend void add(Hasher&, const GlyphDisplayListCacheEntry&);
@@ -90,8 +91,8 @@ inline void add(Hasher& hasher, const GlyphDisplayListCacheEntry& entry)
 }
 
 struct GlyphDisplayListCacheEntryHash {
-    static unsigned hash(GlyphDisplayListCacheEntry* entry) { return computeHash(*entry); }
-    static bool equal(GlyphDisplayListCacheEntry* a, GlyphDisplayListCacheEntry* b) { return a == b; }
+    static unsigned hash(const CheckedPtr<GlyphDisplayListCacheEntry>& entry) { return computeHash(*entry); }
+    static bool equal(const CheckedPtr<GlyphDisplayListCacheEntry>& a, const CheckedPtr<GlyphDisplayListCacheEntry>& b) { return a.get() == b.get(); }
     static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
 
@@ -123,13 +124,13 @@ private:
     void remove(const void* run);
 
     HashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForLayoutRun;
-    HashSet<GlyphDisplayListCacheEntry*> m_entries;
+    HashSet<CheckedPtr<GlyphDisplayListCacheEntry>> m_entries;
 };
 
 } // namespace WebCore
 
 namespace WTF {
 
-template<> struct DefaultHash<WebCore::GlyphDisplayListCacheEntry*> : WebCore::GlyphDisplayListCacheEntryHash { };
+template<> struct DefaultHash<CheckedPtr<WebCore::GlyphDisplayListCacheEntry>> : WebCore::GlyphDisplayListCacheEntryHash { };
 
 } // namespace WTF


### PR DESCRIPTION
#### 1350fbbc39441bcb7d52d8241127a0e045cc91ed
<pre>
Stop storing raw pointers in a HashSet in GlyphDisplayListCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=261704">https://bugs.webkit.org/show_bug.cgi?id=261704</a>

Reviewed by Darin Adler.

* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCacheKeyTranslator::equal):
* Source/WebCore/rendering/GlyphDisplayListCache.h:
(WebCore::GlyphDisplayListCacheEntryHash::hash):
(WebCore::GlyphDisplayListCacheEntryHash::equal):

Canonical link: <a href="https://commits.webkit.org/268139@main">https://commits.webkit.org/268139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecdb3f25bce7b71739b0391795cddad9b1941f06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21573 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17159 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21501 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17928 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16990 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->