### PR TITLE
Add missing `self = [super init]` statements

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -180,8 +180,8 @@ static constexpr NSString *baseURLKey = @"WK.baseURL";
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    auto selfPtr = adoptNS([super initWithString:@""]);
-    if (!selfPtr)
+    self = [super initWithString:@""];
+    if (!self)
         return nil;
 
     NSUInteger length;
@@ -194,7 +194,7 @@ static constexpr NSString *baseURLKey = @"WK.baseURL";
     if (!m_wrappedURL)
         m_wrappedURL = [NSURL URLWithString:@""];
 
-    return selfPtr.leakRef();
+    return self;
 }
 
 - (instancetype)initWithURL:(NSURL *)url
@@ -231,14 +231,14 @@ static constexpr NSString *innerColorKey = @"WK.CocoaColor";
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    auto selfPtr = adoptNS([super init]);
-    if (!selfPtr)
+    self = [super init];
+    if (!self)
         return nil;
 
     RetainPtr<WebCore::CocoaColor> color = static_cast<WebCore::CocoaColor *>([coder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:innerColorKey]);
     m_wrappedColor = color.get().CGColor;
 
-    return selfPtr.leakRef();
+    return self;
 }
 
 - (instancetype)initWithCGColor:(CGColorRef)color

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -310,6 +310,9 @@ private:
 
 - (instancetype)initWithExpectation:(NSArray *)expectedMessages
 {
+    self = [super init];
+    if (!self)
+        return nil;
     _messages = adoptNS([[NSMutableArray alloc] init]);
     _expectedMessages = expectedMessages;
     return self;


### PR DESCRIPTION
#### 45dd419f3fea1f19ac6e03c71faad7533eb77cd2
<pre>
Add missing `self = [super init]` statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=261714">https://bugs.webkit.org/show_bug.cgi?id=261714</a>

Reviewed by Wenson Hsieh.

Add missing `self = [super init]` statements. Those were reported by the static
analyzer.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(-[WKSecureCodingURLWrapper initWithCoder:]):
(-[WKSecureCodingCGColorWrapper initWithCoder:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(-[TestSOAuthorizationScriptMessageHandler initWithExpectation:]):

Canonical link: <a href="https://commits.webkit.org/268125@main">https://commits.webkit.org/268125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce2e4879811e979986f468a10722736c73407ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21473 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23515 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21412 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21268 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2298 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->