### PR TITLE
Introduce PushSubscriptionOwner

### DIFF
--- a/Source/WebCore/Modules/push-api/PushManager.h
+++ b/Source/WebCore/Modules/push-api/PushManager.h
@@ -31,19 +31,19 @@
 #include "PushPermissionState.h"
 #include "PushSubscription.h"
 #include "PushSubscriptionOptionsInit.h"
-#include "ServiceWorkerRegistration.h"
 #include <optional>
 #include <wtf/IsoMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
+class PushSubscriptionOwner;
 class ScriptExecutionContext;
 
 class PushManager {
     WTF_MAKE_ISO_ALLOCATED(PushManager);
 public:
-    explicit PushManager(ServiceWorkerRegistration&);
+    explicit PushManager(PushSubscriptionOwner&);
     ~PushManager();
 
     void ref() const;
@@ -56,7 +56,7 @@ public:
     void permissionState(ScriptExecutionContext&, std::optional<PushSubscriptionOptionsInit>&&, DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&);
 
 private:
-    ServiceWorkerRegistration& m_serviceWorkerRegistration;
+    PushSubscriptionOwner& m_pushSubscriptionOwner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/PushSubscription.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscription.cpp
@@ -32,6 +32,7 @@
 #include "Exception.h"
 #include "JSDOMPromiseDeferred.h"
 #include "PushSubscriptionOptions.h"
+#include "PushSubscriptionOwner.h"
 #include "ScriptExecutionContext.h"
 #include "ServiceWorkerContainer.h"
 #include <JavaScriptCore/ArrayBuffer.h>
@@ -42,9 +43,9 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(PushSubscription);
 
-PushSubscription::PushSubscription(PushSubscriptionData&& data, RefPtr<ServiceWorkerRegistration>&& registration)
+PushSubscription::PushSubscription(PushSubscriptionData&& data, RefPtr<PushSubscriptionOwner>&& owner)
     : m_data(WTFMove(data))
-    , m_serviceWorkerRegistration(WTFMove(registration))
+    , m_pushSubscriptionOwner(WTFMove(owner))
 {
 }
 
@@ -109,12 +110,12 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> PushSubscription::getKey(PushEncryptionKey
 void PushSubscription::unsubscribe(ScriptExecutionContext& scriptExecutionContext, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
     scriptExecutionContext.eventLoop().queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, pushSubscriptionIdentifier = m_data.identifier, promise = WTFMove(promise)]() mutable {
-        if (!m_serviceWorkerRegistration) {
+        if (!m_pushSubscriptionOwner) {
             promise.resolve(false);
             return;
         }
 
-        m_serviceWorkerRegistration->unsubscribeFromPushService(pushSubscriptionIdentifier, WTFMove(promise));
+        m_pushSubscriptionOwner->unsubscribeFromPushService(pushSubscriptionIdentifier, WTFMove(promise));
     });
 }
 

--- a/Source/WebCore/Modules/push-api/PushSubscription.h
+++ b/Source/WebCore/Modules/push-api/PushSubscription.h
@@ -46,9 +46,9 @@ class ArrayBuffer;
 namespace WebCore {
 
 class PushSubscriptionOptions;
+class PushSubscriptionOwner;
 class ScriptExecutionContext;
 class ServiceWorkerContainer;
-class ServiceWorkerRegistration;
 
 class PushSubscription : public RefCounted<PushSubscription> {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(PushSubscription, WEBCORE_EXPORT);
@@ -70,10 +70,10 @@ public:
     PushSubscriptionJSON toJSON() const;
 
 private:
-    WEBCORE_EXPORT explicit PushSubscription(PushSubscriptionData&&, RefPtr<ServiceWorkerRegistration>&& = nullptr);
+    WEBCORE_EXPORT explicit PushSubscription(PushSubscriptionData&&, RefPtr<PushSubscriptionOwner>&& = nullptr);
 
     PushSubscriptionData m_data;
-    RefPtr<ServiceWorkerRegistration> m_serviceWorkerRegistration;
+    RefPtr<PushSubscriptionOwner> m_pushSubscriptionOwner;
     mutable RefPtr<PushSubscriptionOptions> m_options;
 };
 

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOwner.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOwner.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSDOMPromiseDeferredForward.h"
+#include "PushSubscription.h"
+
+namespace WebCore {
+
+class PushSubscription;
+
+enum class PushPermissionState : uint8_t;
+
+class PushSubscriptionOwner {
+public:
+    virtual ~PushSubscriptionOwner() = default;
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
+
+    virtual bool isActive() const = 0;
+
+    virtual void subscribeToPushService(const Vector<uint8_t>& applicationServerKey, DOMPromiseDeferred<IDLInterface<PushSubscription>>&&) = 0;
+    virtual void unsubscribeFromPushService(PushSubscriptionIdentifier, DOMPromiseDeferred<IDLBoolean>&&) = 0;
+    virtual void getPushSubscription(DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&&) = 0;
+    virtual void getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&) = 0;
+};
+
+}

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -35,6 +35,7 @@
 #include "NotificationOptions.h"
 #include "PushPermissionState.h"
 #include "PushSubscription.h"
+#include "PushSubscriptionOwner.h"
 #include "SWClientConnection.h"
 #include "ServiceWorkerRegistrationData.h"
 #include "Supplementable.h"
@@ -52,7 +53,7 @@ class ServiceWorker;
 class ServiceWorkerContainer;
 class WebCoreOpaqueRoot;
 
-class ServiceWorkerRegistration final : public RefCounted<ServiceWorkerRegistration>, public Supplementable<ServiceWorkerRegistration>, public EventTarget, public ActiveDOMObject {
+class ServiceWorkerRegistration final : public RefCounted<ServiceWorkerRegistration>, public Supplementable<ServiceWorkerRegistration>, public EventTarget, public ActiveDOMObject, public PushSubscriptionOwner {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(ServiceWorkerRegistration, WEBCORE_EXPORT);
 public:
     static Ref<ServiceWorkerRegistration> getOrCreate(ScriptExecutionContext&, Ref<ServiceWorkerContainer>&&, ServiceWorkerRegistrationData&&);
@@ -64,6 +65,8 @@ public:
     ServiceWorker* installing();
     ServiceWorker* waiting();
     ServiceWorker* active();
+
+    bool isActive() const final { return !!m_activeWorker; }
 
     ServiceWorker* getNewestWorker() const;
 
@@ -85,9 +88,9 @@ public:
     void getPushSubscription(DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&&);
     void getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&);
 
-    using RefCounted::ref;
-    using RefCounted::deref;
-    
+    void ref() const final { RefCounted::ref(); };
+    void deref() const final { RefCounted::deref(); };
+
     const ServiceWorkerRegistrationData& data() const { return m_registrationData; }
 
     void updateStateFromServer(ServiceWorkerRegistrationState, RefPtr<ServiceWorker>&&);


### PR DESCRIPTION
#### 64acc68e8da636201e7a01af80aaae82bfd60b07
<pre>
Introduce PushSubscriptionOwner
<a href="https://bugs.webkit.org/show_bug.cgi?id=261711">https://bugs.webkit.org/show_bug.cgi?id=261711</a>
rdar://115690541

Reviewed by Megan Gardner and Andy Estes.

To support Declarative Web Push, a few push-related areas that currently refer to ServiceWorkerRegistration
will need to refer to a more abstract &quot;PushSubscriptionOwner&quot; instead.

Introduce that concept here in a standalone patch before starting to pile on to it.

* Source/WebCore/Modules/push-api/PushManager.cpp:
(WebCore::PushManager::PushManager):
(WebCore::PushManager::ref const):
(WebCore::PushManager::deref const):
(WebCore::PushManager::subscribe):
(WebCore::PushManager::getSubscription):
* Source/WebCore/Modules/push-api/PushManager.h:
* Source/WebCore/Modules/push-api/PushSubscription.cpp:
(WebCore::PushSubscription::PushSubscription):
(WebCore::PushSubscription::unsubscribe):
* Source/WebCore/Modules/push-api/PushSubscription.h:
* Source/WebCore/Modules/push-api/PushSubscriptionOwner.h: Copied from Source/WebCore/Modules/push-api/PushManager.h.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:

Canonical link: <a href="https://commits.webkit.org/268129@main">https://commits.webkit.org/268129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a127bb19e0898eac9931246bfc44ace27fe6d896

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19350 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21456 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23502 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21396 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15132 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16886 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4460 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->