### PR TITLE
[scroll-anchoring] Implement suppression triggers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Ancestor changes in document scroller. assert_equals: expected 150 but got 220
-FAIL Ancestor changes in scrollable <div>. assert_equals: expected 150 but got 220
+PASS Ancestor changes in document scroller.
+PASS Ancestor changes in scrollable <div>.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Positioned ancestors with dynamic changes to offsets trigger scroll suppressions. assert_equals: expected 200 but got 310
+PASS Positioned ancestors with dynamic changes to offsets trigger scroll suppressions.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-expected.txt
@@ -1,4 +1,4 @@
 content
 
-FAIL Dynamically styling 'overflow-anchor: none' on the anchor node should prevent scroll anchoring assert_equals: expected 150 but got 200
+PASS Dynamically styling 'overflow-anchor: none' on the anchor node should prevent scroll anchoring
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-scroller-expected.txt
@@ -1,4 +1,4 @@
 content
 
-FAIL Dynamically styling 'overflow-anchor: none' on the scroller element should prevent scroll anchoring assert_equals: expected 150 but got 200
+PASS Dynamically styling 'overflow-anchor: none' on the scroller element should prevent scroll anchoring
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Position changes in document scroller. assert_equals: expected 200 but got 175
-FAIL Position changes in scrollable <div>. assert_equals: expected 200 but got 175
+PASS Position changes in document scroller.
+PASS Position changes in scrollable <div>.
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -747,6 +747,7 @@ public:
     void updateScrollAnchoringElement() final;
     void updateScrollPositionForScrollAnchoringController() final;
     void invalidateScrollAnchoringElement() final;
+    ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
 
 private:
     explicit LocalFrameView(LocalFrame&);

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Document.h"
+#include "Element.h"
 #include "FloatPoint.h"
 #include "ScrollTypes.h"
 #include <wtf/WeakPtr.h>
@@ -44,11 +45,15 @@ class ScrollAnchoringController final : public CanMakeWeakPtr<ScrollAnchoringCon
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ScrollAnchoringController(ScrollableArea&);
+    ~ScrollAnchoringController();
     void invalidateAnchorElement();
     void adjustScrollPositionForAnchoring();
     void selectAnchorElement();
     void chooseAnchorElement(Document&);
     void updateAnchorElement();
+    void notifyChildHadSuppressingStyleChange();
+    bool isInScrollAnchoringAncestorChain(const RenderObject&);
+    Element* anchorElement() const { return m_anchorElement.get(); }
 
 private:
     Element* findAnchorElementRecursive(Element*);
@@ -62,6 +67,7 @@ private:
     FloatPoint m_lastOffsetForAnchorElement;
     bool m_midUpdatingScrollPositionForAnchorElement { false };
     bool m_isQueuedForScrollPositionUpdate { false };
+    bool m_shouldSupressScrollPositionUpdate { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1010,6 +1010,14 @@ void RenderElement::styleDidChange(StyleDifference diff, const RenderStyle* oldS
         updateOutlineAutoAncestor(hasOutlineAuto);
         issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().outlineSize() : oldStyle->outlineSize());
     }
+
+    bool shouldCheckIfInAncestorChain = false;
+    if (frame().settings().cssScrollAnchoringEnabled() && (style().outOfFlowPositionStyleDidChange(oldStyle) || (shouldCheckIfInAncestorChain = style().scrollAnchoringSuppressionStyleDidChange(oldStyle)))) {
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "RenderElement::styleDidChange() found node with style change: " << *this << " from: " << oldStyle->position() <<" to: " << style().position());
+        auto* controller = findScrollAnchoringControllerForRenderer(*this);
+        if (controller && (!shouldCheckIfInAncestorChain || (shouldCheckIfInAncestorChain && controller->isInScrollAnchoringAncestorChain(*this))))
+            controller->notifyChildHadSuppressingStyleChange();
+    }
 }
 
 void RenderElement::insertedIntoTree(IsInternalMove isInternalMove)

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -256,6 +256,7 @@ public:
     void updateScrollAnchoringElement() final;
     void updateScrollPositionForScrollAnchoringController() final;
     void invalidateScrollAnchoringElement() final;
+    ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
 
 private:
     bool hasHorizontalOverflow() const;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -60,6 +60,7 @@
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
 #include "RenderLayerCompositor.h"
+#include "RenderLayerScrollableArea.h"
 #include "RenderLineBreak.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
@@ -2344,6 +2345,22 @@ Vector<FloatRect> RenderObject::absoluteBorderAndTextRects(const SimpleRange& ra
 Vector<FloatRect> RenderObject::clientBorderAndTextRects(const SimpleRange& range)
 {
     return borderAndTextRects(range, CoordinateSpace::Client, { });
+}
+
+ScrollAnchoringController* RenderObject::findScrollAnchoringControllerForRenderer(const RenderObject& renderer)
+{
+    if (renderer.hasLayer()) {
+        if (auto* scrollableArea = downcast<RenderLayerModelObject>(renderer).layer()->scrollableArea())
+            return scrollableArea->scrollAnchoringController();
+    }
+    for (auto* enclosingLayer = renderer.enclosingLayer(); enclosingLayer; enclosingLayer = enclosingLayer->parent()) {
+        if (RenderLayerScrollableArea* scrollableArea = enclosingLayer->scrollableArea()) {
+            auto controller = scrollableArea->scrollAnchoringController();
+            if (controller && controller->anchorElement())
+                return controller;
+        }
+    }
+    return renderer.view().frameView().scrollAnchoringController();
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -406,6 +406,8 @@ public:
 
     bool everHadLayout() const { return m_bitfields.everHadLayout(); }
 
+    static ScrollAnchoringController* findScrollAnchoringControllerForRenderer(const RenderObject&);
+
     bool childrenInline() const { return m_bitfields.childrenInline(); }
     virtual void setChildrenInline(bool b) { m_bitfields.setChildrenInline(b); }
     

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2142,6 +2142,8 @@ public:
     static constexpr BlockStepInsert initialBlockStepInsert();
     inline BlockStepInsert blockStepInsert() const;
     inline void setBlockStepInsert(BlockStepInsert);
+    bool scrollAnchoringSuppressionStyleDidChange(const RenderStyle*) const;
+    bool outOfFlowPositionStyleDidChange(const RenderStyle*) const;
 
 private:
     struct NonInheritedFlags {


### PR DESCRIPTION
#### b02b493840f0ce869e34fcd65a027245d392bc91
<pre>
[scroll-anchoring] Implement suppression triggers
<a href="https://bugs.webkit.org/show_bug.cgi?id=261719">https://bugs.webkit.org/show_bug.cgi?id=261719</a>
<a href="https://rdar.apple.com/115704143">rdar://115704143</a>

Reviewed by Simon Fraser.

Implement suppression of scroll anchoring adjustments according to the spec
(<a href="https://www.w3.org/TR/css-scroll-anchoring-1/#suppression-triggers).">https://www.w3.org/TR/css-scroll-anchoring-1/#suppression-triggers).</a> This involves suppressing scroll
 anchoring adjustments  when certain “suppression trigger” operations occur when an anchor element has
 been chosen but before a scroll anchoring adjustment has occurred, that would cause the next scroll
anchoring adjustment to be incorrect. These suppression triggers are certain style changes on the anchor
element or any element in the anchor element ancestor chain, up to and including the scrolling element
that owns the scroll anchroing controller, as well as changing to or from being absolutely posititioned,
for any element under the owning scrolling element.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-scroller-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-expected.txt:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scheduleResizeEventIfNeeded):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::elementIsScrollableArea):
(WebCore::setInScrollAnchoringAncestorChain):
(WebCore::ScrollAnchoringController::invalidateAnchorElement):
(WebCore::ScrollAnchoringController::notifyChildHadSuppressingStyleChange):
(WebCore::scrollAnchoringControllerForElement):
(WebCore::ScrollAnchoringController::notifyParentScrollAnchoringControllerHadSuppressingStyleChange):
(WebCore::ScrollAnchoringController::didFindPriorityCandidate):
(WebCore::ScrollAnchoringController::chooseAnchorElement):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isInScrollAnchoringAncestorChain const):
(WebCore::RenderObject::setIsInScrollAnchoringAncestorChain):
(WebCore::RenderObject::RenderObjectBitfields::RenderObjectBitfields):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::scrollAnchoringSuppressionStyleDidChange const):
(WebCore::RenderStyle::absolutePositionStyleDidChange const):
* Source/WebCore/rendering/style/RenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/270455@main">https://commits.webkit.org/270455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71c6a63db64514e25666fbd0c93a7f85d2e7d2f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23527 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28177 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29029 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26853 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4045 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3118 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3261 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->