### PR TITLE
css/filter-effects/backdrop-filter-containing-block.html fails because backdrop-filter doesn't create a containing block.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5151,7 +5151,6 @@ webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/selection-tex
 
 
 # css/filter-effects
-imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-containing-block.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-fixed-clip.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-isolation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1972,6 +1972,7 @@ void RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded(con
     auto mayNotBeContainingBlockForDescendantsAnymore = oldStyle.position() != m_style.position()
         || oldStyle.hasTransformRelatedProperty() != m_style.hasTransformRelatedProperty()
         || oldStyle.willChange() != newStyle.willChange()
+        || oldStyle.hasBackdropFilter() != newStyle.hasBackdropFilter()
         || oldStyle.containsLayout() != newStyle.containsLayout()
         || oldStyle.containsSize() != newStyle.containsSize();
     if (!mayNotBeContainingBlockForDescendantsAnymore)

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -47,7 +47,8 @@ inline bool RenderElement::canContainAbsolutelyPositionedObjects() const
     return isRenderView()
         || style().position() != PositionType::Static
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
-        || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForAbsolutelyPositioned()) // FIXME: will-change should create containing blocks on inline boxes (bug 225035)
+        || (hasBackdropFilter() && !isDocumentElementRenderer())
+        || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForAbsolutelyPositioned(isDocumentElementRenderer()))
         || isSVGForeignObjectOrLegacySVGForeignObject()
         || shouldApplyLayoutOrPaintContainment();
 }
@@ -56,7 +57,8 @@ inline bool RenderElement::canContainFixedPositionObjects() const
 {
     return isRenderView()
         || (canEstablishContainingBlockWithTransform() && hasTransformRelatedProperty())
-        || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForOutOfFlowPositioned()) // FIXME: will-change should create containing blocks on inline boxes (bug 225035)
+        || (hasBackdropFilter() && !isDocumentElementRenderer())
+        || (isRenderBlock() && style().willChange() && style().willChange()->createsContainingBlockForOutOfFlowPositioned(isDocumentElementRenderer()))
         || isSVGForeignObjectOrLegacySVGForeignObject()
         || shouldApplyLayoutOrPaintContainment();
 }

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -60,13 +60,13 @@ bool WillChangeData::containsProperty(CSSPropertyID property) const
     return false;
 }
 
-bool WillChangeData::createsContainingBlockForAbsolutelyPositioned() const
+bool WillChangeData::createsContainingBlockForAbsolutelyPositioned(bool isRootElement) const
 {
-    return createsContainingBlockForOutOfFlowPositioned()
+    return createsContainingBlockForOutOfFlowPositioned(isRootElement)
         || containsProperty(CSSPropertyPosition);
 }
 
-bool WillChangeData::createsContainingBlockForOutOfFlowPositioned() const
+bool WillChangeData::createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const
 {
     return containsProperty(CSSPropertyPerspective)
         // CSS transforms
@@ -79,7 +79,7 @@ bool WillChangeData::createsContainingBlockForOutOfFlowPositioned() const
         // CSS filter & backdrop-filter
         // FIXME: exclude root element for those properties (bug 225034)
 #if ENABLE(FILTERS_LEVEL_2)
-        || containsProperty(CSSPropertyWebkitBackdropFilter)
+        || (containsProperty(CSSPropertyWebkitBackdropFilter) && !isRootElement)
 #endif
         || containsProperty(CSSPropertyFilter);
 }

--- a/Source/WebCore/rendering/style/WillChangeData.h
+++ b/Source/WebCore/rendering/style/WillChangeData.h
@@ -48,8 +48,8 @@ public:
     bool containsContents() const;
     bool containsProperty(CSSPropertyID) const;
 
-    bool createsContainingBlockForAbsolutelyPositioned() const;
-    bool createsContainingBlockForOutOfFlowPositioned() const;
+    bool createsContainingBlockForAbsolutelyPositioned(bool isRootElement) const;
+    bool createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const;
     bool canCreateStackingContext() const { return m_canCreateStackingContext; }
     bool canTriggerCompositing() const { return m_canTriggerCompositing; }
     bool canTriggerCompositingOnInline() const { return m_canTriggerCompositingOnInline; }


### PR DESCRIPTION
#### 0f4cd6871883de54429c34b5e162609d0c1c2005
<pre>
css/filter-effects/backdrop-filter-containing-block.html fails because backdrop-filter doesn&apos;t create a containing block.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261662">https://bugs.webkit.org/show_bug.cgi?id=261662</a>
&lt;rdar://115638583&gt;

Reviewed by Simon Fraser.

Backdrop-filter should establish a containing block for absolute and fixed position descendants, except if it&apos;s on the root element.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded):
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::canContainAbsolutelyPositionedObjects const):
(WebCore::RenderElement::canContainFixedPositionObjects const):
* Source/WebCore/rendering/style/WillChangeData.cpp:
(WebCore::WillChangeData::createsContainingBlockForAbsolutelyPositioned const):
(WebCore::WillChangeData::createsContainingBlockForOutOfFlowPositioned const):
* Source/WebCore/rendering/style/WillChangeData.h:

Canonical link: <a href="https://commits.webkit.org/268161@main">https://commits.webkit.org/268161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336012bc4aaf3ccef743560cb3c91c21768aa641

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19349 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21452 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23500 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21394 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15130 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16883 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4485 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->