### PR TITLE
Generate serialization of StreamServerConnectionHandle

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -361,6 +361,8 @@ set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/NetworkProcessCreationParameters.serialization.in
     NetworkProcess/NetworkResourceLoadParameters.serialization.in
 
+    Platform/IPC/StreamServerConnection.serialization.in
+
     Platform/SharedMemory.serialization.in
 
     Shared/BackgroundFetchState.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -136,6 +136,7 @@ $(PROJECT_DIR)/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
 $(PROJECT_DIR)/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
 $(PROJECT_DIR)/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
 $(PROJECT_DIR)/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
+$(PROJECT_DIR)/Platform/IPC/StreamServerConnection.serialization.in
 $(PROJECT_DIR)/Platform/SharedMemory.serialization.in
 $(PROJECT_DIR)/PluginProcess/PluginControllerProxy.messages.in
 $(PROJECT_DIR)/PluginProcess/PluginProcess.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -480,6 +480,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in \
 	GPUProcess/media/TrackPrivateRemoteConfiguration.serialization.in \
 	GPUProcess/media/VideoTrackPrivateRemoteConfiguration.serialization.in \
+	Platform/IPC/StreamServerConnection.serialization.in \
 	Platform/SharedMemory.serialization.in \
 	NetworkProcess/NetworkProcessCreationParameters.serialization.in \
 	Shared/API/APIData.serialization.in \

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -48,21 +48,6 @@ StreamConnectionBuffer::Handle StreamConnectionBuffer::createHandle()
     return { WTFMove(*handle) };
 }
 
-void StreamConnectionBuffer::Handle::encode(Encoder& encoder) &&
-{
-    encoder << WTFMove(memory);
-}
-
-std::optional<StreamConnectionBuffer::Handle> StreamConnectionBuffer::Handle::decode(Decoder& decoder)
-{
-    auto handle = decoder.decode<WebKit::SharedMemory::Handle>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    if (UNLIKELY(!sharedMemorySizeIsValid(handle->size())))
-        return std::nullopt;
-    return Handle { WTFMove(*handle) };
-}
-
 std::span<uint8_t> StreamConnectionBuffer::headerForTesting()
 {
     return { static_cast<uint8_t*>(m_sharedMemory->data()), headerSize() };

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -74,11 +74,7 @@ class StreamConnectionBuffer {
 public:
     ~StreamConnectionBuffer();
 
-    struct Handle {
-        WebKit::SharedMemory::Handle memory;
-        void encode(Encoder&) &&;
-        static std::optional<Handle> decode(Decoder&);
-    };
+    using Handle = WebKit::SharedMemory::Handle;
     Handle createHandle();
 
     size_t wrapOffset(size_t offset) const
@@ -122,6 +118,8 @@ public:
     std::span<uint8_t> headerForTesting();
     std::span<uint8_t> dataForTesting();
 
+    static constexpr bool sharedMemorySizeIsValid(size_t size) { return headerSize() < size && size <= headerSize() + maximumSize(); }
+
 protected:
     StreamConnectionBuffer(Ref<WebKit::SharedMemory>&&);
     StreamConnectionBuffer(StreamConnectionBuffer&&) = default;
@@ -139,8 +137,6 @@ protected:
 
     Header& header() const { return *reinterpret_cast<Header*>(m_sharedMemory->data()); }
     static constexpr size_t headerSize() { return roundUpToMultipleOf<alignof(std::max_align_t)>(sizeof(Header)); }
-
-    static constexpr bool sharedMemorySizeIsValid(size_t size) { return headerSize() < size && size <= headerSize() + maximumSize(); }
 
     size_t m_dataSize { 0 };
     Ref<WebKit::SharedMemory> m_sharedMemory;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.serialization.in
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.serialization.in
@@ -1,0 +1,28 @@
+# Copyright (C) 2023 Sony Interactive Entertainment Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "StreamServerConnection.h"
+
+[CustomHeader, RValue] struct IPC::StreamServerConnectionHandle {
+    IPC::Connection::Handle outOfStreamConnection;
+    [Validator='IPC::StreamConnectionBuffer::sharedMemorySizeIsValid(buffer->size())'] WebKit::SharedMemoryHandle buffer;
+}

--- a/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
@@ -59,7 +59,7 @@ private:
 
 inline std::optional<StreamServerConnectionBuffer> StreamServerConnectionBuffer::map(Handle&& handle)
 {
-    auto sharedMemory = WebKit::SharedMemory::map(WTFMove(handle.memory), WebKit::SharedMemory::Protection::ReadWrite);
+    auto sharedMemory = WebKit::SharedMemory::map(WTFMove(handle), WebKit::SharedMemory::Protection::ReadWrite);
     if (UNLIKELY(!sharedMemory))
         return std::nullopt;
     return StreamServerConnectionBuffer { sharedMemory.releaseNonNull() };

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -269,7 +269,7 @@ public:
     JSObjectRef createJSWrapper(JSContextRef);
     static JSIPCStreamConnectionBuffer* toWrapped(JSContextRef, JSValueRef);
 
-    void encode(IPC::Encoder& encoder) const { m_streamConnection->connection().bufferForTesting().createHandle().encode(encoder); }
+    void encode(IPC::Encoder& encoder) const { encoder << m_streamConnection->connection().bufferForTesting().createHandle(); }
 
 private:
     JSIPCStreamConnectionBuffer(JSIPCStreamClientConnection& streamConnection)


### PR DESCRIPTION
#### 1084b50affac3b51b40ec96aa627dab74600f0f5
<pre>
Generate serialization of StreamServerConnectionHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=261707">https://bugs.webkit.org/show_bug.cgi?id=261707</a>

Reviewed by Alex Christensen.

Migrate `StreamServerConnectionHandle` to the serialization format.
Remove manual serialization.

Remove `struct StreamConnectionBuffer::Handle` and just use a
`WebKit::SharedMemory::Handle` directly. Move the validation checks into
serialization of `StreamServerConnectionHandle`.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::Handle::encode): Deleted.
(IPC::StreamConnectionBuffer::Handle::decode): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
(IPC::StreamConnectionBuffer::sharedMemorySizeIsValid):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnectionHandle::StreamServerConnectionHandle):
(IPC::StreamServerConnection::Handle::encode): Deleted.
(IPC::StreamServerConnection::Handle::decode): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.serialization.in: Added.
* Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h:
(IPC::StreamServerConnectionBuffer::map):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamConnectionBuffer::encode const):

Canonical link: <a href="https://commits.webkit.org/268162@main">https://commits.webkit.org/268162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07430db8d771e88394a4b72b3464c6f29a817b98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17648 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19337 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21611 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16432 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21544 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17952 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17019 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4489 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->