### PR TITLE
[WinCairo] Unreviewed test gardening

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -540,14 +540,6 @@ fast/canvas/canvas-toDataURL-case-insensitive-mimetype.html [ Failure ] # [ Skip
 # resizeTO, resizeBy
 fast/images/animated-gif-window-resizing.html [ Skip ] # Timeout
 
-http/wpt/css/css-images-4/conic-gradient-parsing.html [ Pass ]
-fast/gradients/conic-repeating.html [ Pass ]
-fast/gradients/conic.html [ Pass ]
-fast/gradients/conic-off-center.html [ Pass ]
-fast/gradients/conic-center-outside-box.html [ Pass ]
-fast/gradients/conic-extended-stops.html [ Pass ]
-fast/gradients/conic-from-angle.html [ Pass ]
-fast/gradients/conic-two-hints.html [ Pass ]
 fast/gradients/conic-gradient-alpha.html [ ImageOnlyFailure ]
 
 fast/forms/vertical-writing-mode/meter.html [ ImageOnlyFailure ]
@@ -808,12 +800,17 @@ http/tests/misc/acid3.html [ Failure ]
 
 http/tests/model [ Skip ]
 
-http/tests/navigation [ Skip ]
-http/tests/navigation/post-301-response.html [ Pass ]
-http/tests/navigation/post-302-response.html [ Pass ]
-http/tests/navigation/post-303-response.html [ Pass ]
-http/tests/navigation/post-307-response.html [ Pass ]
-http/tests/navigation/post-308-response.html [ Pass ]
+http/tests/navigation/page-cache-getUserMedia-pending-promise.html [ Skip ] # Failure
+http/tests/navigation/page-cache-mediakeysession.html [ Skip ] # Failure
+http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html [ Skip ] # Failure
+http/tests/navigation/post-frames-goback1-uncached.html [ Skip ] # Failure
+http/tests/navigation/redirect-to-fragment2.html [ Skip ] # Failure
+http/tests/navigation/error404-basic.html [ Skip ] # Missing
+http/tests/navigation/error404-goback.html [ Skip ] # Missing
+http/tests/navigation/javascriptlink-frames.html [ Skip ] # Missing
+http/tests/navigation/postredirect-basic.html [ Skip ] # Missing
+http/tests/navigation/postredirect-goback1.html [ Skip ] # Missing
+http/tests/navigation/page-cache-mediastream.html [ Skip ] # Timeout
 
 http/tests/notifications [ Skip ]
 http/tests/paymentrequest [ Skip ]
@@ -2727,3 +2724,5 @@ http/tests/inspector/network/resource-timing.html [ Pass Failure ]
 
 webkit.org/b/261297 webgl/2.0.y/conformance/glsl/bugs/complex-glsl-does-not-crash.html [ Skip ]
 webkit.org/b/261297 webgl/2.0.y/conformance/glsl/misc/shader-uniform-packing-restrictions.html [ Skip ]
+
+fast/canvas/image-buffer-backend-variants.html [ Skip ]


### PR DESCRIPTION
#### 5a4bacbf612ef4b96a124a6ceb9a909c779e2d6f
<pre>
[WinCairo] Unreviewed test gardening

* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/268096@main">https://commits.webkit.org/268096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/988beba135f1ba9f1819f17f85100d178743dec6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20558 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19176 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18919 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21436 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17809 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/16868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21235 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2291 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->