### PR TITLE
[GTK] MiniBrowser should hide the toolbar when using --full-screen #17909

### DIFF
--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -482,6 +482,20 @@ static GtkWidget *webViewCreate(WebKitWebView *webView, WebKitNavigationAction *
     return GTK_WIDGET(newWebView);
 }
 
+void browser_window_fullscreen(BrowserWindow *window)
+{
+    gtk_window_fullscreen(GTK_WINDOW(window));
+    gtk_widget_hide(window->toolbar);
+    window->fullScreenIsEnabled = TRUE;
+}
+
+static void browserWindowUnfullscreen(BrowserWindow *window)
+{
+    gtk_window_unfullscreen(GTK_WINDOW(window));
+    gtk_widget_show(window->toolbar);
+    window->fullScreenIsEnabled = FALSE;
+}
+
 static gboolean webViewEnterFullScreen(WebKitWebView *webView, BrowserWindow *window)
 {
     gtk_widget_hide(window->toolbar);
@@ -867,15 +881,10 @@ static void loadHomePage(GSimpleAction *action, GVariant *parameter, gpointer us
 static void toggleFullScreen(GSimpleAction *action, GVariant *parameter, gpointer userData)
 {
     BrowserWindow *window = BROWSER_WINDOW(userData);
-    if (!window->fullScreenIsEnabled) {
-        gtk_window_fullscreen(GTK_WINDOW(window));
-        gtk_widget_hide(window->toolbar);
-        window->fullScreenIsEnabled = TRUE;
-    } else {
-        gtk_window_unfullscreen(GTK_WINDOW(window));
-        gtk_widget_show(window->toolbar);
-        window->fullScreenIsEnabled = FALSE;
-    }
+    if (window->fullScreenIsEnabled)
+        browserWindowUnfullscreen(window);
+    else
+        browser_window_fullscreen(window);
 }
 
 static void webKitPrintOperationFailedCallback(WebKitPrintOperation *printOperation, GError *error)

--- a/Tools/MiniBrowser/gtk/BrowserWindow.h
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.h
@@ -58,6 +58,7 @@ GtkWidget* browser_window_new(GtkWindow*, WebKitWebContext*);
 #endif
 WebKitWebContext* browser_window_get_web_context(BrowserWindow*);
 void browser_window_append_view(BrowserWindow*, WebKitWebView*);
+void browser_window_fullscreen(BrowserWindow*);
 void browser_window_load_uri(BrowserWindow*, const char *uri);
 void browser_window_load_session(BrowserWindow *, const char *sessionFile);
 void browser_window_set_background_color(BrowserWindow*, GdkRGBA*);

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -925,7 +925,7 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
     if (darkMode)
         g_object_set(gtk_widget_get_settings(GTK_WIDGET(mainWindow)), "gtk-application-prefer-dark-theme", TRUE, NULL);
     if (fullScreen)
-        gtk_window_fullscreen(GTK_WINDOW(mainWindow));
+        browser_window_fullscreen(mainWindow);
 
     if (backgroundColor)
         browser_window_set_background_color(mainWindow, backgroundColor);


### PR DESCRIPTION
#### e07345343415dd2496edc721daa61a3b42703131
<pre>
[GTK] MiniBrowser should hide the toolbar when using --full-screen #17909
<a href="https://bugs.webkit.org/show_bug.cgi?id=261732">https://bugs.webkit.org/show_bug.cgi?id=261732</a>

Reviewed by Michael Catanzaro.

Entering fullscreen mode with F11 works as expected.
Starting with command line switch `--full-screen` does make the window
fullscreen, but does not hide the toolbar. Let&apos;s change that.

Instead of just making the window fullscreen with `gtk_window_fullscreen()`
this introduces a new function `browser_window_fullscreen()` that hides
the toolbar as well.

Also introduce new function `browserWindowUnfullscreen()`, use both
in `toggleFullScreen()`, and drop extra inversion.

* Tools/MiniBrowser/gtk/BrowserWindow.c
* Tools/MiniBrowser/gtk/BrowserWindow.h
* Tools/MiniBrowser/gtk/main.c

Canonical link: <a href="https://commits.webkit.org/268141@main">https://commits.webkit.org/268141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ca126adef66f6b544ccb3b167e0d12f9f2083e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19315 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21585 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17167 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21513 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17000 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4467 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21367 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->