### PR TITLE
[GCrypt] Add refinements and comments for implementations of RFC 7748 and 8032 functionality

### DIFF
--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 
 static std::optional<Vector<uint8_t>> gcryptDerive(const Vector<uint8_t>& baseKey, const Vector<uint8_t>& publicKey)
 {
-    return X25519(baseKey, publicKey);
+    return GCrypt::RFC7748::X25519(baseKey, publicKey);
 }
 
 std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyOKP& baseKey, const CryptoKeyOKP& publicKey)

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -64,13 +64,6 @@ static bool supportedAlgorithmIdentifier(CryptoAlgorithmIdentifier keyIdentifier
     return false;
 }
 
-static Vector<uint8_t> nine {
-    0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
 }
 
 static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerateEd25519Keys()
@@ -113,7 +106,7 @@ static std::optional<std::pair<Vector<uint8_t>, Vector<uint8_t>>> gcryptGenerate
         return std::nullopt;
 
     // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
-    auto d = X25519(*q, WebCore::CryptoKeyOKPImpl::nine);
+    auto d = GCrypt::RFC7748::X25519(*q, GCrypt::RFC7748::c_X25519BasePointU);
     if (UNLIKELY(!d))
         return std::nullopt;
 
@@ -162,11 +155,11 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier, NamedCurve
     switch (namedCurve) {
     case NamedCurve::X25519: {
         // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
-        auto q = X25519(privateKey, WebCore::CryptoKeyOKPImpl::nine);
+        auto q = GCrypt::RFC7748::X25519(privateKey, GCrypt::RFC7748::c_X25519BasePointU);
         return q && q->size() == 32 && *q == publicKey;
     }
     case NamedCurve::Ed25519:
-        return validateEd25519KeyPair(privateKey, publicKey);
+        return GCrypt::RFC8032::validateEd25519KeyPair(privateKey, publicKey);
     default:
         ASSERT_NOT_REACHED();
         return false;
@@ -481,7 +474,7 @@ String CryptoKeyOKP::generateJwkX() const
 
     if (m_curve == CryptoKeyOKP::NamedCurve::X25519) {
         // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
-        auto q = X25519(m_data, WebCore::CryptoKeyOKPImpl::nine);
+        auto q = GCrypt::RFC7748::X25519(m_data, GCrypt::RFC7748::c_X25519BasePointU);
         if (q && q->size() == 32)
             return base64URLEncodeToString(*q);
 

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC7748.cpp
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC7748.cpp
@@ -20,7 +20,12 @@
 #include "config.h"
 #include "GCryptRFC7748.h"
 
+#include <pal/crypto/gcrypt/Handle.h>
+#include <pal/crypto/gcrypt/Utilities.h>
+
 namespace WebCore {
+namespace GCrypt {
+namespace RFC7748 {
 
 struct X25519Impl {
     static constexpr char s_curveName[] = "Curve25519";
@@ -33,36 +38,35 @@ struct X448Impl {
 };
 
 template<typename ImplType>
-std::optional<Vector<uint8_t>> xImpl(const Vector<uint8_t>& kArg, const Vector<uint8_t>& uArg)
-
+std::optional<Vector<uint8_t>> xImpl(const std::span<const uint8_t>& kArg, const std::span<const uint8_t>& uArg)
 {
-    if (!(kArg.size() == ImplType::argSize) && uArg.size() == ImplType::argSize)
+    if (kArg.size() != ImplType::argSize || uArg.size() != ImplType::argSize)
         return std::nullopt;
 
+    gcry_error_t error = GPG_ERR_NO_ERROR;
+
     PAL::GCrypt::Handle<gcry_ctx_t> context;
-    if (auto error = gcry_mpi_ec_new(&context, nullptr, ImplType::s_curveName)) {
+    error = gcry_mpi_ec_new(&context, nullptr, ImplType::s_curveName);
+    if (error != GPG_ERR_NO_ERROR) {
         PAL::GCrypt::logError(error);
         return std::nullopt;
     }
 
-    Vector<uint8_t> k = kArg;
-    std::reverse(k.begin(), k.end());
-    Vector<uint8_t> u = uArg;
-    std::reverse(u.begin(), u.end());
-
     PAL::GCrypt::Handle<gcry_mpi_t> kMPI;
-    gcry_mpi_scan(&kMPI, GCRYMPI_FMT_USG, k.data(), k.size(), nullptr);
-    PAL::GCrypt::Handle<gcry_mpi_t> uMPI;
-    gcry_mpi_scan(&uMPI, GCRYMPI_FMT_USG, u.data(), u.size(), nullptr);
-
-    if constexpr (std::is_same_v<ImplType, X25519Impl>)
-        gcry_mpi_clear_bit(uMPI, 255);
-
-    PAL::GCrypt::Handle<gcry_mpi_point_t> Q(gcry_mpi_point_new(0));
-    PAL::GCrypt::Handle<gcry_mpi_point_t> P(gcry_mpi_point_set(nullptr, uMPI, nullptr, GCRYMPI_CONST_ONE));
-
-    Vector<uint8_t> result;
     {
+        std::array<uint8_t, ImplType::argSize> k;
+        std::copy(kArg.rbegin(), kArg.rend(), k.begin());
+
+        error = gcry_mpi_scan(&kMPI, GCRYMPI_FMT_USG, k.data(), k.size(), nullptr);
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return std::nullopt;
+        }
+
+        // For X25519:
+        //   - three least-significant bits of the first byte are set to zero,
+        //   - second most-significant bit of the last byte is set to 1,
+        //   - most-significant bit of the of the last byte is set to zero.
         if constexpr (std::is_same_v<ImplType, X25519Impl>) {
             gcry_mpi_clear_bit(kMPI, 0);
             gcry_mpi_clear_bit(kMPI, 1);
@@ -71,36 +75,73 @@ std::optional<Vector<uint8_t>> xImpl(const Vector<uint8_t>& kArg, const Vector<u
             gcry_mpi_clear_bit(kMPI, 255);
         }
 
+        // For X448:
+        //   - two least-significant bits of the first byte are set to zero,
+        //   - most-significant bit of the last byte is set to zero.
         if constexpr (std::is_same_v<ImplType, X448Impl>) {
             gcry_mpi_clear_bit(kMPI, 0);
             gcry_mpi_clear_bit(kMPI, 1);
             gcry_mpi_set_bit(kMPI, 447);
         }
+    }
+
+    PAL::GCrypt::Handle<gcry_mpi_t> uMPI;
+    {
+        std::array<uint8_t, ImplType::argSize> u;
+        std::copy(uArg.rbegin(), uArg.rend(), u.begin());
+
+        error = gcry_mpi_scan(&uMPI, GCRYMPI_FMT_USG, u.data(), u.size(), nullptr);
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return std::nullopt;
+        }
+
+        // For X25519, the most significant bit in the last byte of u-coordinate must be cleared.
+        if constexpr (std::is_same_v<ImplType, X25519Impl>)
+            gcry_mpi_clear_bit(uMPI, 255);
+    }
+
+    Vector<uint8_t> result(ImplType::argSize, uint8_t(0));
+    {
+        // Perform the multiplication on the given curve. The result is retrieved back into kMPI.
+        PAL::GCrypt::Handle<gcry_mpi_point_t> Q(gcry_mpi_point_new(0));
+        PAL::GCrypt::Handle<gcry_mpi_point_t> P(gcry_mpi_point_set(nullptr, uMPI, nullptr, GCRYMPI_CONST_ONE));
 
         gcry_mpi_ec_mul(Q, kMPI, P, context);
         int ret = gcry_mpi_ec_get_affine(kMPI, nullptr, Q, context);
+
+        // Store the resulting MPI data into a separate allocation. In case of an infinite point,
+        // a zero Vector is established. Otherwise, the MPI data is retrieved into a properly-sized Vector.
+        Vector<uint8_t> kData;
         if (!ret) {
             size_t numBytes = 0;
-            gcry_mpi_print(GCRYMPI_FMT_USG, nullptr, 0, &numBytes, kMPI);
-            result = Vector<uint8_t>(numBytes, uint8_t(0));
-            gcry_mpi_print(GCRYMPI_FMT_USG, result.data(), result.size(), nullptr, kMPI);
+            error = gcry_mpi_print(GCRYMPI_FMT_USG, nullptr, 0, &numBytes, kMPI);
+            if (error != GPG_ERR_NO_ERROR) {
+                PAL::GCrypt::logError(error);
+                return std::nullopt;
+            }
+
+            kData = Vector<uint8_t>(numBytes, uint8_t(0));
+            error = gcry_mpi_print(GCRYMPI_FMT_USG, kData.data(), kData.size(), nullptr, kMPI);
+            if (error != GPG_ERR_NO_ERROR) {
+                PAL::GCrypt::logError(error);
+                return std::nullopt;
+            }
         } else
-            result = Vector<uint8_t>(ImplType::argSize, uint8_t(0));
+            kData = Vector<uint8_t>(ImplType::argSize, uint8_t(0));
+
+        // Up to curve-specific amount of bytes of MPI data is copied in reverse order
+        // into the initially-zeroed result Vector.
+        size_t kSize = std::min<size_t>(kData.size(), ImplType::argSize);
+        std::copy(kData.rbegin(), std::next(kData.rbegin(), kSize), result.begin());
     }
-
-    std::reverse(result.begin(), result.end());
-    if (result.size() > ImplType::argSize)
-        result.resize(ImplType::argSize);
-
-    while (result.size() < ImplType::argSize)
-        result.append(0x00);
 
     return result;
 }
 
-std::optional<Vector<uint8_t>> X25519(const Vector<uint8_t>& kArg, const Vector<uint8_t>& uArg)
+std::optional<Vector<uint8_t>> X25519(const std::span<const uint8_t>& kArg, const std::span<const uint8_t>& uArg)
 {
     return xImpl<X25519Impl>(kArg, uArg);
 }
 
-} // namespace WebCore
+} } } // namespace WebCore::GCrypt::RFC7748

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC7748.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC7748.h
@@ -19,8 +19,23 @@
 
 #pragma once
 
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <wtf/Vector.h>
+
 namespace WebCore {
+namespace GCrypt {
+namespace RFC7748 {
 
-std::optional<Vector<uint8_t>> X25519(const Vector<uint8_t>& kArg, const Vector<uint8_t>& uArg);
+static constexpr std::array<uint8_t, 32> c_X25519BasePointU {
+    0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
 
-} // namespace WebCore
+std::optional<Vector<uint8_t>> X25519(const std::span<const uint8_t>& kArg, const std::span<const uint8_t>& uArg);
+
+} } } // namespace WebCore::GCrypt::RFC7748

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC8032.cpp
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC8032.cpp
@@ -21,6 +21,8 @@
 #include "GCryptRFC8032.h"
 
 namespace WebCore {
+namespace GCrypt {
+namespace RFC8032 {
 
 bool validateEd25519KeyPair(const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey)
 {
@@ -29,77 +31,88 @@ bool validateEd25519KeyPair(const Vector<uint8_t>& privateKey, const Vector<uint
 
     gcry_error_t error = GPG_ERR_NO_ERROR;
 
-    std::array<uint8_t, 32> hddata;
-    {
-        std::array<uint8_t, 32> ddata;
-        memcpy(ddata.data(), privateKey.data(), 32);
-
-        std::array<uint8_t, 64> digest;
-        gcry_md_hash_buffer(GCRY_MD_SHA512, digest.data(), ddata.data(), ddata.size());
-
-        memcpy(hddata.data(), digest.data(), 32);
-        std::reverse(hddata.begin(), hddata.end());
-    }
-
-    PAL::GCrypt::Handle<gcry_mpi_t> hdmpi;
-    {
-        error = gcry_mpi_scan(&hdmpi, GCRYMPI_FMT_USG, hddata.data(), hddata.size(), nullptr);
-        if (error != GPG_ERR_NO_ERROR)
-            return false;
-
-        gcry_mpi_clear_bit(hdmpi, 0);
-        gcry_mpi_clear_bit(hdmpi, 1);
-        gcry_mpi_clear_bit(hdmpi, 2);
-        gcry_mpi_set_bit(hdmpi, 254);
-        gcry_mpi_clear_bit(hdmpi, 255);
-    }
-
     PAL::GCrypt::Handle<gcry_ctx_t> context;
     error = gcry_mpi_ec_new(&context, nullptr, "Ed25519");
-    if (error != GPG_ERR_NO_ERROR)
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
         return false;
+    }
 
-    std::array<uint8_t, 32> qdata;
+    PAL::GCrypt::Handle<gcry_mpi_t> hdMPI;
     {
+        // For Ed25519, the private-key data is hashed using SHA-512. The lower 32 bytes
+        // are scanned as MPI data, meaning they also have to be reversed.
+        std::array<uint8_t, 32> hddata;
+        memcpy(hddata.data(), privateKey.data(), 32);
+
+        std::array<uint8_t, 64> digest;
+        gcry_md_hash_buffer(GCRY_MD_SHA512, digest.data(), hddata.data(), hddata.size());
+
+        std::copy(std::next(digest.rbegin(), 32), digest.rend(), hddata.begin());
+        error = gcry_mpi_scan(&hdMPI, GCRYMPI_FMT_USG, hddata.data(), hddata.size(), nullptr);
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return false;
+        }
+
+        // For Ed25519:
+        //   - three least-significant bits of the first byte are set to zero,
+        //   - second most-significant bit of the last byte is set to 1,
+        //   - most-significant bit of the of the last byte is set to zero.
+        gcry_mpi_clear_bit(hdMPI, 0);
+        gcry_mpi_clear_bit(hdMPI, 1);
+        gcry_mpi_clear_bit(hdMPI, 2);
+        gcry_mpi_set_bit(hdMPI, 254);
+        gcry_mpi_clear_bit(hdMPI, 255);
+    }
+
+    std::array<uint8_t, 32> qData;
+    std::fill(qData.begin(), qData.end(), uint8_t(0));
+
+    {
+        // Perform the multiplication on the given curve. Both coordinates of the resulting point
+        // are retrieved. The least-significant bit of the x-coordinate is copied into the
+        // most-significant bit of the y-coordinate, which is then the public key value.
         PAL::GCrypt::Handle<gcry_mpi_point_t> G(gcry_mpi_ec_get_point("g", context, 1));
         PAL::GCrypt::Handle<gcry_mpi_point_t> Q(gcry_mpi_point_new(0));
+        PAL::GCrypt::Handle<gcry_mpi_t> xMPI(gcry_mpi_new(0));
+        PAL::GCrypt::Handle<gcry_mpi_t> yMPI(gcry_mpi_new(0));
 
-        gcry_mpi_ec_mul(Q, hdmpi, G, context);
-        PAL::GCrypt::Handle<gcry_mpi_t> xmpi(gcry_mpi_new(0));
-        PAL::GCrypt::Handle<gcry_mpi_t> ympi(gcry_mpi_new(0));
-        int ret = gcry_mpi_ec_get_affine(xmpi, ympi, Q, context);
+        gcry_mpi_ec_mul(Q, hdMPI, G, context);
+        int ret = gcry_mpi_ec_get_affine(xMPI, yMPI, Q, context);
 
+        if (gcry_mpi_test_bit(xMPI, 0))
+            gcry_mpi_set_bit(yMPI, 255);
+        else
+            gcry_mpi_clear_bit(yMPI, 255);
+
+        // Store the resulting MPI data into a separate allocation. In case of an infinite point,
+        // a zero Vector is established. Otherwise, the MPI data is retrieved into a properly-sized Vector.
         Vector<uint8_t> result;
         if (!ret) {
-            if (gcry_mpi_test_bit(xmpi, 0))
-                gcry_mpi_set_bit(ympi, 255);
-            else
-                gcry_mpi_clear_bit(ympi, 255);
-
-            size_t ylength = 0;
-            error = gcry_mpi_print(GCRYMPI_FMT_USG, nullptr, 0, &ylength, ympi);
-            if (error != GPG_ERR_NO_ERROR)
+            size_t numBytes = 0;
+            error = gcry_mpi_print(GCRYMPI_FMT_USG, nullptr, 0, &numBytes, yMPI);
+            if (error != GPG_ERR_NO_ERROR) {
+                PAL::GCrypt::logError(error);
                 return false;
+            }
 
-            result = Vector<uint8_t>(ylength, uint8_t(0));
-            error = gcry_mpi_print(GCRYMPI_FMT_USG, result.data(), result.size(), nullptr, ympi);
-            if (error != GPG_ERR_NO_ERROR)
+            result = Vector<uint8_t>(numBytes, uint8_t(0));
+            error = gcry_mpi_print(GCRYMPI_FMT_USG, result.data(), result.size(), nullptr, yMPI);
+            if (error != GPG_ERR_NO_ERROR) {
+                PAL::GCrypt::logError(error);
                 return false;
+            }
         } else
             result = Vector<uint8_t>(32, uint8_t(0));
 
-        std::reverse(result.begin(), result.end());
-        if (result.size() > 32)
-            result.resize(32);
-        while (result.size() < 32)
-            result.append(0x00);
-        ASSERT(result.size() == 32);
-
-        memcpy(qdata.data(), result.data(), 32);
+        // Up to curve-specific amount of bytes of MPI data is copied in reverse order
+        // into the initially-zeroed result Vector.
+        size_t resultSize = std::min<size_t>(result.size(), 32);
+        std::copy(result.rbegin(), std::next(result.rbegin(), resultSize), qData.begin());
     }
 
-    return !memcmp(qdata.begin(), publicKey.data(), 32);
+    return !memcmp(qData.begin(), publicKey.data(), 32);
 }
 
-} // namespace WebCore
-
+} } } // namespace WebCore::GCrypt::RFC8032

--- a/Source/WebCore/crypto/gcrypt/GCryptRFC8032.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptRFC8032.h
@@ -20,7 +20,9 @@
 #pragma once
 
 namespace WebCore {
+namespace GCrypt {
+namespace RFC8032 {
 
 static bool validateEd25519KeyPair(const Vector<uint8_t>& privateKey, const Vector<uint8_t>& publicKey);
 
-} // namespace WebCore
+} } } // namespace WebCore::GCrypt::RFC8032


### PR DESCRIPTION
#### 7be67897ce4defc358d78bbec768fa36245d4a75
<pre>
[GCrypt] Add refinements and comments for implementations of RFC 7748 and 8032 functionality
<a href="https://bugs.webkit.org/show_bug.cgi?id=261730">https://bugs.webkit.org/show_bug.cgi?id=261730</a>

Reviewed by Javier Fernandez.

For RFC7748 functionality, the X25519 function and the underlying template
now work on spans, allowing other non-Vector objects that are convertible
to spans to be used. That way, the X25519-specific base U value can be
specified as a static array object.

For both RFC7748 and RFC8032 functionality, the implementations are cleaned
up and improved with additional comments describing the work as specified
in the RFCs. Additional error checking is performed for any libgcrypt
operation that might return an error.

* Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp:
(WebCore::gcryptDerive):
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
(WebCore::gcryptGenerateX25519Keys):
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::generateJwkX const):
(): Deleted.
* Source/WebCore/crypto/gcrypt/GCryptRFC7748.cpp:
(WebCore::GCrypt::RFC7748::xImpl):
(WebCore::GCrypt::RFC7748::X25519):
(WebCore::xImpl): Deleted.
(WebCore::X25519): Deleted.
* Source/WebCore/crypto/gcrypt/GCryptRFC7748.h:
* Source/WebCore/crypto/gcrypt/GCryptRFC8032.cpp:
(WebCore::validateEd25519KeyPair):

Canonical link: <a href="https://commits.webkit.org/268123@main">https://commits.webkit.org/268123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9c94f67e3afddeedc09ecc6538d80de814cd5f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21531 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23562 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21467 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15175 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16953 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4456 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->