### PR TITLE
showPicker() method of inputs doesn't trigger datalist suggestions

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-show-picker-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-show-picker-expected.txt
@@ -1,0 +1,4 @@
+
+Is showing suggestions? true
+
+This test verifies that datalist suggestions UI is shown when calling showPicker.

--- a/LayoutTests/fast/forms/datalist/datalist-show-picker.html
+++ b/LayoutTests/fast/forms/datalist/datalist-show-picker.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+
+body {
+    margin: 0;
+}
+</style>
+<head>
+<body onload="runTest()">
+<input id="input" list="fruits" type="text"/>
+<datalist id="fruits">
+    <option>Apple</option>
+    <option>Orange</option>
+    <option>Pear</option>
+</datalist>
+<pre>Is showing suggestions? <span id="before"></span></pre>
+<br>
+<div>This test verifies that datalist suggestions UI is shown when calling showPicker.</div>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+async function runTest() {
+    await UIHelper.activateAt(0, 0);
+
+    input.showPicker();
+
+    before.textContent = await UIHelper.isShowingDataListSuggestions();
+
+    testRunner.notifyDone();
+}
+</script>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1411,6 +1411,8 @@ webkit.org/b/213386 fast/images/low-memory-decode.html [ Timeout ]
 
 webkit.org/b/214801 fast/forms/datalist/datalist-show-hide.html [ Failure Pass ]
 
+webkit.org/b/262852 fast/forms/datalist/datalist-show-picker.html [ Failure ]
+
 webkit.org/b/214802 http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html [ Failure Pass ]
 
 webkit.org/b/230017 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Failure Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3292,6 +3292,9 @@ fast/forms/datetimelocal/datetimelocal-show-picker.html [ Skip ]
 # showPicker not yet implemented for iOS
 webkit.org/b/261703 fast/forms/select/select-show-picker.html [ Skip ]
 
+# showPicker not yet implemented for iOS
+webkit.org/b/261703 fast/forms/datalist/datalist-show-picker.html [ Skip ]
+
 # <rdar://problem/59636115> REGRESSION: [ iOS & macOS ] two imported/w3c/web-platform-tests/WebCryptoAPI are failing
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker.html [ Failure ]
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -187,6 +187,14 @@ void TextFieldInputType::handleClickEvent(MouseEvent&)
     if (element()->focused() && element()->list())
         displaySuggestions(DataListSuggestionActivationType::ControlClicked);
 }
+
+void TextFieldInputType::showPicker()
+{
+#if !PLATFORM(IOS_FAMILY)
+    if (element()->list())
+        displaySuggestions(DataListSuggestionActivationType::ControlClicked);
+#endif
+}
 #endif
 
 auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -132,6 +132,8 @@ private:
     void displaySuggestions(DataListSuggestionActivationType);
     void closeSuggestions();
 
+    void showPicker() override;
+
     // DataListSuggestionsClient
     IntRect elementRectInRootViewCoordinates() const final;
     Vector<DataListSuggestion> suggestions() final;


### PR DESCRIPTION
#### dddc5bb328a4b8636946a735281b09101f1d3161
<pre>
showPicker() method of inputs doesn&apos;t trigger datalist suggestions
<a href="https://bugs.webkit.org/show_bug.cgi?id=261701">https://bugs.webkit.org/show_bug.cgi?id=261701</a>

Reviewed by Aditya Keerthi.

Implements showPicker for TextFieldInputs that have a datalist.
This does not work on iOS a follow up will address that.

* LayoutTests/fast/forms/datalist/datalist-show-picker-expected.txt: Added.
* LayoutTests/fast/forms/datalist/datalist-show-picker.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::showPicker):
* Source/WebCore/html/TextFieldInputType.h:

Canonical link: <a href="https://commits.webkit.org/269981@main">https://commits.webkit.org/269981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7fff9a2a64fdccd0e8bfdffe3909dbb64048937

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22528 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26635 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27806 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25595 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18945 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5791 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->