### PR TITLE
ImageBufferBackend has three overlapping copy-like functions

### DIFF
--- a/Source/WebCore/platform/graphics/CachedSubimage.cpp
+++ b/Source/WebCore/platform/graphics/CachedSubimage.cpp
@@ -104,7 +104,7 @@ void CachedSubimage::draw(GraphicsContext& context, const FloatRect& destination
     auto scaleFactor = destinationRect.size() / sourceRect.size();
     sourceRectScaled.scale(scaleFactor * context.scaleFactor());
 
-    m_imageBuffer->draw(context, destinationRect, sourceRectScaled, { });
+    context.drawImageBuffer(m_imageBuffer.get(), destinationRect, sourceRectScaled, { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -71,8 +71,14 @@ class GraphicsContext {
     friend class NativeImage;
     friend class ImageBuffer;
 public:
-    WEBCORE_EXPORT GraphicsContext(const GraphicsContextState::ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
-    WEBCORE_EXPORT GraphicsContext(const GraphicsContextState&);
+    // Indicates if draw operations read the sources such as NativeImage backing stores immediately
+    // during draw operations.
+    enum class IsDeferred {
+        No,
+        Yes
+    };
+    WEBCORE_EXPORT GraphicsContext(IsDeferred = IsDeferred::No, const GraphicsContextState::ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
+    WEBCORE_EXPORT GraphicsContext(IsDeferred, const GraphicsContextState&);
     WEBCORE_EXPORT virtual ~GraphicsContext();
 
     virtual bool hasPlatformContext() const { return false; }
@@ -364,10 +370,12 @@ public:
     void releaseWindowsContext(HDC, const IntRect&, bool supportAlphaBlend); // The passed in HDC should be the one handed back by getWindowsContext.
 #endif
 
+    IsDeferred deferred() const { return m_isDeferred; }
 private:
     virtual void drawNativeImageInternal(NativeImage&, const FloatSize& selfSize, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) = 0;
 
 protected:
+    WEBCORE_EXPORT RefPtr<NativeImage> nativeImageForDrawing(ImageBuffer&);
     WEBCORE_EXPORT void fillEllipseAsPath(const FloatRect&);
     WEBCORE_EXPORT void strokeEllipseAsPath(const FloatRect&);
 
@@ -379,6 +387,7 @@ protected:
     Vector<FloatPoint> centerLineAndCutOffCorners(bool isVerticalLine, float cornerWidth, FloatPoint point1, FloatPoint point2) const;
 
     GraphicsContextState m_state;
+    const IsDeferred m_isDeferred;
 
 private:
     Vector<GraphicsContextState, 1> m_stack;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -55,14 +55,9 @@ ImageBufferBackend::ImageBufferBackend(const Parameters& parameters)
 
 ImageBufferBackend::~ImageBufferBackend() = default;
 
-RefPtr<NativeImage> ImageBufferBackend::copyNativeImageForDrawing(GraphicsContext&)
-{
-    return copyNativeImage(DontCopyBackingStore);
-}
-
 RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()
 {
-    return copyNativeImage(DontCopyBackingStore);
+    return createNativeImageReference();
 }
 
 void ImageBufferBackend::convertToLuminanceMask()

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -115,10 +115,8 @@ public:
 
     virtual IntSize backendSize() const { return { }; }
 
-    virtual void finalizeDrawIntoContext(GraphicsContext&) { }
-    virtual RefPtr<NativeImage> copyNativeImage(BackingStoreCopy) = 0;
-
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(GraphicsContext& destination);
+    virtual RefPtr<NativeImage> copyNativeImage() = 0;
+    virtual RefPtr<NativeImage> createNativeImageReference() = 0;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
 
     WEBCORE_EXPORT void convertToLuminanceMask();

--- a/Source/WebCore/platform/graphics/SourceImage.cpp
+++ b/Source/WebCore/platform/graphics/SourceImage.cpp
@@ -60,7 +60,7 @@ NativeImage* SourceImage::nativeImage() const
     if (!m_transformedImageVariant) {
         auto imageBuffer = std::get<Ref<ImageBuffer>>(m_imageVariant);
 
-        auto nativeImage = imageBuffer->copyNativeImage(DontCopyBackingStore);
+        auto nativeImage = imageBuffer->createNativeImageReference();
         if (!nativeImage)
             return nullptr;
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -42,7 +42,7 @@ GraphicsLayerAsyncContentsDisplayDelegateCocoa::GraphicsLayerAsyncContentsDispla
 
 bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer& image)
 {
-    m_image = image.clone()->sinkIntoNativeImage();
+    m_image = ImageBuffer::sinkIntoNativeImage(image.clone());
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -174,24 +174,22 @@ enum PathDrawingStyle {
 
 static void drawShadowLayerBuffer(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatPoint& layerOrigin, const FloatSize& layerSize, const ShadowState& shadowState)
 {
-    if (auto nativeImage = layerImage.copyNativeImage(DontCopyBackingStore)) {
+    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
         drawPlatformImage(platformContext, nativeImage->platformImage().get(), FloatRect(roundedIntPoint(layerOrigin), layerSize), FloatRect(FloatPoint(), layerSize), { shadowState.globalCompositeOperator }, shadowState.globalAlpha, ShadowState());
-    }
 }
 
 // FIXME: This is mostly same as drawShadowLayerBuffer, so we should merge two.
 static void drawShadowImage(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatRect& destRect, const FloatRect& srcRect, const ShadowState& shadowState)
 {
-    if (auto nativeImage = layerImage.copyNativeImage(DontCopyBackingStore)) {
+    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
         drawPlatformImage(platformContext, nativeImage->platformImage().get(), destRect, srcRect, { shadowState.globalCompositeOperator }, shadowState.globalAlpha, ShadowState());
-    }
 }
 
 static void fillShadowBuffer(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatPoint& layerOrigin, const FloatSize& layerSize, const ShadowState& shadowState)
 {
     platformContext.save();
 
-    if (auto nativeImage = layerImage.copyNativeImage(DontCopyBackingStore))
+    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
         clipToImageBuffer(platformContext, nativeImage->platformImage().get(), FloatRect(layerOrigin, expandedIntSize(layerSize)));
 
     FillSource fillSource;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -214,7 +214,7 @@ IntRect GraphicsContextCairo::clipBounds() const
 
 void GraphicsContextCairo::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
 {
-    if (auto nativeImage = buffer.copyNativeImage(DontCopyBackingStore))
+    if (auto nativeImage = nativeImageForDrawing(buffer))
         Cairo::clipToImageBuffer(*this, nativeImage->platformImage().get(), destRect);
 }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -108,6 +108,8 @@ public:
     Vector<float>& layers();
     void pushImageMask(cairo_surface_t*, const FloatRect&);
 
+    // Exposed as public because freestanding functions use this.
+    using GraphicsContext::nativeImageForDrawing;
 private:
     RefPtr<cairo_t> m_cr;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
@@ -42,7 +42,8 @@ public:
 
     IntSize backendSize() const override;
 
-    RefPtr<NativeImage> copyNativeImage(BackingStoreCopy) override;
+    RefPtr<NativeImage> copyNativeImage() override;
+    RefPtr<NativeImage> createNativeImageReference() override;
 
     RefPtr<cairo_surface_t> createCairoSurface() override;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -124,22 +124,18 @@ unsigned ImageBufferCGBitmapBackend::bytesPerRow() const
     return calculateBytesPerRow(backendSize);
 }
 
-RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage(BackingStoreCopy copyBehavior)
+RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage()
 {
-    switch (copyBehavior) {
-    case CopyBackingStore:
-        return NativeImage::create(adoptCF(CGBitmapContextCreateImage(context().platformContext())));
+    return NativeImage::create(adoptCF(CGBitmapContextCreateImage(context().platformContext())));
+}
 
-    case DontCopyBackingStore:
-        auto backendSize = this->backendSize();
-        return NativeImage::create(adoptCF(CGImageCreate(
-            backendSize.width(), backendSize.height(), 8, 32, bytesPerRow(),
-            colorSpace().platformColorSpace(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host), m_dataProvider.get(),
-            0, true, kCGRenderingIntentDefault)));
-    }
-
-    ASSERT_NOT_REACHED();
-    return nullptr;
+RefPtr<NativeImage> ImageBufferCGBitmapBackend::createNativeImageReference()
+{
+    auto backendSize = this->backendSize();
+    return NativeImage::create(adoptCF(CGImageCreate(
+        backendSize.width(), backendSize.height(), 8, 32, bytesPerRow(),
+        colorSpace().platformColorSpace(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host), m_dataProvider.get(),
+        0, true, kCGRenderingIntentDefault)));
 }
 
 void ImageBufferCGBitmapBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -52,7 +52,8 @@ private:
     IntSize backendSize() const final;
     unsigned bytesPerRow() const final;
 
-    RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) final;
+    RefPtr<NativeImage> copyNativeImage() final;
+    RefPtr<NativeImage> createNativeImageReference() final;
 
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -170,22 +170,17 @@ void ImageBufferIOSurfaceBackend::invalidateCachedNativeImage()
     CGContextFillRect(ensurePlatformContext(), CGRect { });
 }
 
-RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage(BackingStoreCopy)
+RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage()
 {
     return NativeImage::create(createImage());
 }
 
-RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(GraphicsContext& destination)
+RefPtr<NativeImage> ImageBufferIOSurfaceBackend::createNativeImageReference()
 {
-    if (destination.hasPlatformContext() && CGContextGetType(destination.platformContext()) == kCGContextTypeBitmap) {
-        // The destination backend is not deferred, so we can return a reference.
-        // The destination backend needs to read the actual pixels. Returning non-refence will
-        // copy the pixels and but still cache the image to the context. This means we must
-        // return the reference or cleanup later if we return the non-reference.
-        return NativeImage::create(createImageReference());
-    }
-    // Other backends are deferred (iosurface, display list) or potentially deferred. Must copy for drawing.
-    return ImageBufferIOSurfaceBackend::copyNativeImage(CopyBackingStore);
+    // The destination backend needs to read the actual pixels. Returning non-refence will
+    // copy the pixels and but still cache the image to the context. This means we must
+    // return the reference or cleanup later if we return the non-reference.
+    return NativeImage::create(createImageReference());
 }
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::sinkIntoNativeImage()

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -61,8 +61,8 @@ protected:
     bool flushContextDraws();
     IntSize backendSize() const override;
     
-    RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) override;
-    RefPtr<NativeImage> copyNativeImageForDrawing(GraphicsContext&) override;
+    RefPtr<NativeImage> copyNativeImage() override;
+    RefPtr<NativeImage> createNativeImageReference() override;
     RefPtr<NativeImage> sinkIntoNativeImage() override;
 
     void getPixelBuffer(const IntRect&, PixelBuffer&) override;

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -119,8 +119,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         auto scaleFactor = destinationRect.size() / sourceRect.size();
         sourceRectScaled.scale(scaleFactor * context.scaleFactor());
 
-        // Draw the ImageBuffer to destinationRect in the destination context.
-        imageBuffer->draw(context, destinationRect, sourceRectScaled, { });
+        context.drawImageBuffer(*imageBuffer, destinationRect, sourceRectScaled, { });
         return true;
     };
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -46,8 +46,8 @@
 namespace WebCore {
 namespace DisplayList {
 
-Recorder::Recorder(const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
-    : GraphicsContext(state)
+Recorder::Recorder(IsDeferred isDeferred, const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode)
+    : GraphicsContext(isDeferred, state)
     , m_initialScale(initialCTM.xScale())
     , m_colorSpace(colorSpace)
     , m_drawGlyphsMode(drawGlyphsMode)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -58,13 +58,18 @@ public:
         DeconstructUsingDrawDecomposedGlyphsCommands,
     };
 
-    WEBCORE_EXPORT Recorder(const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode = DrawGlyphsMode::Normal);
+    Recorder(const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& transform, const DestinationColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode = DrawGlyphsMode::Normal)
+        : Recorder(IsDeferred::Yes, state, initialClip, transform, colorSpace, drawGlyphsMode)
+    {
+    }
     WEBCORE_EXPORT virtual ~Recorder();
 
     // Records possible pending commands. Should be used when recording is known to end.
     WEBCORE_EXPORT void commitRecording();
 
 protected:
+    WEBCORE_EXPORT Recorder(IsDeferred, const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const DestinationColorSpace&, DrawGlyphsMode);
+
     virtual void recordSave() = 0;
     virtual void recordRestore() = 0;
     virtual void recordTranslate(float x, float y) = 0;

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -51,7 +51,8 @@ public:
     void releaseGraphicsContext() final;
 
     // NOTE: These all ASSERT_NOT_REACHED().
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() final;
+    RefPtr<WebCore::NativeImage> createNativeImageReference() final;
     void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -150,7 +150,13 @@ void CGDisplayListImageBufferBackend::releaseGraphicsContext()
     m_context = nullptr;
 }
 
-RefPtr<WebCore::NativeImage> CGDisplayListImageBufferBackend::copyNativeImage(WebCore::BackingStoreCopy)
+RefPtr<WebCore::NativeImage> CGDisplayListImageBufferBackend::copyNativeImage()
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+RefPtr<WebCore::NativeImage> CGDisplayListImageBufferBackend::createNativeImageReference()
 {
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -99,7 +99,9 @@ GraphicsContext& WebImage::context() const
 
 RefPtr<NativeImage> WebImage::copyNativeImage(BackingStoreCopy copyBehavior) const
 {
-    return m_buffer->copyNativeImage(copyBehavior);
+    if (copyBehavior == CopyBackingStore)
+        return m_buffer->copyNativeImage();
+    return m_buffer->createNativeImageReference();
 }
 
 RefPtr<ShareableBitmap> WebImage::bitmap() const

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -139,9 +139,14 @@ RefPtr<cairo_surface_t> ImageBufferShareableBitmapBackend::createCairoSurface()
 }
 #endif
 
-RefPtr<NativeImage> ImageBufferShareableBitmapBackend::copyNativeImage(BackingStoreCopy copyBehavior)
+RefPtr<NativeImage> ImageBufferShareableBitmapBackend::copyNativeImage()
 {
-    return NativeImage::create(m_bitmap->createPlatformImage(copyBehavior));
+    return NativeImage::create(m_bitmap->createPlatformImage(CopyBackingStore));
+}
+
+RefPtr<NativeImage> ImageBufferShareableBitmapBackend::createNativeImageReference()
+{
+    return NativeImage::create(m_bitmap->createPlatformImage(DontCopyBackingStore));
 }
 
 void ImageBufferShareableBitmapBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -61,7 +61,8 @@ public:
     RefPtr<cairo_surface_t> createCairoSurface() final;
 #endif
 
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() final;
+    RefPtr<WebCore::NativeImage> createNativeImageReference() final;
 
     void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -50,7 +50,7 @@ namespace WebKit {
 using namespace WebCore;
 
 RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy(RemoteImageBufferProxy& imageBuffer, RemoteRenderingBackendProxy& renderingBackend, const FloatRect& initialClip, const AffineTransform& initialCTM)
-    : DisplayList::Recorder({ }, initialClip, initialCTM, imageBuffer.colorSpace(), DrawGlyphsMode::DeconstructUsingDrawGlyphsCommands)
+    : DisplayList::Recorder(IsDeferred::No, { }, initialClip, initialCTM, imageBuffer.colorSpace(), DrawGlyphsMode::DeconstructUsingDrawGlyphsCommands)
     , m_destinationBufferIdentifier(imageBuffer.renderingResourceIdentifier())
     , m_imageBuffer(imageBuffer)
     , m_renderingBackend(renderingBackend)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -226,11 +226,11 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackendCreated() const
     return m_backend.get();
 }
 
-RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage(BackingStoreCopy copyBehavior) const
+RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage() const
 {
     if (canMapBackingStore()) {
         const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
-        return ImageBuffer::copyNativeImage(copyBehavior);
+        return ImageBuffer::copyNativeImage();
     }
     if (UNLIKELY(!m_remoteRenderingBackendProxy))
         return { };
@@ -241,13 +241,13 @@ RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage(BackingStoreCopy cop
     return NativeImage::create(bitmap->createPlatformImage(DontCopyBackingStore));
 }
 
-RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImageForDrawing(GraphicsContext& destination) const
+RefPtr<NativeImage> RemoteImageBufferProxy::createNativeImageReference() const
 {
     if (canMapBackingStore()) {
         const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
-        return ImageBuffer::copyNativeImageForDrawing(destination);
+        return ImageBuffer::createNativeImageReference();
     }
-    return copyNativeImage(DontCopyBackingStore);
+    return copyNativeImage();
 }
 
 RefPtr<NativeImage> RemoteImageBufferProxy::sinkIntoNativeImage()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -75,8 +75,8 @@ public:
 private:
     RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
 
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
-    RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::GraphicsContext&) const final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() const final;
+    RefPtr<WebCore::NativeImage> createNativeImageReference() const final;
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
 
     RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -112,7 +112,13 @@ unsigned ImageBufferRemoteIOSurfaceBackend::bytesPerRow() const
     return ImageBufferIOSurfaceBackend::calculateBytesPerRow(backendSize);
 }
 
-RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage(BackingStoreCopy)
+RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage()
+{
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
+}
+
+RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::createNativeImageReference()
 {
     RELEASE_ASSERT_NOT_REACHED();
     return { };

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -60,7 +60,8 @@ public:
 
 private:
     WebCore::IntSize backendSize() const final;
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy) final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() final;
+    RefPtr<WebCore::NativeImage> createNativeImageReference() final;
 
     void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -85,7 +85,7 @@ std::optional<ImageBufferBackendHandle> ImageBufferShareableMappedIOSurfaceBacke
     return ImageBufferBackendHandle(m_surface->createSendRight());
 }
 
-RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBackend::copyNativeImage(BackingStoreCopy copyBehavior)
+RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBackend::copyNativeImage()
 {
     auto currentSeed = m_surface->seed();
 
@@ -94,7 +94,7 @@ RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBackend::copyNativeImage(
     if (std::exchange(m_lastSeedWhenCopyingImage, currentSeed) != currentSeed)
         invalidateCachedNativeImage();
 
-    return ImageBufferIOSurfaceBackend::copyNativeImage(copyBehavior);
+    return ImageBufferIOSurfaceBackend::copyNativeImage();
 }
 
 String ImageBufferShareableMappedIOSurfaceBackend::debugDescription() const

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
@@ -52,7 +52,7 @@ private:
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() final;
 
     String debugDescription() const final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -129,13 +129,13 @@ unsigned ImageBufferShareableMappedIOSurfaceBitmapBackend::bytesPerRow() const
     return m_surface->bytesPerRow();
 }
 
-RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImage(BackingStoreCopy copyBehavior)
+RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImage()
 {
     ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
     return nullptr;
 }
 
-RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImageForDrawing(GraphicsContext&)
+RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::createNativeImageReference()
 {
     ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
     return nullptr;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -63,8 +63,8 @@ private:
     // WebCore::ImageBufferCGBackend
     WebCore::IntSize backendSize() const final;
     unsigned bytesPerRow() const final;
-    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;
-    RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::GraphicsContext&) final;
+    RefPtr<WebCore::NativeImage> copyNativeImage() final;
+    RefPtr<WebCore::NativeImage> createNativeImageReference() final;
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
     bool isInUse() const final;
     void releaseGraphicsContext() final;


### PR DESCRIPTION
#### 329f7da0cc3778b668fd606736876062da438036
<pre>
ImageBufferBackend has three overlapping copy-like functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=261731">https://bugs.webkit.org/show_bug.cgi?id=261731</a>
rdar://115718413

Reviewed by Matt Woodrow.

ImageBuffer and -Backend function copyNativeImage(BackingStoreCopy)
is actually two rather distinct functions: copy and a reference.
copyNativeImageForDrawing() is equivalent to
copyNativeImage(DontBackingStore) and certain custom logic needed for
the call chain.

Move the decision to do a copy for draw or a reference for draw into
top-level GraphicsContext. This information will be also used in future
when implementing more correct display list retaining of backing stores
as well as removing the image buffer related remote drawing commands.

Make a clear distinction between creating a copy and creating a
reference to the backing store by calling the functions with different
names. Use the function in more places that obtain a drawable
NativeImage out of an ImageBuffer.

Removes ImageBuffer::draw because it was a redudundant addition
to the call-stack:
GraphicsContext::drawImageBuffer
    ImageBuffer::draw
       Graphicscontext::drawNativeImageInternal

This is work towards making the NativeImage the only image primitive
being drawn from, where as currently also ImageBuffer is a
pseudo-primitive.

* Source/WebCore/platform/graphics/CachedSubimage.cpp:
(WebCore::CachedSubimage::draw):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::GraphicsContext):
(WebCore::GraphicsContext::nativeImageForDrawing):
(WebCore::GraphicsContext::drawImageBuffer):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::GraphicsContext):
(WebCore::GraphicsContext::deferred const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::copyImageBufferToNativeImage):
(WebCore::ImageBuffer::copyNativeImage const):
(WebCore::ImageBuffer::createNativeImageReference const):
(WebCore::ImageBuffer::copyNativeImageForDrawing const): Deleted.
(WebCore::ImageBuffer::draw): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::sinkIntoNativeImage):
(WebCore::ImageBufferBackend::copyNativeImageForDrawing): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::finalizeDrawIntoContext): Deleted.
* Source/WebCore/platform/graphics/SourceImage.cpp:
(WebCore::SourceImage::nativeImage const):
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawShadowLayerBuffer):
(WebCore::Cairo::drawShadowImage):
(WebCore::Cairo::fillShadowBuffer):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::clipToImageBuffer):
(WebCore::GraphicsContextCairo::drawFocusRing): Deleted.
(WebCore::GraphicsContextCairo::drawLinesForText): Deleted.
(WebCore::GraphicsContextCairo::drawDotsForDocumentMarker): Deleted.
(WebCore::GraphicsContextCairo::translate): Deleted.
(WebCore::GraphicsContextCairo::didUpdateState): Deleted.
(WebCore::GraphicsContextCairo::concatCTM): Deleted.
(WebCore::GraphicsContextCairo::setCTM): Deleted.
(WebCore::GraphicsContextCairo::beginTransparencyLayer): Deleted.
(WebCore::GraphicsContextCairo::endTransparencyLayer): Deleted.
(WebCore::GraphicsContextCairo::clearRect): Deleted.
(WebCore::GraphicsContextCairo::strokeRect): Deleted.
(WebCore::GraphicsContextCairo::setLineCap): Deleted.
(WebCore::GraphicsContextCairo::setLineDash): Deleted.
(WebCore::GraphicsContextCairo::setLineJoin): Deleted.
(WebCore::GraphicsContextCairo::setMiterLimit): Deleted.
(WebCore::GraphicsContextCairo::clipOut): Deleted.
(WebCore::GraphicsContextCairo::rotate): Deleted.
(WebCore::GraphicsContextCairo::scale): Deleted.
(WebCore::GraphicsContextCairo::fillRoundedRectImpl): Deleted.
(WebCore::GraphicsContextCairo::fillRectWithRoundedHole): Deleted.
(WebCore::GraphicsContextCairo::drawPattern): Deleted.
(WebCore::GraphicsContextCairo::renderingMode const): Deleted.
(WebCore::GraphicsContextCairo::cr const): Deleted.
(WebCore::GraphicsContextCairo::layers): Deleted.
(WebCore::GraphicsContextCairo::pushImageMask): Deleted.
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::copyNativeImage):
(WebCore::ImageBufferCairoSurfaceBackend::createNativeImageReference):
(WebCore::ImageBufferCairoSurfaceBackend::cairoSurfaceCoerceToImage):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::isDeferredForCGContext):
(WebCore::GraphicsContextCG::GraphicsContextCG):
(WebCore::GraphicsContextCG::clipToImageBuffer):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::copyNativeImage):
(WebCore::ImageBufferCGBitmapBackend::createNativeImageReference):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::createNativeImageReference):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::draw):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::Recorder):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::Recorder):
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::CGDisplayListImageBufferBackend::copyNativeImage):
(WebKit::CGDisplayListImageBufferBackend::createNativeImageReference):
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::copyNativeImage const):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::copyNativeImage):
(WebKit::ImageBufferShareableBitmapBackend::createNativeImageReference):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::createNativeImageReference const):
(WebKit::RemoteImageBufferProxy::copyNativeImageForDrawing const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::copyNativeImage):
(WebKit::ImageBufferRemoteIOSurfaceBackend::createNativeImageReference):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::copyNativeImage):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImage):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::createNativeImageReference):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImageForDrawing): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:

Canonical link: <a href="https://commits.webkit.org/268243@main">https://commits.webkit.org/268243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa9c72a0d3f4d12ae892d2d019e3485da8ec89ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19601 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21868 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16624 "7 flakes 5 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23790 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21740 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18155 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17260 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4560 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->