### PR TITLE
Store fewer raw pointers in containers in Source/WebCore

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -247,6 +247,8 @@ public:
     void incrementPtrCount() const { ++m_count; }
     void decrementPtrCount() const { ASSERT(m_count); --m_count; }
 
+    friend bool operator==(const CanMakeCheckedPtrBase&, const CanMakeCheckedPtrBase&) { return true; }
+
 private:
     mutable StorageType m_count { 0 };
 };

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6013,9 +6013,11 @@ void LocalFrameView::willRemoveWidgetFromRenderTree(Widget& widget)
     m_widgetsInRenderTree.remove(&widget);
 }
 
-static Vector<RefPtr<Widget>> collectAndProtectWidgets(const HashSet<Widget*>& set)
+static Vector<RefPtr<Widget>> collectAndProtectWidgets(const HashSet<CheckedPtr<Widget>>& set)
 {
-    return copyToVectorOf<RefPtr<Widget>>(set);
+    return WTF::map(set, [](auto& widget) -> RefPtr<Widget> {
+        return widget.get();
+    });
 }
 
 void LocalFrameView::updateWidgetPositions()
@@ -6046,7 +6048,7 @@ void LocalFrameView::updateWidgetPositionsTimerFired()
 void LocalFrameView::notifyWidgets(WidgetNotification notification)
 {
     for (auto& widget : collectAndProtectWidgets(m_widgetsInRenderTree))
-        widget->notifyWidget(notification);
+        widget.get()->notifyWidget(notification);
 }
 
 void LocalFrameView::setViewExposedRect(std::optional<FloatRect> viewExposedRect)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -672,7 +672,7 @@ public:
     void didAddWidgetToRenderTree(Widget&);
     void willRemoveWidgetFromRenderTree(Widget&);
 
-    const HashSet<Widget*>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
+    const HashSet<CheckedPtr<Widget>>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
 
     void notifyAllFramesThatContentAreaWillPaint() const;
 
@@ -933,7 +933,7 @@ private:
 
     std::unique_ptr<Display::View> m_displayView;
 
-    HashSet<Widget*> m_widgetsInRenderTree;
+    HashSet<CheckedPtr<Widget>> m_widgetsInRenderTree;
     std::unique_ptr<ListHashSet<RenderEmbeddedObject*>> m_embeddedObjectsToUpdate;
     std::unique_ptr<WeakHashSet<RenderElement>> m_slowRepaintObjects;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -213,9 +213,9 @@
 
 namespace WebCore {
 
-static HashSet<Page*>& allPages()
+static HashSet<CheckedPtr<Page>>& allPages()
 {
-    static NeverDestroyed<HashSet<Page*>> set;
+    static NeverDestroyed<HashSet<CheckedPtr<Page>>> set;
     return set;
 }
 
@@ -235,7 +235,7 @@ DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, pageCounter, ("Page"));
 
 void Page::forEachPage(const Function<void(Page&)>& function)
 {
-    for (auto* page : allPages())
+    for (auto& page : allPages())
         function(*page);
 }
 
@@ -250,8 +250,8 @@ static void networkStateChanged(bool isOnLine)
     Vector<Ref<LocalFrame>> frames;
 
     // Get all the frames of all the pages in all the page groups
-    for (auto* page : allPages()) {
-        for (auto* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto& page : allPages()) {
+        for (auto* frame = &page.get()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
@@ -476,8 +476,8 @@ void Page::firstTimeInitialization()
 
 void Page::clearPreviousItemFromAllPages(HistoryItem* item)
 {
-    for (auto* page : allPages()) {
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+    for (auto& page : allPages()) {
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(page.get()->mainFrame());
         if (!localMainFrame)
             return;
 
@@ -756,8 +756,8 @@ void Page::updateStyleAfterChangeInEnvironment()
 
 void Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment()
 {
-    for (auto* page : allPages())
-        page->updateStyleAfterChangeInEnvironment();
+    for (auto& page : allPages())
+        page.get()->updateStyleAfterChangeInEnvironment();
 }
 
 void Page::setNeedsRecalcStyleInAllFrames()
@@ -772,8 +772,8 @@ void Page::refreshPlugins(bool reload)
 {
     HashSet<PluginInfoProvider*> pluginInfoProviders;
 
-    for (auto* page : allPages())
-        pluginInfoProviders.add(&page->pluginInfoProvider());
+    for (auto& page : allPages())
+        pluginInfoProviders.add(&page.get()->pluginInfoProvider());
 
     for (auto& pluginInfoProvider : pluginInfoProviders)
         pluginInfoProvider->refresh(reload);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -49,6 +49,7 @@
 #include <memory>
 #include <pal/SessionID.h>
 #include <wtf/Assertions.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
@@ -278,7 +279,7 @@ constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<Render
 };
 
 
-class Page : public Supplementable<Page>, public CanMakeWeakPtr<Page> {
+class Page : public Supplementable<Page>, public CanMakeWeakPtr<Page>, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(Page);
     WTF_MAKE_FAST_ALLOCATED;
     friend class SettingsBase;

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -55,7 +55,7 @@ void platformReleaseMemory(Critical)
     LocaleCocoa::releaseMemory();
 
     for (auto& pool : LayerPool::allLayerPools())
-        pool->drain();
+        pool.get()->drain();
 
 #if PLATFORM(IOS_FAMILY)
     LegacyTileCache::drainLayerPool();

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -34,6 +34,7 @@
 
 #include "IntRect.h"
 #include "PlatformScreen.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TypeCasts.h>
@@ -84,7 +85,7 @@ enum WidgetNotification { WillPaintFlattened, DidPaintFlattened };
 // Scrollbar - Mac, Gtk
 // Plugin - Mac, Windows (windowed only), Qt (windowed only, widget is an HWND on windows), Gtk (windowed only)
 //
-class Widget : public RefCounted<Widget>, public CanMakeWeakPtr<Widget> {
+class Widget : public RefCounted<Widget>, public CanMakeWeakPtr<Widget>, public CanMakeCheckedPtr {
 public:
     WEBCORE_EXPORT explicit Widget(PlatformWidget = nullptr);
     WEBCORE_EXPORT virtual ~Widget();

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 
 #include "PlatformMediaSession.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
@@ -114,7 +115,7 @@ public:
 #endif
 };
 
-class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient> {
+class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient>, public CanMakeCheckedPtr {
 public:
     virtual ~PlaybackSessionModelClient() { };
     virtual void durationChanged(double) { }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -30,6 +30,7 @@
 #include "EventListener.h"
 #include "HTMLMediaElementEnums.h"
 #include "PlaybackSessionModel.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
@@ -117,7 +118,7 @@ private:
 
     RefPtr<HTMLMediaElement> m_mediaElement;
     bool m_isListening { false };
-    HashSet<PlaybackSessionModelClient*> m_clients;
+    HashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -60,8 +60,8 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
 {
     if (m_mediaElement == mediaElement) {
         if (m_mediaElement) {
-            for (auto client : m_clients)
-                client->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
+            for (auto& client : m_clients)
+                client.get()->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
         }
         return;
     }
@@ -108,15 +108,15 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
 
     updateForEventName(eventNameAll());
 
-    for (auto client : m_clients)
-        client->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
+    for (auto& client : m_clients)
+        client.get()->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
 }
 
 void PlaybackSessionModelMediaElement::mediaEngineChanged()
 {
     bool wirelessVideoPlaybackDisabled = this->wirelessVideoPlaybackDisabled();
-    for (auto client : m_clients)
-        client->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
+    for (auto& client : m_clients)
+        client.get()->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
 }
 
 void PlaybackSessionModelMediaElement::handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event& event)
@@ -134,20 +134,20 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
     if (all
         || eventName == eventNames().durationchangeEvent) {
         double duration = this->duration();
-        for (auto client : m_clients)
-            client->durationChanged(duration);
+        for (auto& client : m_clients)
+            client.get()->durationChanged(duration);
         // These is no standard event for minFastReverseRateChange; duration change is a reasonable proxy for it.
         // It happens every time a new item becomes ready to play.
         bool canPlayFastReverse = this->canPlayFastReverse();
-        for (auto client : m_clients)
-            client->canPlayFastReverseChanged(canPlayFastReverse);
+        for (auto& client : m_clients)
+            client.get()->canPlayFastReverseChanged(canPlayFastReverse);
     }
 
     if (all
         || eventName == eventNames().playEvent
         || eventName == eventNames().playingEvent) {
-        for (auto client : m_clients)
-            client->playbackStartedTimeChanged(playbackStartedTime());
+        for (auto& client : m_clients)
+            client.get()->playbackStartedTimeChanged(playbackStartedTime());
     }
 
     if (all
@@ -164,16 +164,16 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
 
         double playbackRate =  this->playbackRate();
         double defaultPlaybackRate = this->defaultPlaybackRate();
-        for (auto client : m_clients)
-            client->rateChanged(playbackState, playbackRate, defaultPlaybackRate);
+        for (auto& client : m_clients)
+            client.get()->rateChanged(playbackState, playbackRate, defaultPlaybackRate);
     }
 
     if (all
         || eventName == eventNames().timeupdateEvent) {
         auto currentTime = this->currentTime();
         auto anchorTime = [[NSProcessInfo processInfo] systemUptime];
-        for (auto client : m_clients)
-            client->currentTimeChanged(currentTime, anchorTime);
+        for (auto& client : m_clients)
+            client.get()->currentTimeChanged(currentTime, anchorTime);
     }
 
     if (all
@@ -182,9 +182,9 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         auto seekableRanges = this->seekableRanges();
         auto seekableTimeRangesLastModifiedTime = this->seekableTimeRangesLastModifiedTime();
         auto liveUpdateInterval = this->liveUpdateInterval();
-        for (auto client : m_clients) {
-            client->bufferedTimeChanged(bufferedTime);
-            client->seekableRangesChanged(seekableRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
+        for (auto& client : m_clients) {
+            client.get()->bufferedTimeChanged(bufferedTime);
+            client.get()->seekableRangesChanged(seekableRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
         }
     }
 
@@ -201,9 +201,9 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
 
         bool wirelessVideoPlaybackDisabled = this->wirelessVideoPlaybackDisabled();
 
-        for (auto client : m_clients) {
-            client->externalPlaybackChanged(enabled, targetType, localizedDeviceName);
-            client->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
+        for (auto& client : m_clients) {
+            client.get()->externalPlaybackChanged(enabled, targetType, localizedDeviceName);
+            client.get()->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
         }
     }
 
@@ -211,8 +211,8 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         || eventName == eventNames().webkitpresentationmodechangedEvent) {
         bool isPictureInPictureActive = this->isPictureInPictureActive();
 
-        for (auto client : m_clients)
-            client->pictureInPictureActiveChanged(isPictureInPictureActive);
+        for (auto& client : m_clients)
+            client.get()->pictureInPictureActiveChanged(isPictureInPictureActive);
     }
 
 
@@ -223,9 +223,9 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
 
     if (all
         || eventName == eventNames().volumechangeEvent) {
-        for (auto client : m_clients) {
-            client->mutedChanged(isMuted());
-            client->volumeChanged(volume());
+        for (auto& client : m_clients) {
+            client.get()->mutedChanged(isMuted());
+            client.get()->volumeChanged(volume());
         }
     }
 }
@@ -406,9 +406,9 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionOptions()
     auto legibleOptions = legibleMediaSelectionOptions();
     auto legibleIndex = legibleMediaSelectedIndex();
 
-    for (auto client : m_clients) {
-        client->audioMediaSelectionOptionsChanged(audioOptions, audioIndex);
-        client->legibleMediaSelectionOptionsChanged(legibleOptions, legibleIndex);
+    for (auto& client : m_clients) {
+        client.get()->audioMediaSelectionOptionsChanged(audioOptions, audioIndex);
+        client.get()->legibleMediaSelectionOptionsChanged(legibleOptions, legibleIndex);
     }
 }
 
@@ -417,9 +417,9 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionIndices()
     auto audioIndex = audioMediaSelectedIndex();
     auto legibleIndex = legibleMediaSelectedIndex();
 
-    for (auto client : m_clients) {
-        client->audioMediaSelectionIndexChanged(audioIndex);
-        client->legibleMediaSelectionIndexChanged(legibleIndex);
+    for (auto& client : m_clients) {
+        client.get()->audioMediaSelectionIndexChanged(audioIndex);
+        client.get()->legibleMediaSelectionIndexChanged(legibleIndex);
     }
 }
 

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
@@ -34,6 +34,7 @@
 #include "MediaPlayerEnums.h"
 #include "MediaPlayerIdentifier.h"
 #include "PlaybackSessionModel.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/WeakPtr.h>
 
@@ -97,7 +98,7 @@ public:
 #endif
 };
 
-class VideoFullscreenModelClient : public CanMakeWeakPtr<VideoFullscreenModelClient> {
+class VideoFullscreenModelClient : public CanMakeWeakPtr<VideoFullscreenModelClient>, public CanMakeCheckedPtr {
 public:
     virtual ~VideoFullscreenModelClient() = default;
     virtual void hasVideoChanged(bool) { }

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
@@ -35,6 +35,7 @@
 #include "MediaPlayerIdentifier.h"
 #include "PlatformLayer.h"
 #include "VideoFullscreenModel.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
@@ -119,7 +120,7 @@ private:
     RefPtr<HTMLVideoElement> m_videoElement;
     RetainPtr<PlatformLayer> m_videoFullscreenLayer;
     bool m_isListening { false };
-    HashSet<VideoFullscreenModelClient*> m_clients;
+    HashSet<CheckedPtr<VideoFullscreenModelClient>> m_clients;
     bool m_hasVideo { false };
     FloatSize m_videoDimensions;
     FloatRect m_videoFrame;

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
@@ -281,7 +281,7 @@ void VideoFullscreenModelVideoElement::setHasVideo(bool hasVideo)
     m_hasVideo = hasVideo;
 
     for (auto& client : copyToVector(m_clients))
-        client->hasVideoChanged(m_hasVideo);
+        client.get()->hasVideoChanged(m_hasVideo);
 }
 
 void VideoFullscreenModelVideoElement::setVideoDimensions(const FloatSize& videoDimensions)
@@ -293,7 +293,7 @@ void VideoFullscreenModelVideoElement::setVideoDimensions(const FloatSize& video
     m_videoDimensions = videoDimensions;
 
     for (auto& client : copyToVector(m_clients))
-        client->videoDimensionsChanged(m_videoDimensions);
+        client.get()->videoDimensionsChanged(m_videoDimensions);
 }
 
 void VideoFullscreenModelVideoElement::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
@@ -303,43 +303,43 @@ void VideoFullscreenModelVideoElement::setPlayerIdentifier(std::optional<MediaPl
 
     m_playerIdentifier = identifier;
 
-    for (auto* client : copyToVector(m_clients))
-        client->setPlayerIdentifier(identifier);
+    for (auto& client : copyToVector(m_clients))
+        client.get()->setPlayerIdentifier(identifier);
 }
 
 void VideoFullscreenModelVideoElement::willEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client->willEnterPictureInPicture();
+        client.get()->willEnterPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::didEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client->didEnterPictureInPicture();
+        client.get()->didEnterPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::failedToEnterPictureInPicture()
 {
     ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client->failedToEnterPictureInPicture();
+        client.get()->failedToEnterPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::willExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client->willExitPictureInPicture();
+        client.get()->willExitPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::didExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client->didExitPictureInPicture();
+        client.get()->didExitPictureInPicture();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
@@ -114,8 +114,8 @@ bool DisplayRefreshMonitor::removeClient(DisplayRefreshMonitorClient& client)
 std::optional<FramesPerSecond> DisplayRefreshMonitor::maximumClientPreferredFramesPerSecond() const
 {
     std::optional<FramesPerSecond> maxFramesPerSecond;
-    for (auto* client : m_clients)
-        maxFramesPerSecond = std::max<FramesPerSecond>(maxFramesPerSecond.value_or(0), client->preferredFramesPerSecond());
+    for (auto& client : m_clients)
+        maxFramesPerSecond = std::max<FramesPerSecond>(maxFramesPerSecond.value_or(0), client.get()->preferredFramesPerSecond());
 
     return maxFramesPerSecond;
 }
@@ -203,11 +203,11 @@ void DisplayRefreshMonitor::displayDidRefresh(const DisplayUpdate& displayUpdate
 
     // Copy the hash table and remove clients from it one by one so we don't notify
     // any client twice, but can respond to removal of clients during the delivery process.
-    HashSet<DisplayRefreshMonitorClient*> clientsToBeNotified = m_clients;
+    auto clientsToBeNotified = m_clients;
     m_clientsToBeNotified = &clientsToBeNotified;
     while (!clientsToBeNotified.isEmpty()) {
-        DisplayRefreshMonitorClient* client = clientsToBeNotified.takeAny();
-        client->fireDisplayRefreshIfNeeded(displayUpdate);
+        auto client = clientsToBeNotified.takeAny();
+        client.get()->fireDisplayRefreshIfNeeded(displayUpdate);
 
         // This checks if this function was reentered. In that case, stop iterating
         // since it's not safe to use the set any more.

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
@@ -28,6 +28,7 @@
 #include "AnimationFrameRate.h"
 #include "DisplayUpdate.h"
 #include "PlatformScreen.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -95,8 +96,8 @@ private:
     std::optional<FramesPerSecond> maximumClientPreferredFramesPerSecond() const;
     void computeMaxPreferredFramesPerSecond();
 
-    HashSet<DisplayRefreshMonitorClient*> m_clients;
-    HashSet<DisplayRefreshMonitorClient*>* m_clientsToBeNotified { nullptr };
+    HashSet<CheckedPtr<DisplayRefreshMonitorClient>> m_clients;
+    HashSet<CheckedPtr<DisplayRefreshMonitorClient>>* m_clientsToBeNotified { nullptr };
 
     PlatformDisplayID m_displayID { 0 };
     std::optional<FramesPerSecond> m_maxClientPreferredFramesPerSecond;

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h
@@ -28,6 +28,7 @@
 #include "AnimationFrameRate.h"
 #include "PlatformScreen.h"
 #include <optional>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class DisplayRefreshMonitorFactory;
 
 struct DisplayUpdate;
 
-class DisplayRefreshMonitorClient {
+class DisplayRefreshMonitorClient : public CanMakeCheckedPtr {
 public:
     DisplayRefreshMonitorClient();
     virtual ~DisplayRefreshMonitorClient();

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -373,7 +373,7 @@ const MediaPlayerFactory* MediaPlayer::mediaEngine(MediaPlayerEnums::MediaEngine
     return engines[currentIndex].get();
 }
 
-static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const MediaEngineSupportParameters& parameters, const HashSet<const MediaPlayerFactory*>& attemptedEngines = { }, const MediaPlayerFactory* current = nullptr)
+static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const MediaEngineSupportParameters& parameters, const WeakHashSet<const MediaPlayerFactory>& attemptedEngines = { }, const MediaPlayerFactory* current = nullptr)
 {
     if (parameters.type.isEmpty() && !parameters.isMediaSource && !parameters.isMediaStream)
         return nullptr;
@@ -394,7 +394,7 @@ static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const Media
                 current = nullptr;
             continue;
         }
-        if (attemptedEngines.contains(engine.get()))
+        if (attemptedEngines.contains(*engine))
             continue;
         MediaPlayer::SupportsType engineSupport = engine->supportsTypeAndCodecs(parameters);
         if (engineSupport > supported) {
@@ -433,7 +433,7 @@ const MediaPlayerFactory* MediaPlayer::nextMediaEngine(const MediaPlayerFactory*
 
     auto* nextEngine = engines[currentIndex + 1].get();
     
-    if (m_attemptedEngines.contains(nextEngine))
+    if (m_attemptedEngines.contains(*nextEngine))
         return nextMediaEngine(nextEngine);
     
     return nextEngine;
@@ -622,7 +622,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         m_private = nullptr;
     } else if (m_currentMediaEngine != engine) {
         m_currentMediaEngine = engine;
-        m_attemptedEngines.add(engine);
+        m_attemptedEngines.add(*engine);
         m_private = engine->createMediaEnginePlayer(this);
         if (m_private) {
             client().mediaPlayerEngineUpdated();

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -49,6 +49,7 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URL.h>
 #include <wtf/WallTime.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/text/StringHash.h>
 
 OBJC_CLASS AVPlayer;
@@ -765,7 +766,7 @@ private:
     Timer m_reloadTimer;
     std::unique_ptr<MediaPlayerPrivateInterface> m_private;
     const MediaPlayerFactory* m_currentMediaEngine { nullptr };
-    HashSet<const MediaPlayerFactory*> m_attemptedEngines;
+    WeakHashSet<const MediaPlayerFactory> m_attemptedEngines;
     URL m_url;
     ContentType m_contentType;
     String m_keySystem;
@@ -801,7 +802,7 @@ private:
     ProcessIdentity m_processIdentity;
 };
 
-class MediaPlayerFactory {
+class MediaPlayerFactory : public CanMakeWeakPtr<MediaPlayerFactory> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     MediaPlayerFactory() = default;

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RenderingResourceIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
@@ -34,7 +35,7 @@ namespace WebCore {
 class RenderingResource
     : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RenderingResource> {
 public:
-    class Observer {
+    class Observer : public CanMakeCheckedPtr {
     public:
         virtual ~Observer() = default;
         virtual void releaseRenderingResource(RenderingResourceIdentifier) = 0;
@@ -46,8 +47,8 @@ public:
     {
         if (!hasValidRenderingResourceIdentifier())
             return;
-        for (auto observer : m_observers)
-            observer->releaseRenderingResource(renderingResourceIdentifier());
+        for (auto& observer : m_observers)
+            observer.get()->releaseRenderingResource(renderingResourceIdentifier());
     }
 
     virtual bool isNativeImage() const { return false; }
@@ -89,7 +90,7 @@ protected:
     {
     }
 
-    HashSet<Observer*> m_observers;
+    HashSet<CheckedPtr<Observer>> m_observers;
     std::optional<RenderingResourceIdentifier> m_renderingResourceIdentifier;
 };
 

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 
 namespace WebCore {
@@ -56,7 +57,7 @@ enum class TiledBackingScrollability : uint8_t {
     VerticallyScrollable    = 1 << 1
 };
 
-class TiledBacking {
+class TiledBacking : public CanMakeCheckedPtr {
 public:
     virtual ~TiledBacking() = default;
 

--- a/Source/WebCore/platform/graphics/ca/LayerPool.cpp
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.cpp
@@ -47,10 +47,10 @@ LayerPool::~LayerPool()
     allLayerPools().remove(this);
 }
 
-HashSet<LayerPool*>& LayerPool::allLayerPools()
+HashSet<CheckedPtr<LayerPool>>& LayerPool::allLayerPools()
 {
     RELEASE_ASSERT(isMainThread());
-    static NeverDestroyed<HashSet<LayerPool*>> allLayerPools;
+    static NeverDestroyed<HashSet<CheckedPtr<LayerPool>>> allLayerPools;
     return allLayerPools.get();
 }
 

--- a/Source/WebCore/platform/graphics/ca/LayerPool.h
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.h
@@ -30,6 +30,7 @@
 #include "IntSizeHash.h"
 #include "PlatformCALayer.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
@@ -37,13 +38,13 @@
 
 namespace WebCore {
     
-class LayerPool {
+class LayerPool : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(LayerPool);
 public:
     WEBCORE_EXPORT LayerPool();
     WEBCORE_EXPORT ~LayerPool();
 
-    static HashSet<LayerPool*>& allLayerPools();
+    static HashSet<CheckedPtr<LayerPool>>& allLayerPools();
     
     void addLayer(const RefPtr<PlatformCALayer>&);
     RefPtr<PlatformCALayer> takeLayerWithSize(const IntSize&);

--- a/Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.cpp
+++ b/Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.cpp
@@ -36,6 +36,10 @@ namespace WebCore {
 
 static const unsigned kMaxCountOfUnparentedTiledLayers = 16;
 
+TileControllerMemoryHandler::TileControllerMemoryHandler() = default;
+
+TileControllerMemoryHandler::~TileControllerMemoryHandler() = default;
+
 void TileControllerMemoryHandler::removeTileController(TileController* controller)
 {
     if (m_tileControllers.contains(controller))
@@ -45,10 +49,8 @@ void TileControllerMemoryHandler::removeTileController(TileController* controlle
 unsigned TileControllerMemoryHandler::totalUnparentedTiledLayers() const
 {
     unsigned totalUnparentedLayers = 0;
-    for (ListHashSet<TileController*>::const_iterator it = m_tileControllers.begin(); it != m_tileControllers.end(); ++it) {
-        TileController* tileController = *it;
-        totalUnparentedLayers += tileController->numberOfUnparentedTiles();
-    }
+    for (auto& tileController : m_tileControllers)
+        totalUnparentedLayers += tileController.get()->numberOfUnparentedTiles();
     return totalUnparentedLayers;
 }
 
@@ -71,8 +73,7 @@ void TileControllerMemoryHandler::tileControllerGainedUnparentedTiles(TileContro
 void TileControllerMemoryHandler::trimUnparentedTilesToTarget(int target)
 {
     while (!m_tileControllers.isEmpty()) {
-        TileController* tileController = m_tileControllers.first();
-        tileController->removeUnparentedTilesNow();
+        m_tileControllers.first().get()->removeUnparentedTilesNow();
         m_tileControllers.removeFirst();
 
         if (target > 0 && totalUnparentedTiledLayers() < static_cast<unsigned>(target))

--- a/Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.h
+++ b/Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -39,15 +40,18 @@ public:
     friend TileControllerMemoryHandler& tileControllerMemoryHandler();
     friend class NeverDestroyed<TileControllerMemoryHandler>;
 
+    ~TileControllerMemoryHandler();
+
     void removeTileController(TileController*);
     void tileControllerGainedUnparentedTiles(TileController*);
     WEBCORE_EXPORT void trimUnparentedTilesToTarget(int target);
 
 private:
-    TileControllerMemoryHandler() { }
+    TileControllerMemoryHandler();
+
     unsigned totalUnparentedTiledLayers() const;
 
-    typedef ListHashSet<TileController*> TileControllerList;
+    using TileControllerList = ListHashSet<CheckedPtr<TileController>>;
     TileControllerList m_tileControllers;
 };
 

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -210,8 +210,8 @@ private:
     void didCleanupFullscreen() final;
     void fullscreenMayReturnToInline() final;
 
-    HashSet<PlaybackSessionModelClient*> m_playbackClients;
-    HashSet<VideoFullscreenModelClient*> m_fullscreenClients;
+    HashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
+    HashSet<CheckedPtr<VideoFullscreenModelClient>> m_fullscreenClients;
     RefPtr<VideoFullscreenInterfaceAVKit> m_interface;
     RefPtr<VideoFullscreenModelVideoElement> m_fullscreenModel;
     RefPtr<PlaybackSessionModelMediaElement> m_playbackModel;
@@ -434,7 +434,7 @@ void VideoFullscreenControllerContext::hasVideoChanged(bool hasVideo)
     }
 
     for (auto& client : m_fullscreenClients)
-        client->hasVideoChanged(hasVideo);
+        client.get()->hasVideoChanged(hasVideo);
 }
 
 void VideoFullscreenControllerContext::videoDimensionsChanged(const FloatSize& videoDimensions)
@@ -447,7 +447,7 @@ void VideoFullscreenControllerContext::videoDimensionsChanged(const FloatSize& v
     }
 
     for (auto& client : m_fullscreenClients)
-        client->videoDimensionsChanged(videoDimensions);
+        client.get()->videoDimensionsChanged(videoDimensions);
 }
 
 void VideoFullscreenControllerContext::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
@@ -649,36 +649,36 @@ bool VideoFullscreenControllerContext::isPictureInPictureSupported() const
 void VideoFullscreenControllerContext::willEnterPictureInPicture()
 {
     ASSERT(isUIThread());
-    for (auto* client : m_fullscreenClients)
-        client->willEnterPictureInPicture();
+    for (auto& client : m_fullscreenClients)
+        client.get()->willEnterPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::didEnterPictureInPicture()
 {
     ASSERT(isUIThread());
-    for (auto* client : m_fullscreenClients)
-        client->didEnterPictureInPicture();
+    for (auto& client : m_fullscreenClients)
+        client.get()->didEnterPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::failedToEnterPictureInPicture()
 {
     ASSERT(isUIThread());
-    for (auto* client : m_fullscreenClients)
-        client->failedToEnterPictureInPicture();
+    for (auto& client : m_fullscreenClients)
+        client.get()->failedToEnterPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::willExitPictureInPicture()
 {
     ASSERT(isUIThread());
-    for (auto* client : m_fullscreenClients)
-        client->willExitPictureInPicture();
+    for (auto& client : m_fullscreenClients)
+        client.get()->willExitPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::didExitPictureInPicture()
 {
     ASSERT(isUIThread());
-    for (auto* client : m_fullscreenClients)
-        client->didExitPictureInPicture();
+    for (auto& client : m_fullscreenClients)
+        client.get()->didExitPictureInPicture();
 }
 
 FloatSize VideoFullscreenControllerContext::videoDimensions() const

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -364,8 +364,8 @@ void RealtimeMediaSource::audioSamplesAvailable(const MediaTime& time, const Pla
     updateHasStartedProducingData();
 
     Locker locker { m_audioSampleObserversLock };
-    for (auto* observer : m_audioSampleObservers)
-        observer->audioSamplesAvailable(time, audioData, description, numberOfFrames);
+    for (auto& observer : m_audioSampleObservers)
+        observer.get()->audioSamplesAvailable(time, audioData, description, numberOfFrames);
 }
 
 void RealtimeMediaSource::start()

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -45,6 +45,7 @@
 #include "RealtimeMediaSourceFactory.h"
 #include "RealtimeMediaSourceIdentifier.h"
 #include "VideoFrameTimeMetadata.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
@@ -102,7 +103,7 @@ public:
 
         virtual void hasStartedProducingData() { }
     };
-    class AudioSampleObserver {
+    class AudioSampleObserver : public CanMakeCheckedPtr {
     public:
         virtual ~AudioSampleObserver() = default;
 
@@ -330,7 +331,7 @@ private:
     WeakHashSet<Observer> m_observers;
 
     mutable Lock m_audioSampleObserversLock;
-    HashSet<AudioSampleObserver*> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
+    HashSet<CheckedPtr<AudioSampleObserver>> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
 
     mutable Lock m_videoFrameObserversLock;
     HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -76,9 +76,9 @@ void BaseAudioSharedUnit::clearClients()
 void BaseAudioSharedUnit::forEachClient(const Function<void(CoreAudioCaptureSource&)>& apply) const
 {
     ASSERT(isMainThread());
-    for (auto* client : copyToVector(m_clients)) {
+    for (auto& client : copyToVector(m_clients)) {
         // Make sure the client has not been destroyed.
-        if (!m_clients.contains(client))
+        if (!m_clients.contains(client.get()))
             continue;
         apply(*client);
     }
@@ -294,9 +294,9 @@ void BaseAudioSharedUnit::audioSamplesAvailable(const MediaTime& time, const Pla
     // For performance reasons, we forbid heap allocations while doing rendering on the capture audio thread.
     ForbidMallocUseForCurrentThreadScope forbidMallocUse;
 
-    for (auto* client : m_audioThreadClients) {
-        if (client->isProducingData())
-            client->audioSamplesAvailable(time, data, description, numberOfFrames);
+    for (auto& client : m_audioThreadClients) {
+        if (client.get()->isProducingData())
+            client.get()->audioSamplesAvailable(time, data, description, numberOfFrames);
     }
 }
 

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -29,6 +29,7 @@
 
 #include "RealtimeMediaSourceCapabilities.h"
 #include "RealtimeMediaSourceCenter.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -135,8 +136,8 @@ private:
     uint32_t m_outputDeviceID { 0 };
     std::optional<std::pair<String, uint32_t>> m_capturingDevice;
 
-    HashSet<CoreAudioCaptureSource*> m_clients;
-    Vector<CoreAudioCaptureSource*> m_audioThreadClients WTF_GUARDED_BY_LOCK(m_audioThreadClientsLock);
+    HashSet<CheckedPtr<CoreAudioCaptureSource>> m_clients;
+    Vector<CheckedPtr<CoreAudioCaptureSource>> m_audioThreadClients WTF_GUARDED_BY_LOCK(m_audioThreadClientsLock);
     Lock m_audioThreadClientsLock;
 
     bool m_isProducingMicrophoneSamples { true };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -34,6 +34,7 @@
 #include "RealtimeMediaSourceFactory.h"
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreAudio/CoreAudioTypes.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/text/WTFString.h>
 
 typedef struct OpaqueCMClock* CMClockRef;
@@ -50,7 +51,7 @@ class BaseAudioSharedUnit;
 class CaptureDeviceInfo;
 class WebAudioSourceProviderAVFObjC;
 
-class CoreAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop> {
+class CoreAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop>, public CanMakeCheckedPtr {
 public:
     WEBCORE_EXPORT static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
     static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, BaseAudioSharedUnit& overrideUnit, PageIdentifier);

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -32,6 +32,7 @@
 #include "ShouldRelaxThirdPartyCookieBlocking.h"
 #include <optional>
 #include <pal/SessionID.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
@@ -90,7 +91,7 @@ enum class ApplyTrackingPrevention : bool { No, Yes };
 enum class ScriptWrittenCookiesOnly : bool { No, Yes };
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-class CookieChangeObserver {
+class CookieChangeObserver : public CanMakeCheckedPtr {
 public:
     virtual ~CookieChangeObserver() { }
     virtual void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&) = 0;
@@ -277,7 +278,7 @@ private:
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     bool m_didRegisterCookieListeners { false };
     RetainPtr<NSMutableSet> m_subscribedDomainsForCookieChanges;
-    MemoryCompactRobinHoodHashMap<String, HashSet<CookieChangeObserver*>> m_cookieChangeObservers;
+    MemoryCompactRobinHoodHashMap<String, HashSet<CheckedPtr<CookieChangeObserver>>> m_cookieChangeObservers;
 #endif
 
     CredentialStorage m_credentialStorage;

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -52,7 +52,7 @@ Vector<MarkedText> MarkedText::subdivide(const Vector<MarkedText>& markedTexts, 
         enum Kind { Begin, End };
         Kind kind;
         unsigned value; // Copy of markedText.startOffset/endOffset to avoid the need to branch based on kind.
-        const MarkedText* markedText;
+        CheckedPtr<const MarkedText> markedText;
     };
 
     // 1. Build table of all offsets.
@@ -75,7 +75,7 @@ Vector<MarkedText> MarkedText::subdivide(const Vector<MarkedText>& markedTexts, 
     // 3. Compute intersection.
     Vector<MarkedText> result;
     result.reserveInitialCapacity(numberOfMarkedTexts);
-    HashSet<const MarkedText*> processedMarkedTexts;
+    HashSet<CheckedPtr<const MarkedText>> processedMarkedTexts;
     unsigned offsetSoFar = offsets[0].value;
     for (unsigned i = 1; i < numberOfOffsets; ++i) {
         if (offsets[i].value > offsets[i - 1].value) {

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -36,7 +37,7 @@ class RenderText;
 class RenderedDocumentMarker;
 struct TextBoxSelectableRange;
 
-struct MarkedText {
+struct MarkedText : public CanMakeCheckedPtr {
     // Sorted by paint order
     enum class Type : uint8_t {
         Unmarked,


### PR DESCRIPTION
#### 856a95b01953c64480004661ac4bfc5d8db35023
<pre>
Store fewer raw pointers in containers in Source/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=261710">https://bugs.webkit.org/show_bug.cgi?id=261710</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/CheckedRef.h:
(WTF::CanMakeCheckedPtrBase::operator==):
* Source/WebCore/page/Page.cpp:
(WebCore::allPages):
(WebCore::Page::forEachPage):
(WebCore::networkStateChanged):
(WebCore::Page::clearPreviousItemFromAllPages):
(WebCore::Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment):
(WebCore::Page::refreshPlugins):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm:
(WebCore::platformReleaseMemory):
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::setMediaElement):
(WebCore::PlaybackSessionModelMediaElement::mediaEngineChanged):
(WebCore::PlaybackSessionModelMediaElement::updateForEventName):
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionOptions):
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionIndices):
* Source/WebCore/platform/cocoa/VideoFullscreenModel.h:
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm:
(WebCore::VideoFullscreenModelVideoElement::setHasVideo):
(WebCore::VideoFullscreenModelVideoElement::setVideoDimensions):
(WebCore::VideoFullscreenModelVideoElement::setPlayerIdentifier):
(WebCore::VideoFullscreenModelVideoElement::willEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::didEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::failedToEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::willExitPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::didExitPictureInPicture):
* Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp:
(WebCore::DisplayRefreshMonitor::maximumClientPreferredFramesPerSecond const):
(WebCore::DisplayRefreshMonitor::displayDidRefresh):
* Source/WebCore/platform/graphics/DisplayRefreshMonitor.h:
* Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::bestMediaEngineForSupportParameters):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::~RenderingResource):
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/LayerPool.cpp:
(WebCore::LayerPool::allLayerPools):
* Source/WebCore/platform/graphics/ca/LayerPool.h:
* Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.cpp:
(WebCore::TileControllerMemoryHandler::totalUnparentedTiledLayers const):
(WebCore::TileControllerMemoryHandler::trimUnparentedTilesToTarget):
* Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.h:
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::hasVideoChanged):
(VideoFullscreenControllerContext::videoDimensionsChanged):
(VideoFullscreenControllerContext::willEnterPictureInPicture):
(VideoFullscreenControllerContext::didEnterPictureInPicture):
(VideoFullscreenControllerContext::failedToEnterPictureInPicture):
(VideoFullscreenControllerContext::willExitPictureInPicture):
(VideoFullscreenControllerContext::didExitPictureInPicture):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::audioSamplesAvailable):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::forEachClient const):
(WebCore::BaseAudioSharedUnit::audioSamplesAvailable):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::registerCookieChangeListenersIfNecessary):
(WebCore::NetworkStorageSession::startListeningForCookieChangeNotifications):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::subdivide):
* Source/WebCore/rendering/MarkedText.h:

Canonical link: <a href="https://commits.webkit.org/268159@main">https://commits.webkit.org/268159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac74a6c5214fce07f1bcb813c36d7f697f8c6b28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19339 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21613 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17196 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16368 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21546 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17953 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22237 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17020 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5412 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21386 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23483 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2309 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17789 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5271 "Passed tests") | 
<!--EWS-Status-Bubble-End-->