### PR TITLE
Combining backface-visibility:hidden and backdrop-filter stops the backface from being hidden.

### DIFF
--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-with-backface-visibility-expected.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-with-backface-visibility-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>This tests that an element with backface-visibility hidden does not show its backdrop filter.</title>
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  position: absolute;
+}
+
+#behind {
+  background: green;
+}
+</style>
+</head>
+<body>
+<div id="behind"></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-with-backface-visibility.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-with-backface-visibility.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>This tests that an element with backface-visibility hidden does not show its backdrop filter.</title>
+<style>
+div {
+  width: 200px;
+  height: 200px;
+  position: absolute;
+}
+
+#behind {
+  background: green;
+}
+
+#outer {
+  transform-style: preserve-3d;
+  transform: rotateX(180deg);
+}
+
+#inner {
+  transform: rotateX(0deg);
+  background: red;
+  backface-visibility: hidden;
+  -webkit-backdrop-filter: blur(1px);
+}
+</style>
+</head>
+<body>
+<div id="behind"></div>
+<div id="outer">
+  <div id="inner">
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2435,7 +2435,8 @@ void GraphicsLayerCA::updateContentsOpaque(float pageScaleFactor)
 
 void GraphicsLayerCA::updateBackfaceVisibility()
 {
-    if (m_structuralLayer && structuralLayerPurpose() == StructuralLayerForReplicaFlattening) {
+    if (m_structuralLayer && (structuralLayerPurpose() == StructuralLayerForReplicaFlattening || structuralLayerPurpose() == StructuralLayerForBackdrop)) {
+
         m_structuralLayer->setDoubleSided(m_backfaceVisibility);
 
         if (m_layerClones) {


### PR DESCRIPTION
#### 93bef5855560f6abc5817869e36e81473204974f
<pre>
Combining backface-visibility:hidden and backdrop-filter stops the backface from being hidden.
<a href="https://bugs.webkit.org/show_bug.cgi?id=249952">https://bugs.webkit.org/show_bug.cgi?id=249952</a>
&lt;rdar://103940530&gt;

Reviewed by Simon Fraser.

Structural layers created for backdrop-filter should still have the double sided property set.

* LayoutTests/css3/filters/backdrop/backdrop-filter-with-backface-visibility-expected.html: Added.
* LayoutTests/css3/filters/backdrop/backdrop-filter-with-backface-visibility.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateBackfaceVisibility):

Canonical link: <a href="https://commits.webkit.org/268427@main">https://commits.webkit.org/268427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4109d37ef1e06bd350c4595ff1dd74ebe30cd598

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19362 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21474 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21413 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15145 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/16901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4699 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->