### PR TITLE
[WebCore] Do not lookup HashSet multiple times in PropertyCascade

### DIFF
--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -163,16 +163,27 @@ inline void Builder::applyPropertiesImpl(int firstProperty, int lastProperty)
 
 void Builder::applyCustomProperties()
 {
-    for (auto& name : m_cascade.customProperties().keys())
-        applyCustomProperty(name);
+    for (auto& [name, value] : m_cascade.customProperties()) {
+        if (m_state.m_appliedCustomProperties.contains(name))
+            continue;
+        applyCustomPropertyImpl(name, value);
+    }
 }
 
 void Builder::applyCustomProperty(const AtomString& name)
 {
-    if (m_state.m_appliedCustomProperties.contains(name) || !m_cascade.customProperties().contains(name))
+    if (m_state.m_appliedCustomProperties.contains(name))
         return;
 
-    auto& property = m_cascade.customProperty(name);
+    auto iterator = m_cascade.customProperties().find(name);
+    if (iterator == m_cascade.customProperties().end())
+        return;
+
+    applyCustomPropertyImpl(name, iterator->value);
+}
+
+void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCascade::Property& property)
+{
     if (!property.cssValue[SelectorChecker::MatchDefault])
         return;
 
@@ -296,10 +307,12 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
             // With the rollback cascade built, we need to obtain the property and apply it. If the property is
             // not present, then we behave like "unset." Otherwise we apply the property instead of our own.
             if (customPropertyValue) {
-                if (registeredCustomProperty && registeredCustomProperty->inherits && rollbackCascade->hasCustomProperty(customPropertyValue->name())) {
-                    auto property = rollbackCascade->customProperty(customPropertyValue->name());
-                    applyRollbackCascadeProperty(property, linkMatchMask);
-                    return;
+                if (registeredCustomProperty && registeredCustomProperty->inherits) {
+                    auto iterator = rollbackCascade->customProperties().find(customPropertyValue->name());
+                    if (iterator != rollbackCascade->customProperties().end()) {
+                        applyRollbackCascadeProperty(iterator->value, linkMatchMask);
+                        return;
+                    }
                 }
             } else if (id < firstDeferredProperty) {
                 if (rollbackCascade->hasNormalProperty(id)) {

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -54,6 +54,7 @@ private:
     void applyProperties(int firstProperty, int lastProperty);
     void applyDeferredProperties();
     void applyCustomProperties();
+    void applyCustomPropertyImpl(const AtomString&, const PropertyCascade::Property&);
 
     enum CustomPropertyCycleTracking { Enabled = 0, Disabled };
     template<CustomPropertyCycleTracking trackCycles>

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -134,9 +134,9 @@ private:
 
     const CSSToLengthConversionData m_cssToLengthConversionData;
 
-    HashSet<String> m_appliedCustomProperties;
-    HashSet<String> m_inProgressCustomProperties;
-    HashSet<String> m_inCycleCustomProperties;
+    HashSet<AtomString> m_appliedCustomProperties;
+    HashSet<AtomString> m_inProgressCustomProperties;
+    HashSet<AtomString> m_inCycleCustomProperties;
     WTF::BitSet<numCSSProperties> m_inProgressProperties;
     WTF::BitSet<numCSSProperties> m_inUnitCycleProperties;
 


### PR DESCRIPTION
#### 6442b8b0a4a1e7b7f644329a83b4fbc751ee4569
<pre>
[WebCore] Do not lookup HashSet multiple times in PropertyCascade
<a href="https://bugs.webkit.org/show_bug.cgi?id=261722">https://bugs.webkit.org/show_bug.cgi?id=261722</a>
rdar://115706784

Reviewed by Antti Koivisto.

Let&apos;s not lookup the same HashSet / HashMap multiple times.
And use HashSet&lt;AtomString&gt; instead of HashSet&lt;String&gt; since name is already atomized.

* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::set):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomProperties):
(WebCore::Style::Builder::applyCustomProperty):
(WebCore::Style::Builder::applyCustomPropertyImpl):
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/268114@main">https://commits.webkit.org/268114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9276a130ec79a874145f87b2958f5119609e024e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20623 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19236 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21504 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23537 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21441 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21293 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2296 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->