### PR TITLE
MediaControlTextTrackContainerElement uses Image redundantly, should use NativeImage

### DIFF
--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -400,7 +400,7 @@ void MediaControlTextTrackContainerElement::updateSizes(ForceUpdate force)
     });
 }
 
-RefPtr<Image> MediaControlTextTrackContainerElement::createTextTrackRepresentationImage()
+RefPtr<NativeImage> MediaControlTextTrackContainerElement::createTextTrackRepresentationImage()
 {
     if (!hasChildNodes())
         return nullptr;
@@ -435,7 +435,7 @@ RefPtr<Image> MediaControlTextTrackContainerElement::createTextTrackRepresentati
     paintFlags.add(RenderLayer::PaintLayerFlag::TemporaryClipRects);
     layer->paint(buffer->context(), paintingRect, LayoutSize(), { PaintBehavior::FlattenCompositingLayers, PaintBehavior::Snapshotting }, nullptr, paintFlags);
 
-    return ImageBuffer::sinkIntoImage(WTFMove(buffer));
+    return ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
 }
 
 void MediaControlTextTrackContainerElement::textTrackRepresentationBoundsChanged(const IntRect&)

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -69,7 +69,7 @@ private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 
     // TextTrackRepresentationClient
-    RefPtr<Image> createTextTrackRepresentationImage() override;
+    RefPtr<NativeImage> createTextTrackRepresentationImage() override;
     void textTrackRepresentationBoundsChanged(const IntRect&) override;
 
     void updateTextTrackRepresentationIfNeeded();

--- a/Source/WebCore/platform/graphics/TextTrackRepresentation.h
+++ b/Source/WebCore/platform/graphics/TextTrackRepresentation.h
@@ -33,14 +33,14 @@
 namespace WebCore {
 
 class HTMLMediaElement;
-class Image;
+class NativeImage;
 class IntRect;
 
 class TextTrackRepresentationClient {
 public:
     virtual ~TextTrackRepresentationClient() = default;
 
-    virtual RefPtr<Image> createTextTrackRepresentationImage() = 0;
+    virtual RefPtr<NativeImage> createTextTrackRepresentationImage() = 0;
     virtual void textTrackRepresentationBoundsChanged(const IntRect&) = 0;
 };
 

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
@@ -140,7 +140,7 @@ TextTrackRepresentationCocoa::~TextTrackRepresentationCocoa()
 void TextTrackRepresentationCocoa::update()
 {
     if (auto representation = m_client.createTextTrackRepresentationImage())
-        [m_layer setContents:(__bridge id)representation->nativeImage()->platformImage().get()];
+        [m_layer setContents:(__bridge id)representation->platformImage().get()];
 }
 
 void TextTrackRepresentationCocoa::setContentScale(float scale)

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -54,10 +54,7 @@ void WebTextTrackRepresentationCocoa::update()
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
     
-    auto representation = m_client.createTextTrackRepresentationImage();
-    if (!representation)
-        return;
-    auto image = representation->nativeImage();
+    auto image = m_client.createTextTrackRepresentationImage();
     if (!image)
         return;
     auto imageSize = image->size();


### PR DESCRIPTION
#### 0e4fcb51c7983b701cf7a9aaadb1b34cd52d2cd2
<pre>
MediaControlTextTrackContainerElement uses Image redundantly, should use NativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=261723">https://bugs.webkit.org/show_bug.cgi?id=261723</a>
rdar://problem/115709836

Reviewed by Said Abou-Hallawa.

WebCore::Image is mostly about DOM images.

Callers of MediaControlTextTrackContainerElement::createTextTrackRepresentationImage()
use the platform image, e.g. WebCore::NativeImage. Return this type.

Work towards removing ImageBuffer::sinkIntoImage().

* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::createTextTrackRepresentationImage):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/platform/graphics/TextTrackRepresentation.h:
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm:
(WebCore::TextTrackRepresentationCocoa::update):
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::update):

Canonical link: <a href="https://commits.webkit.org/268188@main">https://commits.webkit.org/268188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc97acee206ca3589e5b5f81a62546e07ba7a80c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19416 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19173 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21701 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17529 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18018 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17099 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4508 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->